### PR TITLE
Mount repo server token

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -633,6 +633,8 @@ The following properties are available for configuring the Repo server component
 Name | Default | Description
 --- | --- | ---
 Resources | [Empty] | The container compute resources.
+MountSAToken | false | Whether the ServiceAccount token should be mounted to the repo-server pod.
+ServiceAccount | "" | The name of the ServiceAccount to use with the repo-server pod.
 
 ### Repo Example
 
@@ -648,6 +650,8 @@ metadata:
 spec:
   repo:
     resources: {}
+    mountsatoken: false
+    serviceaccount: ""
 ```
 
 ## Resource Customizations

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -225,6 +225,10 @@ type ArgoCDRedisSpec struct {
 type ArgoCDRepoSpec struct {
 	// Resources defines the Compute Resources required by the container for Redis.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+        // MountSAToken describes whether you would like to have the Repo server mount the service account token
+        MountSAToken	bool  `json:"mountsatoken,omitempty"`
+        // ServiceAccount defines the ServiceAccount user that you would like the Repo server to use
+	ServiceAccount	string	`json:"serviceaccount,omitempty"`
 }
 
 // ArgoCDRouteSpec defines the desired state for an OpenShift Route.

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -740,8 +740,17 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 		return nil // Deployment found, do nothing
 	}
 
-	automountToken := false
+        if cr.Spec.Repo.MountSAToken {
+          automountToken := true
+        } else {
+          automountToken := false
+        }
+
 	deploy.Spec.Template.Spec.AutomountServiceAccountToken = &automountToken
+
+        if cr.Spec.Repo.ServiceAccount {
+          deploy.Spec.Template.Spec.ServiceAccountName = cr.Spec.Repo.ServiceAccount
+        }
 
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{{
 		Command:         getArgoRepoCommand(cr),

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -740,15 +740,15 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 		return nil // Deployment found, do nothing
 	}
 
+        automountToken := false
+
         if cr.Spec.Repo.MountSAToken {
-          automountToken := true
-        } else {
-          automountToken := false
+          automountToken = cr.Spec.Repo.MountSAToken
         }
 
-	deploy.Spec.Template.Spec.AutomountServiceAccountToken = &automountToken
+        deploy.Spec.Template.Spec.AutomountServiceAccountToken = &automountToken
 
-        if cr.Spec.Repo.ServiceAccount {
+        if cr.Spec.Repo.ServiceAccount != "" {
           deploy.Spec.Template.Spec.ServiceAccountName = cr.Spec.Repo.ServiceAccount
         }
 


### PR DESCRIPTION
This adds the ability to specify mounting the serviceaccount token to the repo-server pod as well as specifying the serviceaccount it should run as. This can be done by adding the following to the ArgoCD CR:

```
...
spec:
  repo:
    mountsatoken: true
    serviceaccount: argocd-application-controller
...
```

Resolves #110 
