### PR TITLE
Add permissions to manage machineconfig resource

### DIFF
--- a/pkg/reconciler/openshift/openshift.go
+++ b/pkg/reconciler/openshift/openshift.go
@@ -233,6 +233,16 @@ func policyRulesForClusterConfig() []rbacv1.PolicyRule {
 			},
 		}, {
 			APIGroups: []string{
+				"machineconfig.openshift.io",
+			},
+			Resources: []string{
+				"*",
+			},
+			Verbs: []string{
+				"*",
+			},
+		}, {
+			APIGroups: []string{
 				"compliance.openshift.io",
 			},
 			Resources: []string{
@@ -247,7 +257,7 @@ func policyRulesForClusterConfig() []rbacv1.PolicyRule {
 				"watch",
 				"list",
 			},
-		},  {
+		}, {
 			APIGroups: []string{
 				"compliance.openshift.io",
 			},


### PR DESCRIPTION
**machineconfig** is used in post installation machine configuration tasks. Currently, the application controller service account doesn't have permissions to manage **machineconfig** resources. This PR adds a rule in the cluster config cluster role to manage **machineconfig**

More details about machine configuration resource:
https://docs.openshift.com/container-platform/4.7/post_installation_configuration/machine-configuration-tasks.html

How to Test:
Install Argo CD operator by creating a catalog source
Create an argocd instance in test namespace
Add test namespace to cluster config namespaces list ie set an environment variable ARGOCD_CLUSTER_CONFIG_NAMESPACES=test in the Subscription
Verify if machineconfig rule is added in clusterrole <cr-name>-test-argocd-application-controller
```
- apiGroups:
  - 'machineconfig.openshift.io'
  resources:
  - '*'
  verbs:
  - '*'
 ```
Create a sample application with machineconfig
argocd app create machineconfig--repo https://github.com/dewan-ahmed/argocd-machineconfig-example --path=example --dest-server=https://kubernetes.default.svc --dest-namespace=openshift-machine-api
argocd app sync machineconfig
Argo CD should successfully sync and create the **machineconfig**