### PR TITLE
Add permissions to manage machine sets in cluster config scenario

### DIFF
--- a/pkg/reconciler/openshift/openshift.go
+++ b/pkg/reconciler/openshift/openshift.go
@@ -137,6 +137,16 @@ func policyRulesForClusterConfig() []rbacv1.PolicyRule {
 			Verbs: []string{
 				"*",
 			},
+		}, {
+			APIGroups: []string{
+				"machine.openshift.io",
+			},
+			Resources: []string{
+				"*",
+			},
+			Verbs: []string{
+				"*",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Machine Sets are used in cluster configuration scenarios. Currently, the application controller service account doesn't have permissions to manage machine set resources. This PR adds a rule in the cluster config cluster role to manage Machine Sets


How to Test:
1. Install Argo CD operator by creating a catalog source
2. Create an argocd instance in `test` namespace
3. Add `test` namespace to cluster config namespaces list ie set an environment variable `ARGOCD_CLUSTER_CONFIG_NAMESPACES=test` in the Subscription
4. Verify if machine set rule is added in clusterrole `<cr-name>-test-argocd-application-controller`
```yaml
- apiGroups:
  - 'machine.openshift.io'
  resources:
  - '*'
  verbs:
  - '*'
  ```
5. Create a sample application with machine sets
```shell
argocd app create machineset --repo https://github.com/openshift/openshift-gitops-examples.git --path=argocd/machine-sets --dest-server=https://kubernetes.default.svc --dest-namespace=openshift-machine-api
argocd app sync machineset
```
6. Argo CD should successfully sync and create the machine sets

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>