### PR TITLE
Remove context: minikube

### DIFF
--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -32,8 +32,8 @@ kubectl create namespace argocd
 Once the namespace is created, set up the local context to use the new namespace.
 
 ```bash
-kubectl config set-context argocd/minikube --cluster argocd --namespace argocd --user argocd
-kubectl config use-context argocd/minikube
+kubectl config set-context argocd --cluster argocd --namespace argocd --user argocd
+kubectl config use-context argocd
 ```
 
 The remaining resources will now be created in the new namespace.


### PR DESCRIPTION
We are creating minikube with the context name argocd, but while setting context we're giving minikube/argocd.
I understand that if the user didn't specify the cluster name, the default name is used - minikube.

But I think it is better go as per the flow. 
It might create confusion (especially for the one, who simply copy paste from the doc and execute :)).