### PR TITLE
Update Operator to Use Argo CD v1.5.2

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,3 +1,3 @@
-FROM argoproj/argocd:v1.5.1
+FROM argoproj/argocd:v1.5.2
 
 COPY util.sh /usr/local/bin/argocd-operator-util

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -37,7 +37,7 @@ Name | Default | Description
 [**StatusBadgeEnabled**](#status-badge-enabled) | `true` | Enable application status badge feature.
 [**TLS**](#tls-options) | [Object] | TLS configuration options.
 [**UsersAnonymousEnabled**](#users-anonymous-enabled) | `true` | Enable anonymous user access.
-[**Version**](#version) | v1.5.1 (SHA) | The tag to use with the container image for all Argo CD components.
+[**Version**](#version) | v1.5.2 (SHA) | The tag to use with the container image for all Argo CD components.
 
 ## Application Instance Label Key
 
@@ -817,5 +817,5 @@ metadata:
   labels:
     example: version
 spec:
-  version: v1.5.1
+  version: v1.5.2
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-operator
 go 1.13
 
 require (
-	github.com/argoproj/argo-cd v1.5.1
+	github.com/argoproj/argo-cd v1.5.2
 	github.com/coreos/prometheus-operator v0.34.0
 	github.com/go-openapi/spec v0.19.2
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/argoproj/argo-cd v1.4.2 h1:nd2MFXf8Rzl2lUvxYLfGSTaC/jkD4ilX5gtkHuM2lo
 github.com/argoproj/argo-cd v1.4.2/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/argoproj/argo-cd v1.5.1 h1:BlTdXOKLH3guOpuvGMzyaO6/w6KDjwNRe3v2yMKOMog=
 github.com/argoproj/argo-cd v1.5.1/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
+github.com/argoproj/argo-cd v1.5.2 h1:vozOFCjDRLG39ifkV72EI845g2A57oEZQ3+SUhHTyBE=
+github.com/argoproj/argo-cd v1.5.2/go.mod h1:UPOPiF6Y1y/oTL3X1KcuLbu7ljD7f4+SIaXvlowBmhE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -775,6 +777,7 @@ sigs.k8s.io/controller-tools v0.2.2/go.mod h1:8SNGuj163x/sMwydREj7ld5mIMJu1cDanI
 sigs.k8s.io/controller-tools v0.2.4 h1:la1h46EzElvWefWLqfsXrnsO3lZjpkI0asTpX6h8PLA=
 sigs.k8s.io/controller-tools v0.2.5 h1:kH7HKWed9XO42OTxyhUtqyImiefdZV2Q9Jbrytvhf18=
 sigs.k8s.io/controller-tools v0.2.8 h1:UmYsnu89dn8/wBhjKL3lkGyaDGRnPDYUx2+iwXRnylA=
+sigs.k8s.io/controller-tools v0.2.9 h1:DEZuCFWANX2zlZVMlf/XmhSq0HzmGCZ/GTdPJig62ig=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -31,7 +31,7 @@ const (
 	ArgoCDDefaultArgoImage = "argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:515d6cecf70169491efba5b9802b1ddb21a30e7ec59e87ab1f29196d6945afd5" // v1.5.1
+	ArgoCDDefaultArgoVersion = "sha256:ebaa82eb629d8fcc4a23659d1f6602ab64db4f5e13b9146f4742247593af9697" // v1.5.2
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -128,7 +128,7 @@ const (
 	ArgoCDDefaultGrafanaConfigPath = "/var/lib/grafana"
 
 	// ArgoCDDefaultGrafanaVersion is the Grafana container image tag to use when not specified.
-	ArgoCDDefaultGrafanaVersion = "sha256:1ff3999e0fc08a3909e9a3ecdf6e74b4789db9b67c8297c44fdee1e167b9375f" // 6.7.1
+	ArgoCDDefaultGrafanaVersion = "sha256:afef23a1b4cf159ec3180aac3ad693c10e560657313bfe3ec81f344ace6d2f05" // 6.7.2
 
 	// ArgoCDDefaultHelpChatURL is the default help chat URL.
 	ArgoCDDefaultHelpChatURL = "https://mycorp.slack.com/argo-cd"


### PR DESCRIPTION
This PR updates the operator to use Argo CD v1.5.2, which addresses [CVE-2020-5260](http://cve.circl.lu/cve/CVE-2020-5260).

See the following for more information:

- https://github.com/git/git/security/advisories/GHSA-qm7j-c969-7j4q
- https://github.com/argoproj/argo-cd/releases/tag/v1.5.2