### PR TITLE
Allow override operator

### DIFF
--- a/docs/contribute/development.md
+++ b/docs/contribute/development.md
@@ -30,6 +30,8 @@ Have a look at the scripts in the `hack` directory for all of the environment va
 
 Run the provided shell script to build the operator. A container image wil be created locally.
 
+The path to the `operator-sdk` binary can be overridden with by setting `OPERATOR_SDK`.
+
 ``` bash
 hack/build.sh
 ```

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -16,8 +16,10 @@
 #
 # Script to build the operator from source and create a new container image.
 
+OPERATOR_SDK=${OPERATOR_SDK:-operator-sdk}
+
 HACK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${HACK_DIR}/env.sh
 
 echo "Building image ${ARGOCD_OPERATOR_IMAGE}"
-operator-sdk build ${ARGOCD_OPERATOR_IMAGE} --image-builder ${ARGOCD_OPERATOR_IMAGE_BUILDER}
+${OPERATOR_SDK} build ${ARGOCD_OPERATOR_IMAGE} --image-builder ${ARGOCD_OPERATOR_IMAGE_BUILDER}


### PR DESCRIPTION
This allows overriding the binary to be executed as `operator-sdk` to make it easier to support the older version that's needed to build this operator.

Setting `OPERATOR_SDK=/usr/local/bin/operator-sdk` will be picked up by the build script.