### PR TITLE
Fix dex-pod init-container image during rereconciles.

### DIFF
--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -476,11 +476,19 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 
 	existing := newDeploymentWithSuffix("dex-server", "dex-server", cr)
 	if argoutil.IsObjectFound(r.client, cr.Namespace, existing.Name, existing) {
+		changed := false
 		actualImage := existing.Spec.Template.Spec.Containers[0].Image
 		desiredImage := getDexContainerImage(cr)
-		changed := false
 		if actualImage != desiredImage {
 			existing.Spec.Template.Spec.Containers[0].Image = desiredImage
+			existing.Spec.Template.ObjectMeta.Labels["image.upgraded"] = time.Now().UTC().Format("01022006-150406-MST")
+			changed = true
+		}
+
+		actualImage = existing.Spec.Template.Spec.InitContainers[0].Image
+		desiredImage = getArgoContainerImage(cr)
+		if actualImage != desiredImage {
+			existing.Spec.Template.Spec.InitContainers[0].Image = desiredImage
 			existing.Spec.Template.ObjectMeta.Labels["image.upgraded"] = time.Now().UTC().Format("01022006-150406-MST")
 			changed = true
 		}


### PR DESCRIPTION
When rereconciling the init-container for the Dex pod, the image was not being
updated if it had changed.

Signed-off-by: Kevin McDermott <bigkevmcd@gmail.com>

Fixes: #211 