### PR TITLE
Set env var to configure ArgoCD for Cluster Config

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -371,17 +371,6 @@ spec:
               description: KustomizeBuildOptions is used to specify build options/parameters
                 to use with `kustomize build`.
               type: string
-            managementScope:
-              description: ManagementScope defines the cluster scope or namespace
-                scope managed by argocd.
-              properties:
-                clusterconfignamespaces:
-                  description: List of namespaces where ArgoCD is allowed to manage
-                    cluster resources.
-                  items:
-                    type: string
-                  type: array
-              type: object
             oidcConfig:
               description: OIDCConfig is the OIDC configuration as an alternative
                 to dex.

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -316,18 +316,9 @@ type ArgoCDServerServiceSpec struct {
 	Type corev1.ServiceType `json:"type"`
 }
 
-// ArgoCDScope defines the scope of resources that ArgoCD would be managing
-type ArgoCDScope struct {
-	// List of namespaces where ArgoCD is allowed to manage cluster resources.
-	ClusterConfigNamespaces []string `json:"clusterconfignamespaces,omitempty"`
-}
-
 // ArgoCDSpec defines the desired state of ArgoCD
 // +k8s:openapi-gen=true
 type ArgoCDSpec struct {
-
-	// ManagementScope defines the cluster scope or namespace scope managed by argocd.
-	ManagementScope ArgoCDScope `json:"managementScope,omitempty"`
 
 	// ApplicationInstanceLabelKey is the key name where Argo CD injects the app name as a tracking label.
 	ApplicationInstanceLabelKey string `json:"applicationInstanceLabelKey,omitempty"`

--- a/pkg/controller/argocd/hooks_test.go
+++ b/pkg/controller/argocd/hooks_test.go
@@ -48,7 +48,7 @@ func TestReconcileArgoCD_testDeploymentHook(t *testing.T) {
 
 func TestReconcileArgoCD_testMultipleHooks(t *testing.T) {
 	defer resetHooks()()
-	a := makeTestArgoCDForClusterConfig()
+	a := makeTestArgoCD()
 
 	testDeployment := makeTestDeployment()
 	testClusterRole := makeTestClusterRole()
@@ -70,7 +70,7 @@ func TestReconcileArgoCD_testMultipleHooks(t *testing.T) {
 
 func TestReconcileArgoCD_hooks_end_upon_error(t *testing.T) {
 	defer resetHooks()()
-	a := makeTestArgoCDForClusterConfig()
+	a := makeTestArgoCD()
 	Register(testErrorHook, testClusterRoleHook)
 
 	testClusterRole := makeTestClusterRole()

--- a/pkg/controller/argocd/testing.go
+++ b/pkg/controller/argocd/testing.go
@@ -64,25 +64,6 @@ func makeTestArgoCD(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
 	return a
 }
 
-func makeTestArgoCDForClusterConfig(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
-	allowedNamespaces := []string{testNamespace, "dummyNamespace"}
-	a := &argoprojv1alpha1.ArgoCD{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testArgoCDName,
-			Namespace: testNamespace,
-		},
-		Spec: argoprojv1alpha1.ArgoCDSpec{
-			ManagementScope: argoprojv1alpha1.ArgoCDScope{
-				ClusterConfigNamespaces: allowedNamespaces,
-			},
-		},
-	}
-	for _, o := range opts {
-		o(a)
-	}
-	return a
-}
-
 func makeTestClusterRole() *v1.ClusterRole {
 	return &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/openshift/clusterconfig_test.go
+++ b/pkg/reconciler/openshift/clusterconfig_test.go
@@ -1,6 +1,8 @@
 package openshift
 
 import (
+	"os"
+
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -12,6 +14,7 @@ const (
 	testNamespace             = "argocd"
 	testArgoCDName            = "argocd"
 	testApplicationController = "argocd-application-controller"
+	testDummyNameSpace        = "dummy"
 )
 
 func makeTestPolicyRules() []rbacv1.PolicyRule {
@@ -31,26 +34,33 @@ func makeTestPolicyRules() []rbacv1.PolicyRule {
 }
 
 func makeTestArgoCDForClusterConfig() *argoprojv1alpha1.ArgoCD {
-	allowedNamespaces := []string{testNamespace, "dummyNamespace"}
+	a := makeTestArgoCD()
+	a.Namespace = testNamespace
+	return a
+}
+
+func makeTestArgoCD() *argoprojv1alpha1.ArgoCD {
 	a := &argoprojv1alpha1.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testArgoCDName,
-			Namespace: testNamespace,
-		},
-		Spec: argoprojv1alpha1.ArgoCDSpec{
-			ManagementScope: argoprojv1alpha1.ArgoCDScope{
-				ClusterConfigNamespaces: allowedNamespaces,
-			},
+			Namespace: testDummyNameSpace,
 		},
 	}
 	return a
 }
 
+func setClusterConfigNamespaces() {
+	os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "argocd,foo,bar")
+}
+
+func unSetClusterConfigNamespaces() {
+	os.Unsetenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES")
+}
+
 func makeTestClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      testApplicationController,
-			Namespace: testNamespace,
+			Name: testApplicationController,
 		},
 		Rules: makeTestPolicyRules(),
 	}


### PR DESCRIPTION
This commit Modifies the behaviour of https://github.com/argoproj-labs/argocd-operator/pull/225. 

What?
Cluster admin should set a env variable "ARGOCD_CLUSTER_CONFIG_NAMESPACES" with a list of namespaces(comma separated) where ArgoCD instance can manage cluster config resources. Users should request admin to get their namespaces added to the ARGOCD_CLUSTER_CONFIG_NAMESPACES env variable.

User cannot request for a ArgoCD instance without such privileges in  ARGOCD_CLUSTER_CONFIG_NAMESPACES. In such cases, corresponding namespace should be removed from the ARGOCD_CLUSTER_CONFIG_NAMESPACES env variable.

