### PR TITLE
Allow disable dex

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -97,6 +97,9 @@ spec:
                 config:
                   description: Config is the dex connector configuration.
                   type: string
+                disabled:
+                  description: If Disabled is true, then Dex will not be setup.
+                  type: boolean
                 image:
                   description: Image is the Dex container image.
                   type: string

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -86,7 +86,7 @@ type ArgoCDCertificateSpec struct {
 
 // ArgoCDDexSpec defines the desired state for the Dex server component.
 type ArgoCDDexSpec struct {
-	//Config is the dex connector configuration.
+	// Config is the dex connector configuration.
 	Config string `json:"config,omitempty"`
 
 	// Image is the Dex container image.
@@ -100,6 +100,9 @@ type ArgoCDDexSpec struct {
 
 	// Version is the Dex container image tag.
 	Version string `json:"version,omitempty"`
+
+	// If Disabled is true, then Dex will not be setup.
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // ArgoCDDexOAuthSpec defines the desired state for the Dex OAuth configuration.

--- a/pkg/controller/argocd/argocd_controller_test.go
+++ b/pkg/controller/argocd/argocd_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -55,12 +54,10 @@ func TestReconcileArgoCD_Reconcile_with_deleted(t *testing.T) {
 	}
 
 	deployment := &appsv1.Deployment{}
-	if !apierrors.IsNotFound(r.client.Get(context.TODO(), types.NamespacedName{
+	assertNotFound(t, r.client.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-redis",
 		Namespace: testNamespace,
-	}, deployment)) {
-		t.Fatalf("expected not found error, got %#v\n", err)
-	}
+	}, deployment))
 }
 
 func TestReconcileArgoCD_Reconcile(t *testing.T) {


### PR DESCRIPTION
This adds functionality for disabling Dex, defaulting to enabled, you would need to explicitly disable it.

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: basic
spec:
  dex:
    disabled: true
```