### PR TITLE
Add Status Values for All Argo CD Components

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -542,6 +542,28 @@ spec:
         status:
           description: ArgoCDStatus defines the observed state of ArgoCD
           properties:
+            applicationController:
+              description: 'ApplicationController is a simple, high-level summary
+                of where the Argo CD application controller component is in its lifecycle.
+                There are five possible ApplicationController values: Pending: The
+                Argo CD application controller component has been accepted by the
+                Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                application controller component are in a Ready state. Failed: At
+                least one of the  Argo CD application controller component Pods had
+                a failure. Unknown: For some reason the state of the Argo CD application
+                controller component could not be obtained.'
+              type: string
+            dex:
+              description: 'Dex is a simple, high-level summary of where the Argo
+                CD Dex component is in its lifecycle. There are five possible dex
+                values: Pending: The Argo CD Dex component has been accepted by the
+                Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                Dex component are in a Ready state. Failed: At least one of the  Argo
+                CD Dex component Pods had a failure. Unknown: For some reason the
+                state of the Argo CD Dex component could not be obtained.'
+              type: string
             phase:
               description: 'Phase is a simple, high-level summary of where the ArgoCD
                 is in its lifecycle. There are five possible phase values: Pending:
@@ -550,6 +572,26 @@ spec:
                 of the resources for the ArgoCD are ready. Failed: At least one resource
                 has experienced a failure. Unknown: For some reason the state of the
                 ArgoCD phase could not be obtained.'
+              type: string
+            redis:
+              description: 'Redis is a simple, high-level summary of where the Argo
+                CD Redis component is in its lifecycle. There are five possible redis
+                values: Pending: The Argo CD Redis component has been accepted by
+                the Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                Redis component are in a Ready state. Failed: At least one of the  Argo
+                CD Redis component Pods had a failure. Unknown: For some reason the
+                state of the Argo CD Redis component could not be obtained.'
+              type: string
+            repo:
+              description: 'Repo is a simple, high-level summary of where the Argo
+                CD Repo component is in its lifecycle. There are five possible repo
+                values: Pending: The Argo CD Repo component has been accepted by the
+                Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                Repo component are in a Ready state. Failed: At least one of the  Argo
+                CD Repo component Pods had a failure. Unknown: For some reason the
+                state of the Argo CD Repo component could not be obtained.'
               type: string
             server:
               description: 'Server is a simple, high-level summary of where the Argo
@@ -562,7 +604,11 @@ spec:
                 state of the Argo CD server component could not be obtained.'
               type: string
           required:
+          - applicationController
+          - dex
           - phase
+          - redis
+          - repo
           - server
           type: object
       type: object

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -356,6 +356,22 @@ type ArgoCDSpec struct {
 // ArgoCDStatus defines the observed state of ArgoCD
 // +k8s:openapi-gen=true
 type ArgoCDStatus struct {
+	// ApplicationController is a simple, high-level summary of where the Argo CD application controller component is in its lifecycle.
+	// There are five possible ApplicationController values:
+	// Pending: The Argo CD application controller component has been accepted by the Kubernetes system, but one or more of the required resources have not been created.
+	// Running: All of the required Pods for the Argo CD application controller component are in a Ready state.
+	// Failed: At least one of the  Argo CD application controller component Pods had a failure.
+	// Unknown: For some reason the state of the Argo CD application controller component could not be obtained.
+	ApplicationController string `json:"applicationController"`
+
+	// Dex is a simple, high-level summary of where the Argo CD Dex component is in its lifecycle.
+	// There are five possible dex values:
+	// Pending: The Argo CD Dex component has been accepted by the Kubernetes system, but one or more of the required resources have not been created.
+	// Running: All of the required Pods for the Argo CD Dex component are in a Ready state.
+	// Failed: At least one of the  Argo CD Dex component Pods had a failure.
+	// Unknown: For some reason the state of the Argo CD Dex component could not be obtained.
+	Dex string `json:"dex"`
+
 	// Phase is a simple, high-level summary of where the ArgoCD is in its lifecycle.
 	// There are five possible phase values:
 	// Pending: The ArgoCD has been accepted by the Kubernetes system, but one or more of the required resources have not been created.
@@ -363,6 +379,22 @@ type ArgoCDStatus struct {
 	// Failed: At least one resource has experienced a failure.
 	// Unknown: For some reason the state of the ArgoCD phase could not be obtained.
 	Phase string `json:"phase"`
+
+	// Redis is a simple, high-level summary of where the Argo CD Redis component is in its lifecycle.
+	// There are five possible redis values:
+	// Pending: The Argo CD Redis component has been accepted by the Kubernetes system, but one or more of the required resources have not been created.
+	// Running: All of the required Pods for the Argo CD Redis component are in a Ready state.
+	// Failed: At least one of the  Argo CD Redis component Pods had a failure.
+	// Unknown: For some reason the state of the Argo CD Redis component could not be obtained.
+	Redis string `json:"redis"`
+
+	// Repo is a simple, high-level summary of where the Argo CD Repo component is in its lifecycle.
+	// There are five possible repo values:
+	// Pending: The Argo CD Repo component has been accepted by the Kubernetes system, but one or more of the required resources have not been created.
+	// Running: All of the required Pods for the Argo CD Repo component are in a Ready state.
+	// Failed: At least one of the  Argo CD Repo component Pods had a failure.
+	// Unknown: For some reason the state of the Argo CD Repo component could not be obtained.
+	Repo string `json:"repo"`
 
 	// Server is a simple, high-level summary of where the Argo CD server component is in its lifecycle.
 	// There are five possible server values:

--- a/pkg/apis/argoproj/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/argoproj/v1alpha1/zz_generated.openapi.go
@@ -401,9 +401,37 @@ func schema_pkg_apis_argoproj_v1alpha1_ArgoCDStatus(ref common.ReferenceCallback
 				Description: "ArgoCDStatus defines the observed state of ArgoCD",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"applicationController": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ApplicationController is a simple, high-level summary of where the Argo CD application controller component is in its lifecycle. There are five possible ApplicationController values: Pending: The Argo CD application controller component has been accepted by the Kubernetes system, but one or more of the required resources have not been created. Running: All of the required Pods for the Argo CD application controller component are in a Ready state. Failed: At least one of the  Argo CD application controller component Pods had a failure. Unknown: For some reason the state of the Argo CD application controller component could not be obtained.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"dex": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Dex is a simple, high-level summary of where the Argo CD Dex component is in its lifecycle. There are five possible dex values: Pending: The Argo CD Dex component has been accepted by the Kubernetes system, but one or more of the required resources have not been created. Running: All of the required Pods for the Argo CD Dex component are in a Ready state. Failed: At least one of the  Argo CD Dex component Pods had a failure. Unknown: For some reason the state of the Argo CD Dex component could not be obtained.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"phase": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Phase is a simple, high-level summary of where the ArgoCD is in its lifecycle. There are five possible phase values: Pending: The ArgoCD has been accepted by the Kubernetes system, but one or more of the required resources have not been created. Available: All of the resources for the ArgoCD are ready. Failed: At least one resource has experienced a failure. Unknown: For some reason the state of the ArgoCD phase could not be obtained.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"redis": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Redis is a simple, high-level summary of where the Argo CD Redis component is in its lifecycle. There are five possible redis values: Pending: The Argo CD Redis component has been accepted by the Kubernetes system, but one or more of the required resources have not been created. Running: All of the required Pods for the Argo CD Redis component are in a Ready state. Failed: At least one of the  Argo CD Redis component Pods had a failure. Unknown: For some reason the state of the Argo CD Redis component could not be obtained.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"repo": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Repo is a simple, high-level summary of where the Argo CD Repo component is in its lifecycle. There are five possible repo values: Pending: The Argo CD Repo component has been accepted by the Kubernetes system, but one or more of the required resources have not been created. Running: All of the required Pods for the Argo CD Repo component are in a Ready state. Failed: At least one of the  Argo CD Repo component Pods had a failure. Unknown: For some reason the state of the Argo CD Repo component could not be obtained.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -416,7 +444,7 @@ func schema_pkg_apis_argoproj_v1alpha1_ArgoCDStatus(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"phase", "server"},
+				Required: []string{"applicationController", "dex", "phase", "redis", "repo", "server"},
 			},
 		},
 	}

--- a/pkg/controller/argocd/status.go
+++ b/pkg/controller/argocd/status.go
@@ -79,7 +79,7 @@ func (r *ReconcileArgoCD) reconcileStatusDex(cr *argoprojv1a1.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoprojv1a1.ArgoCD) error {
 	phase := "Unknown"
 
-	if cr.Status.ApplicationController == "Running" && cr.Status.Server == "Running" {
+	if cr.Status.ApplicationController == "Running" && cr.Status.Redis == "Running" && cr.Status.Repo == "Running" && cr.Status.Server == "Running" {
 		phase = "Available"
 	} else {
 		phase = "Pending"

--- a/pkg/controller/argocd/status.go
+++ b/pkg/controller/argocd/status.go
@@ -23,6 +23,9 @@ import (
 
 // reconcileStatus will ensure that all of the Status properties are updated for the given ArgoCD.
 func (r *ReconcileArgoCD) reconcileStatus(cr *argoprojv1a1.ArgoCD) error {
+	if err := r.reconcileStatusApplicationController(cr); err != nil {
+		return err
+	}
 	if err := r.reconcileStatusPhase(cr); err != nil {
 		return err
 	}
@@ -32,11 +35,51 @@ func (r *ReconcileArgoCD) reconcileStatus(cr *argoprojv1a1.ArgoCD) error {
 	return nil
 }
 
+// reconcileStatusApplicationController will ensure that the ApplicationController Status is updated for the given ArgoCD.
+func (r *ReconcileArgoCD) reconcileStatusApplicationController(cr *argoprojv1a1.ArgoCD) error {
+	status := "Unknown"
+
+	deploy := newDeploymentWithSuffix("application-controller", "application-controller", cr)
+	if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
+		status = "Pending"
+
+		if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+			status = "Running"
+		}
+	}
+
+	if cr.Status.ApplicationController != status {
+		cr.Status.ApplicationController = status
+		return r.client.Status().Update(context.TODO(), cr)
+	}
+	return nil
+}
+
+// reconcileStatusDex will ensure that the Dex status is updated for the given ArgoCD.
+func (r *ReconcileArgoCD) reconcileStatusDex(cr *argoprojv1a1.ArgoCD) error {
+	status := "Unknown"
+
+	deploy := newDeploymentWithSuffix("dex-server", "dex-server", cr)
+	if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
+		status = "Pending"
+
+		if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+			status = "Running"
+		}
+	}
+
+	if cr.Status.Dex != status {
+		cr.Status.Dex = status
+		return r.client.Status().Update(context.TODO(), cr)
+	}
+	return nil
+}
+
 // reconcileStatusPhase will ensure that the Status Phase is updated for the given ArgoCD.
 func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoprojv1a1.ArgoCD) error {
 	phase := "Unknown"
 
-	if cr.Status.Server == "Running" {
+	if cr.Status.ApplicationController == "Running" && cr.Status.Server == "Running" {
 		phase = "Available"
 	} else {
 		phase = "Pending"
@@ -49,7 +92,59 @@ func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoprojv1a1.ArgoCD) error {
 	return nil
 }
 
-// reconcileStatusPhase will ensure that the Status Phase is updated for the given ArgoCD.
+// reconcileStatusRedis will ensure that the Redis status is updated for the given ArgoCD.
+func (r *ReconcileArgoCD) reconcileStatusRedis(cr *argoprojv1a1.ArgoCD) error {
+	status := "Unknown"
+
+	if !cr.Spec.HA.Enabled {
+		deploy := newDeploymentWithSuffix("redis", "redis", cr)
+		if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
+			status = "Pending"
+
+			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+				status = "Running"
+			}
+		}
+	} else {
+		ss := newStatefulSetWithSuffix("redis-ha-server", "redis-ha-server", cr)
+		if argoutil.IsObjectFound(r.client, cr.Namespace, ss.Name, ss) {
+			status = "Pending"
+
+			if ss.Status.ReadyReplicas == *ss.Spec.Replicas {
+				status = "Running"
+			}
+		}
+		// TODO: Add check for HA proxy deployment here as well?
+	}
+
+	if cr.Status.Redis != status {
+		cr.Status.Redis = status
+		return r.client.Status().Update(context.TODO(), cr)
+	}
+	return nil
+}
+
+// reconcileStatusRepo will ensure that the Repo status is updated for the given ArgoCD.
+func (r *ReconcileArgoCD) reconcileStatusRepo(cr *argoprojv1a1.ArgoCD) error {
+	status := "Unknown"
+
+	deploy := newDeploymentWithSuffix("repo-server", "repo-server", cr)
+	if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
+		status = "Pending"
+
+		if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+			status = "Running"
+		}
+	}
+
+	if cr.Status.Repo != status {
+		cr.Status.Repo = status
+		return r.client.Status().Update(context.TODO(), cr)
+	}
+	return nil
+}
+
+// reconcileStatusServer will ensure that the Server status is updated for the given ArgoCD.
 func (r *ReconcileArgoCD) reconcileStatusServer(cr *argoprojv1a1.ArgoCD) error {
 	status := "Unknown"
 

--- a/pkg/controller/argocd/status.go
+++ b/pkg/controller/argocd/status.go
@@ -26,9 +26,23 @@ func (r *ReconcileArgoCD) reconcileStatus(cr *argoprojv1a1.ArgoCD) error {
 	if err := r.reconcileStatusApplicationController(cr); err != nil {
 		return err
 	}
+
+	if err := r.reconcileStatusDex(cr); err != nil {
+		return err
+	}
+
 	if err := r.reconcileStatusPhase(cr); err != nil {
 		return err
 	}
+
+	if err := r.reconcileStatusRedis(cr); err != nil {
+		return err
+	}
+
+	if err := r.reconcileStatusRepo(cr); err != nil {
+		return err
+	}
+
 	if err := r.reconcileStatusServer(cr); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR addresses #75 to add status values on the ArgoCD custom resource for all of the Argo CD components.

The status `Phase` value is used as an overall status for the cluster. When all of the components are in a `Running` status, the `Phase` is set to `Available`. This can be used to determine when the cluster is ready for action. 