### PR TITLE
Update RBAC for manual installation of the operator

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-operator
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - '*'

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-operator
+subjects:
+- kind: ServiceAccount
+  name: argocd-operator
+  namespace: argocd
+roleRef:
+  kind: ClusterRole
+  name: argocd-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -78,3 +78,9 @@ rules:
   - routes/custom-host
   verbs:
   - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -49,6 +49,8 @@ NOTE: The ClusterRoleBindings defined in `deploy/role_binding.yaml` use the `arg
 kubectl create -f deploy/service_account.yaml
 kubectl create -f deploy/role.yaml
 kubectl create -f deploy/role_binding.yaml
+kubectl create -f deploy/cluster_role.yaml
+kubectl create -f deploy/cluster_role_binding.yaml
 ```
 
 ### CRDs


### PR DESCRIPTION
Update the local RBAC files to provide permissions for the argocd operator service account. This PR will fix the broken manual installation steps

Fixes: #255

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>