### PR TITLE
feat: Reconcile argocd-repo-server-tls volume mounts

### DIFF
--- a/pkg/common/values.go
+++ b/pkg/common/values.go
@@ -73,4 +73,7 @@ const (
 
 	// ArgoCDTLSCertsConfigMapName is the upstream hard-coded TLS certificate data ConfigMap name.
 	ArgoCDTLSCertsConfigMapName = "argocd-tls-certs-cm"
+
+	// ArgoCDRepoServerTLSSecretName is the name of the TLS secret for the repo-server
+	ArgoCDRepoServerTLSSecretName = "argocd-repo-server-tls"
 )

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -810,6 +810,10 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 				Name:      "gpg-keyring",
 				MountPath: "/app/config/gpg/keys",
 			},
+			{
+				Name:      "argocd-repo-server-tls",
+				MountPath: "/app/config/reposerver/tls",
+			},
 		},
 	}}
 
@@ -848,6 +852,15 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 			Name: "gpg-keyring",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: "argocd-repo-server-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.ArgoCDRepoServerTLSSecretName,
+					Optional:   boolPtr(true),
+				},
 			},
 		},
 	}
@@ -934,6 +947,10 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoprojv1a1.ArgoCD) err
 				Name:      "tls-certs",
 				MountPath: "/app/config/tls",
 			},
+			{
+				Name:      "argocd-repo-server-tls",
+				MountPath: "/app/config/server/tls",
+			},
 		},
 	}}
 	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, "argocd-server")
@@ -954,6 +971,14 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoprojv1a1.ArgoCD) err
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: common.ArgoCDTLSCertsConfigMapName,
 					},
+				},
+			},
+		}, {
+			Name: "argocd-repo-server-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.ArgoCDRepoServerTLSSecretName,
+					Optional:   boolPtr(true),
 				},
 			},
 		},

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -1004,6 +1004,15 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoprojv1a1.ArgoCD) err
 			existing.Spec.Template.Spec.Containers[0].Command = deploy.Spec.Template.Spec.Containers[0].Command
 			changed = true
 		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Volumes, existing.Spec.Template.Spec.Volumes) {
+			existing.Spec.Template.Spec.Volumes = deploy.Spec.Template.Spec.Volumes
+			changed = true
+		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].VolumeMounts,
+			existing.Spec.Template.Spec.Containers[0].VolumeMounts) {
+			existing.Spec.Template.Spec.Containers[0].VolumeMounts = deploy.Spec.Template.Spec.Containers[0].VolumeMounts
+			changed = true
+		}
 		if changed {
 			return r.client.Update(context.TODO(), existing)
 		}

--- a/pkg/controller/argocd/statefulset.go
+++ b/pkg/controller/argocd/statefulset.go
@@ -338,8 +338,25 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 			PeriodSeconds:       10,
 		},
 		Resources: getArgoApplicationControllerResources(cr),
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "argocd-repo-server-tls",
+				MountPath: "/app/config/controller/tls",
+			},
+		},
 	}}
 	podSpec.ServiceAccountName = nameWithSuffix("argocd-application-controller", cr)
+	podSpec.Volumes = []corev1.Volume{
+		{
+			Name: "argocd-repo-server-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.ArgoCDRepoServerTLSSecretName,
+					Optional:   boolPtr(true),
+				},
+			},
+		},
+	}
 
 	ss.Spec.Template.Spec.Affinity = &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{

--- a/pkg/controller/argocd/statefulset.go
+++ b/pkg/controller/argocd/statefulset.go
@@ -423,6 +423,15 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 			existing.Spec.Template.Spec.Containers[0].Env = ss.Spec.Template.Spec.Containers[0].Env
 			changed = true
 		}
+		if !reflect.DeepEqual(ss.Spec.Template.Spec.Volumes, existing.Spec.Template.Spec.Volumes) {
+			existing.Spec.Template.Spec.Volumes = ss.Spec.Template.Spec.Volumes
+			changed = true
+		}
+		if !reflect.DeepEqual(ss.Spec.Template.Spec.Containers[0].VolumeMounts,
+			existing.Spec.Template.Spec.Containers[0].VolumeMounts) {
+			existing.Spec.Template.Spec.Containers[0].VolumeMounts = ss.Spec.Template.Spec.Containers[0].VolumeMounts
+			changed = true
+		}
 
 		if changed {
 			return r.client.Update(context.TODO(), existing)

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -889,3 +889,8 @@ func withClusterLabels(cr *argoprojv1a1.ArgoCD, addLabels map[string]string) map
 	}
 	return labels
 }
+
+// boolPtr returns a pointer to val
+func boolPtr(val bool) *bool {
+	return &val
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

Argo CD v2.0 introduced a Secret mount for a TLS secret named `argocd-repo-server-tls`. This secret can be used to specify the TLS certificate used by the repo server's gRPC endpoint. It must be made available to the workloads of the server, application controller and the repo server itself.

This PR adds reconciliation logic for adding the required volume mounts.

The next step will be to provide configuration to request this TLS from OpenShift service CA.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #288

**How to test changes / Special notes to the reviewer**:

* Reconcile any `ArgoCD` CR
* Inspect the `<instance>-repo-server` deployment and look for the `argocd-repo-server-tls` Volume and VolumeMount, e.g. given your instance is named `argocd`:
  ```
  $ kubectl describe deployment argocd-repo-server
  ...
  Pod Template:
    Containers:
      argocd-repo-server:
    Mounts:
      /app/config/reposerver/tls from argocd-repo-server-tls (rw)
  Volumes:
   argocd-repo-server-tls:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  argocd-repo-server-tls
    Optional:    true
  ```
* Same for `<instance>-server` and `<instance>-application-controller`, but with different mount paths:
  * server: `/app/config/server/tls`
  * application-controller: `/app/config/controller/tls`