### PR TITLE
Release Operator v0.0.9

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: argocd-operator
       containers:
         - name: argocd-operator
-          image: quay.io/jmckind/argocd-operator@sha256:d1385d23a60205636bc3789b0127d6159d33d7a7521dd07d6b679b7f734ee4b3
+          image: quay.io/jmckind/argocd-operator@sha256:0fa4b7709e1e9c9cb9ca064be50618f71ff3eef07e185c631b1227f8e5a57776
           command:
           - argocd-operator
           imagePullPolicy: Always

--- a/docs/reference/argocdexport.md
+++ b/docs/reference/argocdexport.md
@@ -13,7 +13,7 @@ Name | Default | Description
 [**Image**](#image) | `quay.io/jmckind/argocd-operator-util` | The container image for the export Job.
 [**Schedule**](#schedule) | [Empty] | Export schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 [**Storage**](#storage-options) | [Object] | The storage configuration options.
-[**Version**](#version) | v0.0.8 (SHA) | The tag to use with the container image for the export Job.
+[**Version**](#version) | v0.0.9 (SHA) | The tag to use with the container image for the export Job.
 
 ## Argocd
 
@@ -116,5 +116,5 @@ metadata:
   labels:
     example: version
 spec:
-  version: v0.0.8
+  version: v0.0.9
 ```

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -86,7 +86,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/jmckind/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:dad24d8a2b09cbe3c6c78f2d2cdf344a88b5735a3db5a6aec84dc8b57b2cbdd0" // v0.0.8
+	ArgoCDDefaultExportJobVersion = "sha256:15fcd9f7faf30dba0eef849b8d9a3c8743c8a0de6cc8d0e1c86de29fea399e07" // v0.0.9
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ package version
 
 var (
 	// Version is the ArgoCD Operator version.
-	Version = "0.0.8"
+	Version = "0.0.9"
 )


### PR DESCRIPTION
This PR updates the operator to v0.0.9, which includes the following.

- Update Operator to Argo CD v1.5.5
- Add Support for Backups to an Azure Storage Container
- Add Support for Backups to a GCP Bucket
- Upgrade operator-sdk to v0.17.0