### PR TITLE
Add Property to Disable Admin User

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -135,6 +135,9 @@ spec:
                   description: Version is the Dex container image tag.
                   type: string
               type: object
+            disableAdmin:
+              description: DisableAdmin will disable the admin user.
+              type: boolean
             gaAnonymizeUsers:
               description: GAAnonymizeUsers toggles user IDs being hashed before sending
                 to google analytics.

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -15,6 +15,7 @@ Name | Default | Description
 [**ConfigManagementPlugins**](#config-management-plugins) | [Empty] | Configuration to add a config management plugin.
 [**Controller**](#controller-options) | [Object] | Argo CD Application Controller options.
 [**Dex**](#dex-options) | [Object] | Dex configuration options.
+[**DisableAdmin**](#disable-admin) | `false` | Disable the admin user.
 [**GATrackingID**](#ga-tracking-id) | [Empty] | The google analytics tracking ID to use.
 [**GAAnonymizeUsers**](#ga-anonymize-users) | `false` | Enable hashed usernames sent to google analytics.
 [**Grafana**](#grafana-options) | [Object] | Grafana configuration options.
@@ -181,6 +182,25 @@ A quick fix will be to create an `admins` group, add the user to the group and t
 oc adm groups new admins
 oc adm groups add-users admins USER
 oc adm policy add-cluster-role-to-group cluster-admin admins
+```
+
+## Disable Admin
+
+Disable the admin user. This property maps directly to the `admin.enabled` field in the `argocd-cm` ConfigMap.
+
+### Disable Admin Example
+
+The following example disables the admin user using the `DisableAdmin` property on the `ArgoCD` resource.
+
+``` yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: disable-admin
+spec:
+  disableAdmin: true
 ```
 
 ## GA Tracking ID

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -331,6 +331,9 @@ type ArgoCDSpec struct {
 	// Dex defines the Dex server options for ArgoCD.
 	Dex ArgoCDDexSpec `json:"dex,omitempty"`
 
+	// DisableAdmin will disable the admin user.
+	DisableAdmin bool `json:"disableAdmin,omitempty"`
+
 	// GATrackingID is the google analytics tracking ID to use.
 	GATrackingID string `json:"gaTrackingID,omitempty"`
 

--- a/pkg/apis/argoproj/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/argoproj/v1alpha1/zz_generated.openapi.go
@@ -228,6 +228,13 @@ func schema_pkg_apis_argoproj_v1alpha1_ArgoCDSpec(ref common.ReferenceCallback) 
 							Ref:         ref("./pkg/apis/argoproj/v1alpha1.ArgoCDDexSpec"),
 						},
 					},
+					"disableAdmin": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DisableAdmin will disable the admin user.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"gaTrackingID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "GATrackingID is the google analytics tracking ID to use.",

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -20,6 +20,9 @@ import (
 )
 
 const (
+	// ArgoCDKeyAdminEnabled is the configuration key for the admin enabled setting..
+	ArgoCDKeyAdminEnabled = "admin.enabled"
+
 	// ArgoCDKeyApplicationInstanceLabelKey is the configuration key for the application instance label.
 	ArgoCDKeyApplicationInstanceLabelKey = "application.instanceLabelKey"
 

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -318,6 +318,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 
 	cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = getApplicationInstanceLabelKey(cr)
 	cm.Data[common.ArgoCDKeyConfigManagementPlugins] = getConfigManagementPlugins(cr)
+	cm.Data[common.ArgoCDKeyAdminEnabled] = fmt.Sprintf("%t", !cr.Spec.DisableAdmin)
 	cm.Data[common.ArgoCDKeyDexConfig] = getDexConfig(cr)
 	cm.Data[common.ArgoCDKeyGATrackingID] = getGATrackingID(cr)
 	cm.Data[common.ArgoCDKeyGAAnonymizeUsers] = fmt.Sprint(cr.Spec.GAAnonymizeUsers)
@@ -386,6 +387,11 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 
 func (r *ReconcileArgoCD) reconcileExistingArgoConfigMap(cm *corev1.ConfigMap, cr *argoprojv1a1.ArgoCD) error {
 	changed := false
+
+	if cm.Data[common.ArgoCDKeyAdminEnabled] == fmt.Sprintf("%t", cr.Spec.DisableAdmin) {
+		cm.Data[common.ArgoCDKeyAdminEnabled] = fmt.Sprintf("%t", !cr.Spec.DisableAdmin)
+		changed = true
+	}
 
 	if cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] != cr.Spec.ApplicationInstanceLabelKey {
 		cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = cr.Spec.ApplicationInstanceLabelKey

--- a/pkg/controller/argocd/configmap_test.go
+++ b/pkg/controller/argocd/configmap_test.go
@@ -93,6 +93,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 
 	want := map[string]string{
 		"application.instanceLabelKey": "mycompany.com/appname",
+		"admin.enabled":                "true",
 		"configManagementPlugins":      "",
 		"dex.config":                   "",
 		"ga.anonymizeusers":            "false",
@@ -112,6 +113,28 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 
 	if diff := cmp.Diff(want, cm.Data); diff != "" {
 		t.Fatalf("reconcileArgoConfigMap failed:\n%s", diff)
+	}
+}
+
+func TestReconcileArgoCD_reconcileArgoConfigMap_withDisableAdmin(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a.Spec.DisableAdmin = true
+	})
+	r := makeTestReconciler(t, a)
+
+	err := r.reconcileArgoConfigMap(a)
+	assertNoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      common.ArgoCDConfigMapName,
+		Namespace: testNamespace,
+	}, cm)
+	assertNoError(t, err)
+
+	if c := cm.Data["admin.enabled"]; c != "false" {
+		t.Fatalf("reconcileArgoConfigMap failed got %q, want %q", c, "false")
 	}
 }
 

--- a/tests/e2e/argocd-tests/04-assert.yaml
+++ b/tests/e2e/argocd-tests/04-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  admin.enabled: "false"

--- a/tests/e2e/argocd-tests/04-disable-admin.yaml
+++ b/tests/e2e/argocd-tests/04-disable-admin.yaml
@@ -1,0 +1,16 @@
+# Delete previous cluster
+apiVersion: kudo.dev/v1alpha1
+kind: TestStep
+delete:
+- apiVersion: argoproj.io/v1alpha1
+  kind: ArgoCD
+  name: example-argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: disable-admin
+spec:
+  disableAdmin: true


### PR DESCRIPTION
This PR addresses #158 by adding a new property to the ArgoCD custom resource to toggle the admin user. The `Spec.DisableAdmin` property **inversely** maps to the `admin.enabled` key in the `argocd-cm` ConfigMap. 

See: https://argoproj.github.io/argo-cd/operator-manual/user-management/#disable-admin-user