### PR TITLE
Add support for getting the images from the environment.

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -22,7 +22,7 @@ Name | Default | Description
 [**HA**](#ha-options) | [Object] | High Availability options.
 [**HelpChatURL**](#help-chat-url) | `https://mycorp.slack.com/argo-cd` | URL for getting chat help, this will typically be your Slack channel for support.
 [**HelpChatText**](#help-chat-text) | `Chat now!` | The text for getting chat help.
-[**Image**](#image) | `argoproj/argocd` | The container image for all Argo CD components.
+[**Image**](#image) | `argoproj/argocd` | The container image for all Argo CD components. This overrides the `ARGOCD_IMAGE` environment variable.
 [**Import**](#import-options) | [Object] | Import configuration options.
 [**Ingress**](#ingress-options) | [Object] | Ingress configuration options.
 [**InitialRepositories**](#initial-repositories) | [Empty] | Initial git repositories to configure Argo CD to use upon creation of the cluster.
@@ -123,7 +123,7 @@ The following properties are available for configuring the Dex component.
 Name | Default | Description
 --- | --- | ---
 Config | [Empty] | The `dex.config` property in the `argocd-cm` ConfigMap.
-Image | `quay.io/dexidp/dex` | The container image for Dex.
+Image | `quay.io/dexidp/dex` | The container image for Dex. This overrides the `ARGOCD_DEX_IMAGE` environment variable.
 OpenShiftOAuth | false | Enable automatic configuration of OpenShift OAuth authentication for the Dex server. This is ignored if a value is presnt for `Dex.Config`.
 Resources | [Empty] | The container compute resources.
 Version | v2.21.0 (SHA) | The tag to use with the Dex container image.
@@ -250,7 +250,7 @@ Name | Default | Description
 --- | --- | ---
 Enabled | false | Toggle Grafana support globally for ArgoCD.
 Host | `example-argocd-grafana` | The hostname to use for Ingress/Route resources.
-Image | `grafana/grafana` | The container image for Grafana.
+Image | `grafana/grafana` | The container image for Grafana. This overrides the `ARGOCD_GRAFANA_IMAGE` environment variable.
 [Ingress](#grafana-ingress-options) | [Object] | Ingress configuration for Grafana.
 Resources | [Empty] | The container compute resources.
 [Route](#grafana-route-options) | [Object] | Route configuration options.
@@ -311,7 +311,7 @@ The following properties are available for configuring High Availability for the
 Name | Default | Description
 --- | --- | ---
 Enabled | `false` | Toggle High Availability support globally for Argo CD.
-RedisProxyImage | `haproxy` | The Redis HAProxy container image.
+RedisProxyImage | `haproxy` | The Redis HAProxy container image. This overrides the `ARGOCD_REDIS_HA_IMAGE`.
 RedisProxyVersion | `2.0.4` | The tag to use for the Redis HAProxy container image.
 
 ### HA Example
@@ -677,7 +677,7 @@ The following properties are available for configuring the Redis component.
 
 Name | Default | Description
 --- | --- | ---
-Image | `redis` | The container image for Redis.
+Image | `redis` | The container image for Redis. This overrides the `ARGOCD_REDIS_IMAGE` environment variable.
 Resources | [Empty] | The container compute resources.
 Version | 5.0.3 (SHA) | The tag to use with the Redis container image.
 

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -160,4 +160,24 @@ const (
 
 	// ArgoCDKeyUsersAnonymousEnabled is the configuration key for anonymous user access.
 	ArgoCDKeyUsersAnonymousEnabled = "users.anonymous.enabled"
+
+	// ArgoCDDexImageEnvName is the environment variable used to get the image
+	// to used for the Dex container.
+	ArgoCDDexImageEnvName = "ARGOCD_DEX_IMAGE"
+
+	// ArgoCDImageEnvName is the environment variable used to get the image
+	// to used for the argocd container.
+	ArgoCDImageEnvName = "ARGOCD_IMAGE"
+
+	// ArgoCDRedisHAImageEnvName is the environment variable used to get the image
+	// to used for the Redis HA Proxy image.
+	ArgoCDRedisHAImageEnvName = "ARGOCD_REDIS_HA_IMAGE"
+
+	// ArgoCDRedisImageEnvName is the environment variable used to get the image
+	// to used for the Redis container.
+	ArgoCDRedisImageEnvName = "ARGOCD_REDIS_IMAGE"
+
+	// ArgoCDGrafanaImageEnvName is the environment variable used to get the image
+	// to used for the Grafana container.
+	ArgoCDGrafanaImageEnvName = "ARGOCD_GRAFANA_IMAGE"
 )

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -73,17 +73,6 @@ func generateArgoServerSessionKey() ([]byte, error) {
 
 // getArgoApplicationControllerResources will return the ResourceRequirements for the Argo CD application controller container.
 func getArgoApplicationControllerResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
-	// resources := corev1.ResourceRequirements{
-	// 	Limits: corev1.ResourceList{
-	// 		corev1.ResourceCPU:    resource.MustParse(common.ArgoCDDefaultControllerResourceLimitCPU),
-	// 		corev1.ResourceMemory: resource.MustParse(common.ArgoCDDefaultControllerResourceLimitMemory),
-	// 	},
-	// 	Requests: corev1.ResourceList{
-	// 		corev1.ResourceCPU:    resource.MustParse(common.ArgoCDDefaultControllerResourceRequestCPU),
-	// 		corev1.ResourceMemory: resource.MustParse(common.ArgoCDDefaultControllerResourceRequestMemory),
-	// 	},
-	// }
-
 	resources := corev1.ResourceRequirements{}
 
 	// Allow override of resource requirements from CR
@@ -96,14 +85,20 @@ func getArgoApplicationControllerResources(cr *argoprojv1a1.ArgoCD) corev1.Resou
 
 // getArgoContainerImage will return the container image for ArgoCD.
 func getArgoContainerImage(cr *argoprojv1a1.ArgoCD) string {
+	defaultTag, defaultImg := false, false
 	img := cr.Spec.Image
-	if len(img) <= 0 {
+	if img == "" {
 		img = common.ArgoCDDefaultArgoImage
+		defaultImg = true
 	}
 
 	tag := cr.Spec.Version
-	if len(tag) <= 0 {
+	if tag == "" {
 		tag = common.ArgoCDDefaultArgoVersion
+		defaultTag = true
+	}
+	if e := os.Getenv(common.ArgoCDImageEnvName); e != "" && (defaultTag && defaultImg) {
+		return e
 	}
 
 	return argoutil.CombineImageTag(img, tag)
@@ -212,15 +207,31 @@ func getArgoServerStatusProcessors(cr *argoprojv1a1.ArgoCD) int32 {
 }
 
 // getDexContainerImage will return the container image for the Dex server.
+//
+// There are three possible options for configuring the image, and this is the
+// order of preference.
+//
+// 1. from the Spec, the spec.dex field has an image and version to use for
+// generating an image reference.
+// 2. from the Environment, this looks for the `ARGOCD_DEX_IMAGE` field and uses
+// that if the spec is not configured.
+// 3. the default is configured in common.ArgoCDDefaultDexVersion and
+// common.ArgoCDDefaultDexImage.
 func getDexContainerImage(cr *argoprojv1a1.ArgoCD) string {
+	defaultImg, defaultTag := false, false
 	img := cr.Spec.Dex.Image
-	if len(img) <= 0 {
+	if img == "" {
 		img = common.ArgoCDDefaultDexImage
+		defaultImg = true
 	}
 
 	tag := cr.Spec.Dex.Version
-	if len(tag) <= 0 {
+	if tag == "" {
 		tag = common.ArgoCDDefaultDexVersion
+		defaultTag = true
+	}
+	if e := os.Getenv(common.ArgoCDDexImageEnvName); e != "" && (defaultTag && defaultImg) {
+		return e
 	}
 	return argoutil.CombineImageTag(img, tag)
 }
@@ -292,14 +303,20 @@ func getDexResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
 
 // getGrafanaContainerImage will return the container image for the Grafana server.
 func getGrafanaContainerImage(cr *argoprojv1a1.ArgoCD) string {
+	defaultTag, defaultImg := false, false
 	img := cr.Spec.Grafana.Image
-	if len(img) <= 0 {
+	if img == "" {
 		img = common.ArgoCDDefaultGrafanaImage
+		defaultImg = true
 	}
 
 	tag := cr.Spec.Grafana.Version
-	if len(tag) <= 0 {
+	if tag == "" {
 		tag = common.ArgoCDDefaultGrafanaVersion
+		defaultTag = true
+	}
+	if e := os.Getenv(common.ArgoCDGrafanaImageEnvName); e != "" && (defaultTag && defaultImg) {
+		return e
 	}
 	return argoutil.CombineImageTag(img, tag)
 }
@@ -369,28 +386,38 @@ func getRedisConf(cr *argoprojv1a1.ArgoCD) string {
 
 // getRedisContainerImage will return the container image for the Redis server.
 func getRedisContainerImage(cr *argoprojv1a1.ArgoCD) string {
+	defaultImg, defaultTag := false, false
 	img := cr.Spec.Redis.Image
-	if len(img) <= 0 {
+	if img == "" {
 		img = common.ArgoCDDefaultRedisImage
+		defaultImg = true
 	}
-
 	tag := cr.Spec.Redis.Version
-	if len(tag) <= 0 {
+	if tag == "" {
 		tag = common.ArgoCDDefaultRedisVersion
+		defaultTag = true
+	}
+	if e := os.Getenv(common.ArgoCDRedisImageEnvName); e != "" && (defaultTag && defaultImg) {
+		return e
 	}
 	return argoutil.CombineImageTag(img, tag)
 }
 
 // getRedisHAContainerImage will return the container image for the Redis server in HA mode.
 func getRedisHAContainerImage(cr *argoprojv1a1.ArgoCD) string {
+	defaultImg, defaultTag := false, false
 	img := cr.Spec.Redis.Image
-	if len(img) <= 0 {
+	if img == "" {
 		img = common.ArgoCDDefaultRedisImage
+		defaultImg = true
 	}
-
 	tag := cr.Spec.Redis.Version
-	if len(tag) <= 0 {
+	if tag == "" {
 		tag = common.ArgoCDDefaultRedisVersionHA
+		defaultTag = true
+	}
+	if e := os.Getenv(common.ArgoCDRedisHAImageEnvName); e != "" && (defaultTag && defaultImg) {
+		return e
 	}
 	return argoutil.CombineImageTag(img, tag)
 }

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -1,0 +1,173 @@
+package argocd
+
+import (
+	"os"
+	"testing"
+
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/pkg/common"
+	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
+)
+
+const (
+	dexTestImage     = "testing/dex:latest"
+	argoTestImage    = "testing/argocd:latest"
+	grafanaTestImage = "testing/grafana:latest"
+	redisTestImage   = "testing/redis:latest"
+	redisHATestImage = "testing/redis:latest-ha"
+)
+
+var imageTests = []struct {
+	name      string
+	pre       func(t *testing.T)
+	opts      []argoCDOpt
+	want      string
+	imageFunc func(a *argoprojv1alpha1.ArgoCD) string
+}{
+	{
+		name:      "dex default configuration",
+		imageFunc: getDexContainerImage,
+		want:      argoutil.CombineImageTag(common.ArgoCDDefaultDexImage, common.ArgoCDDefaultDexVersion),
+	},
+	{
+		name:      "dex spec configuration",
+		imageFunc: getDexContainerImage,
+		want:      dexTestImage,
+		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Dex.Image = "testing/dex"
+			a.Spec.Dex.Version = "latest"
+		}},
+	},
+	{
+		name:      "dex env configuration",
+		imageFunc: getDexContainerImage,
+		want:      dexTestImage,
+		pre: func(t *testing.T) {
+			old := os.Getenv(common.ArgoCDDexImageEnvName)
+			t.Cleanup(func() {
+				os.Setenv(common.ArgoCDDexImageEnvName, old)
+			})
+			os.Setenv(common.ArgoCDDexImageEnvName, dexTestImage)
+		},
+	},
+	{
+		name:      "argo default configuration",
+		imageFunc: getArgoContainerImage,
+		want:      argoutil.CombineImageTag(common.ArgoCDDefaultArgoImage, common.ArgoCDDefaultArgoVersion),
+	},
+	{
+		name:      "argo spec configuration",
+		imageFunc: getArgoContainerImage,
+		want:      argoTestImage, opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Image = "testing/argocd"
+			a.Spec.Version = "latest"
+		}},
+	},
+	{
+		name:      "argo env configuration",
+		imageFunc: getArgoContainerImage,
+		want:      argoTestImage,
+		pre: func(t *testing.T) {
+			old := os.Getenv(common.ArgoCDImageEnvName)
+			t.Cleanup(func() {
+				os.Setenv(common.ArgoCDImageEnvName, old)
+			})
+			os.Setenv(common.ArgoCDImageEnvName, argoTestImage)
+		},
+	},
+	{
+		name:      "grafana default configuration",
+		imageFunc: getGrafanaContainerImage,
+		want:      argoutil.CombineImageTag(common.ArgoCDDefaultGrafanaImage, common.ArgoCDDefaultGrafanaVersion),
+	},
+	{
+		name:      "grafana spec configuration",
+		imageFunc: getGrafanaContainerImage,
+		want:      grafanaTestImage,
+		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Grafana.Image = "testing/grafana"
+			a.Spec.Grafana.Version = "latest"
+		}},
+	},
+	{
+		name:      "grafana env configuration",
+		imageFunc: getGrafanaContainerImage,
+		want:      grafanaTestImage,
+		pre: func(t *testing.T) {
+			old := os.Getenv(common.ArgoCDGrafanaImageEnvName)
+			t.Cleanup(func() {
+				os.Setenv(common.ArgoCDGrafanaImageEnvName, old)
+			})
+			os.Setenv(common.ArgoCDGrafanaImageEnvName, grafanaTestImage)
+		},
+	},
+	{
+		name:      "redis default configuration",
+		imageFunc: getRedisContainerImage,
+		want:      argoutil.CombineImageTag(common.ArgoCDDefaultRedisImage, common.ArgoCDDefaultRedisVersion),
+	},
+	{
+		name:      "redis spec configuration",
+		imageFunc: getRedisContainerImage,
+		want:      redisTestImage,
+		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Redis.Image = "testing/redis"
+			a.Spec.Redis.Version = "latest"
+		}},
+	},
+	{
+		name:      "redis env configuration",
+		imageFunc: getRedisContainerImage,
+		want:      redisTestImage,
+		pre: func(t *testing.T) {
+			old := os.Getenv(common.ArgoCDRedisImageEnvName)
+			t.Cleanup(func() {
+				os.Setenv(common.ArgoCDRedisImageEnvName, old)
+			})
+			os.Setenv(common.ArgoCDRedisImageEnvName, redisTestImage)
+		},
+	},
+	{
+		name:      "redis ha default configuration",
+		imageFunc: getRedisHAContainerImage,
+		want: argoutil.CombineImageTag(
+			common.ArgoCDDefaultRedisImage,
+			common.ArgoCDDefaultRedisVersionHA),
+	},
+	{
+		name:      "redis ha spec configuration",
+		imageFunc: getRedisHAContainerImage,
+		want:      redisHATestImage,
+		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Redis.Image = "testing/redis"
+			a.Spec.Redis.Version = "latest-ha"
+		}},
+	},
+	{
+		name:      "redis ha env configuration",
+		imageFunc: getRedisHAContainerImage,
+		want:      redisHATestImage,
+		pre: func(t *testing.T) {
+			old := os.Getenv(common.ArgoCDRedisHAImageEnvName)
+			t.Cleanup(func() {
+				os.Setenv(common.ArgoCDRedisHAImageEnvName, old)
+			})
+			os.Setenv(common.ArgoCDRedisHAImageEnvName, redisHATestImage)
+		},
+	},
+}
+
+func TestContainerImages_configuration(t *testing.T) {
+	for _, tt := range imageTests {
+		t.Run(tt.name, func(rt *testing.T) {
+			if tt.pre != nil {
+				tt.pre(rt)
+			}
+			a := makeTestArgoCD(tt.opts...)
+			image := tt.imageFunc(a)
+			if image != tt.want {
+				rt.Errorf("got %q, want %q", image, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds functionality for fetching the images from the configured environment variables for the operator process.

* ARGOCD_DEX_IMAGE
* ARGOCD_IMAGE
* ARGOCD_REDIS_HA_IMAGE
* ARGOCD_REDIS_IMAGE
* ARGOCD_GRAFANA_IMAGE

The resolution order for these images:

1. From the ArgoCD object configuration (there are spec entries for each image).
2. From the environment variables above.
3. From the hard-coded values in pkg/common/defaults.go