### PR TITLE
Only Initialize Repos, SSH Known Host and Certs

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -216,6 +216,14 @@ spec:
                   description: Path used for the Ingress resource.
                   type: string
               type: object
+            initialRepositories:
+              description: InitialRepositories to configure Argo CD with upon creation
+                of the cluster.
+              type: string
+            initialSSHKnownHosts:
+              description: InitialSSHKnownHosts defines the SSH known hosts data upon
+                creation of the cluster for connecting Git repositories via SSH.
+              type: string
             kustomizeBuildOptions:
               description: KustomizeBuildOptions is used to specify build options/parameters
                 to use with `kustomize build`.
@@ -323,9 +331,6 @@ spec:
                       type: object
                   type: object
               type: object
-            repositories:
-              description: Repositories to configure Argo CD with.
-              type: string
             resourceCustomizations:
               description: 'ResourceCustomizations customizes resource behavior. Keys
                 are in the form: group/Kind.'
@@ -448,10 +453,6 @@ spec:
                   - type
                   type: object
               type: object
-            sshKnownHosts:
-              description: SSHKnownHosts defines the SSH known hosts data for connecting
-                Git repositories via SSH.
-              type: string
             statusBadgeEnabled:
               description: StatusBadgeEnabled toggles application status badge feature.
               type: boolean
@@ -470,11 +471,11 @@ spec:
                         the CA Certificate and Key.
                       type: string
                   type: object
-                certs:
+                initialCerts:
                   additionalProperties:
                     type: string
-                  description: Certs defines custom TLS certificates for connecting
-                    Git repositories via HTTPS.
+                  description: InitialCerts defines custom TLS certificates upon creation
+                    of the cluster for connecting Git repositories via HTTPS.
                   type: object
               type: object
             usersAnonymousEnabled:

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -24,16 +24,16 @@ Name | Default | Description
 [**Image**](#image) | `argoproj/argocd` | The container image for all Argo CD components.
 [**Import**](#import-options) | [Object] | Import configuration options.
 [**Ingress**](#ingress-options) | [Object] | Ingress configuration options.
+[**InitialRepositories**](#initial-repositories) | [Empty] | Initial git repositories to configure Argo CD to use upon creation of the cluster.
+[**InitialSSHKnownHosts**](#initial-ssh-known-hosts) | [Default Argo CD Known Hosts] | Initial SSH Known Hosts for Argo CD to use upon creation of the cluster.
 [**KustomizeBuildOptions**](#kustomize-build-options) | [Empty] | The build options/parameters to use with `kustomize build`.
 [**OIDCConfig**](#oidc-config) | [Empty] | The OIDC configuration as an alternative to Dex.
 [**Prometheus**](#prometheus-options) | [Object] | Prometheus configuration options.
 [**RBAC**](#rbac-options) | [Object] | RBAC configuration options.
 [**Redis**](#redis-options) | [Object] | Redis configuration options.
-[**Repositories**](#repositories) | [Empty] | Git repositories to configure Argo CD with initially.
 [**ResourceCustomizations**](#resource-customizations) | [Empty] | Customize resource behavior.
 [**ResourceExclusions**](#resource-exclusions) | [Empty] | The configuration to completely ignore entire classes of resource group/kinds.
 [**Server**](#server-options) | [Object] | Argo CD Server configuration options.
-[**SSHKnownHosts**](#ssh-known-hosts) | [Default Argo CD Known Hosts] | Define the SSH Known Hosts for Argo CD.
 [**StatusBadgeEnabled**](#status-badge-enabled) | `true` | Enable application status badge feature.
 [**TLS**](#tls-options) | [Object] | TLS configuration options.
 [**UsersAnonymousEnabled**](#users-anonymous-enabled) | `true` | Enable anonymous user access.
@@ -370,6 +370,72 @@ spec:
     insecure: true
 ```
 
+## Initial Repositories
+
+Initial git repositories to configure Argo CD to use upon creation of the cluster.
+
+This property maps directly to the `repositories` field in the `argocd-cm` ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Modifications to the `repositories` field should then be made through the Argo CD web UI or CLI.
+
+### Initial Repositories Example
+
+The following example sets a value in the `argocd-cm` ConfigMap using the `InitialRepositories` property on the `ArgoCD` resource.
+
+``` yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: initial-repositories
+spec:
+  initialRepositories: |
+    - url: https://github.com/argoproj/my-private-repository
+      passwordSecret:
+        name: my-secret
+        key: password
+      usernameSecret:
+        name: my-secret
+        key: username
+      sshPrivateKeySecret:
+        name: my-secret
+        key: sshPrivateKey
+    - type: helm
+      url: https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts
+      name: istio.io
+    - type: helm
+      url: https://my-private-chart-repo.internal
+      name: private-repo
+      usernameSecret:
+        name: my-secret
+        key: username
+      passwordSecret:
+        name: my-secret
+        key: password
+```
+
+## Initial SSH Known Hosts
+
+Initial SSH Known Hosts for Argo CD to use upon creation of the cluster.
+
+This property maps directly to the `ssh_known_hosts` field in the `argocd-ssh-known-hosts-cm` ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Modifications to the `ssh_known_hosts` field should then be made through the Argo CD web UI or CLI.
+
+### Initial SSH Known Hosts Example
+
+The following example sets a value in the `argocd-ssh-known-hosts-cm` ConfigMap using the `InitialSSHKnownHosts` property on the `ArgoCD` resource. The example values have been truncated for clarity.
+
+``` yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: initial-ssh-known-hosts
+spec:
+  initialSSHKnownHosts: |
+    bitbucket.org ssh-rsa AAAAB3NzaC...
+    github.com ssh-rsa AAAAB3NzaC...
+```
+
 ## Kustomize Build Options
 
 Build options/parameters to use with `kustomize build` (optional). This property maps directly to the `kustomize.buildOptions` field in the `argocd-cm` ConfigMap.
@@ -529,49 +595,6 @@ spec:
     resources: {}
 ```
 
-## Repositories
-
-Git repositories to configure Argo CD with (optional). This list is updated when configuring/removing repos from the UI/CLI
-
-This property maps directly to the `repositories` field in the `argocd-cm` ConfigMap.
-
-### Repositories Example
-
-The following example sets a value in the `argocd-cm` ConfigMap using the `Repositories` property on the `ArgoCD` resource.
-
-``` yaml
-apiVersion: argoproj.io/v1alpha1
-kind: ArgoCD
-metadata:
-  name: example-argocd
-  labels:
-    example: repositories
-spec:
-  repositories: |
-    - url: https://github.com/argoproj/my-private-repository
-      passwordSecret:
-        name: my-secret
-        key: password
-      usernameSecret:
-        name: my-secret
-        key: username
-      sshPrivateKeySecret:
-        name: my-secret
-        key: sshPrivateKey
-    - type: helm
-      url: https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts
-      name: istio.io
-    - type: helm
-      url: https://my-private-chart-repo.internal
-      name: private-repo
-      usernameSecret:
-        name: my-secret
-        key: username
-      passwordSecret:
-        name: my-secret
-        key: password
-```
-
 ## Resource Customizations
 
 The configuration to customize resource behavior. This property maps directly to the `resource.customizations` field in the `argocd-cm` ConfigMap.
@@ -711,27 +734,6 @@ spec:
       type: ClusterIP
 ```
 
-## SSH Known Hosts
-
-Define the SSH Known Hosts for Argo CD. This property maps directly to the `ssh_known_hosts` field in the `argocd-ssh-known-hosts-cm` ConfigMap.
-
-### SSH Known Hosts Example
-
-The following example sets a value in the `argocd-ssh-known-hosts-cm` ConfigMap using the `SSHKnownHosts` property on the `ArgoCD` resource. The example values have been truncated for clarity.
-
-``` yaml
-apiVersion: argoproj.io/v1alpha1
-kind: ArgoCD
-metadata:
-  name: example-argocd
-  labels:
-    example: ssh-known-hosts
-spec:
-  sshKnownHosts: |
-    bitbucket.org ssh-rsa AAAAB3NzaC...
-    github.com ssh-rsa AAAAB3NzaC...
-```
-
 ## Status Badge Enabled
 
 Enable application status badge feature. This property maps directly to the `statusbadge.enabled` field in the `argocd-cm` ConfigMap.
@@ -759,7 +761,7 @@ Name | Default | Description
 --- | --- | ---
 CA.ConfigMapName | `example-argocd-ca` | The name of the ConfigMap containing the CA Certificate.
 CA.SecretName | `example-argocd-ca` | The name of the Secret containing the CA Certificate and Key.
-Certs | [Empty] | Properties in the `argocd-tls-certs-cm` ConfigMap. Define custom TLS certificates for connecting Git repositories via HTTPS.
+InitialCerts | [Empty] | Initial set of certificates in the `argocd-tls-certs-cm` ConfigMap for connecting Git repositories via HTTPS.
 
 ### TLS Example
 
@@ -771,13 +773,13 @@ kind: ArgoCD
 metadata:
   name: example-argocd
   labels:
-    example: server
+    example: tls
 spec:
   tls:
     ca:
       configMapName: example-argocd-ca
       secretName: example-argocd-ca
-    certs: []
+    initialCerts: []
 ```
 
 ## Users Anonymous Enabled

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -303,6 +303,12 @@ type ArgoCDSpec struct {
 	// Import is the import/restore options for ArgoCD.
 	Import *ArgoCDImportSpec `json:"import,omitempty"`
 
+	// InitialRepositories to configure Argo CD with upon creation of the cluster.
+	InitialRepositories string `json:"initialRepositories,omitempty"`
+
+	// InitialSSHKnownHosts defines the SSH known hosts data upon creation of the cluster for connecting Git repositories via SSH.
+	InitialSSHKnownHosts string `json:"initialSSHKnownHosts,omitempty"`
+
 	// Ingress defines the Ingress options for ArgoCD.
 	Ingress ArgoCDIngressSpec `json:"ingress,omitempty"`
 
@@ -321,9 +327,6 @@ type ArgoCDSpec struct {
 	// Redis defines the Redis server options for ArgoCD.
 	Redis ArgoCDRedisSpec `json:"redis,omitempty"`
 
-	// Repositories to configure Argo CD with.
-	Repositories string `json:"repositories,omitempty"`
-
 	// Repo defines the repo server options for Argo CD.
 	Repo ArgoCDRepoSpec `json:"repo,omitempty"`
 
@@ -335,9 +338,6 @@ type ArgoCDSpec struct {
 
 	// Server defines the options for the ArgoCD Server component.
 	Server ArgoCDServerSpec `json:"server,omitempty"`
-
-	// SSHKnownHosts defines the SSH known hosts data for connecting Git repositories via SSH.
-	SSHKnownHosts string `json:"sshKnownHosts,omitempty"`
 
 	// StatusBadgeEnabled toggles application status badge feature.
 	StatusBadgeEnabled bool `json:"statusBadgeEnabled,omitempty"`
@@ -378,6 +378,6 @@ type ArgoCDTLSSpec struct {
 	// CA defines the CA options.
 	CA ArgoCDCASpec `json:"ca,omitempty"`
 
-	// Certs defines custom TLS certificates for connecting Git repositories via HTTPS.
-	Certs map[string]string `json:"certs,omitempty"`
+	// InitialCerts defines custom TLS certificates upon creation of the cluster for connecting Git repositories via HTTPS.
+	InitialCerts map[string]string `json:"initialCerts,omitempty"`
 }

--- a/pkg/apis/argoproj/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/argoproj/v1alpha1/zz_generated.deepcopy.go
@@ -625,8 +625,8 @@ func (in *ArgoCDStatus) DeepCopy() *ArgoCDStatus {
 func (in *ArgoCDTLSSpec) DeepCopyInto(out *ArgoCDTLSSpec) {
 	*out = *in
 	out.CA = in.CA
-	if in.Certs != nil {
-		in, out := &in.Certs, &out.Certs
+	if in.InitialCerts != nil {
+		in, out := &in.InitialCerts, &out.InitialCerts
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/pkg/apis/argoproj/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/argoproj/v1alpha1/zz_generated.openapi.go
@@ -281,6 +281,20 @@ func schema_pkg_apis_argoproj_v1alpha1_ArgoCDSpec(ref common.ReferenceCallback) 
 							Ref:         ref("./pkg/apis/argoproj/v1alpha1.ArgoCDImportSpec"),
 						},
 					},
+					"initialRepositories": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InitialRepositories to configure Argo CD with upon creation of the cluster.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"initialSSHKnownHosts": {
+						SchemaProps: spec.SchemaProps{
+							Description: "InitialSSHKnownHosts defines the SSH known hosts data upon creation of the cluster for connecting Git repositories via SSH.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"ingress": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Ingress defines the Ingress options for ArgoCD.",
@@ -319,13 +333,6 @@ func schema_pkg_apis_argoproj_v1alpha1_ArgoCDSpec(ref common.ReferenceCallback) 
 							Ref:         ref("./pkg/apis/argoproj/v1alpha1.ArgoCDRedisSpec"),
 						},
 					},
-					"repositories": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Repositories to configure Argo CD with.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"repo": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Repo defines the repo server options for Argo CD.",
@@ -350,13 +357,6 @@ func schema_pkg_apis_argoproj_v1alpha1_ArgoCDSpec(ref common.ReferenceCallback) 
 						SchemaProps: spec.SchemaProps{
 							Description: "Server defines the options for the ArgoCD Server component.",
 							Ref:         ref("./pkg/apis/argoproj/v1alpha1.ArgoCDServerSpec"),
-						},
-					},
-					"sshKnownHosts": {
-						SchemaProps: spec.SchemaProps{
-							Description: "SSHKnownHosts defines the SSH known hosts data for connecting Git repositories via SSH.",
-							Type:        []string{"string"},
-							Format:      "",
 						},
 					},
 					"statusBadgeEnabled": {


### PR DESCRIPTION
This PR addresses #55 to change the behaviour of the operator (and name) for the following properties.

- `Repositories` -> `InitialRepositories`
- `SSHKnownHosts` -> `InitialSSHKnownHosts`
- `TLS.Certs` -> `TLS.InitialCerts`

The operator will use the new properties to set the initial value for the corresponding keys in the Argo CD ConfigMaps and Secrets. Any changes to these properties on a CR once the cluster has been created will have no effect.