### PR TITLE
fix: add compute resources to init containers

### DIFF
--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -349,6 +349,7 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 		Image:           getArgoContainerImage(cr),
 		ImagePullPolicy: corev1.PullAlways,
 		Name:            "copyutil",
+		Resources: getDexResources(cr),
 		VolumeMounts: []corev1.VolumeMount{{
 			Name:      "static-files",
 			MountPath: "/shared",
@@ -695,6 +696,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoprojv1a1.ArgoC
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            "config-init",
 		Env:             proxyEnvVars(),
+		Resources: getRedisHAProxyResources(cr),
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "config-volume",

--- a/pkg/controller/argocd/deployment_test.go
+++ b/pkg/controller/argocd/deployment_test.go
@@ -126,6 +126,38 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 		deployment))
 }
 
+func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
+	restoreEnv(t)
+
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCDWithResources()
+	r := makeTestReconciler(t, a)
+
+	assert.NilError(t, r.reconcileDexDeployment(a))
+
+	deployment := &appsv1.Deployment{}
+	assert.NilError(t, r.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      a.Name + "-dex-server",
+			Namespace: a.Namespace,
+		},
+		deployment))
+
+	testResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("250m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("256Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("500m"),
+		},
+	}
+	assert.DeepEqual(t, deployment.Spec.Template.Spec.Containers[0].Resources, testResources)
+	assert.DeepEqual(t, deployment.Spec.Template.Spec.InitContainers[0].Resources, testResources)
+}
+
 // reconcileRepoDeployments creates a Deployment with the proxy settings from the
 // environment propagated.
 func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
@@ -233,7 +265,7 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy_with_resources(t *testing
 		},
 	}
 	assert.DeepEqual(t, deployment.Spec.Template.Spec.Containers[0].Resources, testResources)
-
+	assert.DeepEqual(t, deployment.Spec.Template.Spec.InitContainers[0].Resources, testResources)
 }
 
 func TestReconcileArgoCD_reconcileRepoDeployment_updatesVolumeMounts(t *testing.T) {

--- a/pkg/controller/argocd/statefulset.go
+++ b/pkg/controller/argocd/statefulset.go
@@ -393,6 +393,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 		podSpec.InitContainers = []corev1.Container{{
 			Command:         getArgoImportCommand(r.client, cr),
 			Env:             proxyEnvVars(getArgoImportContainerEnv(export)...),
+			Resources:       getArgoApplicationControllerResources(cr),
 			Image:           getArgoImportContainerImage(export),
 			ImagePullPolicy: corev1.PullAlways,
 			Name:            "argocd-import",

--- a/pkg/controller/argocd/testing.go
+++ b/pkg/controller/argocd/testing.go
@@ -78,6 +78,12 @@ func makeTestArgoCDWithResources(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
 			HA: argoprojv1alpha1.ArgoCDHASpec{
 				Resources: makeTestHAResources(),
 			},
+			Dex: argoprojv1alpha1.ArgoCDDexSpec{
+				Resources: makeTestDexResources(),
+			},
+			Controller: argoprojv1alpha1.ArgoCDApplicationControllerSpec{
+				Resources: makeTestControllerResources(),
+			},
 		},
 	}
 	for _, o := range opts {
@@ -171,6 +177,19 @@ func stringMapKeys(m map[string]string) []string {
 	return r
 }
 
+func makeTestControllerResources() *corev1.ResourceRequirements {
+	return &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("1024Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("1000m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("2048Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("2000m"),
+		},
+	}
+}
+
 func makeTestApplicationSetResources() *corev1.ResourceRequirements {
 	return &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -185,6 +204,19 @@ func makeTestApplicationSetResources() *corev1.ResourceRequirements {
 }
 
 func makeTestHAResources() *corev1.ResourceRequirements {
+	return &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("250m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resourcev1.MustParse("256Mi"),
+			corev1.ResourceCPU:    resourcev1.MustParse("500m"),
+		},
+	}
+}
+
+func makeTestDexResources() *corev1.ResourceRequirements {
 	return &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resourcev1.MustParse("128Mi"),


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
This PR adds compute resources to definition of several of the ArgoCD init containers.  Without this, the associated pods will fail to start if ArgoCD is installed into a namespace which has resource quotas set.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #304 

**How to test changes / Special notes to the reviewer**:

To test, define a namespace that has resource quotas set, then create an ArgoCD CR that defines compute resources for its components, and install into the namespace.  All pods should start successfully.
