### PR TITLE
Update InitialSSHKnownHosts handling

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -341,7 +341,16 @@ spec:
             initialSSHKnownHosts:
               description: InitialSSHKnownHosts defines the SSH known hosts data upon
                 creation of the cluster for connecting Git repositories via SSH.
-              type: string
+              properties:
+                excludedefaulthosts:
+                  description: Defaulthosts describes whether you would like to include the default
+                    list of SSH Known Hosts provided by ArgoCD
+                  type: boolean
+                keys:
+                  description: Keys describes a custom set of SSH Known Hosts that you would like to have
+                    included in your ArgoCD server.
+                  type: string
+              type: object
             kustomizeBuildOptions:
               description: KustomizeBuildOptions is used to specify build options/parameters
                 to use with `kustomize build`.

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -477,6 +477,13 @@ Initial SSH Known Hosts for Argo CD to use upon creation of the cluster.
 
 This property maps directly to the `ssh_known_hosts` field in the `argocd-ssh-known-hosts-cm` ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Modifications to the `ssh_known_hosts` field should then be made through the Argo CD web UI or CLI.
 
+The following properties are available for configuring the import process.
+
+Name | Default | Description
+--- | --- | ---
+ExcludeDefaultHosts | false | Whether you would like to exclude the default SSH Hosts entries that ArgoCD provides
+Keys | "" | Additional SSH Hosts entries that you would like to include with ArgoCD
+
 ### Initial SSH Known Hosts Example
 
 The following example sets a value in the `argocd-ssh-known-hosts-cm` ConfigMap using the `InitialSSHKnownHosts` property on the `ArgoCD` resource. The example values have been truncated for clarity.
@@ -489,9 +496,11 @@ metadata:
   labels:
     example: initial-ssh-known-hosts
 spec:
-  initialSSHKnownHosts: |
-    bitbucket.org ssh-rsa AAAAB3NzaC...
-    github.com ssh-rsa AAAAB3NzaC...
+  initialSSHKnownHosts:
+    excludedefaulthosts: false
+    keys: |
+      my-git.org ssh-rsa AAAAB3NzaC...
+      my-git.com ssh-rsa AAAAB3NzaC...
 ```
 
 ## Kustomize Build Options

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -345,7 +345,7 @@ type ArgoCDSpec struct {
 	InitialRepositories string `json:"initialRepositories,omitempty"`
 
 	// InitialSSHKnownHosts defines the SSH known hosts data upon creation of the cluster for connecting Git repositories via SSH.
-	InitialSSHKnownHosts string `json:"initialSSHKnownHosts,omitempty"`
+	InitialSSHKnownHosts SSHHostsSpec `json:"initialSSHKnownHosts,omitempty"`
 
 	// KustomizeBuildOptions is used to specify build options/parameters to use with `kustomize build`.
 	KustomizeBuildOptions string `json:"kustomizeBuildOptions,omitempty"`
@@ -450,4 +450,9 @@ type ArgoCDTLSSpec struct {
 
 	// InitialCerts defines custom TLS certificates upon creation of the cluster for connecting Git repositories via HTTPS.
 	InitialCerts map[string]string `json:"initialCerts,omitempty"`
+}
+
+type SSHHostsSpec struct {
+	ExcludeDefaultHosts bool   `json:"excludedefaulthosts,omitempty"`
+	Keys                string `json:"keys,omitempty"`
 }

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -30,17 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	defaultKnownHosts = `bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
-github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
-gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
-gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
-gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
-ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
-vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H	
-`
-)
-
 // createRBACConfigMap will create the Argo CD RBAC ConfigMap resource.
 func (r *ReconcileArgoCD) createRBACConfigMap(cm *corev1.ConfigMap, cr *argoprojv1a1.ArgoCD) error {
 	data := make(map[string]string)
@@ -200,8 +189,11 @@ func getRepositoryCredentials(cr *argoprojv1a1.ArgoCD) string {
 // getSSHKnownHosts will return the SSH Known Hosts data for the given ArgoCD.
 func getInitialSSHKnownHosts(cr *argoprojv1a1.ArgoCD) string {
 	skh := common.ArgoCDDefaultSSHKnownHosts
-	if len(cr.Spec.InitialSSHKnownHosts) > 0 {
-		skh = cr.Spec.InitialSSHKnownHosts
+	if cr.Spec.InitialSSHKnownHosts.ExcludeDefaultHosts {
+		skh = ""
+	}
+	if len(cr.Spec.InitialSSHKnownHosts.Keys) > 0 {
+		skh += cr.Spec.InitialSSHKnownHosts.Keys
 	}
 	return skh
 }


### PR DESCRIPTION
resolves #82 

This modifies `initialSSHKnownHosts` to have two different keys:

```yaml
initialSSHKnownHosts:
  excludedefaulthosts: false
  keys: |
    my-git.org: alkjasldkfjalskdfj
```

This allows users to either include/exclude the default ssh hosts that are included with ArgoCD by default. Previously if you wanted to provide your own set of keys, it would overwrite these default keys and you would be responsible for adding them back in if you wanted them.

Now the default behavior is if you don't exclude them, your specified keys will just be appended to the default keys.