### PR TITLE
feat: Handle resource requirements for Application set and Redis HA Proxy Containers

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -42,6 +42,33 @@ spec:
                 image:
                   description: Image is the Argo CD ApplicationSet image (optional)
                   type: string
+                resources:
+                  description: Resources defines the Compute Resources required by
+                    the container for ApplicationSet.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
                 version:
                   description: Version is the Argo CD ApplicationSet image tag. (optional)
                   type: string
@@ -334,6 +361,33 @@ spec:
                   description: RedisProxyVersion is the Redis HAProxy container image
                     tag.
                   type: string
+                resources:
+                  description: Resources defines the Compute Resources required by
+                    the container for HA.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
               required:
               - enabled
               type: object

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -78,6 +78,9 @@ type ArgoCDApplicationSet struct {
 
 	// Version is the Argo CD ApplicationSet image tag. (optional)
 	Version string `json:"version,omitempty"`
+
+	// Resources defines the Compute Resources required by the container for ApplicationSet.
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // ArgoCDCASpec defines the CA options for ArgCD.
@@ -156,6 +159,9 @@ type ArgoCDHASpec struct {
 
 	// RedisProxyVersion is the Redis HAProxy container image tag.
 	RedisProxyVersion string `json:"redisProxyVersion,omitempty"`
+
+	// Resources defines the Compute Resources required by the container for HA.
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // ArgoCDImportSpec defines the desired state for the ArgoCD import/restore process.

--- a/pkg/controller/argocd/applicationset.go
+++ b/pkg/controller/argocd/applicationset.go
@@ -81,6 +81,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoprojv1a1.Arg
 		Image:           getApplicationSetContainerImage(cr),
 		ImagePullPolicy: corev1.PullAlways,
 		Name:            "argocd-applicationset-controller",
+		Resources:       getApplicationSetResources(cr),
 	}}
 
 	if existing := newDeploymentWithSuffix("applicationset-controller", "controller", cr); argoutil.IsObjectFound(r.client, cr.Namespace, existing.Name, existing) {
@@ -298,6 +299,18 @@ func getApplicationSetContainerImage(cr *argoprojv1a1.ArgoCD) string {
 		return e
 	}
 	return argoutil.CombineImageTag(img, tag)
+}
+
+// getApplicationSetResources will return the ResourceRequirements for the Application Sets container.
+func getApplicationSetResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{}
+
+	// Allow override of resource requirements from CR
+	if cr.Spec.ApplicationSet.Resources != nil {
+		resources = *cr.Spec.ApplicationSet.Resources
+	}
+
+	return resources
 }
 
 func setAppSetLabels(obj *metav1.ObjectMeta) {

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -671,6 +671,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoprojv1a1.ArgoC
 				Name:          "redis",
 			},
 		},
+		Resources: getRedisHAProxyResources(cr),
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "data",

--- a/pkg/controller/argocd/testing.go
+++ b/pkg/controller/argocd/testing.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
+	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -56,6 +57,27 @@ func makeTestArgoCD(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testArgoCDName,
 			Namespace: testNamespace,
+		},
+	}
+	for _, o := range opts {
+		o(a)
+	}
+	return a
+}
+
+func makeTestArgoCDWithResources(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
+	a := &argoprojv1alpha1.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testArgoCDName,
+			Namespace: testNamespace,
+		},
+		Spec: argoprojv1alpha1.ArgoCDSpec{
+			ApplicationSet: &argoprojv1alpha1.ArgoCDApplicationSet{
+				Resources: makeTestApplicationSetResources(),
+			},
+			HA: argoprojv1alpha1.ArgoCDHASpec{
+				Resources: makeTestHAResources(),
+			},
 		},
 	}
 	for _, o := range opts {
@@ -147,4 +169,30 @@ func stringMapKeys(m map[string]string) []string {
 	}
 	sort.Strings(r)
 	return r
+}
+
+func makeTestApplicationSetResources() *corev1.ResourceRequirements {
+	return &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("1024Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("1000m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("2048Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("2000m"),
+		},
+	}
+}
+
+func makeTestHAResources() *corev1.ResourceRequirements {
+	return &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("250m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("256Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("500m"),
+		},
+	}
 }

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -517,6 +517,18 @@ func getRedisResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
 	return resources
 }
 
+// getRedisHAProxyResources will return the ResourceRequirements for the Redis HA Proxy.
+func getRedisHAProxyResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{}
+
+	// Allow override of resource requirements from CR
+	if cr.Spec.HA.Resources != nil {
+		resources = *cr.Spec.HA.Resources
+	}
+
+	return resources
+}
+
 // getRedisSentinelConf will load the redis sentinel configuration from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
 func getRedisSentinelConf(cr *argoprojv1a1.ArgoCD) string {


### PR DESCRIPTION
Problem: Cannot deploy Application set and Redis HA Proxy pods in namespace where resource quota is associated. It is mandatory to assign resource requests and limits for containers in such namespaces.

```
(combined from similar events): Error creating: pods "example-argocd-applicationset-controller-5984478995-g98wr" is forbidden: failed quota: mem-cpu-demo: must specify limits.cpu,limits.memory,requests.cpu,requests.memory
```

```
(combined from similar events): Error creating: pods "example-argocd-redis-ha-haproxy-6fd9d65fd4-wtjbb" is forbidden: failed quota: mem-cpu-demo: must specify limits.cpu,limits.memory,requests.cpu,requests.memory
```

Solution: Provide an option(place holder) in the ArgoCD CR where user can define the resource requirements.

How to Test:
Create a namespace with resource quota
Create Argo CD CR
Make sure Application Set and Redis HA Proxy Pods are running.