### PR TITLE
support compliance.openshift.io apiGroup for cluster config

### DIFF
--- a/pkg/reconciler/openshift/openshift.go
+++ b/pkg/reconciler/openshift/openshift.go
@@ -147,6 +147,16 @@ func policyRulesForClusterConfig() []rbacv1.PolicyRule {
 			Verbs: []string{
 				"*",
 			},
+		}, {
+			APIGroups: []string{
+				"compliance.openshift.io",
+			},
+			Resources: []string{
+				"*",
+			},
+			Verbs: []string{
+				"*",
+			},
 		},
 	}
 }

--- a/pkg/reconciler/openshift/openshift.go
+++ b/pkg/reconciler/openshift/openshift.go
@@ -152,7 +152,23 @@ func policyRulesForClusterConfig() []rbacv1.PolicyRule {
 				"compliance.openshift.io",
 			},
 			Resources: []string{
-				"*",
+				"scansettings",
+				"compliancesuites",
+				"compliancescans",
+				"compliancecheckresults",
+				"complianceremediations",
+			},
+			Verbs: []string{
+				"get",
+				"watch",
+				"list",
+			},
+		},  {
+			APIGroups: []string{
+				"compliance.openshift.io",
+			},
+			Resources: []string{
+				"scansettingbindings",
 			},
 			Verbs: []string{
 				"*",


### PR DESCRIPTION
Currently, the cluster role associated with the application controller service account doesn't have permissions to manage `compliance.openshift.io` apiGroup. 
This PR appends a rule in the ClusterConfig cluster role for the application controller to manage `compliance.openshift.io`.

[How-To-Test]

- Deploy the latest ArgoCD operator
- Create an ArgoCD instance in `argocd` namespace
- Add `argocd` namespace to cluster config namespaces list ie set an environment variable `ARGOCD_CLUSTER_CONFIG_NAMESPACES=argocd` in the Subscription
- Verify if rule for `compliance.openshift.io` is added to the clusterrole `<cr-name>-<namespace>-argocd-application-controller`
```
  - verbs:
      - get
      - watch
      - list
    apiGroups:
      - compliance.openshift.io
    resources:
      - scansettings
      - compliancesuites
      - compliancescans
      - compliancecheckresults
      - complianceremediations
  - verbs:
      - '*'
    apiGroups:
      - compliance.openshift.io
    resources:
      - scansettingbindings
```