### PR TITLE
Added kustomization in root dir referencing the deploy kustomization

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deploy/


### PR DESCRIPTION
I have added this commit to enable others to reference Kustomize from the root directory. You can use my fork as an example by running `kustomize build https://github.com/jdbohrman/argocd-operator`.