### PR TITLE
Update Argo ConfigMap when CRD Changes

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -145,6 +145,31 @@ spec:
     version: v2.21.0
 ```
 
+### Dex OpenShift OAuth Example
+
+The following example configures Dex to use the OAuth server built into OpenShift. 
+
+The `OpenShiftOAuth` property can be used to trigger the operator to auto configure the built-in OpenShift OAuth server. The RBAC `Policy` property is used to give the admin role in the Argo CD cluster to users in the OpenShift `cluster-admins` group. 
+
+``` yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: openshift-oauth
+spec:
+  dex:
+    image: quay.io/ablock/dex
+    openShiftOAuth: true
+    version: openshift-connector
+  rbac:
+    defaultPolicy: 'role:readonly'
+    policy: |
+      g, system:cluster-admins, role:admin
+    scopes: '[groups]'
+```
+
 ## GA Tracking ID
 
 The google analytics tracking ID to use. This property maps directly to the `ga.trackingid` field in the `argocd-cm` ConfigMap.
@@ -287,7 +312,7 @@ spec:
 
 The container image for all Argo CD components.
 
-## Image Example
+### Image Example
 
 The following example sets the default value using the `Image` property on the `ArgoCD` resource.
 
@@ -446,8 +471,9 @@ metadata:
     example: rbac
 spec:
   rbac:
-    defaultPolicy: role:readonly
-    policy: ""
+    defaultPolicy: 'role:readonly'
+    policy: |
+      g, system:cluster-admins, role:admin
     scopes: '[groups]'
 ```
 
@@ -689,7 +715,7 @@ spec:
 
 Define the SSH Known Hosts for Argo CD. This property maps directly to the `ssh_known_hosts` field in the `argocd-ssh-known-hosts-cm` ConfigMap.
 
-### SSH Known Hosts
+### SSH Known Hosts Example
 
 The following example sets a value in the `argocd-ssh-known-hosts-cm` ConfigMap using the `SSHKnownHosts` property on the `ArgoCD` resource. The example values have been truncated for clarity.
 
@@ -779,7 +805,7 @@ spec:
 
 The tag to use with the container image for all Argo CD components.
 
-## Version Example
+### Version Example
 
 The following example sets the default value using the `Version` property on the `ArgoCD` resource.
 

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -296,77 +296,10 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoprojv1a1.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
 	if argoutil.IsObjectFound(r.client, cr.Namespace, cm.Name, cm) {
-
-		uri := r.getArgoServerURI(cr)
-		if cm.Data[common.ArgoCDKeyServerURL] != uri {
-			cm.Data[common.ArgoCDKeyServerURL] = uri
-			return r.client.Update(context.TODO(), cm)
-		}
-
 		if err := r.reconcileDexConfiguration(cm, cr); err != nil {
 			return err
 		}
-
-		changed := false
-
-		if cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] != cr.Spec.ApplicationInstanceLabelKey {
-			cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = cr.Spec.ApplicationInstanceLabelKey
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyConfigManagementPlugins] != cr.Spec.ConfigManagementPlugins {
-			cm.Data[common.ArgoCDKeyConfigManagementPlugins] = cr.Spec.ConfigManagementPlugins
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyGATrackingID] != cr.Spec.GATrackingID {
-			cm.Data[common.ArgoCDKeyGATrackingID] = cr.Spec.GATrackingID
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyGAAnonymizeUsers] != fmt.Sprint(cr.Spec.GAAnonymizeUsers) {
-			cm.Data[common.ArgoCDKeyGAAnonymizeUsers] = fmt.Sprint(cr.Spec.GAAnonymizeUsers)
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyHelpChatURL] != cr.Spec.HelpChatURL {
-			cm.Data[common.ArgoCDKeyHelpChatURL] = cr.Spec.HelpChatURL
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyHelpChatText] != cr.Spec.HelpChatText {
-			cm.Data[common.ArgoCDKeyHelpChatText] = cr.Spec.HelpChatText
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyKustomizeBuildOptions] != cr.Spec.KustomizeBuildOptions {
-			cm.Data[common.ArgoCDKeyKustomizeBuildOptions] = cr.Spec.KustomizeBuildOptions
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyOIDCConfig] != cr.Spec.OIDCConfig {
-			cm.Data[common.ArgoCDKeyOIDCConfig] = cr.Spec.OIDCConfig
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyResourceCustomizations] != cr.Spec.ResourceCustomizations {
-			cm.Data[common.ArgoCDKeyResourceCustomizations] = cr.Spec.ResourceCustomizations
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyResourceExclusions] != cr.Spec.ResourceExclusions {
-			cm.Data[common.ArgoCDKeyResourceExclusions] = cr.Spec.ResourceExclusions
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyRepositories] != cr.Spec.Repositories {
-			cm.Data[common.ArgoCDKeyRepositories] = cr.Spec.Repositories
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyStatusBadgeEnabled] != fmt.Sprint(cr.Spec.StatusBadgeEnabled) {
-			cm.Data[common.ArgoCDKeyStatusBadgeEnabled] = fmt.Sprint(cr.Spec.StatusBadgeEnabled)
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] != fmt.Sprint(cr.Spec.UsersAnonymousEnabled) {
-			cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] = fmt.Sprint(cr.Spec.UsersAnonymousEnabled)
-			changed = true
-		}
-
-		if changed {
-			return r.client.Update(context.TODO(), cm) // TODO: Reload Argo CD server after ConfigMap change (which properties)?
-		}
-
-		return nil // ConfigMap found and configured, do nothing further...
+		return r.reconcileExistingArgoConfigMap(cm, cr)
 	}
 
 	if len(cm.Data) <= 0 {
@@ -422,6 +355,87 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 		return r.client.Update(context.TODO(), cm)
 	}
 	return nil
+}
+
+func (r *ReconcileArgoCD) reconcileExistingArgoConfigMap(cm *corev1.ConfigMap, cr *argoprojv1a1.ArgoCD) error {
+	changed := false
+
+	if cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] != cr.Spec.ApplicationInstanceLabelKey {
+		cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = cr.Spec.ApplicationInstanceLabelKey
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyConfigManagementPlugins] != cr.Spec.ConfigManagementPlugins {
+		cm.Data[common.ArgoCDKeyConfigManagementPlugins] = cr.Spec.ConfigManagementPlugins
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyGATrackingID] != cr.Spec.GATrackingID {
+		cm.Data[common.ArgoCDKeyGATrackingID] = cr.Spec.GATrackingID
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyGAAnonymizeUsers] != fmt.Sprint(cr.Spec.GAAnonymizeUsers) {
+		cm.Data[common.ArgoCDKeyGAAnonymizeUsers] = fmt.Sprint(cr.Spec.GAAnonymizeUsers)
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyHelpChatURL] != cr.Spec.HelpChatURL {
+		cm.Data[common.ArgoCDKeyHelpChatURL] = cr.Spec.HelpChatURL
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyHelpChatText] != cr.Spec.HelpChatText {
+		cm.Data[common.ArgoCDKeyHelpChatText] = cr.Spec.HelpChatText
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyKustomizeBuildOptions] != cr.Spec.KustomizeBuildOptions {
+		cm.Data[common.ArgoCDKeyKustomizeBuildOptions] = cr.Spec.KustomizeBuildOptions
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyOIDCConfig] != cr.Spec.OIDCConfig {
+		cm.Data[common.ArgoCDKeyOIDCConfig] = cr.Spec.OIDCConfig
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyResourceCustomizations] != cr.Spec.ResourceCustomizations {
+		cm.Data[common.ArgoCDKeyResourceCustomizations] = cr.Spec.ResourceCustomizations
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyResourceExclusions] != cr.Spec.ResourceExclusions {
+		cm.Data[common.ArgoCDKeyResourceExclusions] = cr.Spec.ResourceExclusions
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyRepositories] != cr.Spec.Repositories {
+		cm.Data[common.ArgoCDKeyRepositories] = cr.Spec.Repositories
+		changed = true
+	}
+
+	uri := r.getArgoServerURI(cr)
+	if cm.Data[common.ArgoCDKeyServerURL] != uri {
+		cm.Data[common.ArgoCDKeyServerURL] = uri
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyStatusBadgeEnabled] != fmt.Sprint(cr.Spec.StatusBadgeEnabled) {
+		cm.Data[common.ArgoCDKeyStatusBadgeEnabled] = fmt.Sprint(cr.Spec.StatusBadgeEnabled)
+		changed = true
+	}
+
+	if cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] != fmt.Sprint(cr.Spec.UsersAnonymousEnabled) {
+		cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] = fmt.Sprint(cr.Spec.UsersAnonymousEnabled)
+		changed = true
+	}
+
+	if changed {
+		return r.client.Update(context.TODO(), cm) // TODO: Reload Argo CD server after ConfigMap change (which properties)?
+	}
+
+	return nil // Nothing changed, no update needed...
 }
 
 // reconcileGrafanaConfiguration will ensure that the Grafana configuration ConfigMap is present.

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -296,6 +296,7 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoprojv1a1.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
 	if argoutil.IsObjectFound(r.client, cr.Namespace, cm.Name, cm) {
+
 		uri := r.getArgoServerURI(cr)
 		if cm.Data[common.ArgoCDKeyServerURL] != uri {
 			cm.Data[common.ArgoCDKeyServerURL] = uri
@@ -305,6 +306,66 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 		if err := r.reconcileDexConfiguration(cm, cr); err != nil {
 			return err
 		}
+
+		changed := false
+
+		if cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] != cr.Spec.ApplicationInstanceLabelKey {
+			cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = cr.Spec.ApplicationInstanceLabelKey
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyConfigManagementPlugins] != cr.Spec.ConfigManagementPlugins {
+			cm.Data[common.ArgoCDKeyConfigManagementPlugins] = cr.Spec.ConfigManagementPlugins
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyGATrackingID] != cr.Spec.GATrackingID {
+			cm.Data[common.ArgoCDKeyGATrackingID] = cr.Spec.GATrackingID
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyGAAnonymizeUsers] != fmt.Sprint(cr.Spec.GAAnonymizeUsers) {
+			cm.Data[common.ArgoCDKeyGAAnonymizeUsers] = fmt.Sprint(cr.Spec.GAAnonymizeUsers)
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyHelpChatURL] != cr.Spec.HelpChatURL {
+			cm.Data[common.ArgoCDKeyHelpChatURL] = cr.Spec.HelpChatURL
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyHelpChatText] != cr.Spec.HelpChatText {
+			cm.Data[common.ArgoCDKeyHelpChatText] = cr.Spec.HelpChatText
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyKustomizeBuildOptions] != cr.Spec.KustomizeBuildOptions {
+			cm.Data[common.ArgoCDKeyKustomizeBuildOptions] = cr.Spec.KustomizeBuildOptions
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyOIDCConfig] != cr.Spec.OIDCConfig {
+			cm.Data[common.ArgoCDKeyOIDCConfig] = cr.Spec.OIDCConfig
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyResourceCustomizations] != cr.Spec.ResourceCustomizations {
+			cm.Data[common.ArgoCDKeyResourceCustomizations] = cr.Spec.ResourceCustomizations
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyResourceExclusions] != cr.Spec.ResourceExclusions {
+			cm.Data[common.ArgoCDKeyResourceExclusions] = cr.Spec.ResourceExclusions
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyRepositories] != cr.Spec.Repositories {
+			cm.Data[common.ArgoCDKeyRepositories] = cr.Spec.Repositories
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyStatusBadgeEnabled] != fmt.Sprint(cr.Spec.StatusBadgeEnabled) {
+			cm.Data[common.ArgoCDKeyStatusBadgeEnabled] = fmt.Sprint(cr.Spec.StatusBadgeEnabled)
+			changed = true
+		}
+		if cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] != fmt.Sprint(cr.Spec.UsersAnonymousEnabled) {
+			cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] = fmt.Sprint(cr.Spec.UsersAnonymousEnabled)
+			changed = true
+		}
+
+		if changed {
+			return r.client.Update(context.TODO(), cm) // TODO: Reload Argo CD server after ConfigMap change (which properties)?
+		}
+
 		return nil // ConfigMap found and configured, do nothing further...
 	}
 


### PR DESCRIPTION
This PR addresses #41 adds the logic to update the `argocd-cm` ConfigMap when one of the corresponding properties on the `ArgoCD` CRD changes.