### PR TITLE
[WIP] Support an option to enable OIDC using keycloak in Argo CD CR

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -432,6 +432,12 @@ spec:
                     you would like to have included in your ArgoCD server.
                   type: string
               type: object
+            keycloak:
+              description: Keycloak enables/disables OIDC for Argo CD using keycloak
+              properties:
+                enabled:
+                  type: boolean
+              type: object
             kustomizeBuildOptions:
               description: KustomizeBuildOptions is used to specify build options/parameters
                 to use with `kustomize build`.

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -385,6 +385,9 @@ type ArgoCDSpec struct {
 	// InitialSSHKnownHosts defines the SSH known hosts data upon creation of the cluster for connecting Git repositories via SSH.
 	InitialSSHKnownHosts SSHHostsSpec `json:"initialSSHKnownHosts,omitempty"`
 
+	// Keycloak enables/disables OIDC for Argo CD using keycloak
+	Keycloak KeycloakSpec `json:"keycloak,omitempty"`
+
 	// KustomizeBuildOptions is used to specify build options/parameters to use with `kustomize build`.
 	KustomizeBuildOptions string `json:"kustomizeBuildOptions,omitempty"`
 
@@ -502,6 +505,11 @@ type SSHHostsSpec struct {
 	// Keys describes a custom set of SSH Known Hosts that you would like to
 	// have included in your ArgoCD server.
 	Keys string `json:"keys,omitempty"`
+}
+
+// KeycloakSpec defines OIDC configuration for Argo CD using keycloak.
+type KeycloakSpec struct {
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // IsDeletionFinalizerPresent checks if the instance has deletion finalizer


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
This PR provides an option for the user to enable OIDC for Argo CD using keycloak

**Have you updated the necessary documentation?**
NA for now.

**How to test changes / Special notes to the reviewer**:
Once the PR is merged, You should be able to add keycloak section in the ArgoCD spec. 
