### PR TITLE
Release Operator v0.0.14

### DIFF
--- a/deploy/catalog_source.yaml
+++ b/deploy/catalog_source.yaml
@@ -4,6 +4,6 @@ metadata:
   name: argocd-catalog
 spec:
   sourceType: grpc
-  image: quay.io/jmckind/argocd-operator-registry@sha256:58081ef9390278776bd69bafaaf9b8ee413ec071ad44ea4fb05d0de06b40f485
+  image: quay.io/jmckind/argocd-operator-registry@sha256:93d17eaa19857212223f5ea62ace740737c0ea319121d421b9e3c749e91fd08a
   displayName: Argo CD Operators
   publisher: Argo CD Community

--- a/deploy/olm-catalog/argocd-operator/0.0.14/argocd-operator.v0.0.14.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.14/argocd-operator.v0.0.14.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Auto Pilot
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/jmckind/argocd-operator:latest
+    containerImage: quay.io/redhat-cop/argocd-operator@sha256:218a8e9a078aa83ae6c41e524b978c4eb5d73d39dff45f7ecffc03a47afeef29
     createdAt: "2020-10-09 15:19:40"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v0.19.4
@@ -635,7 +635,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: argocd-operator
-                image: quay.io/jmckind/argocd-operator:latest
+                image: quay.io/redhat-cop/argocd-operator@sha256:218a8e9a078aa83ae6c41e524b978c4eb5d73d39dff45f7ecffc03a47afeef29
                 imagePullPolicy: Always
                 name: argocd-operator
                 resources: {}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: argocd-operator
       containers:
         - name: argocd-operator
-          image: quay.io/redhat-cop/argocd-operator@sha256:98cf0265a10fe63d868c554090a310c2b2e96038d0c5ec14802c7741538dea59
+          image: quay.io/redhat-cop/argocd-operator@sha256:218a8e9a078aa83ae6c41e524b978c4eb5d73d39dff45f7ecffc03a47afeef29
           command:
           - argocd-operator
           imagePullPolicy: Always

--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
-# upstream-registry-builder v1.14.3
-FROM quay.io/operator-framework/upstream-registry-builder@sha256:30ac65141ceab0493f7423f966a323842c3aeca817c59a7c23fed8055856ede3 as builder
+# upstream-registry-builder v1.13.4
+FROM quay.io/operator-framework/upstream-registry-builder@sha256:ec1f9ec32f0d011b4fae7ac765ab85cf7eb84fc866f5540c9747a4cbe3688d65 as builder
 
 COPY manifests manifests
 RUN ./bin/initializer -o ./bundles.db

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -86,7 +86,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/jmckind/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:91743a6f8ed9423bab5c68ee6ad2450b2d123dd52f1de836bcbb33d531778487" // v0.0.13
+	ArgoCDDefaultExportJobVersion = "sha256:f987796f3b4be500516689b24988f5c27f8d4f6e537b5c5d862090451de90794" // v0.0.14
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ package version
 
 var (
 	// Version is the ArgoCD Operator version.
-	Version = "0.0.13"
+	Version = "0.0.14"
 )


### PR DESCRIPTION
This PR updates the operator to v0.0.14, which includes the following.

Enhancements

* #148 - Add support for Argo CD 1.7.
* #144 - Add option to control resync frequency for argocd application controller.
* #167 - Support cert-utils-operator with the CA generation.

Bug Fixes

* #122 - Fix reconciliation of argocd-tls-certs-cm.
* #151 - Fix for not updating when changing the ArgoCD resource
* #152 - Fix OLM version mismatch/initialSSHKnownHosts validation error.
* #162 - Don't rereconcile deleted ArgoCD objects.

Documentation

* #140 - Update example with how to enable Routes.
* #156 - Fix a mistake in the Routes documentation with password retrieval.
* #173 - Document a small nuanced issue with group mappings.
