### PR TITLE
Updating to new version of the dex image

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -160,9 +160,9 @@ metadata:
     example: openshift-oauth
 spec:
   dex:
-    image: quay.io/ablock/dex
+    image: quay.io/redhat-cop/dex
     openShiftOAuth: true
-    version: openshift-connector
+    version: v2.22.0-openshift
   rbac:
     defaultPolicy: 'role:readonly'
     policy: |


### PR DESCRIPTION
The dex Image moved to the Red Hat COP Repo. I believe @sabre1041 moved it a bit ago.