### PR TITLE
Upgrade argo-cd from v1.8.7 to v2.0-rc1

### DIFF
--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -49,7 +49,7 @@ const (
 	ArgoCDDefaultArgoImage = "argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:ce34acd7bac34d5a4fdbf96faf11fa5e01a7f96a27041d4472ca498886000cbf" //v1.8.7
+	ArgoCDDefaultArgoVersion = "sha256:abc1499ba68ccf8abfdc7fd01a9baae5b4e6084acee11c7efc7baee0f0d7333c" //v2.0.0-rc1
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -315,7 +315,7 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 	deploy := newDeploymentWithSuffix("dex-server", "dex-server", cr)
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{{
 		Command: []string{
-			"/shared/argocd-util",
+			"/shared/argocd-dex",
 			"rundex",
 		},
 		Image:           getDexContainerImage(cr),
@@ -342,8 +342,8 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 		Command: []string{
 			"cp",
 			"-n",
-			"/usr/local/bin/argocd-util",
-			"/shared",
+			"/usr/local/bin/argocd",
+			"/shared/argocd-dex",
 		},
 		Env:             proxyEnvVars(),
 		Image:           getArgoContainerImage(cr),

--- a/pkg/controller/argocd/deployment_test.go
+++ b/pkg/controller/argocd/deployment_test.go
@@ -345,8 +345,8 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 				Command: []string{
 					"cp",
 					"-n",
-					"/usr/local/bin/argocd-util",
-					"/shared",
+					"/usr/local/bin/argocd",
+					"/shared/argocd-dex",
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -362,7 +362,7 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 				Name:  "dex",
 				Image: getDexContainerImage(a),
 				Command: []string{
-					"/shared/argocd-util",
+					"/shared/argocd-dex",
 					"rundex",
 				},
 				Ports: []corev1.ContainerPort{
@@ -425,8 +425,8 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 				Command: []string{
 					"cp",
 					"-n",
-					"/usr/local/bin/argocd-util",
-					"/shared",
+					"/usr/local/bin/argocd",
+					"/shared/argocd-dex",
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -442,7 +442,7 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 				Name:  "dex",
 				Image: "testdex:v0.0.1",
 				Command: []string{
-					"/shared/argocd-util",
+					"/shared/argocd-dex",
 					"rundex",
 				},
 				Ports: []corev1.ContainerPort{


### PR DESCRIPTION
Upgrade argo-cd from v1.8.7 to v2.0-rc1. Incorporated the below change.

```
The dex commands rundex and gendexcfg have been migrated from argocd-util to argocd-dex. It means that you need to update argocd-dex-server deployment's commands to install argocd-dex binary instead of argocd-util in init container and run dex command from argocd-dex instead of argocd-util
```

Follow up PR'S::
----------------
Consider all the new features introduced in argo-cd v2.0 and identify what needs to be incorporated into argocd-operator

How to Test:
----------------
> Create argocd-cr
> Check if the dex-server pod is created with below changes.
https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/upgrading/1.8-2.0.md#dex-tool-migrated-from-argocd-util-to-argocd-dex
> Validate Dex 
https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#dex
