### PR TITLE
Fixed wrong `TLS` key example for server route

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -948,7 +948,7 @@ spec:
       annotations: {}
       enabled: false
       path: /
-      TLS:
+      tls:
         insecureEdgeTerminationPolicy: Redirect
         termination: passthrough
       wildcardPolicy: None


### PR DESCRIPTION
As per https://github.com/argoproj-labs/argocd-operator/blob/master/pkg/apis/argoproj/v1alpha1/argocd_types.go#L262, TLS key for `ArgoCDRouteSpec` should be lowercased (`tls` instead of `TLS`)