### PR TITLE
Fix reconciliation of argocd-tls-certs-cm.

### DIFF
--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -636,14 +636,13 @@ func (r *ReconcileArgoCD) reconcileSSHKnownHosts(cr *argoprojv1a1.ArgoCD) error 
 // reconcileTLSCerts will ensure that the ArgoCD TLS Certs ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileTLSCerts(cr *argoprojv1a1.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDTLSCertsConfigMapName, cr)
-	if argoutil.IsObjectFound(r.client, cr.Namespace, cm.Name, cm) {
-		return nil // ConfigMap found, move along...
-	}
-
 	cm.Data = getInitialTLSCerts(cr)
-
 	if err := controllerutil.SetControllerReference(cr, cm, r.scheme); err != nil {
 		return err
+	}
+
+	if argoutil.IsObjectFound(r.client, cr.Namespace, cm.Name, cm) {
+		return r.client.Update(context.TODO(), cm)
 	}
 	return r.client.Create(context.TODO(), cm)
 }

--- a/pkg/controller/argocd/testing.go
+++ b/pkg/controller/argocd/testing.go
@@ -15,9 +15,11 @@
 package argocd
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/argoproj-labs/argocd-operator/pkg/apis"
+	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -62,4 +64,28 @@ func assertNoError(t *testing.T, err error) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func initialCerts(t *testing.T, host string) argoCDOpt {
+	t.Helper()
+	return func(a *argoprojv1alpha1.ArgoCD) {
+		key, err := argoutil.NewPrivateKey()
+		assertNoError(t, err)
+		cert, err := argoutil.NewSelfSignedCACertificate(key)
+		assertNoError(t, err)
+		encoded := argoutil.EncodeCertificatePEM(cert)
+
+		a.Spec.TLS.InitialCerts = map[string]string{
+			host: string(encoded),
+		}
+	}
+}
+
+func stringMapKeys(m map[string]string) []string {
+	r := []string{}
+	for k := range m {
+		r = append(r, k)
+	}
+	sort.Strings(r)
+	return r
 }

--- a/pkg/controller/argoutil/resource.go
+++ b/pkg/controller/argoutil/resource.go
@@ -22,6 +22,7 @@ import (
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/pkg/common"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,10 +91,7 @@ func FetchStorageSecretName(export *argoprojv1a1.ArgoCDExport) string {
 // IsObjectFound will perform a basic check that the given object exists via the Kubernetes API.
 // If an error occurs as part of the check, the function will return false.
 func IsObjectFound(client client.Client, namespace string, name string, obj runtime.Object) bool {
-	if err := FetchObject(client, namespace, name, obj); err != nil {
-		return false
-	}
-	return true
+	return !apierrors.IsNotFound(FetchObject(client, namespace, name, obj))
 }
 
 // NameWithSuffix will return a string using the Name from the given ObjectMeta with the provded suffix appended.


### PR DESCRIPTION
This fixes a reconciliation bug, where the TLS cert configmap wasn't updated on subsequent reconciliations.

Fixes: #122