### PR TITLE
chore: Update CRDs to apiextensions.k8s.io/v1

### DIFF
--- a/deploy/crds/argoproj.io_argocdexports_crd.yaml
+++ b/deploy/crds/argoproj.io_argocdexports_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: argocdexports.argoproj.io
@@ -10,202 +10,203 @@ spec:
     plural: argocdexports
     singular: argocdexport
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ArgoCDExport is the Schema for the argocdexports API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ArgoCDExportSpec defines the desired state of ArgoCDExport
-          properties:
-            argocd:
-              description: Argocd is the name of the ArgoCD instance to export.
-              type: string
-            image:
-              description: Image is the container image to use for the export Job.
-              type: string
-            schedule:
-              description: Schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-              type: string
-            storage:
-              description: Storage defines the storage configuration options.
-              properties:
-                backend:
-                  description: Backend defines the storage backend to use, must be
-                    "local" (the default), "aws", "azure" or "gcp".
-                  type: string
-                pvc:
-                  description: PVC is the desired characteristics for a PersistentVolumeClaim.
-                  properties:
-                    accessModes:
-                      description: 'AccessModes contains the desired access modes
-                        the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                      items:
-                        type: string
-                      type: array
-                    dataSource:
-                      description: 'This field can be used to specify either: * An
-                        existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                        - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
-                        custom resource/object that implements data population (Alpha)
-                        In order to use VolumeSnapshot object types, the appropriate
-                        feature gate must be enabled (VolumeSnapshotDataSource or
-                        AnyVolumeDataSource) If the provisioner or an external controller
-                        can support the specified data source, it will create a new
-                        volume based on the contents of the specified data source.
-                        If the specified data source is not supported, the volume
-                        will not be created and the failure will be reported as an
-                        event. In the future, we plan to support more data source
-                        types and the behavior of the provisioner may change.'
-                      properties:
-                        apiGroup:
-                          description: APIGroup is the group for the resource being
-                            referenced. If APIGroup is not specified, the specified
-                            Kind must be in the core API group. For any other third-party
-                            types, APIGroup is required.
-                          type: string
-                        kind:
-                          description: Kind is the type of resource being referenced
-                          type: string
-                        name:
-                          description: Name is the name of resource being referenced
-                          type: string
-                      required:
-                      - kind
-                      - name
-                      type: object
-                    resources:
-                      description: 'Resources represents the minimum resources the
-                        volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    selector:
-                      description: A label query over volumes to consider for binding.
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
-                          items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: key is the label key that the selector
-                                  applies to.
-                                type: string
-                              operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - key
-                            - operator
-                            type: object
-                          type: array
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                    storageClassName:
-                      description: 'Name of the StorageClass required by the claim.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                      type: string
-                    volumeMode:
-                      description: volumeMode defines what type of volume is required
-                        by the claim. Value of Filesystem is implied when not included
-                        in claim spec.
-                      type: string
-                    volumeName:
-                      description: VolumeName is the binding reference to the PersistentVolume
-                        backing this claim.
-                      type: string
-                  type: object
-                secretName:
-                  description: SecretName is the name of a Secret with encryption
-                    key, credentials, etc.
-                  type: string
-              type: object
-            version:
-              description: Version is the tag/digest to use for the export Job container
-                image.
-              type: string
-          required:
-          - argocd
-          type: object
-        status:
-          description: ArgoCDExportStatus defines the observed state of ArgoCDExport
-          properties:
-            phase:
-              description: 'Phase is a simple, high-level summary of where the ArgoCDExport
-                is in its lifecycle. There are five possible phase values: Pending:
-                The ArgoCDExport has been accepted by the Kubernetes system, but one
-                or more of the required resources have not been created. Running:
-                All of the containers for the ArgoCDExport are still running, or in
-                the process of starting or restarting. Succeeded: All containers for
-                the ArgoCDExport have terminated in success, and will not be restarted.
-                Failed: At least one container has terminated in failure, either exited
-                with non-zero status or was terminated by the system. Unknown: For
-                some reason the state of the ArgoCDExport could not be obtained.'
-              type: string
-          required:
-          - phase
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ArgoCDExport is the Schema for the argocdexports API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ArgoCDExportSpec defines the desired state of ArgoCDExport
+            properties:
+              argocd:
+                description: Argocd is the name of the ArgoCD instance to export.
+                type: string
+              image:
+                description: Image is the container image to use for the export Job.
+                type: string
+              schedule:
+                description: Schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+              storage:
+                description: Storage defines the storage configuration options.
+                properties:
+                  backend:
+                    description: Backend defines the storage backend to use, must
+                      be "local" (the default), "aws", "azure" or "gcp".
+                    type: string
+                  pvc:
+                    description: PVC is the desired characteristics for a PersistentVolumeClaim.
+                    properties:
+                      accessModes:
+                        description: 'AccessModes contains the desired access modes
+                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: 'This field can be used to specify either: *
+                          An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                          - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                          custom resource/object that implements data population (Alpha)
+                          In order to use VolumeSnapshot object types, the appropriate
+                          feature gate must be enabled (VolumeSnapshotDataSource or
+                          AnyVolumeDataSource) If the provisioner or an external controller
+                          can support the specified data source, it will create a
+                          new volume based on the contents of the specified data source.
+                          If the specified data source is not supported, the volume
+                          will not be created and the failure will be reported as
+                          an event. In the future, we plan to support more data source
+                          types and the behavior of the provisioner may change.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: 'Resources represents the minimum resources the
+                          volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      selector:
+                        description: A label query over volumes to consider for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      storageClassName:
+                        description: 'Name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        type: string
+                      volumeMode:
+                        description: volumeMode defines what type of volume is required
+                          by the claim. Value of Filesystem is implied when not included
+                          in claim spec.
+                        type: string
+                      volumeName:
+                        description: VolumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  secretName:
+                    description: SecretName is the name of a Secret with encryption
+                      key, credentials, etc.
+                    type: string
+                type: object
+              version:
+                description: Version is the tag/digest to use for the export Job container
+                  image.
+                type: string
+            required:
+            - argocd
+            type: object
+          status:
+            description: ArgoCDExportStatus defines the observed state of ArgoCDExport
+            properties:
+              phase:
+                description: 'Phase is a simple, high-level summary of where the ArgoCDExport
+                  is in its lifecycle. There are five possible phase values: Pending:
+                  The ArgoCDExport has been accepted by the Kubernetes system, but
+                  one or more of the required resources have not been created. Running:
+                  All of the containers for the ArgoCDExport are still running, or
+                  in the process of starting or restarting. Succeeded: All containers
+                  for the ArgoCDExport have terminated in success, and will not be
+                  restarted. Failed: At least one container has terminated in failure,
+                  either exited with non-zero status or was terminated by the system.
+                  Unknown: For some reason the state of the ArgoCDExport could not
+                  be obtained.'
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: argocds.argoproj.io
@@ -10,1063 +10,1076 @@ spec:
     plural: argocds
     singular: argocd
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ArgoCD is the Schema for the argocds API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ArgoCDSpec defines the desired state of ArgoCD
-          properties:
-            applicationInstanceLabelKey:
-              description: ApplicationInstanceLabelKey is the key name where Argo
-                CD injects the app name as a tracking label.
-              type: string
-            applicationSet:
-              description: ArgoCDApplicationSet defines whether the Argo CD ApplicationSet
-                controller should be installed.
-              properties:
-                image:
-                  description: Image is the Argo CD ApplicationSet image (optional)
-                  type: string
-                resources:
-                  description: Resources defines the Compute Resources required by
-                    the container for ApplicationSet.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                version:
-                  description: Version is the Argo CD ApplicationSet image tag. (optional)
-                  type: string
-              type: object
-            configManagementPlugins:
-              description: ConfigManagementPlugins is used to specify additional config
-                management plugins.
-              type: string
-            controller:
-              description: Controller defines the Application Controller options for
-                ArgoCD.
-              properties:
-                appSync:
-                  description: "AppSync is used to control the sync frequency, by
-                    default the ArgoCD controller polls Git every 3m by default. \n
-                    Set this to a duration, e.g. 10m or 600s to control the synchronisation
-                    frequency."
-                  type: string
-                processors:
-                  description: Processors contains the options for the Application
-                    Controller processors.
-                  properties:
-                    operation:
-                      description: Operation is the number of application operation
-                        processors.
-                      format: int32
-                      type: integer
-                    status:
-                      description: Status is the number of application status processors.
-                      format: int32
-                      type: integer
-                  type: object
-                resources:
-                  description: Resources defines the Compute Resources required by
-                    the container for the Application Controller.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-              type: object
-            dex:
-              description: Dex defines the Dex server options for ArgoCD.
-              properties:
-                config:
-                  description: Config is the dex connector configuration.
-                  type: string
-                image:
-                  description: Image is the Dex container image.
-                  type: string
-                openShiftOAuth:
-                  description: OpenShiftOAuth enables OpenShift OAuth authentication
-                    for the Dex server.
-                  type: boolean
-                resources:
-                  description: Resources defines the Compute Resources required by
-                    the container for Dex.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                version:
-                  description: Version is the Dex container image tag.
-                  type: string
-              type: object
-            disableAdmin:
-              description: DisableAdmin will disable the admin user.
-              type: boolean
-            gaAnonymizeUsers:
-              description: GAAnonymizeUsers toggles user IDs being hashed before sending
-                to google analytics.
-              type: boolean
-            gaTrackingID:
-              description: GATrackingID is the google analytics tracking ID to use.
-              type: string
-            grafana:
-              description: Grafana defines the Grafana server options for ArgoCD.
-              properties:
-                enabled:
-                  description: Enabled will toggle Grafana support globally for ArgoCD.
-                  type: boolean
-                host:
-                  description: Host is the hostname to use for Ingress/Route resources.
-                  type: string
-                image:
-                  description: Image is the Grafana container image.
-                  type: string
-                ingress:
-                  description: Ingress defines the desired state for an Ingress for
-                    the Grafana component.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is the map of annotations to apply
-                        to the Ingress.
-                      type: object
-                    enabled:
-                      description: Enabled will toggle the creation of the Ingress.
-                      type: boolean
-                    path:
-                      description: Path used for the Ingress resource.
-                      type: string
-                    tls:
-                      description: TLS configuration. Currently the Ingress only supports
-                        a single TLS port, 443. If multiple members of this list specify
-                        different hosts, they will be multiplexed on the same port
-                        according to the hostname specified through the SNI TLS extension,
-                        if the ingress controller fulfilling the ingress supports
-                        SNI.
-                      items:
-                        description: IngressTLS describes the transport layer security
-                          associated with an Ingress.
-                        properties:
-                          hosts:
-                            description: Hosts are a list of hosts included in the
-                              TLS certificate. The values in this list must match
-                              the name/s used in the tlsSecret. Defaults to the wildcard
-                              host setting for the loadbalancer controller fulfilling
-                              this Ingress, if left unspecified.
-                            items:
-                              type: string
-                            type: array
-                          secretName:
-                            description: SecretName is the name of the secret used
-                              to terminate SSL traffic on 443. Field is left optional
-                              to allow SSL routing based on SNI hostname alone. If
-                              the SNI host in a listener conflicts with the "Host"
-                              header field used by an IngressRule, the SNI host is
-                              used for termination and value of the Host header is
-                              used for routing.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - enabled
-                  type: object
-                resources:
-                  description: Resources defines the Compute Resources required by
-                    the container for Grafana.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                route:
-                  description: Route defines the desired state for an OpenShift Route
-                    for the Grafana component.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is the map of annotations to use for
-                        the Route resource.
-                      type: object
-                    enabled:
-                      description: Enabled will toggle the creation of the OpenShift
-                        Route.
-                      type: boolean
-                    path:
-                      description: Path the router watches for, to route traffic for
-                        to the service.
-                      type: string
-                    tls:
-                      description: TLS provides the ability to configure certificates
-                        and termination for the Route.
-                      properties:
-                        caCertificate:
-                          description: caCertificate provides the cert authority certificate
-                            contents
-                          type: string
-                        certificate:
-                          description: certificate provides certificate contents
-                          type: string
-                        destinationCACertificate:
-                          description: destinationCACertificate provides the contents
-                            of the ca certificate of the final destination.  When
-                            using reencrypt termination this file should be provided
-                            in order to have routers use it for health checks on the
-                            secure connection. If this field is not specified, the
-                            router may provide its own destination CA and perform
-                            hostname validation using the short service name (service.namespace.svc),
-                            which allows infrastructure generated certificates to
-                            automatically verify.
-                          type: string
-                        insecureEdgeTerminationPolicy:
-                          description: "insecureEdgeTerminationPolicy indicates the
-                            desired behavior for insecure connections to a route.
-                            While each router may make its own decisions on which
-                            ports to expose, this is normally port 80. \n * Allow
-                            - traffic is sent to the server on the insecure port (default)
-                            * Disable - no traffic is allowed on the insecure port.
-                            * Redirect - clients are redirected to the secure port."
-                          type: string
-                        key:
-                          description: key provides key file contents
-                          type: string
-                        termination:
-                          description: termination indicates termination type.
-                          type: string
-                      required:
-                      - termination
-                      type: object
-                    wildcardPolicy:
-                      description: WildcardPolicy if any for the route. Currently
-                        only 'Subdomain' or 'None' is allowed.
-                      type: string
-                  required:
-                  - enabled
-                  type: object
-                size:
-                  description: Size is the replica count for the Grafana Deployment.
-                  format: int32
-                  type: integer
-                version:
-                  description: Version is the Grafana container image tag.
-                  type: string
-              required:
-              - enabled
-              type: object
-            ha:
-              description: HA options for High Availability support for the Redis
-                component.
-              properties:
-                enabled:
-                  description: Enabled will toggle HA support globally for Argo CD.
-                  type: boolean
-                redisProxyImage:
-                  description: RedisProxyImage is the Redis HAProxy container image.
-                  type: string
-                redisProxyVersion:
-                  description: RedisProxyVersion is the Redis HAProxy container image
-                    tag.
-                  type: string
-                resources:
-                  description: Resources defines the Compute Resources required by
-                    the container for HA.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-              required:
-              - enabled
-              type: object
-            helpChatText:
-              description: HelpChatText is the text for getting chat help, defaults
-                to "Chat now!"
-              type: string
-            helpChatURL:
-              description: HelpChatURL is the URL for getting chat help, this will
-                typically be your Slack channel for support.
-              type: string
-            image:
-              description: Image is the ArgoCD container image for all ArgoCD components.
-              type: string
-            import:
-              description: Import is the import/restore options for ArgoCD.
-              properties:
-                name:
-                  description: Name of an ArgoCDExport from which to import data.
-                  type: string
-                namespace:
-                  description: Namespace for the ArgoCDExport, defaults to the same
-                    namespace as the ArgoCD.
-                  type: string
-              required:
-              - name
-              type: object
-            initialRepositories:
-              description: InitialRepositories to configure Argo CD with upon creation
-                of the cluster.
-              type: string
-            initialSSHKnownHosts:
-              description: InitialSSHKnownHosts defines the SSH known hosts data upon
-                creation of the cluster for connecting Git repositories via SSH.
-              properties:
-                excludedefaulthosts:
-                  description: ExcludeDefaultHosts describes whether you would like
-                    to include the default list of SSH Known Hosts provided by ArgoCD.
-                  type: boolean
-                keys:
-                  description: Keys describes a custom set of SSH Known Hosts that
-                    you would like to have included in your ArgoCD server.
-                  type: string
-              type: object
-            kustomizeBuildOptions:
-              description: KustomizeBuildOptions is used to specify build options/parameters
-                to use with `kustomize build`.
-              type: string
-            oidcConfig:
-              description: OIDCConfig is the OIDC configuration as an alternative
-                to dex.
-              type: string
-            prometheus:
-              description: Prometheus defines the Prometheus server options for ArgoCD.
-              properties:
-                enabled:
-                  description: Enabled will toggle Prometheus support globally for
-                    ArgoCD.
-                  type: boolean
-                host:
-                  description: Host is the hostname to use for Ingress/Route resources.
-                  type: string
-                ingress:
-                  description: Ingress defines the desired state for an Ingress for
-                    the Prometheus component.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is the map of annotations to apply
-                        to the Ingress.
-                      type: object
-                    enabled:
-                      description: Enabled will toggle the creation of the Ingress.
-                      type: boolean
-                    path:
-                      description: Path used for the Ingress resource.
-                      type: string
-                    tls:
-                      description: TLS configuration. Currently the Ingress only supports
-                        a single TLS port, 443. If multiple members of this list specify
-                        different hosts, they will be multiplexed on the same port
-                        according to the hostname specified through the SNI TLS extension,
-                        if the ingress controller fulfilling the ingress supports
-                        SNI.
-                      items:
-                        description: IngressTLS describes the transport layer security
-                          associated with an Ingress.
-                        properties:
-                          hosts:
-                            description: Hosts are a list of hosts included in the
-                              TLS certificate. The values in this list must match
-                              the name/s used in the tlsSecret. Defaults to the wildcard
-                              host setting for the loadbalancer controller fulfilling
-                              this Ingress, if left unspecified.
-                            items:
-                              type: string
-                            type: array
-                          secretName:
-                            description: SecretName is the name of the secret used
-                              to terminate SSL traffic on 443. Field is left optional
-                              to allow SSL routing based on SNI hostname alone. If
-                              the SNI host in a listener conflicts with the "Host"
-                              header field used by an IngressRule, the SNI host is
-                              used for termination and value of the Host header is
-                              used for routing.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - enabled
-                  type: object
-                route:
-                  description: Route defines the desired state for an OpenShift Route
-                    for the Prometheus component.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is the map of annotations to use for
-                        the Route resource.
-                      type: object
-                    enabled:
-                      description: Enabled will toggle the creation of the OpenShift
-                        Route.
-                      type: boolean
-                    path:
-                      description: Path the router watches for, to route traffic for
-                        to the service.
-                      type: string
-                    tls:
-                      description: TLS provides the ability to configure certificates
-                        and termination for the Route.
-                      properties:
-                        caCertificate:
-                          description: caCertificate provides the cert authority certificate
-                            contents
-                          type: string
-                        certificate:
-                          description: certificate provides certificate contents
-                          type: string
-                        destinationCACertificate:
-                          description: destinationCACertificate provides the contents
-                            of the ca certificate of the final destination.  When
-                            using reencrypt termination this file should be provided
-                            in order to have routers use it for health checks on the
-                            secure connection. If this field is not specified, the
-                            router may provide its own destination CA and perform
-                            hostname validation using the short service name (service.namespace.svc),
-                            which allows infrastructure generated certificates to
-                            automatically verify.
-                          type: string
-                        insecureEdgeTerminationPolicy:
-                          description: "insecureEdgeTerminationPolicy indicates the
-                            desired behavior for insecure connections to a route.
-                            While each router may make its own decisions on which
-                            ports to expose, this is normally port 80. \n * Allow
-                            - traffic is sent to the server on the insecure port (default)
-                            * Disable - no traffic is allowed on the insecure port.
-                            * Redirect - clients are redirected to the secure port."
-                          type: string
-                        key:
-                          description: key provides key file contents
-                          type: string
-                        termination:
-                          description: termination indicates termination type.
-                          type: string
-                      required:
-                      - termination
-                      type: object
-                    wildcardPolicy:
-                      description: WildcardPolicy if any for the route. Currently
-                        only 'Subdomain' or 'None' is allowed.
-                      type: string
-                  required:
-                  - enabled
-                  type: object
-                size:
-                  description: Size is the replica count for the Prometheus StatefulSet.
-                  format: int32
-                  type: integer
-              required:
-              - enabled
-              type: object
-            rbac:
-              description: RBAC defines the RBAC configuration for Argo CD.
-              properties:
-                defaultPolicy:
-                  description: DefaultPolicy is the name of the default role which
-                    Argo CD will falls back to, when authorizing API requests (optional).
-                    If omitted or empty, users may be still be able to login, but
-                    will see no apps, projects, etc...
-                  type: string
-                policy:
-                  description: 'Policy is CSV containing user-defined RBAC policies
-                    and role definitions. Policy rules are in the form:   p, subject,
-                    resource, action, object, effect Role definitions and bindings
-                    are in the form:   g, subject, inherited-subject See https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/rbac.md
-                    for additional information.'
-                  type: string
-                scopes:
-                  description: 'Scopes controls which OIDC scopes to examine during
-                    rbac enforcement (in addition to `sub` scope). If omitted, defaults
-                    to: ''[groups]''.'
-                  type: string
-              type: object
-            redis:
-              description: Redis defines the Redis server options for ArgoCD.
-              properties:
-                image:
-                  description: Image is the Redis container image.
-                  type: string
-                resources:
-                  description: Resources defines the Compute Resources required by
-                    the container for Redis.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                version:
-                  description: Version is the Redis container image tag.
-                  type: string
-              type: object
-            repo:
-              description: Repo defines the repo server options for Argo CD.
-              properties:
-                mountsatoken:
-                  description: MountSAToken describes whether you would like to have
-                    the Repo server mount the service account token
-                  type: boolean
-                resources:
-                  description: Resources defines the Compute Resources required by
-                    the container for Redis.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                serviceaccount:
-                  description: ServiceAccount defines the ServiceAccount user that
-                    you would like the Repo server to use
-                  type: string
-              type: object
-            repositoryCredentials:
-              description: RepositoryCredentials are the Git pull credentials to configure
-                Argo CD with upon creation of the cluster.
-              type: string
-            resourceCustomizations:
-              description: 'ResourceCustomizations customizes resource behavior. Keys
-                are in the form: group/Kind.'
-              type: string
-            resourceExclusions:
-              description: ResourceExclusions is used to completely ignore entire
-                classes of resource group/kinds.
-              type: string
-            resourceInclusions:
-              description: ResourceInclusions is used to only include specific group/kinds
-                in the reconciliation process.
-              type: string
-            server:
-              description: Server defines the options for the ArgoCD Server component.
-              properties:
-                autoscale:
-                  description: Autoscale defines the autoscale options for the Argo
-                    CD Server component.
-                  properties:
-                    enabled:
-                      description: Enabled will toggle autoscaling support for the
-                        Argo CD Server component.
-                      type: boolean
-                    hpa:
-                      description: HPA defines the HorizontalPodAutoscaler options
-                        for the Argo CD Server component.
-                      properties:
-                        maxReplicas:
-                          description: upper limit for the number of pods that can
-                            be set by the autoscaler; cannot be smaller than MinReplicas.
-                          format: int32
-                          type: integer
-                        minReplicas:
-                          description: minReplicas is the lower limit for the number
-                            of replicas to which the autoscaler can scale down.  It
-                            defaults to 1 pod.  minReplicas is allowed to be 0 if
-                            the alpha feature gate HPAScaleToZero is enabled and at
-                            least one Object or External metric is configured.  Scaling
-                            is active as long as at least one metric value is available.
-                          format: int32
-                          type: integer
-                        scaleTargetRef:
-                          description: reference to scaled resource; horizontal pod
-                            autoscaler will learn the current resource consumption
-                            and will set the desired number of pods by using its Scale
-                            subresource.
-                          properties:
-                            apiVersion:
-                              description: API version of the referent
-                              type: string
-                            kind:
-                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                              type: string
-                            name:
-                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                              type: string
-                          required:
-                          - kind
-                          - name
-                          type: object
-                        targetCPUUtilizationPercentage:
-                          description: target average CPU utilization (represented
-                            as a percentage of requested CPU) over all the pods; if
-                            not specified the default autoscaling policy will be used.
-                          format: int32
-                          type: integer
-                      required:
-                      - maxReplicas
-                      - scaleTargetRef
-                      type: object
-                  required:
-                  - enabled
-                  type: object
-                grpc:
-                  description: GRPC defines the state for the Argo CD Server GRPC
-                    options.
-                  properties:
-                    host:
-                      description: Host is the hostname to use for Ingress/Route resources.
-                      type: string
-                    ingress:
-                      description: Ingress defines the desired state for the Argo
-                        CD Server GRPC Ingress.
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Annotations is the map of annotations to apply
-                            to the Ingress.
-                          type: object
-                        enabled:
-                          description: Enabled will toggle the creation of the Ingress.
-                          type: boolean
-                        path:
-                          description: Path used for the Ingress resource.
-                          type: string
-                        tls:
-                          description: TLS configuration. Currently the Ingress only
-                            supports a single TLS port, 443. If multiple members of
-                            this list specify different hosts, they will be multiplexed
-                            on the same port according to the hostname specified through
-                            the SNI TLS extension, if the ingress controller fulfilling
-                            the ingress supports SNI.
-                          items:
-                            description: IngressTLS describes the transport layer
-                              security associated with an Ingress.
-                            properties:
-                              hosts:
-                                description: Hosts are a list of hosts included in
-                                  the TLS certificate. The values in this list must
-                                  match the name/s used in the tlsSecret. Defaults
-                                  to the wildcard host setting for the loadbalancer
-                                  controller fulfilling this Ingress, if left unspecified.
-                                items:
-                                  type: string
-                                type: array
-                              secretName:
-                                description: SecretName is the name of the secret
-                                  used to terminate SSL traffic on 443. Field is left
-                                  optional to allow SSL routing based on SNI hostname
-                                  alone. If the SNI host in a listener conflicts with
-                                  the "Host" header field used by an IngressRule,
-                                  the SNI host is used for termination and value of
-                                  the Host header is used for routing.
-                                type: string
-                            type: object
-                          type: array
-                      required:
-                      - enabled
-                      type: object
-                  type: object
-                host:
-                  description: Host is the hostname to use for Ingress/Route resources.
-                  type: string
-                ingress:
-                  description: Ingress defines the desired state for an Ingress for
-                    the Argo CD Server component.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is the map of annotations to apply
-                        to the Ingress.
-                      type: object
-                    enabled:
-                      description: Enabled will toggle the creation of the Ingress.
-                      type: boolean
-                    path:
-                      description: Path used for the Ingress resource.
-                      type: string
-                    tls:
-                      description: TLS configuration. Currently the Ingress only supports
-                        a single TLS port, 443. If multiple members of this list specify
-                        different hosts, they will be multiplexed on the same port
-                        according to the hostname specified through the SNI TLS extension,
-                        if the ingress controller fulfilling the ingress supports
-                        SNI.
-                      items:
-                        description: IngressTLS describes the transport layer security
-                          associated with an Ingress.
-                        properties:
-                          hosts:
-                            description: Hosts are a list of hosts included in the
-                              TLS certificate. The values in this list must match
-                              the name/s used in the tlsSecret. Defaults to the wildcard
-                              host setting for the loadbalancer controller fulfilling
-                              this Ingress, if left unspecified.
-                            items:
-                              type: string
-                            type: array
-                          secretName:
-                            description: SecretName is the name of the secret used
-                              to terminate SSL traffic on 443. Field is left optional
-                              to allow SSL routing based on SNI hostname alone. If
-                              the SNI host in a listener conflicts with the "Host"
-                              header field used by an IngressRule, the SNI host is
-                              used for termination and value of the Host header is
-                              used for routing.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - enabled
-                  type: object
-                insecure:
-                  description: Insecure toggles the insecure flag.
-                  type: boolean
-                resources:
-                  description: Resources defines the Compute Resources required by
-                    the container for the Argo CD server component.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                route:
-                  description: Route defines the desired state for an OpenShift Route
-                    for the Argo CD Server component.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is the map of annotations to use for
-                        the Route resource.
-                      type: object
-                    enabled:
-                      description: Enabled will toggle the creation of the OpenShift
-                        Route.
-                      type: boolean
-                    path:
-                      description: Path the router watches for, to route traffic for
-                        to the service.
-                      type: string
-                    tls:
-                      description: TLS provides the ability to configure certificates
-                        and termination for the Route.
-                      properties:
-                        caCertificate:
-                          description: caCertificate provides the cert authority certificate
-                            contents
-                          type: string
-                        certificate:
-                          description: certificate provides certificate contents
-                          type: string
-                        destinationCACertificate:
-                          description: destinationCACertificate provides the contents
-                            of the ca certificate of the final destination.  When
-                            using reencrypt termination this file should be provided
-                            in order to have routers use it for health checks on the
-                            secure connection. If this field is not specified, the
-                            router may provide its own destination CA and perform
-                            hostname validation using the short service name (service.namespace.svc),
-                            which allows infrastructure generated certificates to
-                            automatically verify.
-                          type: string
-                        insecureEdgeTerminationPolicy:
-                          description: "insecureEdgeTerminationPolicy indicates the
-                            desired behavior for insecure connections to a route.
-                            While each router may make its own decisions on which
-                            ports to expose, this is normally port 80. \n * Allow
-                            - traffic is sent to the server on the insecure port (default)
-                            * Disable - no traffic is allowed on the insecure port.
-                            * Redirect - clients are redirected to the secure port."
-                          type: string
-                        key:
-                          description: key provides key file contents
-                          type: string
-                        termination:
-                          description: termination indicates termination type.
-                          type: string
-                      required:
-                      - termination
-                      type: object
-                    wildcardPolicy:
-                      description: WildcardPolicy if any for the route. Currently
-                        only 'Subdomain' or 'None' is allowed.
-                      type: string
-                  required:
-                  - enabled
-                  type: object
-                service:
-                  description: Service defines the options for the Service backing
-                    the ArgoCD Server component.
-                  properties:
-                    type:
-                      description: Type is the ServiceType to use for the Service
-                        resource.
-                      type: string
-                  required:
-                  - type
-                  type: object
-              type: object
-            statusBadgeEnabled:
-              description: StatusBadgeEnabled toggles application status badge feature.
-              type: boolean
-            tls:
-              description: TLS defines the TLS options for ArgoCD.
-              properties:
-                ca:
-                  description: CA defines the CA options.
-                  properties:
-                    configMapName:
-                      description: ConfigMapName is the name of the ConfigMap containing
-                        the CA Certificate.
-                      type: string
-                    secretName:
-                      description: SecretName is the name of the Secret containing
-                        the CA Certificate and Key.
-                      type: string
-                  type: object
-                initialCerts:
-                  additionalProperties:
-                    type: string
-                  description: InitialCerts defines custom TLS certificates upon creation
-                    of the cluster for connecting Git repositories via HTTPS.
-                  type: object
-              type: object
-            usersAnonymousEnabled:
-              description: UsersAnonymousEnabled toggles anonymous user access. The
-                anonymous users get default role permissions specified argocd-rbac-cm.
-              type: boolean
-            version:
-              description: Version is the tag to use with the ArgoCD container image
-                for all ArgoCD components.
-              type: string
-          type: object
-        status:
-          description: ArgoCDStatus defines the observed state of ArgoCD
-          properties:
-            applicationController:
-              description: 'ApplicationController is a simple, high-level summary
-                of where the Argo CD application controller component is in its lifecycle.
-                There are five possible ApplicationController values: Pending: The
-                Argo CD application controller component has been accepted by the
-                Kubernetes system, but one or more of the required resources have
-                not been created. Running: All of the required Pods for the Argo CD
-                application controller component are in a Ready state. Failed: At
-                least one of the  Argo CD application controller component Pods had
-                a failure. Unknown: For some reason the state of the Argo CD application
-                controller component could not be obtained.'
-              type: string
-            dex:
-              description: 'Dex is a simple, high-level summary of where the Argo
-                CD Dex component is in its lifecycle. There are five possible dex
-                values: Pending: The Argo CD Dex component has been accepted by the
-                Kubernetes system, but one or more of the required resources have
-                not been created. Running: All of the required Pods for the Argo CD
-                Dex component are in a Ready state. Failed: At least one of the  Argo
-                CD Dex component Pods had a failure. Unknown: For some reason the
-                state of the Argo CD Dex component could not be obtained.'
-              type: string
-            phase:
-              description: 'Phase is a simple, high-level summary of where the ArgoCD
-                is in its lifecycle. There are five possible phase values: Pending:
-                The ArgoCD has been accepted by the Kubernetes system, but one or
-                more of the required resources have not been created. Available: All
-                of the resources for the ArgoCD are ready. Failed: At least one resource
-                has experienced a failure. Unknown: For some reason the state of the
-                ArgoCD phase could not be obtained.'
-              type: string
-            redis:
-              description: 'Redis is a simple, high-level summary of where the Argo
-                CD Redis component is in its lifecycle. There are five possible redis
-                values: Pending: The Argo CD Redis component has been accepted by
-                the Kubernetes system, but one or more of the required resources have
-                not been created. Running: All of the required Pods for the Argo CD
-                Redis component are in a Ready state. Failed: At least one of the  Argo
-                CD Redis component Pods had a failure. Unknown: For some reason the
-                state of the Argo CD Redis component could not be obtained.'
-              type: string
-            repo:
-              description: 'Repo is a simple, high-level summary of where the Argo
-                CD Repo component is in its lifecycle. There are five possible repo
-                values: Pending: The Argo CD Repo component has been accepted by the
-                Kubernetes system, but one or more of the required resources have
-                not been created. Running: All of the required Pods for the Argo CD
-                Repo component are in a Ready state. Failed: At least one of the  Argo
-                CD Repo component Pods had a failure. Unknown: For some reason the
-                state of the Argo CD Repo component could not be obtained.'
-              type: string
-            server:
-              description: 'Server is a simple, high-level summary of where the Argo
-                CD server component is in its lifecycle. There are five possible server
-                values: Pending: The Argo CD server component has been accepted by
-                the Kubernetes system, but one or more of the required resources have
-                not been created. Running: All of the required Pods for the Argo CD
-                server component are in a Ready state. Failed: At least one of the  Argo
-                CD server component Pods had a failure. Unknown: For some reason the
-                state of the Argo CD server component could not be obtained.'
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ArgoCD is the Schema for the argocds API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ArgoCDSpec defines the desired state of ArgoCD
+            properties:
+              applicationInstanceLabelKey:
+                description: ApplicationInstanceLabelKey is the key name where Argo
+                  CD injects the app name as a tracking label.
+                type: string
+              applicationSet:
+                description: ArgoCDApplicationSet defines whether the Argo CD ApplicationSet
+                  controller should be installed.
+                properties:
+                  image:
+                    description: Image is the Argo CD ApplicationSet image (optional)
+                    type: string
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for ApplicationSet.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  version:
+                    description: Version is the Argo CD ApplicationSet image tag.
+                      (optional)
+                    type: string
+                type: object
+              configManagementPlugins:
+                description: ConfigManagementPlugins is used to specify additional
+                  config management plugins.
+                type: string
+              controller:
+                description: Controller defines the Application Controller options
+                  for ArgoCD.
+                properties:
+                  appSync:
+                    description: "AppSync is used to control the sync frequency, by
+                      default the ArgoCD controller polls Git every 3m by default.
+                      \n Set this to a duration, e.g. 10m or 600s to control the synchronisation
+                      frequency."
+                    type: string
+                  processors:
+                    description: Processors contains the options for the Application
+                      Controller processors.
+                    properties:
+                      operation:
+                        description: Operation is the number of application operation
+                          processors.
+                        format: int32
+                        type: integer
+                      status:
+                        description: Status is the number of application status processors.
+                        format: int32
+                        type: integer
+                    type: object
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for the Application Controller.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              dex:
+                description: Dex defines the Dex server options for ArgoCD.
+                properties:
+                  config:
+                    description: Config is the dex connector configuration.
+                    type: string
+                  image:
+                    description: Image is the Dex container image.
+                    type: string
+                  openShiftOAuth:
+                    description: OpenShiftOAuth enables OpenShift OAuth authentication
+                      for the Dex server.
+                    type: boolean
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for Dex.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  version:
+                    description: Version is the Dex container image tag.
+                    type: string
+                type: object
+              disableAdmin:
+                description: DisableAdmin will disable the admin user.
+                type: boolean
+              gaAnonymizeUsers:
+                description: GAAnonymizeUsers toggles user IDs being hashed before
+                  sending to google analytics.
+                type: boolean
+              gaTrackingID:
+                description: GATrackingID is the google analytics tracking ID to use.
+                type: string
+              grafana:
+                description: Grafana defines the Grafana server options for ArgoCD.
+                properties:
+                  enabled:
+                    description: Enabled will toggle Grafana support globally for
+                      ArgoCD.
+                    type: boolean
+                  host:
+                    description: Host is the hostname to use for Ingress/Route resources.
+                    type: string
+                  image:
+                    description: Image is the Grafana container image.
+                    type: string
+                  ingress:
+                    description: Ingress defines the desired state for an Ingress
+                      for the Grafana component.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is the map of annotations to apply
+                          to the Ingress.
+                        type: object
+                      enabled:
+                        description: Enabled will toggle the creation of the Ingress.
+                        type: boolean
+                      path:
+                        description: Path used for the Ingress resource.
+                        type: string
+                      tls:
+                        description: TLS configuration. Currently the Ingress only
+                          supports a single TLS port, 443. If multiple members of
+                          this list specify different hosts, they will be multiplexed
+                          on the same port according to the hostname specified through
+                          the SNI TLS extension, if the ingress controller fulfilling
+                          the ingress supports SNI.
+                        items:
+                          description: IngressTLS describes the transport layer security
+                            associated with an Ingress.
+                          properties:
+                            hosts:
+                              description: Hosts are a list of hosts included in the
+                                TLS certificate. The values in this list must match
+                                the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller
+                                fulfilling this Ingress, if left unspecified.
+                              items:
+                                type: string
+                              type: array
+                            secretName:
+                              description: SecretName is the name of the secret used
+                                to terminate SSL traffic on 443. Field is left optional
+                                to allow SSL routing based on SNI hostname alone.
+                                If the SNI host in a listener conflicts with the "Host"
+                                header field used by an IngressRule, the SNI host
+                                is used for termination and value of the Host header
+                                is used for routing.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - enabled
+                    type: object
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for Grafana.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  route:
+                    description: Route defines the desired state for an OpenShift
+                      Route for the Grafana component.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is the map of annotations to use
+                          for the Route resource.
+                        type: object
+                      enabled:
+                        description: Enabled will toggle the creation of the OpenShift
+                          Route.
+                        type: boolean
+                      path:
+                        description: Path the router watches for, to route traffic
+                          for to the service.
+                        type: string
+                      tls:
+                        description: TLS provides the ability to configure certificates
+                          and termination for the Route.
+                        properties:
+                          caCertificate:
+                            description: caCertificate provides the cert authority
+                              certificate contents
+                            type: string
+                          certificate:
+                            description: certificate provides certificate contents
+                            type: string
+                          destinationCACertificate:
+                            description: destinationCACertificate provides the contents
+                              of the ca certificate of the final destination.  When
+                              using reencrypt termination this file should be provided
+                              in order to have routers use it for health checks on
+                              the secure connection. If this field is not specified,
+                              the router may provide its own destination CA and perform
+                              hostname validation using the short service name (service.namespace.svc),
+                              which allows infrastructure generated certificates to
+                              automatically verify.
+                            type: string
+                          insecureEdgeTerminationPolicy:
+                            description: "insecureEdgeTerminationPolicy indicates
+                              the desired behavior for insecure connections to a route.
+                              While each router may make its own decisions on which
+                              ports to expose, this is normally port 80. \n * Allow
+                              - traffic is sent to the server on the insecure port
+                              (default) * Disable - no traffic is allowed on the insecure
+                              port. * Redirect - clients are redirected to the secure
+                              port."
+                            type: string
+                          key:
+                            description: key provides key file contents
+                            type: string
+                          termination:
+                            description: termination indicates termination type.
+                            type: string
+                        required:
+                        - termination
+                        type: object
+                      wildcardPolicy:
+                        description: WildcardPolicy if any for the route. Currently
+                          only 'Subdomain' or 'None' is allowed.
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                  size:
+                    description: Size is the replica count for the Grafana Deployment.
+                    format: int32
+                    type: integer
+                  version:
+                    description: Version is the Grafana container image tag.
+                    type: string
+                required:
+                - enabled
+                type: object
+              ha:
+                description: HA options for High Availability support for the Redis
+                  component.
+                properties:
+                  enabled:
+                    description: Enabled will toggle HA support globally for Argo
+                      CD.
+                    type: boolean
+                  redisProxyImage:
+                    description: RedisProxyImage is the Redis HAProxy container image.
+                    type: string
+                  redisProxyVersion:
+                    description: RedisProxyVersion is the Redis HAProxy container
+                      image tag.
+                    type: string
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for HA.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - enabled
+                type: object
+              helpChatText:
+                description: HelpChatText is the text for getting chat help, defaults
+                  to "Chat now!"
+                type: string
+              helpChatURL:
+                description: HelpChatURL is the URL for getting chat help, this will
+                  typically be your Slack channel for support.
+                type: string
+              image:
+                description: Image is the ArgoCD container image for all ArgoCD components.
+                type: string
+              import:
+                description: Import is the import/restore options for ArgoCD.
+                properties:
+                  name:
+                    description: Name of an ArgoCDExport from which to import data.
+                    type: string
+                  namespace:
+                    description: Namespace for the ArgoCDExport, defaults to the same
+                      namespace as the ArgoCD.
+                    type: string
+                required:
+                - name
+                type: object
+              initialRepositories:
+                description: InitialRepositories to configure Argo CD with upon creation
+                  of the cluster.
+                type: string
+              initialSSHKnownHosts:
+                description: InitialSSHKnownHosts defines the SSH known hosts data
+                  upon creation of the cluster for connecting Git repositories via
+                  SSH.
+                properties:
+                  excludedefaulthosts:
+                    description: ExcludeDefaultHosts describes whether you would like
+                      to include the default list of SSH Known Hosts provided by ArgoCD.
+                    type: boolean
+                  keys:
+                    description: Keys describes a custom set of SSH Known Hosts that
+                      you would like to have included in your ArgoCD server.
+                    type: string
+                type: object
+              kustomizeBuildOptions:
+                description: KustomizeBuildOptions is used to specify build options/parameters
+                  to use with `kustomize build`.
+                type: string
+              oidcConfig:
+                description: OIDCConfig is the OIDC configuration as an alternative
+                  to dex.
+                type: string
+              prometheus:
+                description: Prometheus defines the Prometheus server options for
+                  ArgoCD.
+                properties:
+                  enabled:
+                    description: Enabled will toggle Prometheus support globally for
+                      ArgoCD.
+                    type: boolean
+                  host:
+                    description: Host is the hostname to use for Ingress/Route resources.
+                    type: string
+                  ingress:
+                    description: Ingress defines the desired state for an Ingress
+                      for the Prometheus component.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is the map of annotations to apply
+                          to the Ingress.
+                        type: object
+                      enabled:
+                        description: Enabled will toggle the creation of the Ingress.
+                        type: boolean
+                      path:
+                        description: Path used for the Ingress resource.
+                        type: string
+                      tls:
+                        description: TLS configuration. Currently the Ingress only
+                          supports a single TLS port, 443. If multiple members of
+                          this list specify different hosts, they will be multiplexed
+                          on the same port according to the hostname specified through
+                          the SNI TLS extension, if the ingress controller fulfilling
+                          the ingress supports SNI.
+                        items:
+                          description: IngressTLS describes the transport layer security
+                            associated with an Ingress.
+                          properties:
+                            hosts:
+                              description: Hosts are a list of hosts included in the
+                                TLS certificate. The values in this list must match
+                                the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller
+                                fulfilling this Ingress, if left unspecified.
+                              items:
+                                type: string
+                              type: array
+                            secretName:
+                              description: SecretName is the name of the secret used
+                                to terminate SSL traffic on 443. Field is left optional
+                                to allow SSL routing based on SNI hostname alone.
+                                If the SNI host in a listener conflicts with the "Host"
+                                header field used by an IngressRule, the SNI host
+                                is used for termination and value of the Host header
+                                is used for routing.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - enabled
+                    type: object
+                  route:
+                    description: Route defines the desired state for an OpenShift
+                      Route for the Prometheus component.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is the map of annotations to use
+                          for the Route resource.
+                        type: object
+                      enabled:
+                        description: Enabled will toggle the creation of the OpenShift
+                          Route.
+                        type: boolean
+                      path:
+                        description: Path the router watches for, to route traffic
+                          for to the service.
+                        type: string
+                      tls:
+                        description: TLS provides the ability to configure certificates
+                          and termination for the Route.
+                        properties:
+                          caCertificate:
+                            description: caCertificate provides the cert authority
+                              certificate contents
+                            type: string
+                          certificate:
+                            description: certificate provides certificate contents
+                            type: string
+                          destinationCACertificate:
+                            description: destinationCACertificate provides the contents
+                              of the ca certificate of the final destination.  When
+                              using reencrypt termination this file should be provided
+                              in order to have routers use it for health checks on
+                              the secure connection. If this field is not specified,
+                              the router may provide its own destination CA and perform
+                              hostname validation using the short service name (service.namespace.svc),
+                              which allows infrastructure generated certificates to
+                              automatically verify.
+                            type: string
+                          insecureEdgeTerminationPolicy:
+                            description: "insecureEdgeTerminationPolicy indicates
+                              the desired behavior for insecure connections to a route.
+                              While each router may make its own decisions on which
+                              ports to expose, this is normally port 80. \n * Allow
+                              - traffic is sent to the server on the insecure port
+                              (default) * Disable - no traffic is allowed on the insecure
+                              port. * Redirect - clients are redirected to the secure
+                              port."
+                            type: string
+                          key:
+                            description: key provides key file contents
+                            type: string
+                          termination:
+                            description: termination indicates termination type.
+                            type: string
+                        required:
+                        - termination
+                        type: object
+                      wildcardPolicy:
+                        description: WildcardPolicy if any for the route. Currently
+                          only 'Subdomain' or 'None' is allowed.
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                  size:
+                    description: Size is the replica count for the Prometheus StatefulSet.
+                    format: int32
+                    type: integer
+                required:
+                - enabled
+                type: object
+              rbac:
+                description: RBAC defines the RBAC configuration for Argo CD.
+                properties:
+                  defaultPolicy:
+                    description: DefaultPolicy is the name of the default role which
+                      Argo CD will falls back to, when authorizing API requests (optional).
+                      If omitted or empty, users may be still be able to login, but
+                      will see no apps, projects, etc...
+                    type: string
+                  policy:
+                    description: 'Policy is CSV containing user-defined RBAC policies
+                      and role definitions. Policy rules are in the form:   p, subject,
+                      resource, action, object, effect Role definitions and bindings
+                      are in the form:   g, subject, inherited-subject See https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/rbac.md
+                      for additional information.'
+                    type: string
+                  scopes:
+                    description: 'Scopes controls which OIDC scopes to examine during
+                      rbac enforcement (in addition to `sub` scope). If omitted, defaults
+                      to: ''[groups]''.'
+                    type: string
+                type: object
+              redis:
+                description: Redis defines the Redis server options for ArgoCD.
+                properties:
+                  image:
+                    description: Image is the Redis container image.
+                    type: string
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for Redis.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  version:
+                    description: Version is the Redis container image tag.
+                    type: string
+                type: object
+              repo:
+                description: Repo defines the repo server options for Argo CD.
+                properties:
+                  mountsatoken:
+                    description: MountSAToken describes whether you would like to
+                      have the Repo server mount the service account token
+                    type: boolean
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for Redis.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  serviceaccount:
+                    description: ServiceAccount defines the ServiceAccount user that
+                      you would like the Repo server to use
+                    type: string
+                type: object
+              repositoryCredentials:
+                description: RepositoryCredentials are the Git pull credentials to
+                  configure Argo CD with upon creation of the cluster.
+                type: string
+              resourceCustomizations:
+                description: 'ResourceCustomizations customizes resource behavior.
+                  Keys are in the form: group/Kind.'
+                type: string
+              resourceExclusions:
+                description: ResourceExclusions is used to completely ignore entire
+                  classes of resource group/kinds.
+                type: string
+              resourceInclusions:
+                description: ResourceInclusions is used to only include specific group/kinds
+                  in the reconciliation process.
+                type: string
+              server:
+                description: Server defines the options for the ArgoCD Server component.
+                properties:
+                  autoscale:
+                    description: Autoscale defines the autoscale options for the Argo
+                      CD Server component.
+                    properties:
+                      enabled:
+                        description: Enabled will toggle autoscaling support for the
+                          Argo CD Server component.
+                        type: boolean
+                      hpa:
+                        description: HPA defines the HorizontalPodAutoscaler options
+                          for the Argo CD Server component.
+                        properties:
+                          maxReplicas:
+                            description: upper limit for the number of pods that can
+                              be set by the autoscaler; cannot be smaller than MinReplicas.
+                            format: int32
+                            type: integer
+                          minReplicas:
+                            description: minReplicas is the lower limit for the number
+                              of replicas to which the autoscaler can scale down.  It
+                              defaults to 1 pod.  minReplicas is allowed to be 0 if
+                              the alpha feature gate HPAScaleToZero is enabled and
+                              at least one Object or External metric is configured.  Scaling
+                              is active as long as at least one metric value is available.
+                            format: int32
+                            type: integer
+                          scaleTargetRef:
+                            description: reference to scaled resource; horizontal
+                              pod autoscaler will learn the current resource consumption
+                              and will set the desired number of pods by using its
+                              Scale subresource.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent
+                                type: string
+                              kind:
+                                description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                type: string
+                              name:
+                                description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          targetCPUUtilizationPercentage:
+                            description: target average CPU utilization (represented
+                              as a percentage of requested CPU) over all the pods;
+                              if not specified the default autoscaling policy will
+                              be used.
+                            format: int32
+                            type: integer
+                        required:
+                        - maxReplicas
+                        - scaleTargetRef
+                        type: object
+                    required:
+                    - enabled
+                    type: object
+                  grpc:
+                    description: GRPC defines the state for the Argo CD Server GRPC
+                      options.
+                    properties:
+                      host:
+                        description: Host is the hostname to use for Ingress/Route
+                          resources.
+                        type: string
+                      ingress:
+                        description: Ingress defines the desired state for the Argo
+                          CD Server GRPC Ingress.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is the map of annotations to
+                              apply to the Ingress.
+                            type: object
+                          enabled:
+                            description: Enabled will toggle the creation of the Ingress.
+                            type: boolean
+                          path:
+                            description: Path used for the Ingress resource.
+                            type: string
+                          tls:
+                            description: TLS configuration. Currently the Ingress
+                              only supports a single TLS port, 443. If multiple members
+                              of this list specify different hosts, they will be multiplexed
+                              on the same port according to the hostname specified
+                              through the SNI TLS extension, if the ingress controller
+                              fulfilling the ingress supports SNI.
+                            items:
+                              description: IngressTLS describes the transport layer
+                                security associated with an Ingress.
+                              properties:
+                                hosts:
+                                  description: Hosts are a list of hosts included
+                                    in the TLS certificate. The values in this list
+                                    must match the name/s used in the tlsSecret. Defaults
+                                    to the wildcard host setting for the loadbalancer
+                                    controller fulfilling this Ingress, if left unspecified.
+                                  items:
+                                    type: string
+                                  type: array
+                                secretName:
+                                  description: SecretName is the name of the secret
+                                    used to terminate SSL traffic on 443. Field is
+                                    left optional to allow SSL routing based on SNI
+                                    hostname alone. If the SNI host in a listener
+                                    conflicts with the "Host" header field used by
+                                    an IngressRule, the SNI host is used for termination
+                                    and value of the Host header is used for routing.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - enabled
+                        type: object
+                    type: object
+                  host:
+                    description: Host is the hostname to use for Ingress/Route resources.
+                    type: string
+                  ingress:
+                    description: Ingress defines the desired state for an Ingress
+                      for the Argo CD Server component.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is the map of annotations to apply
+                          to the Ingress.
+                        type: object
+                      enabled:
+                        description: Enabled will toggle the creation of the Ingress.
+                        type: boolean
+                      path:
+                        description: Path used for the Ingress resource.
+                        type: string
+                      tls:
+                        description: TLS configuration. Currently the Ingress only
+                          supports a single TLS port, 443. If multiple members of
+                          this list specify different hosts, they will be multiplexed
+                          on the same port according to the hostname specified through
+                          the SNI TLS extension, if the ingress controller fulfilling
+                          the ingress supports SNI.
+                        items:
+                          description: IngressTLS describes the transport layer security
+                            associated with an Ingress.
+                          properties:
+                            hosts:
+                              description: Hosts are a list of hosts included in the
+                                TLS certificate. The values in this list must match
+                                the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller
+                                fulfilling this Ingress, if left unspecified.
+                              items:
+                                type: string
+                              type: array
+                            secretName:
+                              description: SecretName is the name of the secret used
+                                to terminate SSL traffic on 443. Field is left optional
+                                to allow SSL routing based on SNI hostname alone.
+                                If the SNI host in a listener conflicts with the "Host"
+                                header field used by an IngressRule, the SNI host
+                                is used for termination and value of the Host header
+                                is used for routing.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - enabled
+                    type: object
+                  insecure:
+                    description: Insecure toggles the insecure flag.
+                    type: boolean
+                  resources:
+                    description: Resources defines the Compute Resources required
+                      by the container for the Argo CD server component.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  route:
+                    description: Route defines the desired state for an OpenShift
+                      Route for the Argo CD Server component.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is the map of annotations to use
+                          for the Route resource.
+                        type: object
+                      enabled:
+                        description: Enabled will toggle the creation of the OpenShift
+                          Route.
+                        type: boolean
+                      path:
+                        description: Path the router watches for, to route traffic
+                          for to the service.
+                        type: string
+                      tls:
+                        description: TLS provides the ability to configure certificates
+                          and termination for the Route.
+                        properties:
+                          caCertificate:
+                            description: caCertificate provides the cert authority
+                              certificate contents
+                            type: string
+                          certificate:
+                            description: certificate provides certificate contents
+                            type: string
+                          destinationCACertificate:
+                            description: destinationCACertificate provides the contents
+                              of the ca certificate of the final destination.  When
+                              using reencrypt termination this file should be provided
+                              in order to have routers use it for health checks on
+                              the secure connection. If this field is not specified,
+                              the router may provide its own destination CA and perform
+                              hostname validation using the short service name (service.namespace.svc),
+                              which allows infrastructure generated certificates to
+                              automatically verify.
+                            type: string
+                          insecureEdgeTerminationPolicy:
+                            description: "insecureEdgeTerminationPolicy indicates
+                              the desired behavior for insecure connections to a route.
+                              While each router may make its own decisions on which
+                              ports to expose, this is normally port 80. \n * Allow
+                              - traffic is sent to the server on the insecure port
+                              (default) * Disable - no traffic is allowed on the insecure
+                              port. * Redirect - clients are redirected to the secure
+                              port."
+                            type: string
+                          key:
+                            description: key provides key file contents
+                            type: string
+                          termination:
+                            description: termination indicates termination type.
+                            type: string
+                        required:
+                        - termination
+                        type: object
+                      wildcardPolicy:
+                        description: WildcardPolicy if any for the route. Currently
+                          only 'Subdomain' or 'None' is allowed.
+                        type: string
+                    required:
+                    - enabled
+                    type: object
+                  service:
+                    description: Service defines the options for the Service backing
+                      the ArgoCD Server component.
+                    properties:
+                      type:
+                        description: Type is the ServiceType to use for the Service
+                          resource.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                type: object
+              statusBadgeEnabled:
+                description: StatusBadgeEnabled toggles application status badge feature.
+                type: boolean
+              tls:
+                description: TLS defines the TLS options for ArgoCD.
+                properties:
+                  ca:
+                    description: CA defines the CA options.
+                    properties:
+                      configMapName:
+                        description: ConfigMapName is the name of the ConfigMap containing
+                          the CA Certificate.
+                        type: string
+                      secretName:
+                        description: SecretName is the name of the Secret containing
+                          the CA Certificate and Key.
+                        type: string
+                    type: object
+                  initialCerts:
+                    additionalProperties:
+                      type: string
+                    description: InitialCerts defines custom TLS certificates upon
+                      creation of the cluster for connecting Git repositories via
+                      HTTPS.
+                    type: object
+                type: object
+              usersAnonymousEnabled:
+                description: UsersAnonymousEnabled toggles anonymous user access.
+                  The anonymous users get default role permissions specified argocd-rbac-cm.
+                type: boolean
+              version:
+                description: Version is the tag to use with the ArgoCD container image
+                  for all ArgoCD components.
+                type: string
+            type: object
+          status:
+            description: ArgoCDStatus defines the observed state of ArgoCD
+            properties:
+              applicationController:
+                description: 'ApplicationController is a simple, high-level summary
+                  of where the Argo CD application controller component is in its
+                  lifecycle. There are five possible ApplicationController values:
+                  Pending: The Argo CD application controller component has been accepted
+                  by the Kubernetes system, but one or more of the required resources
+                  have not been created. Running: All of the required Pods for the
+                  Argo CD application controller component are in a Ready state. Failed:
+                  At least one of the  Argo CD application controller component Pods
+                  had a failure. Unknown: For some reason the state of the Argo CD
+                  application controller component could not be obtained.'
+                type: string
+              dex:
+                description: 'Dex is a simple, high-level summary of where the Argo
+                  CD Dex component is in its lifecycle. There are five possible dex
+                  values: Pending: The Argo CD Dex component has been accepted by
+                  the Kubernetes system, but one or more of the required resources
+                  have not been created. Running: All of the required Pods for the
+                  Argo CD Dex component are in a Ready state. Failed: At least one
+                  of the  Argo CD Dex component Pods had a failure. Unknown: For some
+                  reason the state of the Argo CD Dex component could not be obtained.'
+                type: string
+              phase:
+                description: 'Phase is a simple, high-level summary of where the ArgoCD
+                  is in its lifecycle. There are five possible phase values: Pending:
+                  The ArgoCD has been accepted by the Kubernetes system, but one or
+                  more of the required resources have not been created. Available:
+                  All of the resources for the ArgoCD are ready. Failed: At least
+                  one resource has experienced a failure. Unknown: For some reason
+                  the state of the ArgoCD phase could not be obtained.'
+                type: string
+              redis:
+                description: 'Redis is a simple, high-level summary of where the Argo
+                  CD Redis component is in its lifecycle. There are five possible
+                  redis values: Pending: The Argo CD Redis component has been accepted
+                  by the Kubernetes system, but one or more of the required resources
+                  have not been created. Running: All of the required Pods for the
+                  Argo CD Redis component are in a Ready state. Failed: At least one
+                  of the  Argo CD Redis component Pods had a failure. Unknown: For
+                  some reason the state of the Argo CD Redis component could not be
+                  obtained.'
+                type: string
+              repo:
+                description: 'Repo is a simple, high-level summary of where the Argo
+                  CD Repo component is in its lifecycle. There are five possible repo
+                  values: Pending: The Argo CD Repo component has been accepted by
+                  the Kubernetes system, but one or more of the required resources
+                  have not been created. Running: All of the required Pods for the
+                  Argo CD Repo component are in a Ready state. Failed: At least one
+                  of the  Argo CD Repo component Pods had a failure. Unknown: For
+                  some reason the state of the Argo CD Repo component could not be
+                  obtained.'
+                type: string
+              server:
+                description: 'Server is a simple, high-level summary of where the
+                  Argo CD server component is in its lifecycle. There are five possible
+                  server values: Pending: The Argo CD server component has been accepted
+                  by the Kubernetes system, but one or more of the required resources
+                  have not been created. Running: All of the required Pods for the
+                  Argo CD server component are in a Ready state. Failed: At least
+                  one of the  Argo CD server component Pods had a failure. Unknown:
+                  For some reason the state of the Argo CD server component could
+                  not be obtained.'
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

**What type of PR is this?**

/kind code-refactoring

**What does this PR do / why we need it**:

Our CRDs still reside in `apiextensions.k8s.io/v1beta1`. This API is deprecated and will be removed soon from upstream Kubernetes.

This PR updates CRDs `argocds` and `argocdexports` to `apiextensions.k8s.io/v1`. Changes are the result of `operator-sdk generate crds` with a newer version of kubebuilder.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #261

**How to test changes / Special notes to the reviewer**:

On a virgin cluster / new-install scenario:

1. Deploy CRDs to a "virgin" cluster (`oc apply -f deploy/crds/` and `oc apply -f deploy/argo-cd`)
2. Start operator locally (e.g. `operator-sdk run local`) against that cluster
3. Create some `ArgoCD` CR
4. Verify reconciliation happens succesfully

For an existing installation scenario:

1. Have previous version of Argo CD Operator installed on some cluster
2. Have an existing `ArgoCD` CR that is fully reconciled already
3. Update the CRDs in the cluster: `oc apply -f deploy/crds`
4. Verify that no changes happened to the Argo CD instance