### PR TITLE
Release Argo CD Operator v0.0.15

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: argocd-operator
       containers:
         - name: argocd-operator
-          image: quay.io/redhat-cop/argocd-operator@sha256:d661aba8a5bc7c8a69cd7d5da8193585118b93f3e7ef14a213e1fa9c2684b47c
+          image: quay.io/redhat-cop/argocd-operator@sha256:450367603cd2f3909077f854ce3b659d4c1c22490aebc11c317f97269daeae50
           command:
           - argocd-operator
           imagePullPolicy: Always

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -104,7 +104,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/jmckind/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:f987796f3b4be500516689b24988f5c27f8d4f6e537b5c5d862090451de90794" // v0.0.14
+	ArgoCDDefaultExportJobVersion = "sha256:dd0b52626828629ebf614ec86ed7914119e7f1efcfebcb5da52502582e0797a1" // v0.0.15
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"


### PR DESCRIPTION
This release includes the following enhancements, bug fixes and documentation updates.

Enhancements

* #184 - Add Property to Disable Admin User
* #194 - Add support for proxies in the repo-server deployment
* #280 - Add support for Argo CD 2.0.

Bug Fixes

* #186 - Pods stuck in crashloop after update to 0.0.14
* #187 - Fix issue with replacing the resource configuration
* #191 - Missing gpg configmap after update argocd-operator 0.0.13 to 0.0.14

Documentation

* #189 - Add documentation for the resourceInclusions property
* #190 - Fixed port-forward command
* #195 - Fixed wrong `TLS` key example for server route
