### PR TITLE
Add support for creating an empty gpg-keys map.

### DIFF
--- a/pkg/common/values.go
+++ b/pkg/common/values.go
@@ -26,6 +26,9 @@ const (
 	// ArgoCDConfigMapName is the upstream hard-coded ArgoCD ConfigMap name.
 	ArgoCDConfigMapName = "argocd-cm"
 
+	// ArgoCDGPGKeysConfigMapName is the upstream hard-coded ArgoCD gpg-keys ConfigMap name.
+	ArgoCDGPGKeysConfigMapName = "argocd-gpg-keys-cm"
+
 	// ArgoCDDuration365Days is a duration representing 365 days.
 	ArgoCDDuration365Days = time.Hour * 24 * 365
 

--- a/pkg/controller/argocd/configmap_test.go
+++ b/pkg/controller/argocd/configmap_test.go
@@ -138,6 +138,25 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDisableAdmin(t *testing.T) {
 	}
 }
 
+func TestReconcileArgoCD_reconcileGPGKeysConfigMap(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a.Spec.DisableAdmin = true
+	})
+	r := makeTestReconciler(t, a)
+
+	err := r.reconcileGPGKeysConfigMap(a)
+	assertNoError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      common.ArgoCDGPGKeysConfigMapName,
+		Namespace: testNamespace,
+	}, cm)
+	assertNoError(t, err)
+	// Currently the gpg keys configmap is empty
+}
+
 func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceInclusions(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	customizations := "testing: testing"


### PR DESCRIPTION
This adds support for creating an empty gpg-keys configmap.