### PR TITLE
do not create ServiceAccount for Dex, if disabled

### DIFF
--- a/pkg/controller/argocd/service_account.go
+++ b/pkg/controller/argocd/service_account.go
@@ -154,9 +154,16 @@ func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoprojv1a1.
 		if !errors.IsNotFound(err) {
 			return nil, err
 		}
+		if name == dexServer && isDexDisabled() {
+			return sa, nil // Dex is disabled, do nothing
+		}
 		exists = false
 	}
 	if exists {
+		if name == dexServer && isDexDisabled() {
+			// Delete any existing Service Account created for Dex
+			return sa, r.client.Delete(context.TODO(), sa)
+		}
 		return sa, nil
 	}
 


### PR DESCRIPTION
Operator should not create Service Account for Dex if it has been disabled by the user.