### PR TITLE
Changes to support ArgoCD v1.7.7.

### DIFF
--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -31,7 +31,7 @@ const (
 	ArgoCDDefaultArgoImage = "argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:0a8fa1fee472568c2ec49dc1a71d3af56613b6b62353560a3682abc24492daee" // v1.6.1
+	ArgoCDDefaultArgoVersion = "sha256:b835999eb5cf75d01a2678cd971095926d9c2566c9ffe746d04b83a6a0a2849f" // v1.7.7
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/pkg/controller/argocd/argocd_controller_test.go
+++ b/pkg/controller/argocd/argocd_controller_test.go
@@ -49,7 +49,7 @@ func TestReconcileArgoCD_Reconcile_with_deleted(t *testing.T) {
 		},
 	}
 	res, err := r.Reconcile(req)
-	fatalIfError(t, err)
+	assertNoError(t, err)
 	if res.Requeue {
 		t.Fatal("reconcile requeued request")
 	}
@@ -76,7 +76,7 @@ func TestReconcileArgoCD_Reconcile(t *testing.T) {
 		},
 	}
 	res, err := r.Reconcile(req)
-	fatalIfError(t, err)
+	assertNoError(t, err)
 	if res.Requeue {
 		t.Fatal("reconcile requeued request")
 	}

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -153,7 +153,7 @@ func getRBACScopes(cr *argoprojv1a1.ArgoCD) string {
 // getResourceCustomizations will return the resource customizations for the given ArgoCD.
 func getResourceCustomizations(cr *argoprojv1a1.ArgoCD) string {
 	rc := common.ArgoCDDefaultResourceCustomizations
-	if len(cr.Spec.ResourceCustomizations) > 0 {
+	if cr.Spec.ResourceCustomizations != "" {
 		rc = cr.Spec.ResourceCustomizations
 	}
 	return rc
@@ -312,7 +312,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 		return r.reconcileExistingArgoConfigMap(cm, cr)
 	}
 
-	if len(cm.Data) <= 0 {
+	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
 
@@ -325,7 +325,9 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 	cm.Data[common.ArgoCDKeyHelpChatText] = getHelpChatText(cr)
 	cm.Data[common.ArgoCDKeyKustomizeBuildOptions] = getKustomizeBuildOptions(cr)
 	cm.Data[common.ArgoCDKeyOIDCConfig] = getOIDCConfig(cr)
-	cm.Data[common.ArgoCDKeyResourceCustomizations] = getResourceCustomizations(cr)
+	if c := getResourceCustomizations(cr); c != "" {
+		cm.Data[common.ArgoCDKeyResourceCustomizations] = c
+	}
 	cm.Data[common.ArgoCDKeyResourceExclusions] = getResourceExclusions(cr)
 	cm.Data[common.ArgoCDKeyResourceInclusions] = getResourceInclusions(cr)
 	cm.Data[common.ArgoCDKeyRepositories] = getInitialRepositories(cr)

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -833,9 +833,14 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 			{
 				Name:      "ssh-known-hosts",
 				MountPath: "/app/config/ssh",
-			}, {
+			},
+			{
 				Name:      "tls-certs",
 				MountPath: "/app/config/tls",
+			},
+			{
+				Name:      "gpg-keyring",
+				MountPath: "/app/config/gpg/keys",
 			},
 		},
 	}}
@@ -850,7 +855,8 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 					},
 				},
 			},
-		}, {
+		},
+		{
 			Name: "tls-certs",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -858,6 +864,12 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 						Name: common.ArgoCDTLSCertsConfigMapName,
 					},
 				},
+			},
+		},
+		{
+			Name: "gpg-keyring",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 	}

--- a/pkg/controller/argocd/route_test.go
+++ b/pkg/controller/argocd/route_test.go
@@ -20,11 +20,6 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 )
 
-const (
-	testArgoCDName = "testing-argocd"
-	testNamespace  = "testing-argocd"
-)
-
 func TestReconcileRouteSetsInsecure(t *testing.T) {
 	routeAPIFound = true
 	ctx := context.Background()
@@ -44,7 +39,7 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 		},
 	}
 	_, err := r.Reconcile(req)
-	fatalIfError(t, err, "reconcile: (%v): %s", req, err)
+	assertNoError(t, err)
 
 	loaded := &routev1.Route{}
 	err = r.client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
@@ -114,7 +109,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 		},
 	}
 	_, err := r.Reconcile(req)
-	fatalIfError(t, err, "reconcile: (%v): %s", req, err)
+	assertNoError(t, err)
 
 	loaded := &routev1.Route{}
 	err = r.client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
@@ -143,7 +138,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 	fatalIfError(t, err, "failed to update the ArgoCD: %s", err)
 
 	_, err = r.Reconcile(req)
-	fatalIfError(t, err, "reconcile: (%v): %s", req, err)
+	assertNoError(t, err)
 
 	loaded = &routev1.Route{}
 	err = r.client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
@@ -198,6 +193,7 @@ func fatalIfError(t *testing.T, err error, format string, a ...interface{}) {
 }
 
 func loadSecret(t *testing.T, c client.Client, name string) *corev1.Secret {
+	t.Helper()
 	secret := &corev1.Secret{}
 	err := c.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: testNamespace}, secret)
 	fatalIfError(t, err, "failed to load secret %q", name)

--- a/pkg/controller/argocd/testing.go
+++ b/pkg/controller/argocd/testing.go
@@ -33,7 +33,7 @@ const (
 
 func makeTestReconciler(t *testing.T, objs ...runtime.Object) *ReconcileArgoCD {
 	s := scheme.Scheme
-	fatalIfError(t, apis.AddToScheme(s))
+	assertNoError(t, apis.AddToScheme(s))
 
 	cl := fake.NewFakeClientWithScheme(s, objs...)
 	return &ReconcileArgoCD{
@@ -57,7 +57,7 @@ func makeTestArgoCD(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
 	return a
 }
 
-func fatalIfError(t *testing.T, err error) {
+func assertNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
 * Fix the repo-server deployment
   This updates the repo server to have an emptyDir mounted /app/config/gpg/keys

   This comes from this change https://github.com/argoproj/argo-cd/pull/4136/files

 * Fix for argocd-controller.
   This is arguably a bug in ArgoCD it's parsing an empty string into a
   clearing of the map for resource customizations.

Add go-cmp to the dependencies.

This should fix #148