### PR TITLE
Remove cluster resources on instance deletion

### DIFF
--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	"github.com/argoproj-labs/argocd-operator/pkg/common"
 	routev1 "github.com/openshift/api/route/v1"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
@@ -482,4 +483,14 @@ type SSHHostsSpec struct {
 	// Keys describes a custom set of SSH Known Hosts that you would like to
 	// have included in your ArgoCD server.
 	Keys string `json:"keys,omitempty"`
+}
+
+// IsDeletionFinalizerPresent checks if the instance has deletion finalizer
+func (argocd *ArgoCD) IsDeletionFinalizerPresent() bool {
+	for _, finalizer := range argocd.GetFinalizers() {
+		if finalizer == common.ArgoCDDeletionFinalizer {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -180,4 +180,7 @@ const (
 	// ArgoCDGrafanaImageEnvName is the environment variable used to get the image
 	// to used for the Grafana container.
 	ArgoCDGrafanaImageEnvName = "ARGOCD_GRAFANA_IMAGE"
+
+	// ArgoCDDeletionFinalizer is a finalizer to implement pre-delete hooks
+	ArgoCDDeletionFinalizer = "argoproj.io/finalizer"
 )

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -101,6 +101,9 @@ const (
 	// ArgoCDKeyPartOf is the resource part-of key for labels.
 	ArgoCDKeyPartOf = "app.kubernetes.io/part-of"
 
+	// ArgoCDKeyManagedBy is the managed-by key for labels.
+	ArgoCDKeyManagedBy = "app.kubernetes.io/managed-by"
+
 	// ArgoCDKeyStatefulSetPodName is the resource StatefulSet Pod Name key for labels.
 	ArgoCDKeyStatefulSetPodName = "statefulset.kubernetes.io/pod-name"
 

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -16,6 +16,7 @@ package argocd
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -93,7 +94,7 @@ func (r *ReconcileArgoCD) Reconcile(request reconcile.Request) (reconcile.Result
 	if argocd.GetDeletionTimestamp() != nil {
 		if argocd.IsDeletionFinalizerPresent() {
 			if err := r.deleteClusterResources(argocd); err != nil {
-				return reconcile.Result{}, err
+				return reconcile.Result{}, fmt.Errorf("failed to delete ClusterResources: %w", err)
 			}
 
 			if err := r.removeDeletionFinalizer(argocd); err != nil {

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -109,6 +109,11 @@ func (r *ReconcileArgoCD) Reconcile(request reconcile.Request) (reconcile.Result
 		}
 	}
 
+	// get the latest version of argocd instance before reconciling
+	if err = r.client.Get(context.TODO(), request.NamespacedName, argocd); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if err := r.reconcileResources(argocd); err != nil {
 		// Error reconciling ArgoCD sub-resources - requeue the request.
 		return reconcile.Result{}, err

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -122,12 +122,3 @@ func (r *ReconcileArgoCD) Reconcile(request reconcile.Request) (reconcile.Result
 	// Return and don't requeue
 	return reconcile.Result{}, nil
 }
-
-func containsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/controller/argocd/argocd_controller_test.go
+++ b/pkg/controller/argocd/argocd_controller_test.go
@@ -16,6 +16,7 @@ package argocd
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -129,19 +130,19 @@ func TestReconcileArgoCD_CleanUp(t *testing.T) {
 		resource runtime.Object
 	}{
 		{
-			common.ArgoCDApplicationControllerComponent,
+			fmt.Sprintf("ClusterRole %s", common.ArgoCDApplicationControllerComponent),
 			newClusterRole(common.ArgoCDApplicationControllerComponent, []v1.PolicyRule{}, a),
 		},
 		{
-			common.ArgoCDServerComponent,
+			fmt.Sprintf("ClusterRole %s", common.ArgoCDServerComponent),
 			newClusterRole(common.ArgoCDServerComponent, []v1.PolicyRule{}, a),
 		},
 		{
-			common.ArgoCDApplicationControllerComponent,
+			fmt.Sprintf("ClusterRoleBinding %s", common.ArgoCDApplicationControllerComponent),
 			newClusterRoleBinding(common.ArgoCDApplicationControllerComponent, a),
 		},
 		{
-			common.ArgoCDServerComponent,
+			fmt.Sprintf("ClusterRoleBinding %s", common.ArgoCDServerComponent),
 			newClusterRoleBinding(common.ArgoCDServerComponent, a),
 		},
 	}
@@ -149,18 +150,9 @@ func TestReconcileArgoCD_CleanUp(t *testing.T) {
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
 			if argoutil.IsObjectFound(r.client, "", test.name, test.resource) {
-				t.Errorf("Expected %s cluster resource to be deleted", test.name)
+				t.Errorf("Expected %s to be deleted", test.name)
 			}
 		})
-	}
-
-	// check if argocd instance is deleted
-	argocd := argov1alpha1.ArgoCD{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{
-		Name:      testArgoCDName,
-		Namespace: testNamespace,
-	}, &argocd); err != nil {
-		t.Fatal("Expected argocd instance to be deleted")
 	}
 }
 

--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -115,4 +117,12 @@ func (r *ReconcileArgoCD) reconcileClusterRole(name string, policyRules []v1.Pol
 	clusterRole.Rules = policyRules
 	applyReconcilerHook(cr, clusterRole)
 	return clusterRole, r.client.Update(context.TODO(), clusterRole)
+}
+
+func deleteClusterRole(client client.Client, name string) error {
+	clusterRole := v1.ClusterRole{}
+	if argoutil.IsObjectFound(client, "", name, &clusterRole) {
+		return client.Delete(context.TODO(), &clusterRole)
+	}
+	return nil
 }

--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
-	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,10 +118,11 @@ func (r *ReconcileArgoCD) reconcileClusterRole(name string, policyRules []v1.Pol
 	return clusterRole, r.client.Update(context.TODO(), clusterRole)
 }
 
-func deleteClusterRole(client client.Client, name string) error {
-	clusterRole := v1.ClusterRole{}
-	if argoutil.IsObjectFound(client, "", name, &clusterRole) {
-		return client.Delete(context.TODO(), &clusterRole)
+func deleteClusterRoles(c client.Client, clusterRoleList *v1.ClusterRoleList) error {
+	for _, clusterRole := range clusterRoleList.Items {
+		if err := c.Delete(context.TODO(), &clusterRole); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -121,7 +121,7 @@ func (r *ReconcileArgoCD) reconcileClusterRole(name string, policyRules []v1.Pol
 func deleteClusterRoles(c client.Client, clusterRoleList *v1.ClusterRoleList) error {
 	for _, clusterRole := range clusterRoleList.Items {
 		if err := c.Delete(context.TODO(), &clusterRole); err != nil {
-			return err
+			return fmt.Errorf("failed to delete ClusterRole %q during cleanup: %w", clusterRole.Name, err)
 		}
 	}
 	return nil

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -6,11 +6,13 @@ import (
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/pkg/common"
+	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -205,4 +207,12 @@ func (r *ReconcileArgoCD) reconcileArgoApplier(controlPlaneServiceAccount string
 		return r.client.Create(context.TODO(), roleBinding)
 	}
 	return r.client.Update(context.TODO(), roleBinding)
+}
+
+func deleteClusterRoleBinding(client client.Client, name string) error {
+	clusterRoleBinding := v1.ClusterRoleBinding{}
+	if argoutil.IsObjectFound(client, "", name, &clusterRoleBinding) {
+		return client.Delete(context.TODO(), &clusterRoleBinding)
+	}
+	return nil
 }

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -6,7 +6,6 @@ import (
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/pkg/common"
-	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -209,10 +208,11 @@ func (r *ReconcileArgoCD) reconcileArgoApplier(controlPlaneServiceAccount string
 	return r.client.Update(context.TODO(), roleBinding)
 }
 
-func deleteClusterRoleBinding(client client.Client, name string) error {
-	clusterRoleBinding := v1.ClusterRoleBinding{}
-	if argoutil.IsObjectFound(client, "", name, &clusterRoleBinding) {
-		return client.Delete(context.TODO(), &clusterRoleBinding)
+func deleteClusterRoleBindings(c client.Client, clusterBindingList *v1.ClusterRoleBindingList) error {
+	for _, clusterBinding := range clusterBindingList.Items {
+		if err := c.Delete(context.TODO(), &clusterBinding); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -211,7 +211,7 @@ func (r *ReconcileArgoCD) reconcileArgoApplier(controlPlaneServiceAccount string
 func deleteClusterRoleBindings(c client.Client, clusterBindingList *v1.ClusterRoleBindingList) error {
 	for _, clusterBinding := range clusterBindingList.Items {
 		if err := c.Delete(context.TODO(), &clusterBinding); err != nil {
-			return err
+			return fmt.Errorf("failed to delete ClusterRoleBinding %q during cleanup: %w", clusterBinding.Name, err)
 		}
 	}
 	return nil

--- a/pkg/controller/argocd/service_account.go
+++ b/pkg/controller/argocd/service_account.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // getDexOAuthRedirectURI will return the OAuth redirect URI for the Dex server.
@@ -167,10 +168,14 @@ func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoprojv1a1.
 		return sa, nil
 	}
 
+	if err := controllerutil.SetControllerReference(cr, sa, r.scheme); err != nil {
+		return nil, err
+	}
+
 	err := r.client.Create(context.TODO(), sa)
 	if err != nil {
 		return nil, err
 	}
 
-	return sa, err
+	return sa, nil
 }

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -694,7 +694,7 @@ func argocdInstanceSelector(name string) (labels.Selector, error) {
 	selector := labels.NewSelector()
 	requirement, err := labels.NewRequirement(common.ArgoCDKeyManagedBy, selection.Equals, []string{name})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create a requirement for %w", err)
 	}
 	return selector.Add(*requirement), nil
 }

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -217,27 +217,39 @@ func TestGetArgoServerURI(t *testing.T) {
 }
 
 func TestRemoveDeletionFinalizer(t *testing.T) {
-	a := makeTestArgoCD(addFinalizer(common.ArgoCDDeletionFinalizer))
-	r := makeTestReconciler(t, a)
-
-	err := r.removeDeletionFinalizer(a)
-	assert.NilError(t, err)
-
-	if a.IsDeletionFinalizerPresent() {
-		t.Fatal("Expected deletion finalizer to be removed")
-	}
+	t.Run("ArgoCD resource present", func(t *testing.T) {
+		a := makeTestArgoCD(addFinalizer(common.ArgoCDDeletionFinalizer))
+		r := makeTestReconciler(t, a)
+		err := r.removeDeletionFinalizer(a)
+		assert.NilError(t, err)
+		if a.IsDeletionFinalizerPresent() {
+			t.Fatal("Expected deletion finalizer to be removed")
+		}
+	})
+	t.Run("ArgoCD resource absent", func(t *testing.T) {
+		a := makeTestArgoCD(addFinalizer(common.ArgoCDDeletionFinalizer))
+		r := makeTestReconciler(t)
+		err := r.removeDeletionFinalizer(a)
+		assert.Error(t, err, `failed to remove deletion finalizer from argocd: argocds.argoproj.io "argocd" not found`)
+	})
 }
 
 func TestAddDeletionFinalizer(t *testing.T) {
-	a := makeTestArgoCD()
-	r := makeTestReconciler(t, a)
-
-	err := r.addDeletionFinalizer(a)
-	assert.NilError(t, err)
-
-	if !a.IsDeletionFinalizerPresent() {
-		t.Fatal("Expected deletion finalizer to be added")
-	}
+	t.Run("ArgoCD resource present", func(t *testing.T) {
+		a := makeTestArgoCD()
+		r := makeTestReconciler(t, a)
+		err := r.addDeletionFinalizer(a)
+		assert.NilError(t, err)
+		if !a.IsDeletionFinalizerPresent() {
+			t.Fatal("Expected deletion finalizer to be added")
+		}
+	})
+	t.Run("ArgoCD resource absent", func(t *testing.T) {
+		a := makeTestArgoCD()
+		r := makeTestReconciler(t)
+		err := r.addDeletionFinalizer(a)
+		assert.Error(t, err, `failed to add deletion finalizer for argocd: argocds.argoproj.io "argocd" not found`)
+	})
 }
 
 func TestArgoCDInstanceSelector(t *testing.T) {

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -239,3 +239,18 @@ func TestAddDeletionFinalizer(t *testing.T) {
 		t.Fatal("Expected deletion finalizer to be added")
 	}
 }
+
+func TestArgoCDInstanceSelector(t *testing.T) {
+	t.Run("Selector for a Valid name", func(t *testing.T) {
+		validName := "argocd-server"
+		selector, err := argocdInstanceSelector(validName)
+		assert.NilError(t, err)
+		assert.Equal(t, selector.String(), "app.kubernetes.io/managed-by=argocd-server")
+	})
+	t.Run("Selector for an Invalid name", func(t *testing.T) {
+		invalidName := "argocd-*/"
+		selector, err := argocdInstanceSelector(invalidName)
+		assert.ErrorContains(t, err, `failed to create a requirement for invalid label value: "argocd-*/`)
+		assert.Equal(t, selector, nil)
+	})
+}

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -7,6 +7,7 @@ import (
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/pkg/common"
 	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
+	"gotest.tools/assert"
 )
 
 const (
@@ -212,5 +213,29 @@ func TestGetArgoServerURI(t *testing.T) {
 				t.Errorf("%s test failed, got=%q want=%q", tt.name, result, tt.want)
 			}
 		})
+	}
+}
+
+func TestRemoveDeletionFinalizer(t *testing.T) {
+	a := makeTestArgoCD(addFinalizer(common.ArgoCDDeletionFinalizer))
+	r := makeTestReconciler(t, a)
+
+	err := r.removeDeletionFinalizer(a)
+	assert.NilError(t, err)
+
+	if a.IsDeletionFinalizerPresent() {
+		t.Fatal("Expected deletion finalizer to be removed")
+	}
+}
+
+func TestAddDeletionFinalizer(t *testing.T) {
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+
+	err := r.addDeletionFinalizer(a)
+	assert.NilError(t, err)
+
+	if !a.IsDeletionFinalizerPresent() {
+		t.Fatal("Expected deletion finalizer to be added")
 	}
 }

--- a/pkg/controller/argoutil/resource.go
+++ b/pkg/controller/argoutil/resource.go
@@ -68,8 +68,9 @@ func CreateEvent(client client.Client, action string, message string, reason str
 // DefaultLabels returns the default set of labels for controllers.
 func DefaultLabels(name string) map[string]string {
 	return map[string]string{
-		common.ArgoCDKeyName:   name,
-		common.ArgoCDKeyPartOf: common.ArgoCDAppName,
+		common.ArgoCDKeyName:      name,
+		common.ArgoCDKeyPartOf:    common.ArgoCDAppName,
+		common.ArgoCDKeyManagedBy: name,
 	}
 }
 


### PR DESCRIPTION
Currently, the service accounts and cluster role resources are not cleaned up when the argocd instance is deleted. This PR introduces a finalizer and a pre-delete hook logic to delete the remaining resources. 

How to test:
1. Create a test namespace with the name `argocd-test`.
2. Run the operator locally.
```shell
operator-sdk run local --watch-namespace argocd-test
```
3. Create an instance of argocd in argocd-test. This will create cluster roles and bindings.
4. Delete the instance.
5. Observe the cluster roles, cluster role bindings, and service accounts getting deleted.