### PR TITLE
fix: add repository credentials from CR to the existing argocd config…

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -486,7 +486,7 @@ spec:
 
 Git repository credential templates to configure Argo CD to use upon creation of the cluster.
 
-This property maps directly to the `repository.credentials` field in the `argocd-cm` ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Modifications to the `repository.credentials` field should then be made to the `argocd-cm` ConfigMap directly or by using the Argo CD web UI or CLI. See the [Argo CD Documentation](https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#repository-credentials) for the specifics on setting repository credentials.
+This property maps directly to the `repository.credentials` field in the `argocd-cm` ConfigMap.
 
 ### Repository Credentials Example
 

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -460,6 +460,11 @@ func (r *ReconcileArgoCD) reconcileExistingArgoConfigMap(cm *corev1.ConfigMap, c
 		changed = true
 	}
 
+	if cm.Data[common.ArgoCDKeyRepositoryCredentials] != cr.Spec.RepositoryCredentials {
+		cm.Data[common.ArgoCDKeyRepositoryCredentials] = cr.Spec.RepositoryCredentials
+		changed = true
+	}
+
 	if changed {
 		return r.client.Update(context.TODO(), cm) // TODO: Reload Argo CD server after ConfigMap change (which properties)?
 	}


### PR DESCRIPTION
Updating the `RepositoryCredentials` field should update the existing `argocd-cm` config map by adding the repository's credentials. This would eliminate the need for updating the config map manually.

How to Test:
1. Install the operator by creating a new catalog source
2. Create an Argo CD CR
3. Configure the Argo CD CR with your private repo info
```yaml
repositoryCredentials: |
    url: https://github.com/<org>/<private-repo>    // add your private repo URL
    usernameSecret:
        name: my-secret
        key: username
    passwordSecret:
        name: my-secret
        key: password
``` 
4. Check if the argocd-cm config map is updated with the above config
5. Check if Argo CD is able to deploy resources from private repo
Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>