### PR TITLE
Trigger Rollout for Dex when Configuration Changes

### DIFF
--- a/examples/argocd-oauth.yaml
+++ b/examples/argocd-oauth.yaml
@@ -3,9 +3,11 @@ kind: ArgoCD
 metadata:
   name: example-argocd
   labels:
-    example: defaults
+    example: oauth
 spec:
   dex:
     image: quay.io/ablock/dex
     version: openshift-connector
     openShiftOAuth: true
+  server:
+    route: true

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -351,7 +351,7 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 	}
 
 	if actual != desired {
-		// Update ConfigMap with desirec configuration.
+		// Update ConfigMap with desired configuration.
 		cm.Data[common.ArgoCDKeyDexConfig] = desired
 		if err := r.client.Update(context.TODO(), cm); err != nil {
 			return err


### PR DESCRIPTION
This PR attempts to address #47 by triggering a rollout of the Dex Deployment when the configuration changes. Triggering a rollout has the effect of "restarting" Dex and the new Pod(s) will use the updated configuration.