### PR TITLE
Support disabling the DEX server.

### DIFF
--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -473,10 +473,16 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}}
+	dexDisabled := isDexDisabled()
 
 	existing := newDeploymentWithSuffix("dex-server", "dex-server", cr)
 	if argoutil.IsObjectFound(r.client, cr.Namespace, existing.Name, existing) {
+		if dexDisabled {
+			// Deployment exists but enabled flag has been set to false, delete the Deployment
+			return r.client.Delete(context.TODO(), existing)
+		}
 		changed := false
+
 		actualImage := existing.Spec.Template.Spec.Containers[0].Image
 		desiredImage := getDexContainerImage(cr)
 		if actualImage != desiredImage {
@@ -509,6 +515,10 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 			return r.client.Update(context.TODO(), existing)
 		}
 		return nil // Deployment found with nothing to do, move along...
+	}
+
+	if dexDisabled {
+		return nil
 	}
 
 	if err := controllerutil.SetControllerReference(cr, deploy, r.scheme); err != nil {
@@ -1094,4 +1104,11 @@ func caseInsensitiveGetenv(s string) (string, string) {
 		return ls, v
 	}
 	return "", ""
+}
+
+func isDexDisabled() bool {
+	if v := os.Getenv("DISABLE_DEX"); v != "" {
+		return strings.ToLower(v) == "true"
+	}
+	return false
 }


### PR DESCRIPTION
This adds support for an env-var `DISABLE_DEX` which cause the deployment for Dex to be skipped, and no config to be set in the config map for Dex.