### PR TITLE
Update Docs for Repository Credentials

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -465,7 +465,7 @@ spec:
 
 Git repository credential templates to configure Argo CD to use upon creation of the cluster.
 
-This property maps directly to the `repository.credentials` field in the `argocd-cm` ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Modifications to the `repository.credentials` field should then be made through the Argo CD web UI or CLI.
+This property maps directly to the `repository.credentials` field in the `argocd-cm` ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Modifications to the `repository.credentials` field should then be made to the `argocd-cm` ConfigMap directly or by using the Argo CD web UI or CLI.
 
 ### Repository Credentials Example
 


### PR DESCRIPTION
This PR updates the reference documentation for the RepositoryCredentials property on the ArgoCD CRD to include a note that updates to the value can be made after the cluster has been created by modifying the `argocd-cm` ConfigMap directly.