### PR TITLE
Don't rereconcile deleted ArgoCD objects.

### DIFF
--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -17,7 +17,6 @@ package argocd
 import (
 	"context"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,6 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 )
 
 // blank assignment to verify that ReconcileArgoCD implements reconcile.Reconciler
@@ -89,9 +90,11 @@ func (r *ReconcileArgoCD) Reconcile(request reconcile.Request) (reconcile.Result
 		return reconcile.Result{}, err
 	}
 
-	if err := r.reconcileResources(argocd); err != nil {
-		// Error reconciling ArgoCD sub-resources - requeue the request.
-		return reconcile.Result{}, err
+	if argocd.ObjectMeta.DeletionTimestamp.IsZero() {
+		if err := r.reconcileResources(argocd); err != nil {
+			// Error reconciling ArgoCD sub-resources - requeue the request.
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Return and don't requeue

--- a/pkg/controller/argocd/argocd_controller_test.go
+++ b/pkg/controller/argocd/argocd_controller_test.go
@@ -1,0 +1,126 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/argoproj-labs/argocd-operator/pkg/apis"
+	argov1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+)
+
+var (
+	testNamespace  = "argocd"
+	testArgoCDName = "argocd"
+)
+
+var _ reconcile.Reconciler = &ReconcileArgoCD{}
+
+// When the ArgoCD object has been marked as deleting, we should not reconcile,
+// and trigger the creation of new objects.
+//
+// We have owner references set on created resources, this triggers automatic
+// deletion of the associated objects.
+func TestReconcileArgoCD_Reconcile_with_deleted(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD(deletedAt(time.Now()))
+
+	r := makeTestReconciler(t, a)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      a.Name,
+			Namespace: a.Namespace,
+		},
+	}
+	res, err := r.Reconcile(req)
+	fatalIfError(t, err)
+	if res.Requeue {
+		t.Fatal("reconcile requeued request")
+	}
+
+	deployment := &appsv1.Deployment{}
+	if !apierrors.IsNotFound(r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-redis",
+		Namespace: testNamespace,
+	}, deployment)) {
+		t.Fatalf("expected not found error, got %#v\n", err)
+	}
+}
+
+func TestReconcileArgoCD_Reconcile(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD()
+
+	r := makeTestReconciler(t, a)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      a.Name,
+			Namespace: a.Namespace,
+		},
+	}
+	res, err := r.Reconcile(req)
+	fatalIfError(t, err)
+	if res.Requeue {
+		t.Fatal("reconcile requeued request")
+	}
+
+	deployment := &appsv1.Deployment{}
+	if err = r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-redis",
+		Namespace: testNamespace,
+	}, deployment); err != nil {
+		t.Fatalf("failed to find the redis deployment: %#v\n", err)
+	}
+}
+
+func makeTestReconciler(t *testing.T, objs ...runtime.Object) *ReconcileArgoCD {
+	s := scheme.Scheme
+	fatalIfError(t, apis.AddToScheme(s))
+
+	cl := fake.NewFakeClient(objs...)
+	return &ReconcileArgoCD{
+		client: cl,
+		scheme: s,
+	}
+}
+
+func fatalIfError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type argoCDOpt func(*argov1alpha1.ArgoCD)
+
+func makeTestArgoCD(opts ...argoCDOpt) *argov1alpha1.ArgoCD {
+	a := &argov1alpha1.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testArgoCDName,
+			Namespace: testNamespace,
+		},
+	}
+	for _, o := range opts {
+		o(a)
+	}
+	return a
+}
+
+func deletedAt(now time.Time) argoCDOpt {
+	return func(a *argov1alpha1.ArgoCD) {
+		wrapped := metav1.NewTime(now)
+		a.ObjectMeta.DeletionTimestamp = &wrapped
+	}
+}


### PR DESCRIPTION
When an ArgoCD object is marked for deletion, it's continuing to be reconciled.

This means that it's triggering the creation of resources that should be deleted, and in turn, the objects are into a loop of delete and recreate, which it doesn't recover from.

Fixes #162 