### PR TITLE
Release Operator v0.0.10

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,5 +1,5 @@
-# Argo CD v1.5.5
-FROM argoproj/argocd@sha256:b83f7dafd3d7c21bbaea15d5ce13e699433d7736f5d441e752033663d4fa6e6c
+# Argo CD v1.5.8
+FROM argoproj/argocd@sha256:503e17a5065119991ad23710a01f8f57714234be9f25f51328a7d9ac6766712c
 
 USER root
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: argocd-operator
       containers:
         - name: argocd-operator
-          image: quay.io/jmckind/argocd-operator@sha256:0fa4b7709e1e9c9cb9ca064be50618f71ff3eef07e185c631b1227f8e5a57776
+          image: quay.io/jmckind/argocd-operator@sha256:0ff40a548e30f89b90bbcb5ed4933d177835a4683545b78afa2133e8b1c457a6
           command:
           - argocd-operator
           imagePullPolicy: Always

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -37,7 +37,7 @@ Name | Default | Description
 [**StatusBadgeEnabled**](#status-badge-enabled) | `true` | Enable application status badge feature.
 [**TLS**](#tls-options) | [Object] | TLS configuration options.
 [**UsersAnonymousEnabled**](#users-anonymous-enabled) | `true` | Enable anonymous user access.
-[**Version**](#version) | v1.5.5 (SHA) | The tag to use with the container image for all Argo CD components.
+[**Version**](#version) | v1.5.8 (SHA) | The tag to use with the container image for all Argo CD components.
 
 ## Application Instance Label Key
 
@@ -916,5 +916,5 @@ metadata:
   labels:
     example: version
 spec:
-  version: v1.5.4
+  version: v1.5.8
 ```

--- a/docs/reference/argocdexport.md
+++ b/docs/reference/argocdexport.md
@@ -13,7 +13,7 @@ Name | Default | Description
 [**Image**](#image) | `quay.io/jmckind/argocd-operator-util` | The container image for the export Job.
 [**Schedule**](#schedule) | [Empty] | Export schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 [**Storage**](#storage-options) | [Object] | The storage configuration options.
-[**Version**](#version) | v0.0.9 (SHA) | The tag to use with the container image for the export Job.
+[**Version**](#version) | v0.0.10 (SHA) | The tag to use with the container image for the export Job.
 
 ## Argocd
 
@@ -116,5 +116,5 @@ metadata:
   labels:
     example: version
 spec:
-  version: v0.0.9
+  version: v0.0.10
 ```

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -31,7 +31,7 @@ const (
 	ArgoCDDefaultArgoImage = "argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:b83f7dafd3d7c21bbaea15d5ce13e699433d7736f5d441e752033663d4fa6e6c" // v1.5.5
+	ArgoCDDefaultArgoVersion = "sha256:503e17a5065119991ad23710a01f8f57714234be9f25f51328a7d9ac6766712c" // v1.5.8
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -86,7 +86,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/jmckind/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:15fcd9f7faf30dba0eef849b8d9a3c8743c8a0de6cc8d0e1c86de29fea399e07" // v0.0.9
+	ArgoCDDefaultExportJobVersion = "sha256:e737686d54c125413e1d82a355d837bdab4934bfbf0680df99d023d2d9052eb6" // v0.0.10
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -86,7 +86,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/jmckind/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:e737686d54c125413e1d82a355d837bdab4934bfbf0680df99d023d2d9052eb6" // v0.0.10
+	ArgoCDDefaultExportJobVersion = "sha256:0215a5e6540f2eb3bdd286101a7a5c1311d84bcf1f2750e6a1e4deeb0c406460" // v0.0.10
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"

--- a/tests/e2e/argocd-tests/02-assert.yaml
+++ b/tests/e2e/argocd-tests/02-assert.yaml
@@ -8,7 +8,7 @@ status:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: example-argocd
+  name: example-argocd-server
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/tests/e2e/argocd-tests/02-ingress.yaml
+++ b/tests/e2e/argocd-tests/02-ingress.yaml
@@ -15,6 +15,8 @@ metadata:
 spec:
   server:
     grpc:
-      ingress: true
-    ingress: true
+      ingress:
+        enabled: true
+    ingress:
+      enabled: true
     insecure: true

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ package version
 
 var (
 	// Version is the ArgoCD Operator version.
-	Version = "0.0.9"
+	Version = "0.0.10"
 )


### PR DESCRIPTION
This PR updates the operator to v0.0.10, which includes the following.

### ⚠️ BREAKING CHANGE NOTICE ⚠️

The ArgoCD custom resource has breaking changes to the Ingress and Route properties.

**Ingress:** The `Spec.Ingress` property has been removed from the ArgoCD custom resource. The `Spec.Grafana.Ingress`, `Spec.Prometheus.Ingress` and `Spec.Server.Ingress` properties have all been converted from a boolean value to an object that allows for more customization of the Ingress resource for those components that are managed by the operator. The following shows the old and new way of defining Ingress options.

**OLD**

``` yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
name: example-argocd
spec:
    ingress:
        host: myhost
        path: /mypath
    server:
        grpc:
            ingress: true
        ingress: true
        insecure: true
```

**NEW**

``` yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
    name: example-argocd
spec:
    server:
        grpc:
            ingress:
                enabled: true
        host: myhost
        ingress:
            enabled: true
            path: /mypath
            tls:
                secretName: my-secret
        insecure: true
```

**Routes:** The `Spec.Grafana.Route`, `Spec.Prometheus.Route` and `Spec.Server.Route` properties have all been converted from a boolean value to an object that allows for more customization of the Route resource for those components that are managed by the operator. The following shows the old and new way of defining Route options.

**OLD**

``` yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
    name: example-argocd
spec:
    grafana:
        enabled: true
        route: true
    prometheus:
        enabled: true
        route: true
    server:
        route: true
```

**NEW**

``` yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
    name: example-argocd
spec:
    grafana:
        enabled: true
        route:
            enabled: true     
    prometheus:
        enabled: true
        route:
            enabled: true
    server:
        host: myhost
        route:
            enabled: true
            path: /mypath
            tls:
                termination: passthrough
                insecureEdgeTerminationPolicy: Redirect
            wildcardPolicy: None
```

### New Features

* Add options to customize Ingress and Route resources managed by the operator. See breaking change notice above.
* The operator will now report the status for each component on the ArgoCD custom resource. In addition the `Phase` status property will be updated by looking at the following components.
    * Argo CD Application Controller
    * Redis
    * Repo Server
    * Argo CD Server 
* Generate OLM artifacts using the new OLM bundle format. Currently both formats are supported until the old format is retired.

### Bug Fixes

* Fixed bug in the naming of Argo CD server Ingress resources that prevented the Argo CD URL from being set correctly.
