### PR TITLE
Add basic kustomization

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- operator.yaml
+- role_binding.yaml
+- role.yaml
+- service_account.yaml
+- argo-cd/argoproj.io_applications_crd.yaml
+- argo-cd/argoproj.io_appprojects_crd.yaml
+- crds/argoproj.io_argocdexports_crd.yaml
+- crds/argoproj.io_argocds_crd.yaml


### PR DESCRIPTION
Right now, the main way we have of deploying the operator assumes that everyone is going to be using OLM. While OLM is great, I think there are at least a pocket of folks who think of this as an overhead to getting things up and running (at least initially / during experimentation, etc.)

Since kustomize is already built into `kubectl` at this point, providing a `kustomization.yaml` would provide a low overhead for folks getting started. With this, now instead of having to apply each of the individual manifests, users can either use this as a remote base inside of kustomize, or just run ` kubectl apply -k .`  to get things running.

Likely need to get some documentation updated with this, but wanted to make sure this is something we'd like to include before moving forward.