### PR TITLE
Change oauth example to use supported version

### DIFF
--- a/examples/argocd-oauth.yaml
+++ b/examples/argocd-oauth.yaml
@@ -6,6 +6,6 @@ metadata:
     example: defaults
 spec:
   dex:
-    image: quay.io/dexidp/dex 
-    version: v2.22.0
+    image: quay.io/redhat-cop/dex 
+    version: v2.22.0-openshift
     openShiftOAuth: true

--- a/examples/argocd-oauth.yaml
+++ b/examples/argocd-oauth.yaml
@@ -6,6 +6,6 @@ metadata:
     example: defaults
 spec:
   dex:
-    image: quay.io/ablock/dex
-    version: openshift-connector
+    image: quay.io/dexidp/dex 
+    version: v2.22.0
     openShiftOAuth: true


### PR DESCRIPTION
This changes the oauth example CR to use the dex repo and version that the original PR was merged into.