### PR TITLE
Updated Dex version to v2.28.0

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -189,9 +189,7 @@ metadata:
     example: openshift-oauth
 spec:
   dex:
-    image: quay.io/redhat-cop/dex
     openShiftOAuth: true
-    version: v2.22.0-openshift
   rbac:
     defaultPolicy: 'role:readonly'
     policy: |

--- a/examples/argocd-oauth.yaml
+++ b/examples/argocd-oauth.yaml
@@ -6,8 +6,6 @@ metadata:
     example: oauth
 spec:
   dex:
-    image: quay.io/redhat-cop/dex 
-    version: v2.22.0-openshift
     openShiftOAuth: true
   rbac:
     defaultPolicy: 'role:readonly'

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -98,7 +98,7 @@ const (
 	ArgoCDDefaultDexServiceAccountName = "argocd-dex-server"
 
 	// ArgoCDDefaultDexVersion is the Dex container image tag to use when not specified.
-	ArgoCDDefaultDexVersion = "sha256:01e996b4b60edcc5cc042227c6965dd63ba68764c25d86b481b0d65f6e4da308" // v2.22.0
+	ArgoCDDefaultDexVersion = "sha256:77bfea96e8d8f3e4197b9f6020c8f5dedbb701245c19afd69a15747ae4bf2804" // v2.28.0
 
 	// ArgoCDDefaultExportJobImage is the export job container image to use when not specified.
 	ArgoCDDefaultExportJobImage = "quay.io/jmckind/argocd-operator-util"


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

Updates dex to `v2.28.0`

`v2.22.0` contains a bug in how OpenShift auth is processed and will result in an empty username in ArgoCD. This has been resolved in subsequent versions of ArgoCD

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.
