### PR TITLE
Support cert-utils-operator with the CA generation.

### DIFF
--- a/pkg/controller/argocd/secret.go
+++ b/pkg/controller/argocd/secret.go
@@ -81,9 +81,11 @@ func newCASecret(cr *argoprojv1a1.ArgoCD) (*corev1.Secret, error) {
 		return nil, err
 	}
 
+	// This puts both ca.crt and tls.crt into the secret.
 	secret.Data = map[string][]byte{
-		corev1.TLSCertKey:       argoutil.EncodeCertificatePEM(cert),
-		corev1.TLSPrivateKeyKey: argoutil.EncodePrivateKeyPEM(key),
+		corev1.TLSCertKey:              argoutil.EncodeCertificatePEM(cert),
+		corev1.ServiceAccountRootCAKey: argoutil.EncodeCertificatePEM(cert),
+		corev1.TLSPrivateKeyKey:        argoutil.EncodePrivateKeyPEM(key),
 	}
 
 	return secret, nil

--- a/pkg/controller/argocd/secret_test.go
+++ b/pkg/controller/argocd/secret_test.go
@@ -1,0 +1,43 @@
+package argocd
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+)
+
+func Test_newCASecret(t *testing.T) {
+	cr := &argoprojv1alpha1.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-argocd",
+			Namespace: "argocd",
+		},
+	}
+
+	s, err := newCASecret(cr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		corev1.ServiceAccountRootCAKey,
+		corev1.TLSCertKey,
+		corev1.TLSPrivateKeyKey,
+	}
+	if k := byteMapKeys(s.Data); !reflect.DeepEqual(want, k) {
+		t.Fatalf("got %#v, want %#v", k, want)
+	}
+}
+
+func byteMapKeys(m map[string][]byte) []string {
+	r := []string{}
+	for k := range m {
+		r = append(r, k)
+	}
+	sort.Strings(r)
+	return r
+}


### PR DESCRIPTION
This adds support for putting the CA generated into a key that can be picked up
by cert-utils-operator.

Fixes #166 