### PR TITLE
generate unique name for cluster scoped resources

### DIFF
--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -36,15 +36,15 @@ func generateResourceName(argoComponentName string, cr *argoprojv1a1.ArgoCD) str
 	return cr.Name + "-" + argoComponentName
 }
 
-// generateClusterResourceName generates unique names for cluster scoped resources
-func generateClusterResourceName(argoComponentName string, cr *argoprojv1a1.ArgoCD) string {
+// GenerateUniqueResourceName generates unique names for cluster scoped resources
+func GenerateUniqueResourceName(argoComponentName string, cr *argoprojv1a1.ArgoCD) string {
 	return cr.Name + "-" + cr.Namespace + "-" + argoComponentName
 }
 
 func newClusterRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.ClusterRole {
 	return &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        generateClusterResourceName(name, cr),
+			Name:        GenerateUniqueResourceName(name, cr),
 			Labels:      labelsForCluster(cr),
 			Annotations: annotationsForCluster(cr),
 		},

--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -36,10 +36,15 @@ func generateResourceName(argoComponentName string, cr *argoprojv1a1.ArgoCD) str
 	return cr.Name + "-" + argoComponentName
 }
 
+// generateClusterResourceName generates unique names for cluster scoped resources
+func generateClusterResourceName(argoComponentName string, cr *argoprojv1a1.ArgoCD) string {
+	return cr.Name + "-" + cr.Namespace + "-" + argoComponentName
+}
+
 func newClusterRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.ClusterRole {
 	return &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        generateResourceName(name, cr),
+			Name:        generateClusterResourceName(name, cr),
 			Labels:      labelsForCluster(cr),
 			Annotations: annotationsForCluster(cr),
 		},

--- a/pkg/controller/argocd/role_test.go
+++ b/pkg/controller/argocd/role_test.go
@@ -73,7 +73,7 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	assert.NilError(t, err)
 
 	reconciledClusterRole := &v1.ClusterRole{}
-	clusterRoleName := generateClusterResourceName(workloadIdentifier, a)
+	clusterRoleName := GenerateUniqueResourceName(workloadIdentifier, a)
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 	assert.DeepEqual(t, expectedRules, reconciledClusterRole.Rules)
 

--- a/pkg/controller/argocd/role_test.go
+++ b/pkg/controller/argocd/role_test.go
@@ -73,7 +73,7 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	assert.NilError(t, err)
 
 	reconciledClusterRole := &v1.ClusterRole{}
-	clusterRoleName := generateResourceName(workloadIdentifier, a)
+	clusterRoleName := generateClusterResourceName(workloadIdentifier, a)
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 	assert.DeepEqual(t, expectedRules, reconciledClusterRole.Rules)
 

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -28,7 +28,7 @@ func newClusterRoleBinding(name string, cr *argoprojv1a1.ArgoCD) *v1.ClusterRole
 // newClusterRoleBindingWithname creates a new ClusterRoleBinding with the given name for the given ArgCD.
 func newClusterRoleBindingWithname(name string, cr *argoprojv1a1.ArgoCD) *v1.ClusterRoleBinding {
 	roleBinding := newClusterRoleBinding(name, cr)
-	roleBinding.Name = "cluster-" + generateResourceName(name, cr)
+	roleBinding.Name = generateClusterResourceName(name, cr)
 
 	labels := roleBinding.ObjectMeta.Labels
 	labels[common.ArgoCDKeyName] = name
@@ -160,7 +160,7 @@ func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.Clus
 	roleBinding.RoleRef = v1.RoleRef{
 		APIGroup: v1.GroupName,
 		Kind:     "ClusterRole",
-		Name:     generateResourceName(name, cr),
+		Name:     generateClusterResourceName(name, cr),
 	}
 
 	controllerutil.SetControllerReference(cr, roleBinding, r.scheme)

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -28,7 +28,7 @@ func newClusterRoleBinding(name string, cr *argoprojv1a1.ArgoCD) *v1.ClusterRole
 // newClusterRoleBindingWithname creates a new ClusterRoleBinding with the given name for the given ArgCD.
 func newClusterRoleBindingWithname(name string, cr *argoprojv1a1.ArgoCD) *v1.ClusterRoleBinding {
 	roleBinding := newClusterRoleBinding(name, cr)
-	roleBinding.Name = generateClusterResourceName(name, cr)
+	roleBinding.Name = GenerateUniqueResourceName(name, cr)
 
 	labels := roleBinding.ObjectMeta.Labels
 	labels[common.ArgoCDKeyName] = name
@@ -160,7 +160,7 @@ func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.Clus
 	roleBinding.RoleRef = v1.RoleRef{
 		APIGroup: v1.GroupName,
 		Kind:     "ClusterRole",
-		Name:     generateClusterResourceName(name, cr),
+		Name:     GenerateUniqueResourceName(name, cr),
 	}
 
 	controllerutil.SetControllerReference(cr, roleBinding, r.scheme)

--- a/pkg/controller/argocd/rolebinding_test.go
+++ b/pkg/controller/argocd/rolebinding_test.go
@@ -72,7 +72,7 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding(t *testing.T) {
 	assert.NilError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, expectedServiceAccount, a))
 
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-	expectedName := fmt.Sprintf("cluster-%s-%s", a.Name, workloadIdentifier)
+	expectedName := fmt.Sprintf("%s-%s-%s", a.Name, a.Namespace, workloadIdentifier)
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding))
 
 	// update role reference and subject of the clusterrolebinding

--- a/pkg/controller/argocd/service_account_test.go
+++ b/pkg/controller/argocd/service_account_test.go
@@ -83,11 +83,12 @@ func TestReconcileArgoCD_reconcileServiceAccountClusterPermissions(t *testing.T)
 
 	reconciledServiceAccount := &corev1.ServiceAccount{}
 	reconcileClusterRoleBinding := &v1.ClusterRoleBinding{}
-	expectedClusterRoleBindingName := fmt.Sprintf("cluster-%s-%s", a.Name, workloadIdentifier)
-	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
+	expectedClusterRoleBindingName := fmt.Sprintf("%s-%s-%s", a.Name, a.Namespace, workloadIdentifier)
+	expectedClusterRoleName := fmt.Sprintf("%s-%s-%s", a.Name, a.Namespace, workloadIdentifier)
+	expectedNameSA := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
 
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRoleBindingName}, reconcileClusterRoleBinding))
-	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledServiceAccount))
+	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedNameSA, Namespace: a.Namespace}, reconciledServiceAccount))
 
 	// undesirable changes
 	reconcileClusterRoleBinding.RoleRef.Name = "z"
@@ -104,7 +105,7 @@ func TestReconcileArgoCD_reconcileServiceAccountClusterPermissions(t *testing.T)
 
 	// fetch it
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRoleBindingName}, reconcileClusterRoleBinding))
-	assert.Equal(t, expectedName, reconcileClusterRoleBinding.RoleRef.Name)
+	assert.Equal(t, expectedClusterRoleName, reconcileClusterRoleBinding.RoleRef.Name)
 }
 
 func TestReconcileArgoCD_reconcileServiceAccount_dex_disabled(t *testing.T) {

--- a/pkg/reconciler/openshift/openshift.go
+++ b/pkg/reconciler/openshift/openshift.go
@@ -18,7 +18,7 @@ func init() {
 func reconcilerHook(cr *argoprojv1alpha1.ArgoCD, v interface{}) error {
 	switch o := v.(type) {
 	case *rbacv1.ClusterRole:
-		if o.ObjectMeta.Name == cr.ObjectMeta.Name + cr.ObjectMeta.Namespace + "-argocd-application-controller" {
+		if o.ObjectMeta.Name == argocd.GenerateUniqueResourceName("argocd-application-controller", cr) {
 			if allowedNamespace(cr.ObjectMeta.Namespace, os.Getenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES")) {
 				o.Rules = append(o.Rules, policyRulesForClusterConfig()...)
 			}

--- a/pkg/reconciler/openshift/openshift.go
+++ b/pkg/reconciler/openshift/openshift.go
@@ -18,7 +18,7 @@ func init() {
 func reconcilerHook(cr *argoprojv1alpha1.ArgoCD, v interface{}) error {
 	switch o := v.(type) {
 	case *rbacv1.ClusterRole:
-		if o.ObjectMeta.Name == cr.ObjectMeta.Name+"-argocd-application-controller" {
+		if o.ObjectMeta.Name == cr.ObjectMeta.Name + cr.ObjectMeta.Namespace + "-argocd-application-controller" {
 			if allowedNamespace(cr.ObjectMeta.Namespace, os.Getenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES")) {
 				o.Rules = append(o.Rules, policyRulesForClusterConfig()...)
 			}

--- a/pkg/reconciler/openshift/openshift_test.go
+++ b/pkg/reconciler/openshift/openshift_test.go
@@ -17,7 +17,7 @@ func TestReconcileArgoCD_reconcileApplicableClusterRole(t *testing.T) {
 	a := makeTestArgoCDForClusterConfig()
 	testClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: a.Name + a.Namespace + "-" + testApplicationController,
+			Name: a.Name + "-" + a.Namespace + "-" + testApplicationController,
 		},
 		Rules: makeTestPolicyRules(),
 	}
@@ -47,7 +47,7 @@ func TestReconcileArgoCD_reconcileMultipleClusterRoles(t *testing.T) {
 	a := makeTestArgoCDForClusterConfig()
 	testApplicableClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      a.Name + a.Namespace + "-" + testApplicationController,
+			Name:      a.Name + "-" + a.Namespace + "-" + testApplicationController,
 			Namespace: a.Namespace,
 		},
 		Rules: makeTestPolicyRules(),

--- a/pkg/reconciler/openshift/openshift_test.go
+++ b/pkg/reconciler/openshift/openshift_test.go
@@ -17,7 +17,7 @@ func TestReconcileArgoCD_reconcileApplicableClusterRole(t *testing.T) {
 	a := makeTestArgoCDForClusterConfig()
 	testClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: a.Name + "-" + testApplicationController,
+			Name: a.Name + a.Namespace + "-" + testApplicationController,
 		},
 		Rules: makeTestPolicyRules(),
 	}
@@ -47,7 +47,7 @@ func TestReconcileArgoCD_reconcileMultipleClusterRoles(t *testing.T) {
 	a := makeTestArgoCDForClusterConfig()
 	testApplicableClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      a.Name + "-" + testApplicationController,
+			Name:      a.Name + a.Namespace + "-" + testApplicationController,
 			Namespace: a.Namespace,
 		},
 		Rules: makeTestPolicyRules(),
@@ -82,7 +82,7 @@ func TestReconcileArgoCD_notInClusterConfigNamespaces(t *testing.T) {
 	a := makeTestArgoCD()
 	testClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: a.Name + "-" + testApplicationController,
+			Name: a.Name + a.Namespace + "-" + testApplicationController,
 		},
 		Rules: makeTestPolicyRules(),
 	}


### PR DESCRIPTION
/kind bug

**[Issue]**
Currently the name generated for all resources follows the convention **"instance-name"-"service-name"**, which would work fine for namespace scoped resources.   

The problem occurs in cluster scoped resources.   Each argocd instance needs to reference to its copy of cluster resources.   We need to generate unique name for cluster resources.  Otherwise,  ArgoCD instance A cannot  have its cluster role that is different than ArgoCD instance B for example.

We need to generate unique name for cluster resources for 
@shubhamagarwal19 explained to me that this function is to generate unique name for cluster resources that are used by different argocd instances.   The fact that we need to generate "ClusterResourceName" can still sound strange.  Cluster resource names are re   You are generating a unique name for cluster resource.  IMHO renaming the function to "generateUniqueResourceName" is a better func name.


**[Proposal]**
Append namespace in cluster scoped resources. **"instance-name"-"namespace"-"service-name"**

**[Reproduce-Issue]**

- Using the current operator, create 2 ArgoCD instances in separate namespaces, with the **same instance name**, SAME being very important. 
- You would see that **Cluster Role** and **Role Binding** are only created for the first instance.
- You can confirm this with the **Service Account Mapping in the Cluster Role Binding**. Only the SA for the first instance would be mapped in the Cluster Role Binding. 

**[How-to-test-fix]**

- Again create 2 ArgoCD instances using the latest operator. 
- Make sure the cluster scoped resources (currently just **Cluster Role** and **Role Binding**) are created with the naming convention provided above for both instances respectively. 
- Both **Cluster Role Bindings** should have the mapping for Service Account for each ArgoCD instance. 