### PR TITLE
Upgrade to Argo CD v1.6.1

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,5 +1,5 @@
-# Argo CD v1.5.8
-FROM argoproj/argocd@sha256:503e17a5065119991ad23710a01f8f57714234be9f25f51328a7d9ac6766712c
+# Argo CD v1.6.1
+FROM argoproj/argocd@sha256:0a8fa1fee472568c2ec49dc1a71d3af56613b6b62353560a3682abc24492daee
 
 USER root
 

--- a/deploy/argo-cd/argoproj.io_applications_crd.yaml
+++ b/deploy/argo-cd/argoproj.io_applications_crd.yaml
@@ -35,6 +35,18 @@ spec:
         operation:
           description: Operation contains requested operation parameters.
           properties:
+            info:
+              items:
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - name
+                - value
+                type: object
+              type: array
             initiatedBy:
               description: OperationInitiator holds information about the operation
                 initiator
@@ -572,7 +584,7 @@ spec:
                       type: boolean
                   type: object
                 syncOptions:
-                  description: Options allow youe to specify whole app sync-options
+                  description: Options allow you to specify whole app sync-options
                   items:
                     type: string
                   type: array
@@ -613,6 +625,7 @@ spec:
                 message:
                   type: string
                 status:
+                  description: Represents resource health status
                   type: string
               type: object
             history:
@@ -846,6 +859,18 @@ spec:
                 operation:
                   description: Operation is the original requested operation
                   properties:
+                    info:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
                     initiatedBy:
                       description: OperationInitiator holds information about the
                         operation initiator
@@ -1411,6 +1436,7 @@ spec:
                       message:
                         type: string
                       status:
+                        description: Represents resource health status
                         type: string
                     type: object
                   hook:

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -38,7 +38,7 @@ Name | Default | Description
 [**StatusBadgeEnabled**](#status-badge-enabled) | `true` | Enable application status badge feature.
 [**TLS**](#tls-options) | [Object] | TLS configuration options.
 [**UsersAnonymousEnabled**](#users-anonymous-enabled) | `true` | Enable anonymous user access.
-[**Version**](#version) | v1.5.8 (SHA) | The tag to use with the container image for all Argo CD components.
+[**Version**](#version) | v1.6.1 (SHA) | The tag to use with the container image for all Argo CD components.
 
 ## Application Instance Label Key
 
@@ -947,5 +947,5 @@ metadata:
   labels:
     example: version
 spec:
-  version: v1.5.8
+  version: v1.6.1
 ```

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -31,7 +31,7 @@ const (
 	ArgoCDDefaultArgoImage = "argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:503e17a5065119991ad23710a01f8f57714234be9f25f51328a7d9ac6766712c" // v1.5.8
+	ArgoCDDefaultArgoVersion = "sha256:0a8fa1fee472568c2ec49dc1a71d3af56613b6b62353560a3682abc24492daee" // v1.6.1
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32


### PR DESCRIPTION
This PR updates Argo CD to [v1.6.1](https://github.com/argoproj/argo-cd/releases/tag/v1.6.1).