### PR TITLE
Provide admin access to ArgoCD application-controller for local ns

### DIFF
--- a/pkg/controller/argocd/hooks_test.go
+++ b/pkg/controller/argocd/hooks_test.go
@@ -29,6 +29,14 @@ func testClusterRoleHook(cr *argoprojv1alpha1.ArgoCD, v interface{}) error {
 	return nil
 }
 
+func testRoleBindingHook(cr *argoprojv1alpha1.ArgoCD, v interface{}) error {
+	switch o := v.(type) {
+	case *v1.RoleBinding:
+		o.RoleRef.Name = "test-admin-role"
+	}
+	return nil
+}
+
 func testErrorHook(cr *argoprojv1alpha1.ArgoCD, v interface{}) error {
 	return errMsg
 }

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -124,6 +124,12 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 		Name:     role.Name,
 	}
 
+	if name == applicationController {
+		if err := applyReconcilerHook(cr, roleBinding); err != nil {
+			return err
+		}
+	}
+
 	controllerutil.SetControllerReference(cr, roleBinding, r.scheme)
 	if roleBindingExists {
 		if name == dexServer && isDexDisabled() {

--- a/pkg/controller/argocd/rolebinding_test.go
+++ b/pkg/controller/argocd/rolebinding_test.go
@@ -86,3 +86,17 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding(t *testing.T) {
 	clusterRoleBinding = &rbacv1.ClusterRoleBinding{}
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding))
 }
+
+func TestReconcileArgoCD_reconcileRoleBinding_application_controller(t *testing.T) {
+	// tests reconciler hook for argocd-application-controller role
+	cr := makeTestArgoCD()
+	r := makeTestReconciler(t, cr)
+
+	defer resetHooks()()
+	Register(testRoleBindingHook)
+
+	roleBinding := newRoleBindingWithname(applicationController, cr)
+	assert.NilError(t, r.reconcileRoleBinding(applicationController, policyRuleForApplicationController(), cr))
+	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, roleBinding))
+	assert.DeepEqual(t, roleBinding.RoleRef.Name, "test-admin-role")
+}

--- a/pkg/reconciler/openshift/clusterconfig_test.go
+++ b/pkg/reconciler/openshift/clusterconfig_test.go
@@ -93,3 +93,14 @@ func makeTestDeployment() *appsv1.Deployment {
 		},
 	}
 }
+
+func makeTestRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testArgoCDName,
+			Namespace: testNamespace,
+		},
+		Subjects: []rbacv1.Subject{},
+		RoleRef:  rbacv1.RoleRef{},
+	}
+}

--- a/pkg/reconciler/openshift/openshift.go
+++ b/pkg/reconciler/openshift/openshift.go
@@ -27,6 +27,11 @@ func reconcilerHook(cr *argoprojv1alpha1.ArgoCD, v interface{}) error {
 		if o.ObjectMeta.Name == cr.ObjectMeta.Name+"-redis" {
 			o.Spec.Template.Spec.Containers[0].Args = append(getArgsForRedhatRedis(), o.Spec.Template.Spec.Containers[0].Args...)
 		}
+	case *rbacv1.RoleBinding:
+		if o.ObjectMeta.Name == cr.ObjectMeta.Name+"-argocd-application-controller" {
+			o.RoleRef.Kind = "ClusterRole"
+			o.RoleRef.Name = "admin"
+		}
 	}
 	return nil
 }

--- a/pkg/reconciler/openshift/openshift_test.go
+++ b/pkg/reconciler/openshift/openshift_test.go
@@ -124,3 +124,20 @@ func TestReconcileArgoCD_reconcileRedisDeployment(t *testing.T) {
 	assert.NilError(t, reconcilerHook(a, testDeployment))
 	assert.DeepEqual(t, testDeployment.Spec.Template.Spec.Containers[0].Args, want)
 }
+
+func TestReconcileArgoCD_reconcileRoleBinding_applicationController(t *testing.T) {
+	a := makeTestArgoCD()
+	testRoleBinding := makeTestRoleBinding()
+
+	testRoleBinding.ObjectMeta.Name = a.Name + "-argocd-application-controller"
+	want := "admin"
+
+	assert.NilError(t, reconcilerHook(a, testRoleBinding))
+	assert.DeepEqual(t, testRoleBinding.RoleRef.Name, want)
+
+	testRoleBinding = makeTestRoleBinding()
+	testRoleBinding.ObjectMeta.Name = a.Name + "-" + "not-argocd-application-controller"
+
+	assert.NilError(t, reconcilerHook(a, testRoleBinding))
+	assert.DeepEqual(t, testRoleBinding.RoleRef.Name, "")
+}


### PR DESCRIPTION
This PR adds a hook that provides the `argocd-application-controller` to have `admin` privileges only for the namespace it is installed in and not cluster-wide for Openshift deployments. 

Note: A custom role for `argocd-application-controller` with limited permissions will still be created but for openshift deployments, `Cluster Role - admin` will be used for creating the `RoleBinding`