### PR TITLE
Set up PULL_REQUEST and ISSUE_TEMPLATES

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,19 @@
+---
+name: Task 🔧
+about: Internal things, technical debt, and to-do tasks to be performed.
+title: ''
+labels: 'kind/task'
+assignees: ''
+
+---
+### Is your task related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is.-->
+
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
+
+### Describe alternatives you've considered
+<!--A clear and concise description of any alternative solutions or features you've considered. -->
+
+### Additional context
+<!-- Add any other context or screenshots about the task here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+**What type of PR is this?**
+> Uncomment only one ` /kind` line, and delete the rest.
+> For example, `> /kind bug` would simply become: `/kind bug`
+
+> /kind bug
+> /kind cleanup
+> /kind failing-test
+> /kind enhancement
+> /kind documentation
+> /kind code-refactoring
+
+
+**What does this PR do / why we need it**:
+
+**Have you updated the necessary documentation?**
+
+* [ ] Documentation update is required by this PR.
+* [ ] Documentation has been updated.
+
+**Which issue(s) this PR fixes**:
+
+Fixes #?
+
+**How to test changes / Special notes to the reviewer**:


### PR DESCRIPTION
Once merged, any new PR's or Issues created by contributors  will automatically see the template's contents in the pull request body.

Reference:
[Issues and PR templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates)
