### PR TITLE
Inconsistency between ArgoCD CRD and ArgoCD CR in the version 0.0.13

### DIFF
--- a/deploy/olm-catalog/argocd-operator/0.0.13/argoproj.io_argocds_crd.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.13/argoproj.io_argocds_crd.yaml
@@ -341,7 +341,16 @@ spec:
             initialSSHKnownHosts:
               description: InitialSSHKnownHosts defines the SSH known hosts data upon
                 creation of the cluster for connecting Git repositories via SSH.
-              type: string
+              properties:
+                excludedefaulthosts:
+                  description: ExcludeDefaultHosts describes whether you would like
+                    to include the default list of SSH Known Hosts provided by ArgoCD.
+                  type: boolean
+                keys:
+                  description: Keys describes a custom set of SSH Known Hosts that
+                    you would like to have included in your ArgoCD server.
+                  type: string
+              type: object
             kustomizeBuildOptions:
               description: KustomizeBuildOptions is used to specify build options/parameters
                 to use with `kustomize build`.


### PR DESCRIPTION
There is an inconsistency between ArgoCD CRD and ArgoCD CR in the version 0.0.13
Indeed, the `type` of the `initialSSHKnownHosts` field should be an object with the 2 `excludedefaulthosts ` and `keys ` fields.