### PR TITLE
Release Operator v0.0.12

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
-# RHEL 8 Universal Base Image created 2020-06-22T07:39:38.453712Z
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:45efa640a7a50ec490d22f4e48c8a6e4892ddfee7ebe58ae9453c870e3ad3e00
+# RHEL 8 Universal Base Image created 2020-06-25T19:42:34.833547Z
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:ab6ac16b2ba297db67e036ae279f166834e8d4e881da2fcbbcfd05b44f34d415
 
 ENV OPERATOR=/usr/local/bin/argocd-operator \
     USER_UID=1001 \

--- a/deploy/catalog_source.yaml
+++ b/deploy/catalog_source.yaml
@@ -4,6 +4,6 @@ metadata:
   name: argocd-catalog
 spec:
   sourceType: grpc
-  image: quay.io/jmckind/argocd-operator-registry@sha256:03d7a735c3f46055cd1041c78bff2e961b2786cb6430e545b6f3eae4e1d156a8
+  image: quay.io/jmckind/argocd-operator-registry@sha256:58081ef9390278776bd69bafaaf9b8ee413ec071ad44ea4fb05d0de06b40f485
   displayName: Argo CD Operators
   publisher: Argo CD Community

--- a/deploy/olm-catalog/argocd-operator/0.0.12/argocd-operator.v.0.0.12.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.12/argocd-operator.v.0.0.12.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Auto Pilot
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/jmckind/argocd-operator:issue_124
-    createdAt: "2020-05-27 14:32:34"
+    containerImage: quay.io/jmckind/argocd-operator@sha256:a0ca1a848bf19ae7ddad3c367f083c9713d0040317352e9a52633b4fbf2df1f0
+    createdAt: "2020-07-15 15:23:47"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     repository: https://github.com/argoproj-labs/argocd-operator
     support: Argo CD
@@ -559,7 +559,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: argocd-operator
-                image: quay.io/jmckind/argocd-operator:issue_124
+                image: quay.io/jmckind/argocd-operator@sha256:a0ca1a848bf19ae7ddad3c367f083c9713d0040317352e9a52633b4fbf2df1f0
                 imagePullPolicy: Always
                 name: argocd-operator
                 resources: {}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: argocd-operator
       containers:
         - name: argocd-operator
-          image: quay.io/jmckind/argocd-operator@sha256:a472ee86bbd1ec8e98178c6283f8c748deb9fd9ac396207ff80623b926003faa
+          image: quay.io/jmckind/argocd-operator@sha256:a0ca1a848bf19ae7ddad3c367f083c9713d0040317352e9a52633b4fbf2df1f0
           command:
           - argocd-operator
           imagePullPolicy: Always

--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
-# upstream-registry-builder v1.12.4
-FROM quay.io/operator-framework/upstream-registry-builder@sha256:8d392ab0587d5bcd19a40d60ac6bc8214e6b515605be3113edd01ea99ce95942 as builder
+# upstream-registry-builder v1.13.1
+FROM quay.io/operator-framework/upstream-registry-builder@sha256:8f5db34a1bf254d4f664e280c437e4d708eb54ded5b61597fa267d533ca394c0
 
 COPY manifests manifests
 RUN ./bin/initializer -o ./bundles.db

--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
 # upstream-registry-builder v1.13.1
-FROM quay.io/operator-framework/upstream-registry-builder@sha256:8f5db34a1bf254d4f664e280c437e4d708eb54ded5b61597fa267d533ca394c0
+FROM quay.io/operator-framework/upstream-registry-builder@sha256:8f5db34a1bf254d4f664e280c437e4d708eb54ded5b61597fa267d533ca394c0 as builder
 
 COPY manifests manifests
 RUN ./bin/initializer -o ./bundles.db

--- a/docs/reference/argocdexport.md
+++ b/docs/reference/argocdexport.md
@@ -13,7 +13,7 @@ Name | Default | Description
 [**Image**](#image) | `quay.io/jmckind/argocd-operator-util` | The container image for the export Job.
 [**Schedule**](#schedule) | [Empty] | Export schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 [**Storage**](#storage-options) | [Object] | The storage configuration options.
-[**Version**](#version) | v0.0.11 (SHA) | The tag to use with the container image for the export Job.
+[**Version**](#version) | v0.0.12 (SHA) | The tag to use with the container image for the export Job.
 
 ## Argocd
 
@@ -116,5 +116,5 @@ metadata:
   labels:
     example: version
 spec:
-  version: v0.0.11
+  version: v0.0.12
 ```

--- a/hack/util.sh
+++ b/hack/util.sh
@@ -23,7 +23,7 @@ source ${HACK_DIR}/env.sh
 
 # Build the util container image
 echo "Building image ${ARGOCD_OPERATOR_UTIL_IMAGE}"
-${ARGOCD_OPERATOR_IMAGE_BUILDER} build -t ${ARGOCD_OPERATOR_UTIL_IMAGE} ${ARGOCD_OPERATOR_UTIL_BUILD_DIR}
+${ARGOCD_OPERATOR_IMAGE_BUILDER} build --no-cache -t ${ARGOCD_OPERATOR_UTIL_IMAGE} ${ARGOCD_OPERATOR_UTIL_BUILD_DIR}
 
 # Push the util container image
 echo "Pushing image ${ARGOCD_OPERATOR_UTIL_IMAGE}"

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -86,7 +86,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/jmckind/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:65292413bb82b280580884210bb6ce8de5ba1300c12d65db873719cc36914361" // v0.0.11
+	ArgoCDDefaultExportJobVersion = "sha256:34cd8ddef3828246d0aff8d1eb4d1e30fad3b8186a95af06fc84190d09bcb083" // v0.0.12
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ package version
 
 var (
 	// Version is the ArgoCD Operator version.
-	Version = "0.0.11"
+	Version = "0.0.12"
 )


### PR DESCRIPTION
This PR updates the operator to v0.0.12, which includes the following.

- Upgrade to Operator SDK v0.18.0
- Share ServiceAcount for Redis Components