### PR TITLE
Upgraded ArgoCD version from 1.7.7 to 1.8.7

### DIFF
--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -49,7 +49,7 @@ const (
 	ArgoCDDefaultArgoImage = "argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:de44fb3401d0959f8990c329793105bbcc93ff31d52cb337c412a4d821e70b3f" //v1.8.6
+	ArgoCDDefaultArgoVersion = "sha256:ce34acd7bac34d5a4fdbf96faf11fa5e01a7f96a27041d4472ca498886000cbf" //v1.8.7
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -49,7 +49,7 @@ const (
 	ArgoCDDefaultArgoImage = "argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:b835999eb5cf75d01a2678cd971095926d9c2566c9ffe746d04b83a6a0a2849f" // v1.7.7
+	ArgoCDDefaultArgoVersion = "sha256:de44fb3401d0959f8990c329793105bbcc93ff31d52cb337c412a4d821e70b3f" //v1.8.6
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/pkg/controller/argocd/statefulset_test.go
+++ b/pkg/controller/argocd/statefulset_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+
 	"gotest.tools/assert"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -21,7 +24,7 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_disabled(t *testing.T) {
 
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	s := newStatefulSetWithSuffix("redis-ha-server", "redis", a)
+	s := newStatefulSetWithSuffix("redis-ha", "redis", a)
 
 	assert.NilError(t, r.reconcileRedisStatefulSet(a))
 	// resource Creation should fail as HA was disabled
@@ -33,7 +36,7 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_enabled(t *testing.T) {
 
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	s := newStatefulSetWithSuffix("redis-ha-server", "redis", a)
+	s := newStatefulSetWithSuffix("redis-ha", "redis", a)
 
 	a.Spec.HA.Enabled = true
 	// test resource is Created when HA is enabled
@@ -51,4 +54,74 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_enabled(t *testing.T) {
 	a.Spec.HA.Enabled = false
 	assert.NilError(t, r.reconcileRedisStatefulSet(a))
 	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s), "not found")
+}
+
+func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+
+	assert.NilError(t, r.reconcileApplicationControllerStatefulSet(a))
+
+	ss := &appsv1.StatefulSet{}
+	assert.NilError(t, r.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      "argocd-application-controller",
+			Namespace: a.Namespace,
+		},
+		ss))
+	command := ss.Spec.Template.Spec.Containers[0].Command
+	want := []string{
+		"argocd-application-controller",
+		"--operation-processors", "10",
+		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
+		"--repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081",
+		"--status-processors", "20"}
+	if diff := cmp.Diff(want, command); diff != "" {
+		t.Fatalf("reconciliation failed:\n%s", diff)
+	}
+}
+
+func TestReconcileArgoCD_reconcileApplicationController_withUpdate(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+
+	assert.NilError(t, r.reconcileApplicationControllerStatefulSet(a))
+
+	a = makeTestArgoCD(controllerProcessors(30))
+	assert.NilError(t, r.reconcileApplicationControllerStatefulSet(a))
+
+	ss := &appsv1.StatefulSet{}
+	assert.NilError(t, r.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      "argocd-application-controller",
+			Namespace: a.Namespace,
+		},
+		ss))
+	command := ss.Spec.Template.Spec.Containers[0].Command
+	want := []string{
+		"argocd-application-controller",
+		"--operation-processors", "10",
+		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
+		"--repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081",
+		"--status-processors", "30"}
+	if diff := cmp.Diff(want, command); diff != "" {
+		t.Fatalf("reconciliation failed:\n%s", diff)
+	}
+}
+
+func TestReconcileArgoCD_reconcileApplicationController_withUpgrade(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+
+	deploy := newDeploymentWithSuffix("application-controller", "application-controller", a)
+	assert.NilError(t, r.client.Create(context.TODO(), deploy))
+
+	assert.NilError(t, r.reconcileApplicationControllerStatefulSet(a))
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, deploy)
+	assert.ErrorContains(t, err, "not found")
 }

--- a/pkg/controller/argocd/status.go
+++ b/pkg/controller/argocd/status.go
@@ -53,12 +53,12 @@ func (r *ReconcileArgoCD) reconcileStatus(cr *argoprojv1a1.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileStatusApplicationController(cr *argoprojv1a1.ArgoCD) error {
 	status := "Unknown"
 
-	deploy := newDeploymentWithSuffix("application-controller", "application-controller", cr)
-	if argoutil.IsObjectFound(r.client, cr.Namespace, deploy.Name, deploy) {
+	ss := newStatefulSetWithSuffix("application-controller", "application-controller", cr)
+	if argoutil.IsObjectFound(r.client, cr.Namespace, ss.Name, ss) {
 		status = "Pending"
 
-		if deploy.Spec.Replicas != nil {
-			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
+		if ss.Spec.Replicas != nil {
+			if ss.Status.ReadyReplicas == *ss.Spec.Replicas {
 				status = "Running"
 			}
 		}

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -86,6 +87,21 @@ func getArgoApplicationControllerResources(cr *argoprojv1a1.ArgoCD) corev1.Resou
 	}
 
 	return resources
+}
+
+// getArgoApplicationControllerCommand will return the command for the ArgoCD Application Controller component.
+func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD) []string {
+	cmd := []string{
+		"argocd-application-controller",
+		"--operation-processors", fmt.Sprint(getArgoServerOperationProcessors(cr)),
+		"--redis", getRedisServerAddress(cr),
+		"--repo-server", getRepoServerAddress(cr),
+		"--status-processors", fmt.Sprint(getArgoServerStatusProcessors(cr)),
+	}
+	if cr.Spec.Controller.AppSync != nil {
+		cmd = append(cmd, "--app-resync", strconv.FormatInt(int64(cr.Spec.Controller.AppSync.Seconds()), 10))
+	}
+	return cmd
 }
 
 // getArgoContainerImage will return the container image for ArgoCD.


### PR DESCRIPTION
- Updates the Default ArgoCD version from 1.7.7 -> 1.8.7
- This would now deploy ArgoCD Application Controller as a `StatefulSet` rather than a `Deployment`.
- Cleans up the existing `argocd-application-controller` Deployment before creating the new one as a `StatefulSet`

[Test-Fresh-Installation]
- To test Fresh Installation, Deploy the latest Operator.
- Create an ArgoCD instance.
- Make sure, `application-controller` is deployed as a `StatefulSet` and not as a `Deployment`
- Also, verify the ArgoCD server version, it should be `v1.8.7`

[Test-Upgrade-Scenario]
- To test Upgrade scenario, Upgrade to latest Operator,
- Make sure the existing `application-controller DEPLOYMENT` is removed and is now deployed as a `StatefulSet` with version `v1.8.7` 