### PR TITLE
Add Properties for Redis HAProxy Component

### DIFF
--- a/deploy/crds/argoproj.io_argocdexports_crd.yaml
+++ b/deploy/crds/argoproj.io_argocdexports_crd.yaml
@@ -57,15 +57,19 @@ spec:
                         type: string
                       type: array
                     dataSource:
-                      description: This field requires the VolumeSnapshotDataSource
-                        alpha feature gate to be enabled and currently VolumeSnapshot
-                        is the only supported data source. If the provisioner can
-                        support VolumeSnapshot data source, it will create a new volume
-                        and data will be restored to the volume at the same time.
-                        If the provisioner does not support VolumeSnapshot data source,
-                        volume will not be created and the failure will be reported
-                        as an event. In the future, we plan to support more data source
-                        types and the behavior of the provisioner may change.
+                      description: 'This field can be used to specify either: * An
+                        existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                        - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                        custom resource/object that implements data population (Alpha)
+                        In order to use VolumeSnapshot object types, the appropriate
+                        feature gate must be enabled (VolumeSnapshotDataSource or
+                        AnyVolumeDataSource) If the provisioner or an external controller
+                        can support the specified data source, it will create a new
+                        volume based on the contents of the specified data source.
+                        If the specified data source is not supported, the volume
+                        will not be created and the failure will be reported as an
+                        event. In the future, we plan to support more data source
+                        types and the behavior of the provisioner may change.'
                       properties:
                         apiGroup:
                           description: APIGroup is the group for the resource being
@@ -162,7 +166,7 @@ spec:
                     volumeMode:
                       description: volumeMode defines what type of volume is required
                         by the claim. Value of Filesystem is implied when not included
-                        in claim spec. This is a beta feature.
+                        in claim spec.
                       type: string
                     volumeName:
                       description: VolumeName is the binding reference to the PersistentVolume

--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -307,6 +307,13 @@ spec:
                 enabled:
                   description: Enabled will toggle HA support globally for Argo CD.
                   type: boolean
+                redisProxyImage:
+                  description: RedisProxyImage is the Redis HAProxy container image.
+                  type: string
+                redisProxyVersion:
+                  description: RedisProxyVersion is the Redis HAProxy container image
+                    tag.
+                  type: string
               required:
               - enabled
               type: object

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -277,7 +277,9 @@ The following properties are available for configuring High Availability for the
 
 Name | Default | Description
 --- | --- | ---
-Enabled | false | Toggle High Availability support globally for Argo CD.
+Enabled | `false` | Toggle High Availability support globally for Argo CD.
+RedisProxyImage | `haproxy` | The Redis HAProxy container image.
+RedisProxyVersion | `2.0.4` | The tag to use for the Redis HAProxy container image.
 
 ### HA Example
 
@@ -293,6 +295,8 @@ metadata:
 spec:
   ha:
     enabled: true
+    redisProxyImage: haproxy
+    redisProxyVersion: "2.0.4"
 ```
 
 ## Help Chat URL

--- a/docs/usage/ha.md
+++ b/docs/usage/ha.md
@@ -14,6 +14,8 @@ metadata:
 spec:
   ha:
     enabled: true
+    redisProxyImage: haproxy
+    redisProxyVersion: "2.0.4"
 ```
 
 ## OpenShift

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -20,7 +20,7 @@ HACK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${HACK_DIR}/env.sh
 
 # Generate CRDs for API's
-operator-sdk generate crds
+operator-sdk generate crds --crd-version v1beta1
 
 # Generate Kubernetes code for custom resource
 operator-sdk generate k8s

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -131,6 +131,12 @@ type ArgoCDGrafanaSpec struct {
 type ArgoCDHASpec struct {
 	// Enabled will toggle HA support globally for Argo CD.
 	Enabled bool `json:"enabled"`
+
+	// RedisProxyImage is the Redis HAProxy container image.
+	RedisProxyImage string `json:"redisProxyImage,omitempty"`
+
+	// RedisProxyVersion is the Redis HAProxy container image tag.
+	RedisProxyVersion string `json:"redisProxyVersion,omitempty"`
 }
 
 // ArgoCDImportSpec defines the desired state for the ArgoCD import/restore process.

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -403,10 +403,17 @@ func getRedisHAProxyAddress(cr *argoprojv1a1.ArgoCD) string {
 
 // getRedisHAProxyContainerImage will return the container image for the Redis HA Proxy.
 func getRedisHAProxyContainerImage(cr *argoprojv1a1.ArgoCD) string {
-	return argoutil.CombineImageTag(
-		common.ArgoCDDefaultRedisHAProxyImage,
-		common.ArgoCDDefaultRedisHAProxyVersion,
-	)
+	img := cr.Spec.HA.RedisProxyImage
+	if len(img) <= 0 {
+		img = common.ArgoCDDefaultRedisHAProxyImage
+	}
+
+	tag := cr.Spec.HA.RedisProxyVersion
+	if len(tag) <= 0 {
+		tag = common.ArgoCDDefaultRedisHAProxyVersion
+	}
+
+	return argoutil.CombineImageTag(img, tag)
 }
 
 // getRedisInitScript will load the redis init script from a template on disk for the given ArgoCD.


### PR DESCRIPTION
This PR addresses #131 and adds properties for overriding the container image and tag for the Redis HAProxy component when run with HA mode enabled. 