### PR TITLE
[WIP] Allow user to provide custom external hostname for argo-server

### DIFF
--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"strings"
 	"text/template"
@@ -190,10 +189,6 @@ func (r *ReconcileArgoCD) getArgoServerURI(cr *argoprojv1a1.ArgoCD) string {
 		if argoutil.IsObjectFound(r.client, cr.Namespace, route.Name, route) {
 			host = route.Spec.Host
 		}
-	}
-
-	if _, err := url.ParseRequestURI(host); err == nil {
-		return host
 	}
 
 	return fmt.Sprintf("https://%s", host) // TODO: Safe to assume HTTPS here?

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -184,28 +184,12 @@ var argoServerURITests = []struct {
 		want:         "https://argocd-server",
 	},
 	{
-		name:         "test with external host name - no scheme",
+		name:         "test with external host name",
 		routeEnabled: false,
 		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
 			a.Spec.Server.Host = "test-host-name"
 		}},
 		want: "https://test-host-name",
-	},
-	{
-		name:         "test with external host name - scheme provided",
-		routeEnabled: false,
-		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
-			a.Spec.Server.Host = "https://test-host-name"
-		}},
-		want: "https://test-host-name",
-	},
-	{
-		name:         "test with external http host name",
-		routeEnabled: false,
-		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
-			a.Spec.Server.Host = "http://test-host-name"
-		}},
-		want: "http://test-host-name",
 	},
 }
 

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -173,35 +173,35 @@ func TestContainerImages_configuration(t *testing.T) {
 }
 
 var argoServerURITests = []struct {
-	name        string
-	description string
-	opts        []argoCDOpt
-	want        string
+	name         string
+	routeEnabled bool
+	opts         []argoCDOpt
+	want         string
 }{
 	{
-		name:        "test with no host name - default",
-		description: "test case when no hostname is provided and both ingress and route are disabled",
-		want:        "https://argocd-server",
+		name:         "test with no host name - default",
+		routeEnabled: false,
+		want:         "https://argocd-server",
 	},
 	{
-		name:        "test with external host name - no scheme",
-		description: "test case when external hostname is provided without scheme and both ingress and route are disabled",
+		name:         "test with external host name - no scheme",
+		routeEnabled: false,
 		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
 			a.Spec.Server.Host = "test-host-name"
 		}},
 		want: "https://test-host-name",
 	},
 	{
-		name:        "test with external host name - scheme provided",
-		description: "test case when external hostname is provided with https scheme and both ingress and route are disabled",
+		name:         "test with external host name - scheme provided",
+		routeEnabled: false,
 		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
 			a.Spec.Server.Host = "https://test-host-name"
 		}},
 		want: "https://test-host-name",
 	},
 	{
-		name:        "test with external http host name",
-		description: "test case when external hostname is provided with http scheme and both ingress and route are disabled",
+		name:         "test with external http host name",
+		routeEnabled: false,
 		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
 			a.Spec.Server.Host = "http://test-host-name"
 		}},
@@ -209,13 +209,24 @@ var argoServerURITests = []struct {
 	},
 }
 
+func setRouteAPIFound(t *testing.T, routeEnabled bool) {
+	routeAPIEnabledTemp := routeAPIFound
+	t.Cleanup(func() {
+		routeAPIFound = routeAPIEnabledTemp
+	})
+	routeAPIFound = routeEnabled
+}
+
 func TestGetArgoServerURI(t *testing.T) {
 	for _, tt := range argoServerURITests {
-		cr := makeTestArgoCD(tt.opts...)
-		r := &ReconcileArgoCD{}
-		result := r.getArgoServerURI(cr)
-		if result != tt.want {
-			t.Errorf("%s test failed, got=%q want=%q", tt.name, result, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			cr := makeTestArgoCD(tt.opts...)
+			r := &ReconcileArgoCD{}
+			setRouteAPIFound(t, tt.routeEnabled)
+			result := r.getArgoServerURI(cr)
+			if result != tt.want {
+				t.Errorf("%s test failed, got=%q want=%q", tt.name, result, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -171,3 +171,51 @@ func TestContainerImages_configuration(t *testing.T) {
 		})
 	}
 }
+
+var argoServerURITests = []struct {
+	name        string
+	description string
+	opts        []argoCDOpt
+	want        string
+}{
+	{
+		name:        "test with no host name - default",
+		description: "test case when no hostname is provided and both ingress and route are disabled",
+		want:        "https://argocd-server",
+	},
+	{
+		name:        "test with external host name - no scheme",
+		description: "test case when external hostname is provided without scheme and both ingress and route are disabled",
+		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Server.Host = "test-host-name"
+		}},
+		want: "https://test-host-name",
+	},
+	{
+		name:        "test with external host name - scheme provided",
+		description: "test case when external hostname is provided with https scheme and both ingress and route are disabled",
+		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Server.Host = "https://test-host-name"
+		}},
+		want: "https://test-host-name",
+	},
+	{
+		name:        "test with external http host name",
+		description: "test case when external hostname is provided with http scheme and both ingress and route are disabled",
+		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Server.Host = "http://test-host-name"
+		}},
+		want: "http://test-host-name",
+	},
+}
+
+func TestGetArgoServerURI(t *testing.T) {
+	for _, tt := range argoServerURITests {
+		cr := makeTestArgoCD(tt.opts...)
+		r := &ReconcileArgoCD{}
+		result := r.getArgoServerURI(cr)
+		if result != tt.want {
+			t.Errorf("%s test failed, got=%q want=%q", tt.name, result, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes the issue -> https://github.com/argoproj-labs/argocd-operator/issues/223

Allows user to provide an external hostname as redirect-url to argocd-server without enabling ingress/route. 
When user explicitly sets the field `server.host` with a value and chooses not to enable ingress/route for it, the `url` in `argocd-cm` (argocd config map) should still be populated with the external hostname provided. 