### PR TITLE
Update Travis CI Build Options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: go
 go:
 - "1.13.x"
 env:
+  global:
   - ARGOCD_OPERATOR_IMAGE_BUILDER=docker
   - GO111MODULE=on
 cache:
@@ -12,13 +13,6 @@ cache:
   - $GOCACHE
   - $GOPATH/pkg/mod
 before_install:
-  - echo "Installing podman..."
-  - . /etc/os-release
-  - sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-  - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
-  - sudo apt-get update -qq
-  - sudo apt-get -qq -y install podman
-  - echo "Installing operator-sdk..."
   - git clone https://github.com/operator-framework/operator-sdk $GOPATH/src/github.com/operator-framework/operator-sdk
   - cd $GOPATH/src/github.com/operator-framework/operator-sdk
   - git checkout v0.17.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: bionic
 language: go
 go:
 - "1.13.x"
-go_import_path: github.com/argoproj-labs/argocd-operator
 env:
   - GO111MODULE=on
 cache:
@@ -12,11 +11,10 @@ cache:
   - $GOCACHE
   - $GOPATH/pkg/mod
 before_install:
-  - cd $HOME
-  - git clone https://github.com/operator-framework/operator-sdk operator-framework/operator-sdk
-  - cd operator-framework/operator-sdk
+  - git clone https://github.com/operator-framework/operator-sdk $GOPATH/src/github.com/operator-framework/operator-sdk
+  - cd $GOPATH/src/github.com/operator-framework/operator-sdk
   - git checkout v0.17.0
   - make tidy
   - make install
-  - cd $HOME/argoproj-labs/argocd-operator
+  - cd $GOPATH/src/github.com/argoproj-labs/argocd-operator
 script: hack/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_install:
   - make tidy
   - make install
   - cd $GOPATH/src/github.com/argoproj-labs/argocd-operator
-script: hack/build.sh
+script: bash hack/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ cache:
   - $GOCACHE
   - $GOPATH/pkg/mod
 before_install:
-  - sudo apt-get -y install bash
-  - go get github.com/operator-framework/operator-sdk
-script: bash hack/build.sh
+  - git clone https://github.com/operator-framework/operator-sdk
+  - cd operator-sdk
+  - git checkout v0.17.0
+  - make tidy
+  - make install
+script: hack/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,20 @@ language: go
 go:
 - "1.13.x"
 env:
+  - ARGOCD_OPERATOR_IMAGE_BUILDER=docker
   - GO111MODULE=on
 cache:
   directories:
   - $GOCACHE
   - $GOPATH/pkg/mod
 before_install:
+  - echo "Installing podman..."
+  - . /etc/os-release
+  - sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+  - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get -qq -y install podman
+  - echo "Installing operator-sdk..."
   - git clone https://github.com/operator-framework/operator-sdk $GOPATH/src/github.com/operator-framework/operator-sdk
   - cd $GOPATH/src/github.com/operator-framework/operator-sdk
   - git checkout v0.17.0
@@ -18,3 +26,7 @@ before_install:
   - make install
   - cd $GOPATH/src/github.com/argoproj-labs/argocd-operator
 script: bash hack/build.sh
+branches:
+  only: # safelist
+  - master
+  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,7 @@ cache:
   directories:
   - $GOCACHE
   - $GOPATH/pkg/mod
+before_install:
+  - sudo apt-get -y install bash
+  - go get github.com/operator-framework/operator-sdk
 script: hack/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ cache:
 before_install:
   - sudo apt-get -y install bash
   - go get github.com/operator-framework/operator-sdk
-script: hack/build.sh
+script: bash hack/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-dist: xenial
+os: linux
+arch: amd64
+dist: bionic
 language: go
 go:
-- "1.12.x"
+- "1.13.x"
 go_import_path: github.com/argoproj-labs/argocd-operator
 env:
   - GO111MODULE=on
@@ -9,3 +11,4 @@ cache:
   directories:
   - $GOCACHE
   - $GOPATH/pkg/mod
+script: hack/build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ cache:
   - $GOCACHE
   - $GOPATH/pkg/mod
 before_install:
-  - git clone https://github.com/operator-framework/operator-sdk
-  - cd operator-sdk
+  - cd $HOME
+  - git clone https://github.com/operator-framework/operator-sdk operator-framework/operator-sdk
+  - cd operator-framework/operator-sdk
   - git checkout v0.17.0
   - make tidy
   - make install
+  - cd $HOME/argoproj-labs/argocd-operator
 script: hack/build.sh


### PR DESCRIPTION
This PR updates the Travis CI build options to use the latest OS distribution, as well as go 1.13.