### PR TITLE
Fix for not updating when changing the ArgoCD resource.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/argoproj/argo-cd v1.5.8
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-openapi/spec v0.19.7
+	github.com/google/go-cmp v0.4.0
 	github.com/openshift/api v3.9.1-0.20190916204813-cdbe64fb0c91+incompatible
 	github.com/operator-framework/operator-sdk v0.18.0
 	github.com/sethvargo/go-password v0.2.0

--- a/pkg/controller/argocd/route_test.go
+++ b/pkg/controller/argocd/route_test.go
@@ -1,0 +1,212 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	argov1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	"github.com/google/go-cmp/cmp"
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+const (
+	testArgoCDName = "testing-argocd"
+	testNamespace  = "testing-argocd"
+)
+
+func TestReconcileRouteSetsInsecure(t *testing.T) {
+	routeAPIFound = true
+	ctx := context.Background()
+	logf.SetLogger(logf.ZapLogger(true))
+	argoCD := makeArgoCD(func(a *argov1alpha1.ArgoCD) {
+		a.Spec.Server.Route.Enabled = true
+	})
+	objs := []runtime.Object{
+		argoCD,
+	}
+	r := makeReconciler(t, argoCD, objs...)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      testArgoCDName,
+			Namespace: testNamespace,
+		},
+	}
+	_, err := r.Reconcile(req)
+	fatalIfError(t, err, "reconcile: (%v): %s", req, err)
+
+	loaded := &routev1.Route{}
+	err = r.client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
+
+	wantTLSConfig := &routev1.TLSConfig{
+		Termination:                   routev1.TLSTerminationPassthrough,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+	}
+	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
+		t.Fatalf("failed to reconcile route:\n%s", diff)
+	}
+	wantPort := &routev1.RoutePort{
+		TargetPort: intstr.FromString("https"),
+	}
+	if diff := cmp.Diff(wantPort, loaded.Spec.Port); diff != "" {
+		t.Fatalf("failed to reconcile route:\n%s", diff)
+	}
+
+	// second reconciliation after changing the Insecure flag.
+	err = r.client.Get(ctx, req.NamespacedName, argoCD)
+	fatalIfError(t, err, "failed to load ArgoCD %q: %s", testArgoCDName+"-server", err)
+
+	argoCD.Spec.Server.Insecure = true
+	err = r.client.Update(ctx, argoCD)
+	fatalIfError(t, err, "failed to update the ArgoCD: %s", err)
+
+	_, err = r.Reconcile(req)
+	fatalIfError(t, err, "reconcile: (%v): %s", req, err)
+
+	loaded = &routev1.Route{}
+	err = r.client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
+
+	wantTLSConfig = &routev1.TLSConfig{
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		Termination:                   routev1.TLSTerminationEdge,
+	}
+	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
+		t.Fatalf("failed to reconcile route:\n%s", diff)
+	}
+	wantPort = &routev1.RoutePort{
+		TargetPort: intstr.FromString("http"),
+	}
+	if diff := cmp.Diff(wantPort, loaded.Spec.Port); diff != "" {
+		t.Fatalf("failed to reconcile route:\n%s", diff)
+	}
+}
+
+func TestReconcileRouteUnsetsInsecure(t *testing.T) {
+	routeAPIFound = true
+	ctx := context.Background()
+	logf.SetLogger(logf.ZapLogger(true))
+	argoCD := makeArgoCD(func(a *argov1alpha1.ArgoCD) {
+		a.Spec.Server.Route.Enabled = true
+		a.Spec.Server.Insecure = true
+	})
+	objs := []runtime.Object{
+		argoCD,
+	}
+	r := makeReconciler(t, argoCD, objs...)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      testArgoCDName,
+			Namespace: testNamespace,
+		},
+	}
+	_, err := r.Reconcile(req)
+	fatalIfError(t, err, "reconcile: (%v): %s", req, err)
+
+	loaded := &routev1.Route{}
+	err = r.client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
+
+	wantTLSConfig := &routev1.TLSConfig{
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		Termination:                   routev1.TLSTerminationEdge,
+	}
+	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
+		t.Fatalf("failed to reconcile route:\n%s", diff)
+	}
+	wantPort := &routev1.RoutePort{
+		TargetPort: intstr.FromString("http"),
+	}
+	if diff := cmp.Diff(wantPort, loaded.Spec.Port); diff != "" {
+		t.Fatalf("failed to reconcile route:\n%s", diff)
+	}
+
+	// second reconciliation after changing the Insecure flag.
+	err = r.client.Get(ctx, req.NamespacedName, argoCD)
+	fatalIfError(t, err, "failed to load ArgoCD %q: %s", testArgoCDName+"-server", err)
+
+	argoCD.Spec.Server.Insecure = false
+	err = r.client.Update(ctx, argoCD)
+	fatalIfError(t, err, "failed to update the ArgoCD: %s", err)
+
+	_, err = r.Reconcile(req)
+	fatalIfError(t, err, "reconcile: (%v): %s", req, err)
+
+	loaded = &routev1.Route{}
+	err = r.client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
+
+	wantTLSConfig = &routev1.TLSConfig{
+		Termination:                   routev1.TLSTerminationPassthrough,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+	}
+	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
+		t.Fatalf("failed to reconcile route:\n%s", diff)
+	}
+	wantPort = &routev1.RoutePort{
+		TargetPort: intstr.FromString("https"),
+	}
+	if diff := cmp.Diff(wantPort, loaded.Spec.Port); diff != "" {
+		t.Fatalf("failed to reconcile route:\n%s", diff)
+	}
+}
+
+func makeReconciler(t *testing.T, acd *argov1alpha1.ArgoCD, objs ...runtime.Object) *ReconcileArgoCD {
+	t.Helper()
+	s := scheme.Scheme
+	s.AddKnownTypes(argov1alpha1.SchemeGroupVersion, acd)
+	routev1.Install(s)
+	cl := fake.NewFakeClient(objs...)
+	return &ReconcileArgoCD{
+		client: cl,
+		scheme: s,
+	}
+}
+
+func makeArgoCD(opts ...func(*argov1alpha1.ArgoCD)) *argov1alpha1.ArgoCD {
+	argoCD := &argov1alpha1.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testArgoCDName,
+			Namespace: testNamespace,
+		},
+		Spec: argov1alpha1.ArgoCDSpec{},
+	}
+	for _, o := range opts {
+		o(argoCD)
+	}
+	return argoCD
+}
+
+func fatalIfError(t *testing.T, err error, format string, a ...interface{}) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf(format, a...)
+	}
+}
+
+func loadSecret(t *testing.T, c client.Client, name string) *corev1.Secret {
+	secret := &corev1.Secret{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: testNamespace}, secret)
+	fatalIfError(t, err, "failed to load secret %q", name)
+	return secret
+}
+
+func testNamespacedName(name string) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      name,
+		Namespace: testNamespace,
+	}
+}

--- a/pkg/controller/argocd/status.go
+++ b/pkg/controller/argocd/status.go
@@ -57,8 +57,10 @@ func (r *ReconcileArgoCD) reconcileStatusApplicationController(cr *argoprojv1a1.
 	if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
 		status = "Pending"
 
-		if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
-			status = "Running"
+		if deploy.Spec.Replicas != nil {
+			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+				status = "Running"
+			}
 		}
 	}
 
@@ -77,8 +79,10 @@ func (r *ReconcileArgoCD) reconcileStatusDex(cr *argoprojv1a1.ArgoCD) error {
 	if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
 		status = "Pending"
 
-		if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
-			status = "Running"
+		if deploy.Spec.Replicas != nil {
+			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+				status = "Running"
+			}
 		}
 	}
 
@@ -115,8 +119,10 @@ func (r *ReconcileArgoCD) reconcileStatusRedis(cr *argoprojv1a1.ArgoCD) error {
 		if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
 			status = "Pending"
 
-			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
-				status = "Running"
+			if deploy.Spec.Replicas != nil {
+				if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+					status = "Running"
+				}
 			}
 		}
 	} else {
@@ -146,8 +152,10 @@ func (r *ReconcileArgoCD) reconcileStatusRepo(cr *argoprojv1a1.ArgoCD) error {
 	if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
 		status = "Pending"
 
-		if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
-			status = "Running"
+		if deploy.Spec.Replicas != nil {
+			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+				status = "Running"
+			}
 		}
 	}
 
@@ -166,8 +174,11 @@ func (r *ReconcileArgoCD) reconcileStatusServer(cr *argoprojv1a1.ArgoCD) error {
 	if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
 		status = "Pending"
 
-		if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
-			status = "Running"
+		// TODO: Refactor these checks.
+		if deploy.Spec.Replicas != nil {
+			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+				status = "Running"
+			}
 		}
 	}
 


### PR DESCRIPTION
This changes the behaviour of the route reconciliation to allow it to patch the route objects when the Insecure flag changes.

This also adds a simple test for this behaviour.