### PR TITLE
Rename Cluster Secret to Avoid Name Collisions

### DIFF
--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -34,7 +34,6 @@ kubectl delete rolebinding -n ${ARGOCD_OPERATOR_NAMESPACE} \
     argocd-dex-server \
     argocd-operator \
     argocd-redis-ha \
-    argocd-repo-server \
     argocd-server
 
 kubectl delete role -n ${ARGOCD_OPERATOR_NAMESPACE} \
@@ -42,7 +41,6 @@ kubectl delete role -n ${ARGOCD_OPERATOR_NAMESPACE} \
     argocd-dex-server \
     argocd-operator \
     argocd-redis-ha \
-    argocd-repo-server \
     argocd-server
 
 # ServiceAccounts
@@ -51,7 +49,6 @@ kubectl delete sa -n ${ARGOCD_OPERATOR_NAMESPACE} \
     argocd-dex-server \
     argocd-operator \
     argocd-redis-ha \
-    argocd-repo-server \
     argocd-server
 
 # CustomResourceDefinitions

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -72,7 +72,7 @@ func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD) []string {
 }
 
 func getArgoExportSecretName(export *argoprojv1a1.ArgoCDExport) string {
-	name := argoutil.NameWithSuffix(export.ObjectMeta, "secret")
+	name := argoutil.NameWithSuffix(export.ObjectMeta, "cluster")
 	if export.Spec.Storage != nil && len(export.Spec.Storage.SecretName) > 0 {
 		name = export.Spec.Storage.SecretName
 	}

--- a/pkg/controller/argocd/secret.go
+++ b/pkg/controller/argocd/secret.go
@@ -101,7 +101,7 @@ func newCertificateSecret(suffix string, caCert *x509.Certificate, caKey *rsa.Pr
 
 // reconcileArgoSecret will ensure that the Argo CD Secret is present.
 func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
-	clusterSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "secret")
+	clusterSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "cluster")
 	secret := argoutil.NewSecretWithName(cr.ObjectMeta, common.ArgoCDSecretName)
 
 	if !argoutil.IsObjectFound(r.client, cr.Namespace, clusterSecret.Name, clusterSecret) {
@@ -171,7 +171,7 @@ func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
 
 // reconcileClusterMainSecret will ensure that the main Secret is present for the Argo CD cluster.
 func (r *ReconcileArgoCD) reconcileClusterMainSecret(cr *argoprojv1a1.ArgoCD) error {
-	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "secret")
+	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "cluster")
 	if argoutil.IsObjectFound(r.client, cr.Namespace, secret.Name, secret) {
 		return nil // Secret found, do nothing
 	}

--- a/pkg/controller/argoutil/resource.go
+++ b/pkg/controller/argoutil/resource.go
@@ -80,7 +80,7 @@ func FetchObject(client client.Client, namespace string, name string, obj runtim
 
 // FetchStorageSecretName will return the name of the Secret to use for the export process.
 func FetchStorageSecretName(export *argoprojv1a1.ArgoCDExport) string {
-	name := NameWithSuffix(export.ObjectMeta, "secret")
+	name := NameWithSuffix(export.ObjectMeta, "cluster")
 	if export.Spec.Storage != nil && len(export.Spec.Storage.SecretName) > 0 {
 		name = export.Spec.Storage.SecretName
 	}

--- a/tests/e2e/argocd-tests/02-ingress.yaml
+++ b/tests/e2e/argocd-tests/02-ingress.yaml
@@ -13,7 +13,8 @@ metadata:
   labels:
     example: ingress
 spec:
-  ingress:
-    enabled: true
   server:
+    grpc:
+      ingress: true
+    ingress: true
     insecure: true


### PR DESCRIPTION
This PR addresses #54 by renaming the cluster secret to "[CLUSTER NAME]-cluster" to avoid overwriting the internal Argo CD secret named `argocd-secret`. 