### PR TITLE
make dex init container resilient to restarts

### DIFF
--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -453,6 +453,7 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 	deploy.Spec.Template.Spec.InitContainers = []corev1.Container{{
 		Command: []string{
 			"cp",
+			"-n",
 			"/usr/local/bin/argocd-util",
 			"/shared",
 		},

--- a/pkg/controller/argocd/deployment_test.go
+++ b/pkg/controller/argocd/deployment_test.go
@@ -483,6 +483,7 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 				Image: getArgoContainerImage(a),
 				Command: []string{
 					"cp",
+					"-n",
 					"/usr/local/bin/argocd-util",
 					"/shared",
 				},
@@ -562,6 +563,7 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 				Image: "justatest:latest",
 				Command: []string{
 					"cp",
+					"-n",
 					"/usr/local/bin/argocd-util",
 					"/shared",
 				},


### PR DESCRIPTION
Issue: the dec init container is stuck in a crash loop if the binary is aready in use.

Resolution: do not overwrite existing files as implemented in argocd PR https://github.com/argoproj/argo-cd/pull/3136