### PR TITLE
Add support for using `repository.credentials`

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -25,6 +25,7 @@ Name | Default | Description
 [**Import**](#import-options) | [Object] | Import configuration options.
 [**Ingress**](#ingress-options) | [Object] | Ingress configuration options.
 [**InitialRepositories**](#initial-repositories) | [Empty] | Initial git repositories to configure Argo CD to use upon creation of the cluster.
+[**RepositoryCredentials**](#repository-credentials) | [Empty] | Git repository credential templates to configure Argo CD to use upon creation of the cluster.
 [**InitialSSHKnownHosts**](#initial-ssh-known-hosts) | [Default Argo CD Known Hosts] | Initial SSH Known Hosts for Argo CD to use upon creation of the cluster.
 [**KustomizeBuildOptions**](#kustomize-build-options) | [Empty] | The build options/parameters to use with `kustomize build`.
 [**OIDCConfig**](#oidc-config) | [Empty] | The OIDC configuration as an alternative to Dex.
@@ -450,6 +451,32 @@ spec:
         key: password
     - type: git
       url: https://github.com/argoproj/argocd-example-apps.git
+```
+
+## Repository Credentials
+
+Git repository credential templates to configure Argo CD to use upon creation of the cluster.
+
+This property maps directly to the `repository.credentials` field in the `argocd-cm` ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Modifications to the `repository.credentials` field should then be made through the Argo CD web UI or CLI.
+
+### Repository Credentials Example
+
+The following example sets a value in the `argocd-cm` ConfigMap using the `RepositoryCredentials` property on the `ArgoCD` resource.
+
+``` yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: repository-credentials
+spec:
+  repositoryCredentials: |
+    - sshPrivateKeySecret:
+        key: sshPrivateKey
+        name: my-ssh-secret
+      type: git
+      url: ssh://git@gitlab.com/my-org/
 ```
 
 ## Initial SSH Known Hosts

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -306,6 +306,9 @@ type ArgoCDSpec struct {
 	// InitialRepositories to configure Argo CD with upon creation of the cluster.
 	InitialRepositories string `json:"initialRepositories,omitempty"`
 
+	// RepositoryCredentials are the Git pull credentials to configure Argo CD with upon creation of the cluster.
+	RepositoryCredentials string `json:"repositoryCredentials,omitempty"`
+
 	// InitialSSHKnownHosts defines the SSH known hosts data upon creation of the cluster for connecting Git repositories via SSH.
 	InitialSSHKnownHosts string `json:"initialSSHKnownHosts,omitempty"`
 

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -196,6 +196,9 @@ const (
 	// ArgoCDDefaultRepositories is the default repositories.
 	ArgoCDDefaultRepositories = ""
 
+	// ArgoCDDefaultRepositoryCredentials is the default repository credentials
+	ArgoCDDefaultRepositoryCredentials = ""
+
 	// ArgoCDDefaultResourceCustomizations is the default resource customizations.
 	ArgoCDDefaultResourceCustomizations = ""
 

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -125,6 +125,9 @@ const (
 	// ArgoCDKeyRepositories is the configuration key for repositories.
 	ArgoCDKeyRepositories = "repositories"
 
+	// ArgoCDKeyRepositoryCredentials is the configuration key for repository.credentials.
+	ArgoCDKeyRepositoryCredentials = "repository.credentials"
+
 	// ArgoCDKeyServerSecretKey is the server secret key property name for the Argo secret.
 	ArgoCDKeyServerSecretKey = "server.secretkey"
 

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -188,6 +188,15 @@ func getInitialRepositories(cr *argoprojv1a1.ArgoCD) string {
 	return repos
 }
 
+// getRepositoryCredentials will return the repository credentials for the given ArgoCD.
+func getRepositoryCredentials(cr *argoprojv1a1.ArgoCD) string {
+	repos := common.ArgoCDDefaultRepositoryCredentials
+	if len(cr.Spec.RepositoryCredentials) > 0 {
+		repos = cr.Spec.RepositoryCredentials
+	}
+	return repos
+}
+
 // getSSHKnownHosts will return the SSH Known Hosts data for the given ArgoCD.
 func getInitialSSHKnownHosts(cr *argoprojv1a1.ArgoCD) string {
 	skh := common.ArgoCDDefaultSSHKnownHosts
@@ -318,6 +327,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 	cm.Data[common.ArgoCDKeyResourceCustomizations] = getResourceCustomizations(cr)
 	cm.Data[common.ArgoCDKeyResourceExclusions] = getResourceExclusions(cr)
 	cm.Data[common.ArgoCDKeyRepositories] = getInitialRepositories(cr)
+	cm.Data[common.ArgoCDKeyRepositoryCredentials] = getRepositoryCredentials(cr)
 	cm.Data[common.ArgoCDKeyStatusBadgeEnabled] = fmt.Sprint(cr.Spec.StatusBadgeEnabled)
 	cm.Data[common.ArgoCDKeyServerURL] = r.getArgoServerURI(cr)
 	cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] = fmt.Sprint(cr.Spec.UsersAnonymousEnabled)


### PR DESCRIPTION
Adds support for using the `repository.credentials` key, also called "credential templates" in Argo - very much implemented in the same way that `InitialRepositories` is.