### PR TITLE
feat: Install keycloak for openshift using OpenShift templates

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -10,4 +10,4 @@ scorecard:
         cr-manifest:
           - examples/argocd-basic.yaml
           - examples/argocdexport-basic.yaml
-        csv-path: "deploy/olm-catalog/argocd-operator/0.0.15/argocd-operator.v0.0.15.clusterserviceversion.yaml"
+        csv-path: "deploy/olm-catalog/argocd-operator/0.0.16/argocd-operator.v0.0.16.clusterserviceversion.yaml"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,6 +35,7 @@ import (
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -156,6 +157,14 @@ func main() {
 	// Setup Scheme for OpenShift Routes if available.
 	if argocd.IsRouteAPIAvailable() {
 		if err := routev1.AddToScheme(mgr.GetScheme()); err != nil {
+			log.Error(err, "")
+			os.Exit(1)
+		}
+	}
+
+	// Setup Scheme for OpenShift templates if available.
+	if argocd.IsTemplateAPIAvailable() {
+		if err := templatev1.AddToScheme(mgr.GetScheme()); err != nil {
 			log.Error(err, "")
 			os.Exit(1)
 		}

--- a/deploy/olm-catalog/argocd-operator/0.0.16/argocd-operator.v0.0.16.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.16/argocd-operator.v0.0.16.clusterserviceversion.yaml
@@ -1,0 +1,858 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"argoproj.io/v1alpha1","kind":"ArgoCD","metadata":{"name":"example-argocd"},"spec":{}},{"apiVersion":"argoproj.io/v1alpha1","kind":"ArgoCDExport","metadata":{"name":"example-argocdexport"},"spec":{"argocd":"example-argocd"}},{"apiVersion":"argoproj.io/v1alpha1","kind":"Application","metadata":{"name":"guestbook"},"spec":{"destination":{"namespace":"argocd","server":"https://kubernetes.default.svc"},"project":"default","source":{"path":"guestbook","repoURL":"https://github.com/argoproj/argocd-example-apps.git","targetRevision":"HEAD"}}},{"apiVersion":"argoproj.io/v1alpha1","kind":"AppProject","metadata":{"name":"example-project"},"spec":{"sourceRepos": ["*"]}}]'
+    capabilities: Auto Pilot
+    categories: Integration & Delivery
+    certified: "false"
+    containerImage: quay.io/argoprojlabs/argocd-operator@sha256:38254c8d53172993cb51c0b4c72645757ba36e7e8e3b1251683b00cede47fa7c
+    createdAt: "2020-10-09 15:19:40"
+    description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
+    operators.operatorframework.io/builder: operator-sdk-v0.19.4
+    operators.operatorframework.io/project_layout: go
+    repository: https://github.com/argoproj-labs/argocd-operator
+    support: Argo CD
+  name: argocd-operator.v0.0.16
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: Application
+      name: applications.argoproj.io
+      version: v1alpha1
+      displayName: Application
+      description: An Application is a group of Kubernetes resources as defined by a manifest.
+    - kind: AppProject
+      name: appprojects.argoproj.io
+      version: v1alpha1
+      displayName: AppProject
+      description: An AppProject is a logical grouping of Argo CD Applications.
+    - kind: ArgoCDExport
+      name: argocdexports.argoproj.io
+      version: v1alpha1
+      displayName: ArgoCDExport
+      description: ArgoCDExport describes the desired state for the export of a given Argo CD cluster.
+      resources:
+      - kind: ArgoCD
+        name: ''
+        version: v1alpha1
+      - kind: ArgoCDExport
+        name: ''
+        version: v1alpha1
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      - kind: CronJob
+        name: ''
+        version: v1beta1
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: Ingress
+        name: ''
+        version: v1beta1
+      - kind: Job
+        name: ''
+        version: v1
+      - kind: PersistentVolumeClaim
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: Prometheus
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Route
+        name: ''
+        version: v1
+      - kind: Secret
+        name: ''
+        version: v1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: ServiceMonitor
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: The name of the ArgoCD instance to export.
+        displayName: ArgoCD
+        path: argocd
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The schedule for the export in Cron format, see https://en.wikipedia.org/wiki/Cron.
+        displayName: Schedule
+        path: schedule
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The storage configuration options for the export.
+        displayName: Storage
+        path: storage
+      statusDescriptors:
+      - description: Phase is a simple, high-level summary of where the ArgoCDExport is in its lifecycle.
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - kind: ArgoCD
+      name: argocds.argoproj.io
+      version: v1alpha1
+      displayName: ArgoCD
+      description: ArgoCD is the representation of an Argo CD deployment.
+      resources:
+      - kind: ArgoCD
+        name: ''
+        version: v1alpha1
+      - kind: ArgoCDExport
+        name: ''
+        version: v1alpha1
+      - kind: ConfigMap
+        name: ''
+        version: v1
+      - kind: CronJob
+        name: ''
+        version: v1beta1
+      - kind: Deployment
+        name: ''
+        version: v1
+      - kind: Ingress
+        name: ''
+        version: v1beta1
+      - kind: Job
+        name: ''
+        version: v1
+      - kind: PersistentVolumeClaim
+        name: ''
+        version: v1
+      - kind: Pod
+        name: ''
+        version: v1
+      - kind: Prometheus
+        name: ''
+        version: v1
+      - kind: ReplicaSet
+        name: ''
+        version: v1
+      - kind: Route
+        name: ''
+        version: v1
+      - kind: Secret
+        name: ''
+        version: v1
+      - kind: Service
+        name: ''
+        version: v1
+      - kind: ServiceMonitor
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1
+      specDescriptors:
+      - description: 'The container image to use for the Argo CD components.'
+        displayName: Image
+        path: image
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ArgoCD'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The container image tag (version) to use for the Argo CD components.'
+        displayName: Version
+        path: version
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ArgoCD'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The number of operation processors for the Argo CD Application Controller.'
+        displayName: 'Operation Processor Count'
+        path: controller.processors.operation
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller'
+          - 'urn:alm:descriptor:com.tectonic.ui:number'
+      - description: 'The number of status processors for the Argo CD Application Controller.'
+        displayName: 'Status Processor Count'
+        path: controller.processors.status
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller'
+          - 'urn:alm:descriptor:com.tectonic.ui:number'
+      - description: 'The limits and requests requirements for the Argo CD Application Controller container.'
+        displayName: 'Resource Requirements'
+        path: controller.resources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller'
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: 'The Dex connector configuration.'
+        displayName: Configuration
+        path: dex.config
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The container image name to use for Dex.'
+        displayName: Image
+        path: dex.image
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Selected if OpenShift OAuth should be automatically configured by the operator.'
+        displayName: 'OpenShift OAuth Enabled'
+        path: dex.openShiftOAuth
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The limits and requests requirements for the Dex container.'
+        displayName: 'Resource Requirements'
+        path: dex.resources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex'
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: 'The container image tag (version) to use for Dex.'
+        displayName: Version
+        path: dex.version
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Selected if Grafana resources should created.'
+        displayName: Enabled
+        path: grafana.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The hostname to use for access to Grafana.'
+        displayName: Host
+        path: grafana.host
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The container image name to use for Grafana.'
+        displayName: Image
+        path: grafana.image
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Selected if a Grafana Ingress resource should be created.'
+        displayName: 'Ingress Enabled'
+        path: grafana.ingress.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The limits and requests requirements for the Grafana container.'
+        displayName: 'Resource Requirements'
+        path: grafana.resources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana'
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: 'Selected if a Grafana Route resource should be created.'
+        displayName: 'Route Enabled'
+        path: grafana.route.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The replica count for the Grafana Deployment.'
+        displayName: Size
+        path: grafana.size
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana'
+          - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: 'The container image tag (version) to use for Grafana.'
+        displayName: Version
+        path: grafana.version
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Selected if Argo CD high-availability mode should be enabled.'
+        displayName: Enabled
+        path: ha.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HA'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The name of an ArgoCDExport from which to import initial data.'
+        displayName: Name
+        path: import.name
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Import'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Namespace for the ArgoCDExport, defaults to the same namespace as the ArgoCD.'
+        displayName: Namespace
+        path: import.namespace
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Import'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Selected if Prometheus resources should be created.'
+        displayName: Enabled
+        path: prometheus.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The hostname to use for access to Prometheus.'
+        displayName: Host
+        path: prometheus.host
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Selected if a Prometheus Ingress resource should be created.'
+        displayName: 'Ingress Enabled'
+        path: prometheus.ingress.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'Selected if a Prometheus Route resource should be created.'
+        displayName: 'Route Enabled'
+        path: prometheus.route.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The replica count for the Prometheus Deployment.'
+        displayName: Size
+        path: prometheus.size
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus'
+          - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: 'The default role which Argo CD will fall back to when authorizing API requests.'
+        displayName: 'Default Policy'
+        path: rbac.defaultPolicy
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The user-defined RBAC policies and role definitions in CSV format.'
+        displayName: Policy
+        path: rbac.policy
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The OIDC scopes to examine during RBAC enforcement.'
+        displayName: Scopes
+        path: rbac.scopes
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The container image name to use for Redis.'
+        displayName: Image
+        path: redis.image
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The limits and requests requirements for the Redis container.'
+        displayName: 'Resource Requirements'
+        path: redis.resources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis'
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: 'The container image tag (version) to use for Redis.'
+        displayName: Version
+        path: redis.version
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The limits and requests requirements for the Argo CD repo container.'
+        displayName: 'Resource Requirements'
+        path: repo.resources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo'
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: 'Selected if autoscaling should be enabled for the Argo CD server.'
+        displayName: 'Autoscale Enabled'
+        path: server.autoscale.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The hostname to use for the GRPC Ingress/Route resource.'
+        displayName: GRPC Host
+        path: server.grpc.host
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Selected if a GRPC Ingress resource should be created.'
+        displayName: 'GRPC Ingress Enabled'
+        path: server.grpc.ingress
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The hostname to use for Ingress/Route resources.'
+        displayName: Host
+        path: server.host
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Selected if an Ingress resource should be created.'
+        displayName: 'Ingress Enabled'
+        path: server.ingress.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'Selected if the Argo CD server should be run without TLS.'
+        displayName: Insecure
+        path: server.insecure
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The limits and requests requirements for the Argo CD server container.'
+        displayName: 'Resource Requirements'
+        path: server.resources
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: 'Selected if a Route resource should be created.'
+        displayName: 'Route Enabled'
+        path: server.route.enabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - description: 'The ServiceType to use for the Argo CD server Service resource.'
+        displayName: 'Service Type'
+        path: server.service.type
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server'
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'The metadata.label key name where Argo CD injects the app name as a tracking label.'
+        displayName: 'Application Instance Label Key'
+        path: applicationInstanceLabelKey
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'Additional config management plugins.'
+        displayName: 'Config Management Plugins'
+        path: configManagementPlugins
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'The Google Analytics tracking ID to use for Argo CD.'
+        displayName: 'Google Analytics Tracking ID'
+        path: gaTrackingID
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'Selected if user IDs should be hashed before sending to Google Analytics.'
+        displayName: 'Google Analytics Anonymize Users'
+        path: gaAnonymizeUsers
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'The URL for getting chat help.'
+        displayName: 'Help Chat URL'
+        path: helpChatURL
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'The text to use for getting chat help.'
+        displayName: 'Help Chat Text'
+        path: helpChatText
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'The initial repositories to configure Argo CD to use for projects.'
+        displayName: 'Initial Repositories'
+        path: initialRepositories
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'The build options/parameters to use with `kustomize build`.'
+        displayName: 'Kustomize Build Options'
+        path: kustomizeBuildOptions
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'The OIDC configuration as an alternative to Dex.'
+        displayName: 'OIDC Config'
+        path: oidcConfig
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'Customizes resource behavior. Keys are in the form of group/Kind.'
+        displayName: 'Resource Customizations'
+        path: resourceCustomizations
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'Completely ignore entire classes of resource group/kinds.'
+        displayName: 'Resource Exclusions'
+        path: resourceExclusions
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'Selected if the application status badge feature should be enabled.'
+        displayName: 'Status Badge Enabled'
+        path: statusBadgeEnabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      - description: 'Selected if anonymous user access should be enabled.'
+        displayName: 'Anonymous Users Enabled'
+        path: usersAnonymousEnabled
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+          - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+      statusDescriptors:
+      - description: 'ApplicationController is a simple, high-level summary of where the Argo CD application controller component is in its lifecycle.'
+        displayName: ApplicationController
+        path: applicationController
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Dex is a simple, high-level summary of where the Argo CD Dex component is in its lifecycle.'
+        displayName: Dex
+        path: dex
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Phase is a simple, high-level summary of where the ArgoCD is in its lifecycle.'
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Redis is a simple, high-level summary of where the Argo CD Redis component is in its lifecycle.'
+        displayName: Redis
+        path: redis
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Repo is a simple, high-level summary of where the Argo CD Repo component is in its lifecycle.'
+        displayName: Repo
+        path: repo
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: 'Server is a simple, high-level summary of where the Argo CD server component is in its lifecycle.'
+        displayName: Server
+        path: server
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+  description: | 
+    ## Overview
+
+    The Argo CD Operator manages the full lifecycle for [Argo CD](https://argoproj.github.io/argo-cd/) and it's
+    components. The operator's goal is to automate the tasks required when operating an Argo CD cluster.
+
+    Beyond installation, the operator helps to automate the process of upgrading, backing up and restoring as needed and
+    remove the human as much as possible. In addition, the operator aims to provide deep insights into the Argo CD
+    environment by configuring Prometheus and Grafana to aggregate, visualize and expose the metrics already exported by
+    Argo CD.
+
+    The operator aims to provide the following, and is a work in progress.
+
+    * Easy configuration and installation of the Argo CD components with sane defaults to get up and running quickly.
+    * Provide seamless upgrades to the Argo CD components.
+    * Ability to back up and restore an Argo CD cluster from a point in time or on a recurring schedule.
+    * Aggregate and expose the metrics for Argo CD and the operator itself using Prometheus and Grafana.
+    * Autoscale the Argo CD components as necessary to handle variability in demand.
+
+    ## Usage
+
+    Deploy a basic Argo CD cluster by creating a new ArgoCD resource in the namespace where the operator is installed.
+
+    ```
+    apiVersion: argoproj.io/v1alpha1
+    kind: ArgoCD
+    metadata:
+      name: example-argocd
+    spec: {}
+    ```
+
+    ## Backup
+
+    Backup the cluster above by creating a new ArgoCDExport resource in the namespace where the operator is installed.
+
+    ```
+    apiVersion: argoproj.io/v1alpha1
+    kind: ArgoCDExport
+    metadata:
+      name: example-argocdexport
+    spec:
+      argocd: example-argocd
+    ```
+
+    See the [documentation](https://argocd-operator.readthedocs.io) and examples on
+    [github](https://github.com/argoproj-labs/argocd-operator) for more information.
+  displayName: Argo CD
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+Cjxzdmcgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDIzIDMwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbDpzcGFjZT0icHJlc2VydmUiIHhtbG5zOnNlcmlmPSJodHRwOi8vd3d3LnNlcmlmLmNvbS8iIHN0eWxlPSJmaWxsLXJ1bGU6ZXZlbm9kZDtjbGlwLXJ1bGU6ZXZlbm9kZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MjsiPgogICAgPGcgdHJhbnNmb3JtPSJtYXRyaXgoMSwwLDAsMSwtOS4yLC03KSI+CiAgICAgICAgPGc+CiAgICAgICAgICAgIDxnPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTE2LDI3LjdDMTYsMjcuNyAxNS44LDI4LjMgMTUuNSwyOC42QzE1LjMsMjguOCAxNS4xLDI4LjkgMTQuOCwyOC45QzE0LjEsMjkuMSAxMy4zLDI5LjIgMTMuMywyOS4yQzEzLjMsMjkuMiAxNCwyOS4zIDE0LjgsMjkuNEMxNS4xLDI5LjQgMTUuMSwyOS40IDE1LjMsMjkuNUMxNS44LDI5LjUgMTYsMjkuMiAxNiwyOS4yTDE2LDI3LjdaIiBzdHlsZT0iZmlsbDpyZ2IoMjMzLDEwMSw3NSk7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMjUuMiwyNy43QzI1LjIsMjcuNyAyNS40LDI4LjMgMjUuNywyOC42QzI1LjksMjguOCAyNi4xLDI4LjkgMjYuNCwyOC45QzI3LjEsMjkuMSAyNy45LDI5LjIgMjcuOSwyOS4yQzI3LjksMjkuMiAyNy4yLDI5LjMgMjYuMywyOS40QzI2LDI5LjQgMjYsMjkuNCAyNS44LDI5LjVDMjUuMiwyOS41IDI1LjEsMjkuMiAyNS4xLDI5LjJMMjUuMiwyNy43WiIgc3R5bGU9ImZpbGw6cmdiKDIzMywxMDEsNzUpO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgICAgICAgICA8L2c+CiAgICAgICAgICAgIDxnPgogICAgICAgICAgICAgICAgPGNpcmNsZSBjeD0iMjAuNyIgY3k9IjE3LjgiIHI9IjEwLjgiIHN0eWxlPSJmaWxsOnJnYigxODIsMjA3LDIzNCk7Ii8+CiAgICAgICAgICAgICAgICA8Y2lyY2xlIGN4PSIyMC43IiBjeT0iMTcuOCIgcj0iMTAuNCIgc3R5bGU9ImZpbGw6cmdiKDIzMCwyNDUsMjQ4KTsiLz4KICAgICAgICAgICAgICAgIDxjaXJjbGUgY3g9IjIwLjciIGN5PSIxOCIgcj0iOC41IiBzdHlsZT0iZmlsbDpyZ2IoMjA4LDIzMiwyNDApOyIvPgogICAgICAgICAgICAgICAgPGcgaWQ9IkJvZHlfMV8iPgogICAgICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0xNS43LDIyQzE1LjcsMjIgMTYuNCwzMy4zIDE2LjQsMzMuNUMxNi40LDMzLjYgMTYuNSwzMy44IDE2LDM0QzE1LjUsMzQuMiAxMy45LDM0LjYgMTMuOSwzNC42TDE2LjMsMzQuNkMxNy40LDM0LjYgMTcuNCwzMy43IDE3LjQsMzMuNUMxNy40LDMzLjMgMTcuNywyOSAxNy43LDI5QzE3LjcsMjkgMTcuOCwzNC4xIDE3LjgsMzQuM0MxNy44LDM0LjUgMTcuNywzNC44IDE3LDM1QzE2LjUsMzUuMSAxNSwzNS40IDE1LDM1LjRMMTcuMywzNS40QzE4LjcsMzUuNCAxOC43LDM0LjUgMTguNywzNC41TDE5LDMwQzE5LDMwIDE5LjEsMzQuNSAxOS4xLDM1QzE5LjEsMzUuNCAxOC44LDM1LjcgMTcuNywzNS45QzE3LDM2LjEgMTYuMSwzNi4zIDE2LjEsMzYuM0wxOC43LDM2LjNDMjAsMzYuMiAyMC4yLDM1LjMgMjAuMiwzNS4zTDIyLjQsMjQuMUwxNS43LDIyWiIgc3R5bGU9ImZpbGw6cmdiKDIzOCwxMjEsNzUpO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0yNS43LDIyQzI1LjcsMjIgMjUsMzMuMyAyNSwzMy41QzI1LDMzLjYgMjQuOSwzMy44IDI1LjQsMzRDMjUuOSwzNC4yIDI3LjUsMzQuNiAyNy41LDM0LjZMMjUuMSwzNC42QzI0LDM0LjYgMjQsMzMuNyAyNCwzMy41QzI0LDMzLjMgMjMuNywyOSAyMy43LDI5QzIzLjcsMjkgMjMuNiwzNC4xIDIzLjYsMzQuM0MyMy42LDM0LjUgMjMuNywzNC44IDI0LjQsMzVDMjQuOSwzNS4xIDI2LjQsMzUuNCAyNi40LDM1LjRMMjQuMSwzNS40QzIyLjcsMzUuNCAyMi43LDM0LjUgMjIuNywzNC41TDIyLjQsMzBDMjIuNCwzMCAyMi4zLDM0LjUgMjIuMywzNUMyMi4zLDM1LjQgMjIuNiwzNS43IDIzLjcsMzUuOUMyNC40LDM2LjEgMjUuMywzNi4zIDI1LjMsMzYuM0wyMi43LDM2LjNDMjEuNCwzNi4yIDIxLjIsMzUuMyAyMS4yLDM1LjNMMTksMjQuMUwyNS43LDIyWiIgc3R5bGU9ImZpbGw6cmdiKDIzOCwxMjEsNzUpO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0yNS44LDE2LjVDMjUuOCwxOS4zIDIzLjUsMjEuNSAyMC44LDIxLjVDMTguMSwyMS41IDE1LjgsMTkuMiAxNS44LDE2LjVDMTUuOCwxMy44IDE4LjEsMTEuNSAyMC44LDExLjVDMjMuNSwxMS41IDI1LjgsMTMuNyAyNS44LDE2LjVaIiBzdHlsZT0iZmlsbDpyZ2IoMjM4LDEyMSw3NSk7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICAgICAgICAgICAgICAgICAgPGNsaXBQYXRoIGlkPSJfY2xpcDEiPgogICAgICAgICAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMjUuOCwxNi4zTDI1LjIsMzBMMTYuMiwzMEwxNS43LDE2LjMiLz4KICAgICAgICAgICAgICAgICAgICA8L2NsaXBQYXRoPgogICAgICAgICAgICAgICAgICAgIDxnIGNsaXAtcGF0aD0idXJsKCNfY2xpcDEpIj4KICAgICAgICAgICAgICAgICAgICAgICAgPGNpcmNsZSBjeD0iMjAuOCIgY3k9IjE5LjIiIHI9IjguOSIgc3R5bGU9ImZpbGw6cmdiKDIzOCwxMjEsNzUpOyIvPgogICAgICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMjUuNSwyMkMyNS41LDIyIDI2LjEsMTYuNyAyNS4zLDE0LjdDMjMuOCwxMS4yIDIwLjMsMTEuNSAyMC4zLDExLjVDMjAuMywxMS41IDIyLjMsMTIuMyAyMi40LDE1LjNDMjIuNSwxNy40IDIyLjQsMjAuNSAyMi40LDIwLjVMMjUuNSwyMloiIHN0eWxlPSJmaWxsOnJnYigyMjcsNzgsNTkpO2ZpbGwtb3BhY2l0eTowLjIyO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgICAgICAgICAgICAgPC9nPgogICAgICAgICAgICAgICAgPGcgaWQ9IkZhY2VfMV8iPgogICAgICAgICAgICAgICAgICAgIDxjaXJjbGUgY3g9IjE4LjciIGN5PSIxMy44IiByPSIwLjciIHN0eWxlPSJmaWxsOnJnYigyNTEsMjIzLDE5NSk7ZmlsbC1vcGFjaXR5OjAuNTsiLz4KICAgICAgICAgICAgICAgICAgICA8Zz4KICAgICAgICAgICAgICAgICAgICAgICAgPGc+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMjIuNSwyNEMyMi41LDI1LjcgMjEuNywyNi44IDIwLjcsMjYuOEMxOS43LDI2LjggMTguOSwyNS41IDE4LjksMjMuOEMxOC45LDIzLjggMTkuNywyNS40IDIwLjgsMjUuNEMyMS45LDI1LjQgMjIuNSwyNCAyMi41LDI0WiIgc3R5bGU9ImZpbGw6cmdiKDEsMSwxKTtmaWxsLXJ1bGU6bm9uemVybzsiLz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0yMi41LDI0QzIyLjUsMjUuMSAyMS43LDI1LjcgMjAuNywyNS43QzE5LjcsMjUuNyAxOSwyNC45IDE5LDIzLjlDMTksMjMuOSAxOS44LDI0LjkgMjAuOSwyNC45QzIyLDI0LjkgMjIuNSwyNCAyMi41LDI0WiIgc3R5bGU9ImZpbGw6d2hpdGU7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICAgICAgICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgICAgICAgICAgICAgPGc+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8Zz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8Zz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPGNpcmNsZSBjeD0iMjQuMiIgY3k9IjE5LjMiIHI9IjMuMSIgc3R5bGU9ImZpbGw6cmdiKDIzMywxMDEsNzUpOyIvPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8Y2lyY2xlIGN4PSIxNy4yIiBjeT0iMTkuMyIgcj0iMy4xIiBzdHlsZT0iZmlsbDpyZ2IoMjMzLDEwMSw3NSk7Ii8+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPC9nPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxnPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8Y2lyY2xlIGN4PSIyNC4yIiBjeT0iMTkuMyIgcj0iMi40IiBzdHlsZT0iZmlsbDp3aGl0ZTsiLz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPGNpcmNsZSBjeD0iMTciIGN5PSIxOS4zIiByPSIyLjQiIHN0eWxlPSJmaWxsOndoaXRlOyIvPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxnPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxjaXJjbGUgY3g9IjE3IiBjeT0iMTkiIHI9IjAuNyIgc3R5bGU9ImZpbGw6cmdiKDEsMSwxKTsiLz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8Y2lyY2xlIGN4PSIyNC4yIiBjeT0iMTkiIHI9IjAuNyIgc3R5bGU9ImZpbGw6cmdiKDEsMSwxKTsiLz4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgICAgICAgICAgICAgPC9nPgogICAgICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgICAgIDwvZz4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik05LjcsMjAuNUM5LjQsMjAuNSA5LjIsMjAuMyA5LjIsMjBMOS4yLDE2QzkuMiwxNS43IDkuNCwxNS41IDkuNywxNS41QzEwLDE1LjUgMTAuMiwxNS43IDEwLjIsMTZMMTAuMiwyMEMxMC4yLDIwLjMgMTAsMjAuNSA5LjcsMjAuNVoiIHN0eWxlPSJmaWxsOnJnYigxODIsMjA3LDIzNCk7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMzEuNSwyMC41QzMxLjIsMjAuNSAzMSwyMC4zIDMxLDIwTDMxLDE2QzMxLDE1LjcgMzEuMiwxNS41IDMxLjUsMTUuNUMzMS44LDE1LjUgMzIsMTUuNyAzMiwxNkwzMiwyMEMzMiwyMC4zIDMxLjgsMjAuNSAzMS41LDIwLjVaIiBzdHlsZT0iZmlsbDpyZ2IoMTgyLDIwNywyMzQpO2ZpbGwtcnVsZTpub256ZXJvOyIvPgogICAgICAgICAgICAgICAgPGNpcmNsZSBjeD0iMTcuMyIgY3k9IjkuOCIgcj0iMC41IiBzdHlsZT0iZmlsbDp3aGl0ZTsiLz4KICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0xMy43LDIzLjNDMTMuNiwyMy4zIDEzLjUsMjMuMyAxMy40LDIzLjJDMTIuMiwyMS43IDExLjYsMTkuOCAxMS42LDE3LjlDMTEuNiwxNi4zIDEyLDE0LjggMTIuOCwxMy40QzEzLjYsMTIuMSAxNC43LDExIDE2LDEwLjJDMTYuMiwxMC4xIDE2LjQsMTAuMiAxNi41LDEwLjNDMTYuNiwxMC41IDE2LjUsMTAuNyAxNi40LDEwLjhDMTMuOSwxMi4yIDEyLjMsMTQuOSAxMi4zLDE3LjhDMTIuMywxOS42IDEyLjksMjEuMyAxNCwyMi43QzE0LjEsMjIuOCAxNC4xLDIzLjEgMTMuOSwyMy4yQzEzLjgsMjMuMyAxMy44LDIzLjMgMTMuNywyMy4zWiIgc3R5bGU9ImZpbGw6d2hpdGU7ZmlsbC1ydWxlOm5vbnplcm87Ii8+CiAgICAgICAgICAgICAgICA8cGF0aCBkPSJNMjUuMiwyOEwyNS4yLDI3LjJDMjMuOCwyOCAyMi4zLDI4LjggMjAuNSwyOC44QzE4LjUsMjguOCAxNy4yLDI3LjkgMTUuOSwyNy4yTDE2LDI4QzE2LDI4IDE3LjUsMjkuNiAyMC42LDI5LjZDMjMuNSwyOS41IDI1LjIsMjggMjUuMiwyOFoiIHN0eWxlPSJmaWxsOnJnYigyMzMsMTAxLDc1KTtmaWxsLW9wYWNpdHk6MC4yNTtmaWxsLXJ1bGU6bm9uemVybzsiLz4KICAgICAgICAgICAgPC9nPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+Cg== 
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - '*'
+        serviceAccountName: argocd-operator
+      deployments:
+      - name: argocd-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: argocd-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: argocd-operator
+            spec:
+              containers:
+              - command:
+                - argocd-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: argocd-operator
+                image: quay.io/argoprojlabs/argocd-operator@sha256:38254c8d53172993cb51c0b4c72645757ba36e7e8e3b1251683b00cede47fa7c
+                imagePullPolicy: Always
+                name: argocd-operator
+                resources: {}
+              serviceAccountName: argocd-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          - daemonsets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - argocd-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - argocds
+          - argocds/finalizers
+          - argocds/status
+          - argocdexports
+          - argocdexports/finalizers
+          - argocdexports/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheuses
+          - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - templates
+          - templateinstances
+          - templateconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - applications
+          - appprojects
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - pods/log
+          verbs:
+          - get
+        serviceAccountName: argocd-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - applications
+          - appprojects
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - list
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        serviceAccountName: argocd-application-controller
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: argocd-dex-server
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - get
+        serviceAccountName: argocd-redis-ha
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - argoproj.io
+          resources:
+          - applications
+          - appprojects
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - delete
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - list
+        serviceAccountName: argocd-server
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - gitops
+  - kubernetes
+  links:
+  - name: Argo CD Project
+    url: https://argoproj.github.io/argo-cd/
+  - name: Operator Documentation
+    url: https://argocd-operator.readthedocs.io
+  - name: Operator Source Code
+    url: https://github.com/argoproj-labs/argocd-operator
+  maintainers:
+  - email: john.mckenzie@redhat.com
+    name: John McKenzie
+  maturity: alpha
+  provider:
+    name: Argo CD Community
+  replaces: argocd-operator.v0.0.15
+  version: 0.0.16

--- a/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_applications_crd.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_applications_crd.yaml
@@ -1,0 +1,1760 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: applications.argoproj.io
+    app.kubernetes.io/part-of: argocd
+  name: applications.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    shortNames:
+    - app
+    - apps
+    singular: application
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.sync.status
+      name: Sync Status
+      type: string
+    - jsonPath: .status.health.status
+      name: Health Status
+      type: string
+    - jsonPath: .status.sync.revision
+      name: Revision
+      priority: 10
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Application is a definition of Application resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          operation:
+            description: Operation contains information about a requested or running operation
+            properties:
+              info:
+                description: Info is a list of informational items for this operation
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              initiatedBy:
+                description: InitiatedBy contains information about who initiated the operations
+                properties:
+                  automated:
+                    description: Automated is set to true if operation was initiated automatically by the application controller.
+                    type: boolean
+                  username:
+                    description: Username contains the name of a user who started operation
+                    type: string
+                type: object
+              retry:
+                description: Retry controls the strategy to apply if a sync fails
+                properties:
+                  backoff:
+                    description: Backoff controls how to backoff on subsequent retries of failed syncs
+                    properties:
+                      duration:
+                        description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                        type: string
+                      factor:
+                        description: Factor is a factor to multiply the base duration after each failed retry
+                        format: int64
+                        type: integer
+                      maxDuration:
+                        description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                        type: string
+                    type: object
+                  limit:
+                    description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                    format: int64
+                    type: integer
+                type: object
+              sync:
+                description: Sync contains parameters for the operation
+                properties:
+                  dryRun:
+                    description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
+                    type: boolean
+                  manifests:
+                    description: Manifests is an optional field that overrides sync source with a local directory for development
+                    items:
+                      type: string
+                    type: array
+                  prune:
+                    description: Prune specifies to delete resources from the cluster that are no longer tracked in git
+                    type: boolean
+                  resources:
+                    description: Resources describes which resources shall be part of the sync
+                    items:
+                      description: SyncOperationResource contains resources to sync.
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                  revision:
+                    description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
+                    type: string
+                  source:
+                    description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
+                    properties:
+                      chart:
+                        description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                        type: string
+                      directory:
+                        description: Directory holds path/directory specific options
+                        properties:
+                          exclude:
+                            description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                            type: string
+                          include:
+                            description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                            type: string
+                          jsonnet:
+                            description: Jsonnet holds options specific to Jsonnet
+                            properties:
+                              extVars:
+                                description: ExtVars is a list of Jsonnet External Variables
+                                items:
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              libs:
+                                description: Additional library search dirs
+                                items:
+                                  type: string
+                                type: array
+                              tlas:
+                                description: TLAS is a list of Jsonnet Top-level Arguments
+                                items:
+                                  description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          recurse:
+                            description: Recurse specifies whether to scan a directory recursively for manifests
+                            type: boolean
+                        type: object
+                      helm:
+                        description: Helm holds helm specific options
+                        properties:
+                          fileParameters:
+                            description: FileParameters are file parameters to the helm template
+                            items:
+                              description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                              properties:
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                path:
+                                  description: Path is the path to the file containing the values for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          parameters:
+                            description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                            items:
+                              description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                              properties:
+                                forceString:
+                                  description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                  type: boolean
+                                name:
+                                  description: Name is the name of the Helm parameter
+                                  type: string
+                                value:
+                                  description: Value is the value for the Helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          releaseName:
+                            description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                            type: string
+                          valueFiles:
+                            description: ValuesFiles is a list of Helm value files to use when generating a template
+                            items:
+                              type: string
+                            type: array
+                          values:
+                            description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                            type: string
+                          version:
+                            description: Version is the Helm version to use for templating (either "2" or "3")
+                            type: string
+                        type: object
+                      ksonnet:
+                        description: Ksonnet holds ksonnet specific options
+                        properties:
+                          environment:
+                            description: Environment is a ksonnet application environment name
+                            type: string
+                          parameters:
+                            description: Parameters are a list of ksonnet component parameter override values
+                            items:
+                              description: KsonnetParameter is a ksonnet component parameter
+                              properties:
+                                component:
+                                  type: string
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      kustomize:
+                        description: Kustomize holds kustomize specific options
+                        properties:
+                          commonAnnotations:
+                            additionalProperties:
+                              type: string
+                            description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                            type: object
+                          commonLabels:
+                            additionalProperties:
+                              type: string
+                            description: CommonLabels is a list of additional labels to add to rendered manifests
+                            type: object
+                          images:
+                            description: Images is a list of Kustomize image override specifications
+                            items:
+                              description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                              type: string
+                            type: array
+                          namePrefix:
+                            description: NamePrefix is a prefix appended to resources for Kustomize apps
+                            type: string
+                          nameSuffix:
+                            description: NameSuffix is a suffix appended to resources for Kustomize apps
+                            type: string
+                          version:
+                            description: Version controls which version of Kustomize to use for rendering manifests
+                            type: string
+                        type: object
+                      path:
+                        description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                        type: string
+                      plugin:
+                        description: ConfigManagementPlugin holds config management plugin specific options
+                        properties:
+                          env:
+                            description: Env is a list of environment variable entries
+                            items:
+                              description: EnvEntry represents an entry in the application's environment
+                              properties:
+                                name:
+                                  description: Name is the name of the variable, usually expressed in uppercase
+                                  type: string
+                                value:
+                                  description: Value is the value of the variable
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                        type: object
+                      repoURL:
+                        description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                        type: string
+                      targetRevision:
+                        description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                        type: string
+                    required:
+                    - repoURL
+                    type: object
+                  syncOptions:
+                    description: SyncOptions provide per-sync sync-options, e.g. Validate=false
+                    items:
+                      type: string
+                    type: array
+                  syncStrategy:
+                    description: SyncStrategy describes how to perform the sync
+                    properties:
+                      apply:
+                        description: Apply will perform a `kubectl apply` to perform the sync.
+                        properties:
+                          force:
+                            description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                            type: boolean
+                        type: object
+                      hook:
+                        description: Hook will submit any referenced resources to perform the sync. This is the default strategy
+                        properties:
+                          force:
+                            description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+            type: object
+          spec:
+            description: ApplicationSpec represents desired application state. Contains link to repository with application definition and additional parameters link definition revision.
+            properties:
+              destination:
+                description: Destination is a reference to the target Kubernetes server and namespace
+                properties:
+                  name:
+                    description: Name is an alternate way of specifying the target cluster by its symbolic name
+                    type: string
+                  namespace:
+                    description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                    type: string
+                  server:
+                    description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
+                    type: string
+                type: object
+              ignoreDifferences:
+                description: IgnoreDifferences is a list of resources and their fields which should be ignored during comparison
+                items:
+                  description: ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.
+                  properties:
+                    group:
+                      type: string
+                    jsonPointers:
+                      items:
+                        type: string
+                      type: array
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - jsonPointers
+                  - kind
+                  type: object
+                type: array
+              info:
+                description: Info contains a list of information (URLs, email addresses, and plain text) that relates to the application
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              project:
+                description: Project is a reference to the project this application belongs to. The empty string means that application belongs to the 'default' project.
+                type: string
+              revisionHistoryLimit:
+                description: RevisionHistoryLimit limits the number of items kept in the application's revision history, which is used for informational purposes as well as for rollbacks to previous versions. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.
+                format: int64
+                type: integer
+              source:
+                description: Source is a reference to the location of the application's manifests or chart
+                properties:
+                  chart:
+                    description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                    type: string
+                  directory:
+                    description: Directory holds path/directory specific options
+                    properties:
+                      exclude:
+                        description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                        type: string
+                      include:
+                        description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                        type: string
+                      jsonnet:
+                        description: Jsonnet holds options specific to Jsonnet
+                        properties:
+                          extVars:
+                            description: ExtVars is a list of Jsonnet External Variables
+                            items:
+                              description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                              properties:
+                                code:
+                                  type: boolean
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          libs:
+                            description: Additional library search dirs
+                            items:
+                              type: string
+                            type: array
+                          tlas:
+                            description: TLAS is a list of Jsonnet Top-level Arguments
+                            items:
+                              description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                              properties:
+                                code:
+                                  type: boolean
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      recurse:
+                        description: Recurse specifies whether to scan a directory recursively for manifests
+                        type: boolean
+                    type: object
+                  helm:
+                    description: Helm holds helm specific options
+                    properties:
+                      fileParameters:
+                        description: FileParameters are file parameters to the helm template
+                        items:
+                          description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                          properties:
+                            name:
+                              description: Name is the name of the Helm parameter
+                              type: string
+                            path:
+                              description: Path is the path to the file containing the values for the Helm parameter
+                              type: string
+                          type: object
+                        type: array
+                      parameters:
+                        description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                        items:
+                          description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                          properties:
+                            forceString:
+                              description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                              type: boolean
+                            name:
+                              description: Name is the name of the Helm parameter
+                              type: string
+                            value:
+                              description: Value is the value for the Helm parameter
+                              type: string
+                          type: object
+                        type: array
+                      releaseName:
+                        description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                        type: string
+                      valueFiles:
+                        description: ValuesFiles is a list of Helm value files to use when generating a template
+                        items:
+                          type: string
+                        type: array
+                      values:
+                        description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                        type: string
+                      version:
+                        description: Version is the Helm version to use for templating (either "2" or "3")
+                        type: string
+                    type: object
+                  ksonnet:
+                    description: Ksonnet holds ksonnet specific options
+                    properties:
+                      environment:
+                        description: Environment is a ksonnet application environment name
+                        type: string
+                      parameters:
+                        description: Parameters are a list of ksonnet component parameter override values
+                        items:
+                          description: KsonnetParameter is a ksonnet component parameter
+                          properties:
+                            component:
+                              type: string
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                    type: object
+                  kustomize:
+                    description: Kustomize holds kustomize specific options
+                    properties:
+                      commonAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                        type: object
+                      commonLabels:
+                        additionalProperties:
+                          type: string
+                        description: CommonLabels is a list of additional labels to add to rendered manifests
+                        type: object
+                      images:
+                        description: Images is a list of Kustomize image override specifications
+                        items:
+                          description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                          type: string
+                        type: array
+                      namePrefix:
+                        description: NamePrefix is a prefix appended to resources for Kustomize apps
+                        type: string
+                      nameSuffix:
+                        description: NameSuffix is a suffix appended to resources for Kustomize apps
+                        type: string
+                      version:
+                        description: Version controls which version of Kustomize to use for rendering manifests
+                        type: string
+                    type: object
+                  path:
+                    description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                    type: string
+                  plugin:
+                    description: ConfigManagementPlugin holds config management plugin specific options
+                    properties:
+                      env:
+                        description: Env is a list of environment variable entries
+                        items:
+                          description: EnvEntry represents an entry in the application's environment
+                          properties:
+                            name:
+                              description: Name is the name of the variable, usually expressed in uppercase
+                              type: string
+                            value:
+                              description: Value is the value of the variable
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                    type: object
+                  repoURL:
+                    description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                    type: string
+                  targetRevision:
+                    description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                    type: string
+                required:
+                - repoURL
+                type: object
+              syncPolicy:
+                description: SyncPolicy controls when and how a sync will be performed
+                properties:
+                  automated:
+                    description: Automated will keep an application synced to the target revision
+                    properties:
+                      allowEmpty:
+                        description: 'AllowEmpty allows apps have zero live resources (default: false)'
+                        type: boolean
+                      prune:
+                        description: 'Prune specifies whether to delete resources from the cluster that are not found in the sources anymore as part of automated sync (default: false)'
+                        type: boolean
+                      selfHeal:
+                        description: 'SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)'
+                        type: boolean
+                    type: object
+                  retry:
+                    description: Retry controls failed sync retry behavior
+                    properties:
+                      backoff:
+                        description: Backoff controls how to backoff on subsequent retries of failed syncs
+                        properties:
+                          duration:
+                            description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                            type: string
+                          factor:
+                            description: Factor is a factor to multiply the base duration after each failed retry
+                            format: int64
+                            type: integer
+                          maxDuration:
+                            description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                            type: string
+                        type: object
+                      limit:
+                        description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                        format: int64
+                        type: integer
+                    type: object
+                  syncOptions:
+                    description: Options allow you to specify whole app sync-options
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - destination
+            - project
+            - source
+            type: object
+          status:
+            description: ApplicationStatus contains status information for the application
+            properties:
+              conditions:
+                description: Conditions is a list of currently observed application conditions
+                items:
+                  description: ApplicationCondition contains details about an application condition, which is usally an error or warning
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the time the condition was last observed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message contains human-readable message indicating details about condition
+                      type: string
+                    type:
+                      description: Type is an application condition type
+                      type: string
+                  required:
+                  - message
+                  - type
+                  type: object
+                type: array
+              health:
+                description: Health contains information about the application's current health status
+                properties:
+                  message:
+                    description: Message is a human-readable informational message describing the health status
+                    type: string
+                  status:
+                    description: Status holds the status code of the application or resource
+                    type: string
+                type: object
+              history:
+                description: History contains information about the application's sync history
+                items:
+                  description: RevisionHistory contains history information about a previous sync
+                  properties:
+                    deployStartedAt:
+                      description: DeployStartedAt holds the time the sync operation started
+                      format: date-time
+                      type: string
+                    deployedAt:
+                      description: DeployedAt holds the time the sync operation completed
+                      format: date-time
+                      type: string
+                    id:
+                      description: ID is an auto incrementing identifier of the RevisionHistory
+                      format: int64
+                      type: integer
+                    revision:
+                      description: Revision holds the revision the sync was performed against
+                      type: string
+                    source:
+                      description: Source is a reference to the application source used for the sync operation
+                      properties:
+                        chart:
+                          description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                          type: string
+                        directory:
+                          description: Directory holds path/directory specific options
+                          properties:
+                            exclude:
+                              description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                              type: string
+                            include:
+                              description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                              type: string
+                            jsonnet:
+                              description: Jsonnet holds options specific to Jsonnet
+                              properties:
+                                extVars:
+                                  description: ExtVars is a list of Jsonnet External Variables
+                                  items:
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                    properties:
+                                      code:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                libs:
+                                  description: Additional library search dirs
+                                  items:
+                                    type: string
+                                  type: array
+                                tlas:
+                                  description: TLAS is a list of Jsonnet Top-level Arguments
+                                  items:
+                                    description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                    properties:
+                                      code:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                              type: object
+                            recurse:
+                              description: Recurse specifies whether to scan a directory recursively for manifests
+                              type: boolean
+                          type: object
+                        helm:
+                          description: Helm holds helm specific options
+                          properties:
+                            fileParameters:
+                              description: FileParameters are file parameters to the helm template
+                              items:
+                                description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                properties:
+                                  name:
+                                    description: Name is the name of the Helm parameter
+                                    type: string
+                                  path:
+                                    description: Path is the path to the file containing the values for the Helm parameter
+                                    type: string
+                                type: object
+                              type: array
+                            parameters:
+                              description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                              items:
+                                description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                properties:
+                                  forceString:
+                                    description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                    type: boolean
+                                  name:
+                                    description: Name is the name of the Helm parameter
+                                    type: string
+                                  value:
+                                    description: Value is the value for the Helm parameter
+                                    type: string
+                                type: object
+                              type: array
+                            releaseName:
+                              description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                              type: string
+                            valueFiles:
+                              description: ValuesFiles is a list of Helm value files to use when generating a template
+                              items:
+                                type: string
+                              type: array
+                            values:
+                              description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                              type: string
+                            version:
+                              description: Version is the Helm version to use for templating (either "2" or "3")
+                              type: string
+                          type: object
+                        ksonnet:
+                          description: Ksonnet holds ksonnet specific options
+                          properties:
+                            environment:
+                              description: Environment is a ksonnet application environment name
+                              type: string
+                            parameters:
+                              description: Parameters are a list of ksonnet component parameter override values
+                              items:
+                                description: KsonnetParameter is a ksonnet component parameter
+                                properties:
+                                  component:
+                                    type: string
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        kustomize:
+                          description: Kustomize holds kustomize specific options
+                          properties:
+                            commonAnnotations:
+                              additionalProperties:
+                                type: string
+                              description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                              type: object
+                            commonLabels:
+                              additionalProperties:
+                                type: string
+                              description: CommonLabels is a list of additional labels to add to rendered manifests
+                              type: object
+                            images:
+                              description: Images is a list of Kustomize image override specifications
+                              items:
+                                description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                type: string
+                              type: array
+                            namePrefix:
+                              description: NamePrefix is a prefix appended to resources for Kustomize apps
+                              type: string
+                            nameSuffix:
+                              description: NameSuffix is a suffix appended to resources for Kustomize apps
+                              type: string
+                            version:
+                              description: Version controls which version of Kustomize to use for rendering manifests
+                              type: string
+                          type: object
+                        path:
+                          description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                          type: string
+                        plugin:
+                          description: ConfigManagementPlugin holds config management plugin specific options
+                          properties:
+                            env:
+                              description: Env is a list of environment variable entries
+                              items:
+                                description: EnvEntry represents an entry in the application's environment
+                                properties:
+                                  name:
+                                    description: Name is the name of the variable, usually expressed in uppercase
+                                    type: string
+                                  value:
+                                    description: Value is the value of the variable
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                          type: object
+                        repoURL:
+                          description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                          type: string
+                        targetRevision:
+                          description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                          type: string
+                      required:
+                      - repoURL
+                      type: object
+                  required:
+                  - deployedAt
+                  - id
+                  - revision
+                  type: object
+                type: array
+              observedAt:
+                description: 'ObservedAt indicates when the application state was updated without querying latest git state Deprecated: controller no longer updates ObservedAt field'
+                format: date-time
+                type: string
+              operationState:
+                description: OperationState contains information about any ongoing operations, such as a sync
+                properties:
+                  finishedAt:
+                    description: FinishedAt contains time of operation completion
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message holds any pertinent messages when attempting to perform operation (typically errors).
+                    type: string
+                  operation:
+                    description: Operation is the original requested operation
+                    properties:
+                      info:
+                        description: Info is a list of informational items for this operation
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      initiatedBy:
+                        description: InitiatedBy contains information about who initiated the operations
+                        properties:
+                          automated:
+                            description: Automated is set to true if operation was initiated automatically by the application controller.
+                            type: boolean
+                          username:
+                            description: Username contains the name of a user who started operation
+                            type: string
+                        type: object
+                      retry:
+                        description: Retry controls the strategy to apply if a sync fails
+                        properties:
+                          backoff:
+                            description: Backoff controls how to backoff on subsequent retries of failed syncs
+                            properties:
+                              duration:
+                                description: Duration is the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+                                type: string
+                              factor:
+                                description: Factor is a factor to multiply the base duration after each failed retry
+                                format: int64
+                                type: integer
+                              maxDuration:
+                                description: MaxDuration is the maximum amount of time allowed for the backoff strategy
+                                type: string
+                            type: object
+                          limit:
+                            description: Limit is the maximum number of attempts for retrying a failed sync. If set to 0, no retries will be performed.
+                            format: int64
+                            type: integer
+                        type: object
+                      sync:
+                        description: Sync contains parameters for the operation
+                        properties:
+                          dryRun:
+                            description: DryRun specifies to perform a `kubectl apply --dry-run` without actually performing the sync
+                            type: boolean
+                          manifests:
+                            description: Manifests is an optional field that overrides sync source with a local directory for development
+                            items:
+                              type: string
+                            type: array
+                          prune:
+                            description: Prune specifies to delete resources from the cluster that are no longer tracked in git
+                            type: boolean
+                          resources:
+                            description: Resources describes which resources shall be part of the sync
+                            items:
+                              description: SyncOperationResource contains resources to sync.
+                              properties:
+                                group:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            type: array
+                          revision:
+                            description: Revision is the revision (Git) or chart version (Helm) which to sync the application to If omitted, will use the revision specified in app spec.
+                            type: string
+                          source:
+                            description: Source overrides the source definition set in the application. This is typically set in a Rollback operation and is nil during a Sync operation
+                            properties:
+                              chart:
+                                description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                                type: string
+                              directory:
+                                description: Directory holds path/directory specific options
+                                properties:
+                                  exclude:
+                                    description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                    type: string
+                                  include:
+                                    description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                    type: string
+                                  jsonnet:
+                                    description: Jsonnet holds options specific to Jsonnet
+                                    properties:
+                                      extVars:
+                                        description: ExtVars is a list of Jsonnet External Variables
+                                        items:
+                                          description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      libs:
+                                        description: Additional library search dirs
+                                        items:
+                                          type: string
+                                        type: array
+                                      tlas:
+                                        description: TLAS is a list of Jsonnet Top-level Arguments
+                                        items:
+                                          description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                          properties:
+                                            code:
+                                              type: boolean
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                    type: object
+                                  recurse:
+                                    description: Recurse specifies whether to scan a directory recursively for manifests
+                                    type: boolean
+                                type: object
+                              helm:
+                                description: Helm holds helm specific options
+                                properties:
+                                  fileParameters:
+                                    description: FileParameters are file parameters to the helm template
+                                    items:
+                                      description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                      properties:
+                                        name:
+                                          description: Name is the name of the Helm parameter
+                                          type: string
+                                        path:
+                                          description: Path is the path to the file containing the values for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  parameters:
+                                    description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                    items:
+                                      description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                      properties:
+                                        forceString:
+                                          description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                          type: boolean
+                                        name:
+                                          description: Name is the name of the Helm parameter
+                                          type: string
+                                        value:
+                                          description: Value is the value for the Helm parameter
+                                          type: string
+                                      type: object
+                                    type: array
+                                  releaseName:
+                                    description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                    type: string
+                                  valueFiles:
+                                    description: ValuesFiles is a list of Helm value files to use when generating a template
+                                    items:
+                                      type: string
+                                    type: array
+                                  values:
+                                    description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                    type: string
+                                  version:
+                                    description: Version is the Helm version to use for templating (either "2" or "3")
+                                    type: string
+                                type: object
+                              ksonnet:
+                                description: Ksonnet holds ksonnet specific options
+                                properties:
+                                  environment:
+                                    description: Environment is a ksonnet application environment name
+                                    type: string
+                                  parameters:
+                                    description: Parameters are a list of ksonnet component parameter override values
+                                    items:
+                                      description: KsonnetParameter is a ksonnet component parameter
+                                      properties:
+                                        component:
+                                          type: string
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              kustomize:
+                                description: Kustomize holds kustomize specific options
+                                properties:
+                                  commonAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                    type: object
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels is a list of additional labels to add to rendered manifests
+                                    type: object
+                                  images:
+                                    description: Images is a list of Kustomize image override specifications
+                                    items:
+                                      description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                      type: string
+                                    type: array
+                                  namePrefix:
+                                    description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                    type: string
+                                  nameSuffix:
+                                    description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                    type: string
+                                  version:
+                                    description: Version controls which version of Kustomize to use for rendering manifests
+                                    type: string
+                                type: object
+                              path:
+                                description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                                type: string
+                              plugin:
+                                description: ConfigManagementPlugin holds config management plugin specific options
+                                properties:
+                                  env:
+                                    description: Env is a list of environment variable entries
+                                    items:
+                                      description: EnvEntry represents an entry in the application's environment
+                                      properties:
+                                        name:
+                                          description: Name is the name of the variable, usually expressed in uppercase
+                                          type: string
+                                        value:
+                                          description: Value is the value of the variable
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                type: object
+                              repoURL:
+                                description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                                type: string
+                              targetRevision:
+                                description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                                type: string
+                            required:
+                            - repoURL
+                            type: object
+                          syncOptions:
+                            description: SyncOptions provide per-sync sync-options, e.g. Validate=false
+                            items:
+                              type: string
+                            type: array
+                          syncStrategy:
+                            description: SyncStrategy describes how to perform the sync
+                            properties:
+                              apply:
+                                description: Apply will perform a `kubectl apply` to perform the sync.
+                                properties:
+                                  force:
+                                    description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                                    type: boolean
+                                type: object
+                              hook:
+                                description: Hook will submit any referenced resources to perform the sync. This is the default strategy
+                                properties:
+                                  force:
+                                    description: Force indicates whether or not to supply the --force flag to `kubectl apply`. The --force flag deletes and re-create the resource, when PATCH encounters conflict and has retried for 5 times.
+                                    type: boolean
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  phase:
+                    description: Phase is the current phase of the operation
+                    type: string
+                  retryCount:
+                    description: RetryCount contains time of operation retries
+                    format: int64
+                    type: integer
+                  startedAt:
+                    description: StartedAt contains time of operation start
+                    format: date-time
+                    type: string
+                  syncResult:
+                    description: SyncResult is the result of a Sync operation
+                    properties:
+                      resources:
+                        description: Resources contains a list of sync result items for each individual resource in a sync operation
+                        items:
+                          description: ResourceResult holds the operation result details of a specific resource
+                          properties:
+                            group:
+                              description: Group specifies the API group of the resource
+                              type: string
+                            hookPhase:
+                              description: HookPhase contains the state of any operation associated with this resource OR hook This can also contain values for non-hook resources.
+                              type: string
+                            hookType:
+                              description: HookType specifies the type of the hook. Empty for non-hook resources
+                              type: string
+                            kind:
+                              description: Kind specifies the API kind of the resource
+                              type: string
+                            message:
+                              description: Message contains an informational or error message for the last sync OR operation
+                              type: string
+                            name:
+                              description: Name specifies the name of the resource
+                              type: string
+                            namespace:
+                              description: Namespace specifies the target namespace of the resource
+                              type: string
+                            status:
+                              description: Status holds the final result of the sync. Will be empty if the resources is yet to be applied/pruned and is always zero-value for hooks
+                              type: string
+                            syncPhase:
+                              description: SyncPhase indicates the particular phase of the sync that this result was acquired in
+                              type: string
+                            version:
+                              description: Version specifies the API version of the resource
+                              type: string
+                          required:
+                          - group
+                          - kind
+                          - name
+                          - namespace
+                          - version
+                          type: object
+                        type: array
+                      revision:
+                        description: Revision holds the revision this sync operation was performed to
+                        type: string
+                      source:
+                        description: Source records the application source information of the sync, used for comparing auto-sync
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                type: string
+                              include:
+                                description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                type: string
+                              jsonnet:
+                                description: Jsonnet holds options specific to Jsonnet
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External Variables
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level Arguments
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                description: Recurse specifies whether to scan a directory recursively for manifests
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path to the file containing the values for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              parameters:
+                                description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                items:
+                                  description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              releaseName:
+                                description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                type: string
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for templating (either "2" or "3")
+                                type: string
+                            type: object
+                          ksonnet:
+                            description: Ksonnet holds ksonnet specific options
+                            properties:
+                              environment:
+                                description: Environment is a ksonnet application environment name
+                                type: string
+                              parameters:
+                                description: Parameters are a list of ksonnet component parameter override values
+                                items:
+                                  description: KsonnetParameter is a ksonnet component parameter
+                                  properties:
+                                    component:
+                                      type: string
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels is a list of additional labels to add to rendered manifests
+                                type: object
+                              images:
+                                description: Images is a list of Kustomize image override specifications
+                                items:
+                                  description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                type: string
+                              version:
+                                description: Version controls which version of Kustomize to use for rendering manifests
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                            type: string
+                          plugin:
+                            description: ConfigManagementPlugin holds config management plugin specific options
+                            properties:
+                              env:
+                                description: Env is a list of environment variable entries
+                                items:
+                                  description: EnvEntry represents an entry in the application's environment
+                                  properties:
+                                    name:
+                                      description: Name is the name of the variable, usually expressed in uppercase
+                                      type: string
+                                    value:
+                                      description: Value is the value of the variable
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                    required:
+                    - revision
+                    type: object
+                required:
+                - operation
+                - phase
+                - startedAt
+                type: object
+              reconciledAt:
+                description: ReconciledAt indicates when the application state was reconciled using the latest git version
+                format: date-time
+                type: string
+              resources:
+                description: Resources is a list of Kubernetes resources managed by this application
+                items:
+                  description: 'ResourceStatus holds the current sync and health status of a resource TODO: describe members of this type'
+                  properties:
+                    group:
+                      type: string
+                    health:
+                      description: HealthStatus contains information about the currently observed health state of an application or resource
+                      properties:
+                        message:
+                          description: Message is a human-readable informational message describing the health status
+                          type: string
+                        status:
+                          description: Status holds the status code of the application or resource
+                          type: string
+                      type: object
+                    hook:
+                      type: boolean
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    requiresPruning:
+                      type: boolean
+                    status:
+                      description: SyncStatusCode is a type which represents possible comparison results
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                type: array
+              sourceType:
+                description: SourceType specifies the type of this application
+                type: string
+              summary:
+                description: Summary contains a list of URLs and container images used by this application
+                properties:
+                  externalURLs:
+                    description: ExternalURLs holds all external URLs of application child resources.
+                    items:
+                      type: string
+                    type: array
+                  images:
+                    description: Images holds all images of application child resources.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              sync:
+                description: Sync contains information about the application's current sync status
+                properties:
+                  comparedTo:
+                    description: ComparedTo contains information about what has been compared
+                    properties:
+                      destination:
+                        description: Destination is a reference to the application's destination used for comparison
+                        properties:
+                          name:
+                            description: Name is an alternate way of specifying the target cluster by its symbolic name
+                            type: string
+                          namespace:
+                            description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                            type: string
+                          server:
+                            description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
+                            type: string
+                        type: object
+                      source:
+                        description: Source is a reference to the application's source used for comparison
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name, and must be specified for applications sourced from a Helm repo.
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                description: Exclude contains a glob pattern to match paths against that should be explicitly excluded from being used during manifest generation
+                                type: string
+                              include:
+                                description: Include contains a glob pattern to match paths against that should be explicitly included during manifest generation
+                                type: string
+                              jsonnet:
+                                description: Jsonnet holds options specific to Jsonnet
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External Variables
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level Arguments
+                                    items:
+                                      description: JsonnetVar represents a variable to be passed to jsonnet during manifest generation
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                description: Recurse specifies whether to scan a directory recursively for manifests
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path to the file containing the values for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              parameters:
+                                description: Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
+                                items:
+                                  description: HelmParameter is a parameter that's passed to helm template during manifest generation
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether to tell Helm to interpret booleans and numbers as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the Helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the Helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              releaseName:
+                                description: ReleaseName is the Helm release name to use. If omitted it will use the application name
+                                type: string
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values specifies Helm values to be passed to helm template, typically defined as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for templating (either "2" or "3")
+                                type: string
+                            type: object
+                          ksonnet:
+                            description: Ksonnet holds ksonnet specific options
+                            properties:
+                              environment:
+                                description: Environment is a ksonnet application environment name
+                                type: string
+                              parameters:
+                                description: Parameters are a list of ksonnet component parameter override values
+                                items:
+                                  description: KsonnetParameter is a ksonnet component parameter
+                                  properties:
+                                    component:
+                                      type: string
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations is a list of additional annotations to add to rendered manifests
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels is a list of additional labels to add to rendered manifests
+                                type: object
+                              images:
+                                description: Images is a list of Kustomize image override specifications
+                                items:
+                                  description: KustomizeImage represents a Kustomize image definition in the format [old_image_name=]<image_name>:<image_tag>
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources for Kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources for Kustomize apps
+                                type: string
+                              version:
+                                description: Version controls which version of Kustomize to use for rendering manifests
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository, and is only valid for applications sourced from Git.
+                            type: string
+                          plugin:
+                            description: ConfigManagementPlugin holds config management plugin specific options
+                            properties:
+                              env:
+                                description: Env is a list of environment variable entries
+                                items:
+                                  description: EnvEntry represents an entry in the application's environment
+                                  properties:
+                                    name:
+                                      description: Name is the name of the variable, usually expressed in uppercase
+                                      type: string
+                                    value:
+                                      description: Value is the value of the variable
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the URL to the repository (Git or Helm) that contains the application manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch. If omitted, will equal to HEAD. In case of Helm, this is a semver tag for the Chart's version.
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                    required:
+                    - destination
+                    - source
+                    type: object
+                  revision:
+                    description: Revision contains information about the revision the comparison has been performed to
+                    type: string
+                  status:
+                    description: Status is the sync state of the comparison
+                    type: string
+                required:
+                - status
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_applicationsets_crd.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_applicationsets_crd.yaml
@@ -1,0 +1,1743 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: applicationsets.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ApplicationSet
+    listKind: ApplicationSetList
+    plural: applicationsets
+    singular: applicationset
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ApplicationSet is a set of Application resources
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ApplicationSetSpec represents a class of application set
+              state.
+            properties:
+              generators:
+                items:
+                  description: ApplicationSetGenerator include list item info
+                  properties:
+                    clusters:
+                      description: ClusterGenerator defines a generator to match against
+                        clusters registered with ArgoCD.
+                      properties:
+                        selector:
+                          description: Selector defines a label selector to match
+                            against all clusters registered with ArgoCD. Clusters
+                            today are stored as Kubernetes Secrets, thus the Secret
+                            labels will be used for matching the selector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        template:
+                          description: ApplicationSetTemplate represents argocd ApplicationSpec
+                          properties:
+                            metadata:
+                              description: ApplicationSetTemplateMeta represents the
+                                Argo CD application fields that may be used for Applications
+                                generated from the ApplicationSet (based on metav1.ObjectMeta)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              description: ApplicationSpec represents desired application
+                                state. Contains link to repository with application
+                                definition and additional parameters link definition
+                                revision.
+                              properties:
+                                destination:
+                                  description: Destination overrides the kubernetes
+                                    server and namespace defined in the environment
+                                    ksonnet app.yaml
+                                  properties:
+                                    name:
+                                      description: Name of the destination cluster
+                                        which can be used instead of server (url)
+                                        field
+                                      type: string
+                                    namespace:
+                                      description: Namespace overrides the environment
+                                        namespace value in the ksonnet app.yaml
+                                      type: string
+                                    server:
+                                      description: Server overrides the environment
+                                        server value in the ksonnet app.yaml
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  description: IgnoreDifferences controls resources
+                                    fields which should be ignored during comparison
+                                  items:
+                                    description: ResourceIgnoreDifferences contains
+                                      resource filter and list of json paths which
+                                      should be ignored during comparison with live
+                                      state.
+                                    properties:
+                                      group:
+                                        type: string
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - jsonPointers
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  description: Infos contains a list of useful information
+                                    (URLs, email addresses, and plain text) that relates
+                                    to the application
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  description: Project is a application project name.
+                                    Empty name means that application belongs to 'default'
+                                    project.
+                                  type: string
+                                revisionHistoryLimit:
+                                  description: This limits this number of items kept
+                                    in the apps revision history. This should only
+                                    be changed in exceptional circumstances. Setting
+                                    to zero will store no history. This will reduce
+                                    storage used. Increasing will increase the space
+                                    used to store the history, so we do not recommend
+                                    increasing it. Default is 10.
+                                  format: int64
+                                  type: integer
+                                source:
+                                  description: Source is a reference to the location
+                                    ksonnet application definition
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory
+                                        specific options
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        jsonnet:
+                                          description: ApplicationSourceJsonnet holds
+                                            jsonnet specific options
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet
+                                                External Variables
+                                              items:
+                                                description: JsonnetVar is a jsonnet
+                                                  variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search
+                                                dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet
+                                                Top-level Arguments
+                                              items:
+                                                description: JsonnetVar is a jsonnet
+                                                  variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        fileParameters:
+                                          description: FileParameters are file parameters
+                                            to the helm template
+                                          items:
+                                            description: HelmFileParameter is a file
+                                              parameter to a helm template
+                                            properties:
+                                              name:
+                                                description: Name is the name of the
+                                                  helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path value
+                                                  for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        parameters:
+                                          description: Parameters are parameters to
+                                            the helm template
+                                          items:
+                                            description: HelmParameter is a parameter
+                                              to a helm template
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines
+                                                  whether to tell Helm to interpret
+                                                  booleans and numbers as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the
+                                                  helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for
+                                                  the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        releaseName:
+                                          description: The Helm release name. If omitted
+                                            it will use the application name
+                                          type: string
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm
+                                            value files to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values is Helm values, typically
+                                            defined as a block
+                                          type: string
+                                        version:
+                                          description: Version is the Helm version
+                                            to use for templating with
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      description: Ksonnet holds ksonnet specific
+                                        options
+                                      properties:
+                                        environment:
+                                          description: Environment is a ksonnet application
+                                            environment name
+                                          type: string
+                                        parameters:
+                                          description: Parameters are a list of ksonnet
+                                            component parameter override values
+                                          items:
+                                            description: KsonnetParameter is a ksonnet
+                                              component parameter
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific
+                                        options
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations adds additional
+                                            kustomize commonAnnotations
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels adds additional
+                                            kustomize commonLabels
+                                          type: object
+                                        images:
+                                          description: Images are kustomize image
+                                            overrides
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended
+                                            to resources for kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended
+                                            to resources for kustomize apps
+                                          type: string
+                                        version:
+                                          description: Version contains optional Kustomize
+                                            version
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within
+                                        the Git repository
+                                      type: string
+                                    plugin:
+                                      description: ConfigManagementPlugin holds config
+                                        management plugin specific options
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                description: the name, usually uppercase
+                                                type: string
+                                              value:
+                                                description: the value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      description: RepoURL is the repository URL of
+                                        the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: TargetRevision defines the commit,
+                                        tag, or branch in which to sync the application
+                                        to. If omitted, will sync to HEAD
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  description: SyncPolicy controls when a sync will
+                                    be performed
+                                  properties:
+                                    automated:
+                                      description: Automated will keep an application
+                                        synced to the target revision
+                                      properties:
+                                        allowEmpty:
+                                          description: 'AllowEmpty allows apps have
+                                            zero live resources (default: false)'
+                                          type: boolean
+                                        prune:
+                                          description: 'Prune will prune resources
+                                            automatically as part of automated sync
+                                            (default: false)'
+                                          type: boolean
+                                        selfHeal:
+                                          description: 'SelfHeal enables auto-syncing
+                                            if  (default: false)'
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      description: Retry controls failed sync retry
+                                        behavior
+                                      properties:
+                                        backoff:
+                                          description: Backoff is a backoff strategy
+                                          properties:
+                                            duration:
+                                              description: Duration is the amount
+                                                to back off. Default unit is seconds,
+                                                but could also be a duration (e.g.
+                                                "2m", "1h")
+                                              type: string
+                                            factor:
+                                              description: Factor is a factor to multiply
+                                                the base duration after each failed
+                                                retry
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              description: MaxDuration is the maximum
+                                                amount of time allowed for the backoff
+                                                strategy
+                                              type: string
+                                          type: object
+                                        limit:
+                                          description: Limit is the maximum number
+                                            of attempts when retrying a container
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      description: Options allow you to specify whole
+                                        app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                        values:
+                          additionalProperties:
+                            type: string
+                          description: Values contains key/value pairs which are passed
+                            directly as parameters to the template
+                          type: object
+                      type: object
+                    git:
+                      properties:
+                        directories:
+                          items:
+                            properties:
+                              path:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        files:
+                          items:
+                            properties:
+                              path:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          type: array
+                        repoURL:
+                          type: string
+                        requeueAfterSeconds:
+                          format: int64
+                          type: integer
+                        revision:
+                          type: string
+                        template:
+                          description: ApplicationSetTemplate represents argocd ApplicationSpec
+                          properties:
+                            metadata:
+                              description: ApplicationSetTemplateMeta represents the
+                                Argo CD application fields that may be used for Applications
+                                generated from the ApplicationSet (based on metav1.ObjectMeta)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              description: ApplicationSpec represents desired application
+                                state. Contains link to repository with application
+                                definition and additional parameters link definition
+                                revision.
+                              properties:
+                                destination:
+                                  description: Destination overrides the kubernetes
+                                    server and namespace defined in the environment
+                                    ksonnet app.yaml
+                                  properties:
+                                    name:
+                                      description: Name of the destination cluster
+                                        which can be used instead of server (url)
+                                        field
+                                      type: string
+                                    namespace:
+                                      description: Namespace overrides the environment
+                                        namespace value in the ksonnet app.yaml
+                                      type: string
+                                    server:
+                                      description: Server overrides the environment
+                                        server value in the ksonnet app.yaml
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  description: IgnoreDifferences controls resources
+                                    fields which should be ignored during comparison
+                                  items:
+                                    description: ResourceIgnoreDifferences contains
+                                      resource filter and list of json paths which
+                                      should be ignored during comparison with live
+                                      state.
+                                    properties:
+                                      group:
+                                        type: string
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - jsonPointers
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  description: Infos contains a list of useful information
+                                    (URLs, email addresses, and plain text) that relates
+                                    to the application
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  description: Project is a application project name.
+                                    Empty name means that application belongs to 'default'
+                                    project.
+                                  type: string
+                                revisionHistoryLimit:
+                                  description: This limits this number of items kept
+                                    in the apps revision history. This should only
+                                    be changed in exceptional circumstances. Setting
+                                    to zero will store no history. This will reduce
+                                    storage used. Increasing will increase the space
+                                    used to store the history, so we do not recommend
+                                    increasing it. Default is 10.
+                                  format: int64
+                                  type: integer
+                                source:
+                                  description: Source is a reference to the location
+                                    ksonnet application definition
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory
+                                        specific options
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        jsonnet:
+                                          description: ApplicationSourceJsonnet holds
+                                            jsonnet specific options
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet
+                                                External Variables
+                                              items:
+                                                description: JsonnetVar is a jsonnet
+                                                  variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search
+                                                dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet
+                                                Top-level Arguments
+                                              items:
+                                                description: JsonnetVar is a jsonnet
+                                                  variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        fileParameters:
+                                          description: FileParameters are file parameters
+                                            to the helm template
+                                          items:
+                                            description: HelmFileParameter is a file
+                                              parameter to a helm template
+                                            properties:
+                                              name:
+                                                description: Name is the name of the
+                                                  helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path value
+                                                  for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        parameters:
+                                          description: Parameters are parameters to
+                                            the helm template
+                                          items:
+                                            description: HelmParameter is a parameter
+                                              to a helm template
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines
+                                                  whether to tell Helm to interpret
+                                                  booleans and numbers as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the
+                                                  helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for
+                                                  the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        releaseName:
+                                          description: The Helm release name. If omitted
+                                            it will use the application name
+                                          type: string
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm
+                                            value files to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values is Helm values, typically
+                                            defined as a block
+                                          type: string
+                                        version:
+                                          description: Version is the Helm version
+                                            to use for templating with
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      description: Ksonnet holds ksonnet specific
+                                        options
+                                      properties:
+                                        environment:
+                                          description: Environment is a ksonnet application
+                                            environment name
+                                          type: string
+                                        parameters:
+                                          description: Parameters are a list of ksonnet
+                                            component parameter override values
+                                          items:
+                                            description: KsonnetParameter is a ksonnet
+                                              component parameter
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific
+                                        options
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations adds additional
+                                            kustomize commonAnnotations
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels adds additional
+                                            kustomize commonLabels
+                                          type: object
+                                        images:
+                                          description: Images are kustomize image
+                                            overrides
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended
+                                            to resources for kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended
+                                            to resources for kustomize apps
+                                          type: string
+                                        version:
+                                          description: Version contains optional Kustomize
+                                            version
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within
+                                        the Git repository
+                                      type: string
+                                    plugin:
+                                      description: ConfigManagementPlugin holds config
+                                        management plugin specific options
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                description: the name, usually uppercase
+                                                type: string
+                                              value:
+                                                description: the value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      description: RepoURL is the repository URL of
+                                        the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: TargetRevision defines the commit,
+                                        tag, or branch in which to sync the application
+                                        to. If omitted, will sync to HEAD
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  description: SyncPolicy controls when a sync will
+                                    be performed
+                                  properties:
+                                    automated:
+                                      description: Automated will keep an application
+                                        synced to the target revision
+                                      properties:
+                                        allowEmpty:
+                                          description: 'AllowEmpty allows apps have
+                                            zero live resources (default: false)'
+                                          type: boolean
+                                        prune:
+                                          description: 'Prune will prune resources
+                                            automatically as part of automated sync
+                                            (default: false)'
+                                          type: boolean
+                                        selfHeal:
+                                          description: 'SelfHeal enables auto-syncing
+                                            if  (default: false)'
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      description: Retry controls failed sync retry
+                                        behavior
+                                      properties:
+                                        backoff:
+                                          description: Backoff is a backoff strategy
+                                          properties:
+                                            duration:
+                                              description: Duration is the amount
+                                                to back off. Default unit is seconds,
+                                                but could also be a duration (e.g.
+                                                "2m", "1h")
+                                              type: string
+                                            factor:
+                                              description: Factor is a factor to multiply
+                                                the base duration after each failed
+                                                retry
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              description: MaxDuration is the maximum
+                                                amount of time allowed for the backoff
+                                                strategy
+                                              type: string
+                                          type: object
+                                        limit:
+                                          description: Limit is the maximum number
+                                            of attempts when retrying a container
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      description: Options allow you to specify whole
+                                        app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      required:
+                      - repoURL
+                      - revision
+                      type: object
+                    list:
+                      description: ListGenerator include items info
+                      properties:
+                        elements:
+                          items:
+                            description: ListGeneratorElement include cluster and
+                              url info
+                            properties:
+                              cluster:
+                                type: string
+                              url:
+                                type: string
+                              values:
+                                additionalProperties:
+                                  type: string
+                                description: Values contains key/value pairs which
+                                  are passed directly as parameters to the template
+                                type: object
+                            required:
+                            - cluster
+                            - url
+                            type: object
+                          type: array
+                        template:
+                          description: ApplicationSetTemplate represents argocd ApplicationSpec
+                          properties:
+                            metadata:
+                              description: ApplicationSetTemplateMeta represents the
+                                Argo CD application fields that may be used for Applications
+                                generated from the ApplicationSet (based on metav1.ObjectMeta)
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              description: ApplicationSpec represents desired application
+                                state. Contains link to repository with application
+                                definition and additional parameters link definition
+                                revision.
+                              properties:
+                                destination:
+                                  description: Destination overrides the kubernetes
+                                    server and namespace defined in the environment
+                                    ksonnet app.yaml
+                                  properties:
+                                    name:
+                                      description: Name of the destination cluster
+                                        which can be used instead of server (url)
+                                        field
+                                      type: string
+                                    namespace:
+                                      description: Namespace overrides the environment
+                                        namespace value in the ksonnet app.yaml
+                                      type: string
+                                    server:
+                                      description: Server overrides the environment
+                                        server value in the ksonnet app.yaml
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  description: IgnoreDifferences controls resources
+                                    fields which should be ignored during comparison
+                                  items:
+                                    description: ResourceIgnoreDifferences contains
+                                      resource filter and list of json paths which
+                                      should be ignored during comparison with live
+                                      state.
+                                    properties:
+                                      group:
+                                        type: string
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - jsonPointers
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  description: Infos contains a list of useful information
+                                    (URLs, email addresses, and plain text) that relates
+                                    to the application
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  description: Project is a application project name.
+                                    Empty name means that application belongs to 'default'
+                                    project.
+                                  type: string
+                                revisionHistoryLimit:
+                                  description: This limits this number of items kept
+                                    in the apps revision history. This should only
+                                    be changed in exceptional circumstances. Setting
+                                    to zero will store no history. This will reduce
+                                    storage used. Increasing will increase the space
+                                    used to store the history, so we do not recommend
+                                    increasing it. Default is 10.
+                                  format: int64
+                                  type: integer
+                                source:
+                                  description: Source is a reference to the location
+                                    ksonnet application definition
+                                  properties:
+                                    chart:
+                                      description: Chart is a Helm chart name
+                                      type: string
+                                    directory:
+                                      description: Directory holds path/directory
+                                        specific options
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        jsonnet:
+                                          description: ApplicationSourceJsonnet holds
+                                            jsonnet specific options
+                                          properties:
+                                            extVars:
+                                              description: ExtVars is a list of Jsonnet
+                                                External Variables
+                                              items:
+                                                description: JsonnetVar is a jsonnet
+                                                  variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              description: Additional library search
+                                                dirs
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              description: TLAS is a list of Jsonnet
+                                                Top-level Arguments
+                                              items:
+                                                description: JsonnetVar is a jsonnet
+                                                  variable
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      description: Helm holds helm specific options
+                                      properties:
+                                        fileParameters:
+                                          description: FileParameters are file parameters
+                                            to the helm template
+                                          items:
+                                            description: HelmFileParameter is a file
+                                              parameter to a helm template
+                                            properties:
+                                              name:
+                                                description: Name is the name of the
+                                                  helm parameter
+                                                type: string
+                                              path:
+                                                description: Path is the path value
+                                                  for the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        parameters:
+                                          description: Parameters are parameters to
+                                            the helm template
+                                          items:
+                                            description: HelmParameter is a parameter
+                                              to a helm template
+                                            properties:
+                                              forceString:
+                                                description: ForceString determines
+                                                  whether to tell Helm to interpret
+                                                  booleans and numbers as strings
+                                                type: boolean
+                                              name:
+                                                description: Name is the name of the
+                                                  helm parameter
+                                                type: string
+                                              value:
+                                                description: Value is the value for
+                                                  the helm parameter
+                                                type: string
+                                            type: object
+                                          type: array
+                                        releaseName:
+                                          description: The Helm release name. If omitted
+                                            it will use the application name
+                                          type: string
+                                        valueFiles:
+                                          description: ValuesFiles is a list of Helm
+                                            value files to use when generating a template
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          description: Values is Helm values, typically
+                                            defined as a block
+                                          type: string
+                                        version:
+                                          description: Version is the Helm version
+                                            to use for templating with
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      description: Ksonnet holds ksonnet specific
+                                        options
+                                      properties:
+                                        environment:
+                                          description: Environment is a ksonnet application
+                                            environment name
+                                          type: string
+                                        parameters:
+                                          description: Parameters are a list of ksonnet
+                                            component parameter override values
+                                          items:
+                                            description: KsonnetParameter is a ksonnet
+                                              component parameter
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      description: Kustomize holds kustomize specific
+                                        options
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonAnnotations adds additional
+                                            kustomize commonAnnotations
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: CommonLabels adds additional
+                                            kustomize commonLabels
+                                          type: object
+                                        images:
+                                          description: Images are kustomize image
+                                            overrides
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          description: NamePrefix is a prefix appended
+                                            to resources for kustomize apps
+                                          type: string
+                                        nameSuffix:
+                                          description: NameSuffix is a suffix appended
+                                            to resources for kustomize apps
+                                          type: string
+                                        version:
+                                          description: Version contains optional Kustomize
+                                            version
+                                          type: string
+                                      type: object
+                                    path:
+                                      description: Path is a directory path within
+                                        the Git repository
+                                      type: string
+                                    plugin:
+                                      description: ConfigManagementPlugin holds config
+                                        management plugin specific options
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                description: the name, usually uppercase
+                                                type: string
+                                              value:
+                                                description: the value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      description: RepoURL is the repository URL of
+                                        the application manifests
+                                      type: string
+                                    targetRevision:
+                                      description: TargetRevision defines the commit,
+                                        tag, or branch in which to sync the application
+                                        to. If omitted, will sync to HEAD
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  description: SyncPolicy controls when a sync will
+                                    be performed
+                                  properties:
+                                    automated:
+                                      description: Automated will keep an application
+                                        synced to the target revision
+                                      properties:
+                                        allowEmpty:
+                                          description: 'AllowEmpty allows apps have
+                                            zero live resources (default: false)'
+                                          type: boolean
+                                        prune:
+                                          description: 'Prune will prune resources
+                                            automatically as part of automated sync
+                                            (default: false)'
+                                          type: boolean
+                                        selfHeal:
+                                          description: 'SelfHeal enables auto-syncing
+                                            if  (default: false)'
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      description: Retry controls failed sync retry
+                                        behavior
+                                      properties:
+                                        backoff:
+                                          description: Backoff is a backoff strategy
+                                          properties:
+                                            duration:
+                                              description: Duration is the amount
+                                                to back off. Default unit is seconds,
+                                                but could also be a duration (e.g.
+                                                "2m", "1h")
+                                              type: string
+                                            factor:
+                                              description: Factor is a factor to multiply
+                                                the base duration after each failed
+                                                retry
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              description: MaxDuration is the maximum
+                                                amount of time allowed for the backoff
+                                                strategy
+                                              type: string
+                                          type: object
+                                        limit:
+                                          description: Limit is the maximum number
+                                            of attempts when retrying a container
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      description: Options allow you to specify whole
+                                        app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      required:
+                      - elements
+                      type: object
+                  type: object
+                type: array
+              syncPolicy:
+                description: ApplicationSetSyncPolicy configures how generated Applications
+                  will relate to their ApplicationSet.
+                properties:
+                  skipPrune:
+                    description: SkipPrune will disable the default behavior which
+                      will delete Applications that are no longer being generated
+                      for the ApplicationSet which created them, or the ApplicationSet
+                      itself is deleted. If SkipPrune is set to true, these Applications
+                      will be orphaned but continue to exist.
+                    type: boolean
+                type: object
+              template:
+                description: ApplicationSetTemplate represents argocd ApplicationSpec
+                properties:
+                  metadata:
+                    description: ApplicationSetTemplateMeta represents the Argo CD
+                      application fields that may be used for Applications generated
+                      from the ApplicationSet (based on metav1.ObjectMeta)
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  spec:
+                    description: ApplicationSpec represents desired application state.
+                      Contains link to repository with application definition and
+                      additional parameters link definition revision.
+                    properties:
+                      destination:
+                        description: Destination overrides the kubernetes server and
+                          namespace defined in the environment ksonnet app.yaml
+                        properties:
+                          name:
+                            description: Name of the destination cluster which can
+                              be used instead of server (url) field
+                            type: string
+                          namespace:
+                            description: Namespace overrides the environment namespace
+                              value in the ksonnet app.yaml
+                            type: string
+                          server:
+                            description: Server overrides the environment server value
+                              in the ksonnet app.yaml
+                            type: string
+                        type: object
+                      ignoreDifferences:
+                        description: IgnoreDifferences controls resources fields which
+                          should be ignored during comparison
+                        items:
+                          description: ResourceIgnoreDifferences contains resource
+                            filter and list of json paths which should be ignored
+                            during comparison with live state.
+                          properties:
+                            group:
+                              type: string
+                            jsonPointers:
+                              items:
+                                type: string
+                              type: array
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - jsonPointers
+                          - kind
+                          type: object
+                        type: array
+                      info:
+                        description: Infos contains a list of useful information (URLs,
+                          email addresses, and plain text) that relates to the application
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      project:
+                        description: Project is a application project name. Empty
+                          name means that application belongs to 'default' project.
+                        type: string
+                      revisionHistoryLimit:
+                        description: This limits this number of items kept in the
+                          apps revision history. This should only be changed in exceptional
+                          circumstances. Setting to zero will store no history. This
+                          will reduce storage used. Increasing will increase the space
+                          used to store the history, so we do not recommend increasing
+                          it. Default is 10.
+                        format: int64
+                        type: integer
+                      source:
+                        description: Source is a reference to the location ksonnet
+                          application definition
+                        properties:
+                          chart:
+                            description: Chart is a Helm chart name
+                            type: string
+                          directory:
+                            description: Directory holds path/directory specific options
+                            properties:
+                              exclude:
+                                type: string
+                              jsonnet:
+                                description: ApplicationSourceJsonnet holds jsonnet
+                                  specific options
+                                properties:
+                                  extVars:
+                                    description: ExtVars is a list of Jsonnet External
+                                      Variables
+                                    items:
+                                      description: JsonnetVar is a jsonnet variable
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  libs:
+                                    description: Additional library search dirs
+                                    items:
+                                      type: string
+                                    type: array
+                                  tlas:
+                                    description: TLAS is a list of Jsonnet Top-level
+                                      Arguments
+                                    items:
+                                      description: JsonnetVar is a jsonnet variable
+                                      properties:
+                                        code:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                type: object
+                              recurse:
+                                type: boolean
+                            type: object
+                          helm:
+                            description: Helm holds helm specific options
+                            properties:
+                              fileParameters:
+                                description: FileParameters are file parameters to
+                                  the helm template
+                                items:
+                                  description: HelmFileParameter is a file parameter
+                                    to a helm template
+                                  properties:
+                                    name:
+                                      description: Name is the name of the helm parameter
+                                      type: string
+                                    path:
+                                      description: Path is the path value for the
+                                        helm parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              parameters:
+                                description: Parameters are parameters to the helm
+                                  template
+                                items:
+                                  description: HelmParameter is a parameter to a helm
+                                    template
+                                  properties:
+                                    forceString:
+                                      description: ForceString determines whether
+                                        to tell Helm to interpret booleans and numbers
+                                        as strings
+                                      type: boolean
+                                    name:
+                                      description: Name is the name of the helm parameter
+                                      type: string
+                                    value:
+                                      description: Value is the value for the helm
+                                        parameter
+                                      type: string
+                                  type: object
+                                type: array
+                              releaseName:
+                                description: The Helm release name. If omitted it
+                                  will use the application name
+                                type: string
+                              valueFiles:
+                                description: ValuesFiles is a list of Helm value files
+                                  to use when generating a template
+                                items:
+                                  type: string
+                                type: array
+                              values:
+                                description: Values is Helm values, typically defined
+                                  as a block
+                                type: string
+                              version:
+                                description: Version is the Helm version to use for
+                                  templating with
+                                type: string
+                            type: object
+                          ksonnet:
+                            description: Ksonnet holds ksonnet specific options
+                            properties:
+                              environment:
+                                description: Environment is a ksonnet application
+                                  environment name
+                                type: string
+                              parameters:
+                                description: Parameters are a list of ksonnet component
+                                  parameter override values
+                                items:
+                                  description: KsonnetParameter is a ksonnet component
+                                    parameter
+                                  properties:
+                                    component:
+                                      type: string
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          kustomize:
+                            description: Kustomize holds kustomize specific options
+                            properties:
+                              commonAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: CommonAnnotations adds additional kustomize
+                                  commonAnnotations
+                                type: object
+                              commonLabels:
+                                additionalProperties:
+                                  type: string
+                                description: CommonLabels adds additional kustomize
+                                  commonLabels
+                                type: object
+                              images:
+                                description: Images are kustomize image overrides
+                                items:
+                                  type: string
+                                type: array
+                              namePrefix:
+                                description: NamePrefix is a prefix appended to resources
+                                  for kustomize apps
+                                type: string
+                              nameSuffix:
+                                description: NameSuffix is a suffix appended to resources
+                                  for kustomize apps
+                                type: string
+                              version:
+                                description: Version contains optional Kustomize version
+                                type: string
+                            type: object
+                          path:
+                            description: Path is a directory path within the Git repository
+                            type: string
+                          plugin:
+                            description: ConfigManagementPlugin holds config management
+                              plugin specific options
+                            properties:
+                              env:
+                                items:
+                                  properties:
+                                    name:
+                                      description: the name, usually uppercase
+                                      type: string
+                                    value:
+                                      description: the value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          repoURL:
+                            description: RepoURL is the repository URL of the application
+                              manifests
+                            type: string
+                          targetRevision:
+                            description: TargetRevision defines the commit, tag, or
+                              branch in which to sync the application to. If omitted,
+                              will sync to HEAD
+                            type: string
+                        required:
+                        - repoURL
+                        type: object
+                      syncPolicy:
+                        description: SyncPolicy controls when a sync will be performed
+                        properties:
+                          automated:
+                            description: Automated will keep an application synced
+                              to the target revision
+                            properties:
+                              allowEmpty:
+                                description: 'AllowEmpty allows apps have zero live
+                                  resources (default: false)'
+                                type: boolean
+                              prune:
+                                description: 'Prune will prune resources automatically
+                                  as part of automated sync (default: false)'
+                                type: boolean
+                              selfHeal:
+                                description: 'SelfHeal enables auto-syncing if  (default:
+                                  false)'
+                                type: boolean
+                            type: object
+                          retry:
+                            description: Retry controls failed sync retry behavior
+                            properties:
+                              backoff:
+                                description: Backoff is a backoff strategy
+                                properties:
+                                  duration:
+                                    description: Duration is the amount to back off.
+                                      Default unit is seconds, but could also be a
+                                      duration (e.g. "2m", "1h")
+                                    type: string
+                                  factor:
+                                    description: Factor is a factor to multiply the
+                                      base duration after each failed retry
+                                    format: int64
+                                    type: integer
+                                  maxDuration:
+                                    description: MaxDuration is the maximum amount
+                                      of time allowed for the backoff strategy
+                                    type: string
+                                type: object
+                              limit:
+                                description: Limit is the maximum number of attempts
+                                  when retrying a container
+                                format: int64
+                                type: integer
+                            type: object
+                          syncOptions:
+                            description: Options allow you to specify whole app sync-options
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    required:
+                    - destination
+                    - project
+                    - source
+                    type: object
+                required:
+                - metadata
+                - spec
+                type: object
+            required:
+            - generators
+            - template
+            type: object
+          status:
+            description: ApplicationSetStatus defines the observed state of ApplicationSet
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_appprojects_crd.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_appprojects_crd.yaml
@@ -1,0 +1,257 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/name: appprojects.argoproj.io
+    app.kubernetes.io/part-of: argocd
+  name: appprojects.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: AppProject
+    listKind: AppProjectList
+    plural: appprojects
+    shortNames:
+    - appproj
+    - appprojs
+    singular: appproject
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'AppProject provides a logical grouping of applications, providing controls for: * where the apps may deploy to (cluster whitelist) * what may be deployed (repository whitelist, resource whitelist/blacklist) * who can access these applications (roles, OIDC group claims bindings) * and what they can do (RBAC policies) * automation access to these roles (JWT tokens)'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AppProjectSpec is the specification of an AppProject
+            properties:
+              clusterResourceBlacklist:
+                description: ClusterResourceBlacklist contains list of blacklisted cluster level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              clusterResourceWhitelist:
+                description: ClusterResourceWhitelist contains list of whitelisted cluster level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              description:
+                description: Description contains optional project description
+                type: string
+              destinations:
+                description: Destinations contains list of destinations available for deployment
+                items:
+                  description: ApplicationDestination holds information about the application's destination
+                  properties:
+                    name:
+                      description: Name is an alternate way of specifying the target cluster by its symbolic name
+                      type: string
+                    namespace:
+                      description: Namespace specifies the target namespace for the application's resources. The namespace will only be set for namespace-scoped resources that have not set a value for .metadata.namespace
+                      type: string
+                    server:
+                      description: Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API
+                      type: string
+                  type: object
+                type: array
+              namespaceResourceBlacklist:
+                description: NamespaceResourceBlacklist contains list of blacklisted namespace level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              namespaceResourceWhitelist:
+                description: NamespaceResourceWhitelist contains list of whitelisted namespace level resources
+                items:
+                  description: GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                type: array
+              orphanedResources:
+                description: OrphanedResources specifies if controller should monitor orphaned resources of apps in this project
+                properties:
+                  ignore:
+                    description: Ignore contains a list of resources that are to be excluded from orphaned resources monitoring
+                    items:
+                      description: OrphanedResourceKey is a reference to a resource to be ignored from
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  warn:
+                    description: Warn indicates if warning condition should be created for apps which have orphaned resources
+                    type: boolean
+                type: object
+              roles:
+                description: Roles are user defined RBAC roles associated with this project
+                items:
+                  description: ProjectRole represents a role that has access to a project
+                  properties:
+                    description:
+                      description: Description is a description of the role
+                      type: string
+                    groups:
+                      description: Groups are a list of OIDC group claims bound to this role
+                      items:
+                        type: string
+                      type: array
+                    jwtTokens:
+                      description: JWTTokens are a list of generated JWT tokens bound to this role
+                      items:
+                        description: JWTToken holds the issuedAt and expiresAt values of a token
+                        properties:
+                          exp:
+                            format: int64
+                            type: integer
+                          iat:
+                            format: int64
+                            type: integer
+                          id:
+                            type: string
+                        required:
+                        - iat
+                        type: object
+                      type: array
+                    name:
+                      description: Name is a name for this role
+                      type: string
+                    policies:
+                      description: Policies Stores a list of casbin formated strings that define access policies for the role in the project
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+              signatureKeys:
+                description: SignatureKeys contains a list of PGP key IDs that commits in Git must be signed with in order to be allowed for sync
+                items:
+                  description: SignatureKey is the specification of a key required to verify commit signatures with
+                  properties:
+                    keyID:
+                      description: The ID of the key in hexadecimal notation
+                      type: string
+                  required:
+                  - keyID
+                  type: object
+                type: array
+              sourceRepos:
+                description: SourceRepos contains list of repository URLs which can be used for deployment
+                items:
+                  type: string
+                type: array
+              syncWindows:
+                description: SyncWindows controls when syncs can be run for apps in this project
+                items:
+                  description: SyncWindow contains the kind, time, duration and attributes that are used to assign the syncWindows to apps
+                  properties:
+                    applications:
+                      description: Applications contains a list of applications that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    clusters:
+                      description: Clusters contains a list of clusters that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    duration:
+                      description: Duration is the amount of time the sync window will be open
+                      type: string
+                    kind:
+                      description: Kind defines if the window allows or blocks syncs
+                      type: string
+                    manualSync:
+                      description: ManualSync enables manual syncs when they would otherwise be blocked
+                      type: boolean
+                    namespaces:
+                      description: Namespaces contains a list of namespaces that the window will apply to
+                      items:
+                        type: string
+                      type: array
+                    schedule:
+                      description: Schedule is the time the window will begin, specified in cron format
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: AppProjectStatus contains status information for AppProject CRs
+            properties:
+              jwtTokensByRole:
+                additionalProperties:
+                  description: JWTTokens represents a list of JWT tokens
+                  properties:
+                    items:
+                      items:
+                        description: JWTToken holds the issuedAt and expiresAt values of a token
+                        properties:
+                          exp:
+                            format: int64
+                            type: integer
+                          iat:
+                            format: int64
+                            type: integer
+                          id:
+                            type: string
+                        required:
+                        - iat
+                        type: object
+                      type: array
+                  type: object
+                description: JWTTokensByRole contains a list of JWT tokens issued for a given role
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_argocdexports_crd.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_argocdexports_crd.yaml
@@ -1,0 +1,211 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: argocdexports.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ArgoCDExport
+    listKind: ArgoCDExportList
+    plural: argocdexports
+    singular: argocdexport
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ArgoCDExport is the Schema for the argocdexports API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ArgoCDExportSpec defines the desired state of ArgoCDExport
+          properties:
+            argocd:
+              description: Argocd is the name of the ArgoCD instance to export.
+              type: string
+            image:
+              description: Image is the container image to use for the export Job.
+              type: string
+            schedule:
+              description: Schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+              type: string
+            storage:
+              description: Storage defines the storage configuration options.
+              properties:
+                backend:
+                  description: Backend defines the storage backend to use, must be
+                    "local" (the default), "aws", "azure" or "gcp".
+                  type: string
+                pvc:
+                  description: PVC is the desired characteristics for a PersistentVolumeClaim.
+                  properties:
+                    accessModes:
+                      description: 'AccessModes contains the desired access modes
+                        the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                      items:
+                        type: string
+                      type: array
+                    dataSource:
+                      description: 'This field can be used to specify either: * An
+                        existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                        - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                        custom resource/object that implements data population (Alpha)
+                        In order to use VolumeSnapshot object types, the appropriate
+                        feature gate must be enabled (VolumeSnapshotDataSource or
+                        AnyVolumeDataSource) If the provisioner or an external controller
+                        can support the specified data source, it will create a new
+                        volume based on the contents of the specified data source.
+                        If the specified data source is not supported, the volume
+                        will not be created and the failure will be reported as an
+                        event. In the future, we plan to support more data source
+                        types and the behavior of the provisioner may change.'
+                      properties:
+                        apiGroup:
+                          description: APIGroup is the group for the resource being
+                            referenced. If APIGroup is not specified, the specified
+                            Kind must be in the core API group. For any other third-party
+                            types, APIGroup is required.
+                          type: string
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    resources:
+                      description: 'Resources represents the minimum resources the
+                        volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    selector:
+                      description: A label query over volumes to consider for binding.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    storageClassName:
+                      description: 'Name of the StorageClass required by the claim.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                      type: string
+                    volumeMode:
+                      description: volumeMode defines what type of volume is required
+                        by the claim. Value of Filesystem is implied when not included
+                        in claim spec.
+                      type: string
+                    volumeName:
+                      description: VolumeName is the binding reference to the PersistentVolume
+                        backing this claim.
+                      type: string
+                  type: object
+                secretName:
+                  description: SecretName is the name of a Secret with encryption
+                    key, credentials, etc.
+                  type: string
+              type: object
+            version:
+              description: Version is the tag/digest to use for the export Job container
+                image.
+              type: string
+          required:
+          - argocd
+          type: object
+        status:
+          description: ArgoCDExportStatus defines the observed state of ArgoCDExport
+          properties:
+            phase:
+              description: 'Phase is a simple, high-level summary of where the ArgoCDExport
+                is in its lifecycle. There are five possible phase values: Pending:
+                The ArgoCDExport has been accepted by the Kubernetes system, but one
+                or more of the required resources have not been created. Running:
+                All of the containers for the ArgoCDExport are still running, or in
+                the process of starting or restarting. Succeeded: All containers for
+                the ArgoCDExport have terminated in success, and will not be restarted.
+                Failed: At least one container has terminated in failure, either exited
+                with non-zero status or was terminated by the system. Unknown: For
+                some reason the state of the ArgoCDExport could not be obtained.'
+              type: string
+          required:
+          - phase
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_argocds_crd.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.16/argoproj.io_argocds_crd.yaml
@@ -1,0 +1,1018 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: argocds.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ArgoCD
+    listKind: ArgoCDList
+    plural: argocds
+    singular: argocd
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ArgoCD is the Schema for the argocds API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ArgoCDSpec defines the desired state of ArgoCD
+          properties:
+            applicationInstanceLabelKey:
+              description: ApplicationInstanceLabelKey is the key name where Argo
+                CD injects the app name as a tracking label.
+              type: string
+            applicationSet:
+              description: ArgoCDApplicationSet defines whether the Argo CD ApplicationSet
+                controller should be installed.
+              properties:
+                image:
+                  description: Image is the Argo CD ApplicationSet image (optional)
+                  type: string
+                version:
+                  description: Version is the Argo CD ApplicationSet image tag. (optional)
+                  type: string
+              type: object
+            configManagementPlugins:
+              description: ConfigManagementPlugins is used to specify additional config
+                management plugins.
+              type: string
+            controller:
+              description: Controller defines the Application Controller options for
+                ArgoCD.
+              properties:
+                appSync:
+                  description: "AppSync is used to control the sync frequency, by
+                    default the ArgoCD controller polls Git every 3m by default. \n
+                    Set this to a duration, e.g. 10m or 600s to control the synchronisation
+                    frequency."
+                  type: string
+                processors:
+                  description: Processors contains the options for the Application
+                    Controller processors.
+                  properties:
+                    operation:
+                      description: Operation is the number of application operation
+                        processors.
+                      format: int32
+                      type: integer
+                    status:
+                      description: Status is the number of application status processors.
+                      format: int32
+                      type: integer
+                  type: object
+                resources:
+                  description: Resources defines the Compute Resources required by
+                    the container for the Application Controller.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+              type: object
+            dex:
+              description: Dex defines the Dex server options for ArgoCD.
+              properties:
+                config:
+                  description: Config is the dex connector configuration.
+                  type: string
+                image:
+                  description: Image is the Dex container image.
+                  type: string
+                openShiftOAuth:
+                  description: OpenShiftOAuth enables OpenShift OAuth authentication
+                    for the Dex server.
+                  type: boolean
+                resources:
+                  description: Resources defines the Compute Resources required by
+                    the container for Dex.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                version:
+                  description: Version is the Dex container image tag.
+                  type: string
+              type: object
+            disableAdmin:
+              description: DisableAdmin will disable the admin user.
+              type: boolean
+            gaAnonymizeUsers:
+              description: GAAnonymizeUsers toggles user IDs being hashed before sending
+                to google analytics.
+              type: boolean
+            gaTrackingID:
+              description: GATrackingID is the google analytics tracking ID to use.
+              type: string
+            grafana:
+              description: Grafana defines the Grafana server options for ArgoCD.
+              properties:
+                enabled:
+                  description: Enabled will toggle Grafana support globally for ArgoCD.
+                  type: boolean
+                host:
+                  description: Host is the hostname to use for Ingress/Route resources.
+                  type: string
+                image:
+                  description: Image is the Grafana container image.
+                  type: string
+                ingress:
+                  description: Ingress defines the desired state for an Ingress for
+                    the Grafana component.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations is the map of annotations to apply
+                        to the Ingress.
+                      type: object
+                    enabled:
+                      description: Enabled will toggle the creation of the Ingress.
+                      type: boolean
+                    path:
+                      description: Path used for the Ingress resource.
+                      type: string
+                    tls:
+                      description: TLS configuration. Currently the Ingress only supports
+                        a single TLS port, 443. If multiple members of this list specify
+                        different hosts, they will be multiplexed on the same port
+                        according to the hostname specified through the SNI TLS extension,
+                        if the ingress controller fulfilling the ingress supports
+                        SNI.
+                      items:
+                        description: IngressTLS describes the transport layer security
+                          associated with an Ingress.
+                        properties:
+                          hosts:
+                            description: Hosts are a list of hosts included in the
+                              TLS certificate. The values in this list must match
+                              the name/s used in the tlsSecret. Defaults to the wildcard
+                              host setting for the loadbalancer controller fulfilling
+                              this Ingress, if left unspecified.
+                            items:
+                              type: string
+                            type: array
+                          secretName:
+                            description: SecretName is the name of the secret used
+                              to terminate SSL traffic on 443. Field is left optional
+                              to allow SSL routing based on SNI hostname alone. If
+                              the SNI host in a listener conflicts with the "Host"
+                              header field used by an IngressRule, the SNI host is
+                              used for termination and value of the Host header is
+                              used for routing.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - enabled
+                  type: object
+                resources:
+                  description: Resources defines the Compute Resources required by
+                    the container for Grafana.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                route:
+                  description: Route defines the desired state for an OpenShift Route
+                    for the Grafana component.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations is the map of annotations to use for
+                        the Route resource.
+                      type: object
+                    enabled:
+                      description: Enabled will toggle the creation of the OpenShift
+                        Route.
+                      type: boolean
+                    path:
+                      description: Path the router watches for, to route traffic for
+                        to the service.
+                      type: string
+                    tls:
+                      description: TLS provides the ability to configure certificates
+                        and termination for the Route.
+                      properties:
+                        caCertificate:
+                          description: caCertificate provides the cert authority certificate
+                            contents
+                          type: string
+                        certificate:
+                          description: certificate provides certificate contents
+                          type: string
+                        destinationCACertificate:
+                          description: destinationCACertificate provides the contents
+                            of the ca certificate of the final destination.  When
+                            using reencrypt termination this file should be provided
+                            in order to have routers use it for health checks on the
+                            secure connection. If this field is not specified, the
+                            router may provide its own destination CA and perform
+                            hostname validation using the short service name (service.namespace.svc),
+                            which allows infrastructure generated certificates to
+                            automatically verify.
+                          type: string
+                        insecureEdgeTerminationPolicy:
+                          description: "insecureEdgeTerminationPolicy indicates the
+                            desired behavior for insecure connections to a route.
+                            While each router may make its own decisions on which
+                            ports to expose, this is normally port 80. \n * Allow
+                            - traffic is sent to the server on the insecure port (default)
+                            * Disable - no traffic is allowed on the insecure port.
+                            * Redirect - clients are redirected to the secure port."
+                          type: string
+                        key:
+                          description: key provides key file contents
+                          type: string
+                        termination:
+                          description: termination indicates termination type.
+                          type: string
+                      required:
+                      - termination
+                      type: object
+                    wildcardPolicy:
+                      description: WildcardPolicy if any for the route. Currently
+                        only 'Subdomain' or 'None' is allowed.
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                size:
+                  description: Size is the replica count for the Grafana Deployment.
+                  format: int32
+                  type: integer
+                version:
+                  description: Version is the Grafana container image tag.
+                  type: string
+              required:
+              - enabled
+              type: object
+            ha:
+              description: HA options for High Availability support for the Redis
+                component.
+              properties:
+                enabled:
+                  description: Enabled will toggle HA support globally for Argo CD.
+                  type: boolean
+                redisProxyImage:
+                  description: RedisProxyImage is the Redis HAProxy container image.
+                  type: string
+                redisProxyVersion:
+                  description: RedisProxyVersion is the Redis HAProxy container image
+                    tag.
+                  type: string
+              required:
+              - enabled
+              type: object
+            helpChatText:
+              description: HelpChatText is the text for getting chat help, defaults
+                to "Chat now!"
+              type: string
+            helpChatURL:
+              description: HelpChatURL is the URL for getting chat help, this will
+                typically be your Slack channel for support.
+              type: string
+            image:
+              description: Image is the ArgoCD container image for all ArgoCD components.
+              type: string
+            import:
+              description: Import is the import/restore options for ArgoCD.
+              properties:
+                name:
+                  description: Name of an ArgoCDExport from which to import data.
+                  type: string
+                namespace:
+                  description: Namespace for the ArgoCDExport, defaults to the same
+                    namespace as the ArgoCD.
+                  type: string
+              required:
+              - name
+              type: object
+            initialRepositories:
+              description: InitialRepositories to configure Argo CD with upon creation
+                of the cluster.
+              type: string
+            initialSSHKnownHosts:
+              description: InitialSSHKnownHosts defines the SSH known hosts data upon
+                creation of the cluster for connecting Git repositories via SSH.
+              properties:
+                excludedefaulthosts:
+                  description: ExcludeDefaultHosts describes whether you would like
+                    to include the default list of SSH Known Hosts provided by ArgoCD.
+                  type: boolean
+                keys:
+                  description: Keys describes a custom set of SSH Known Hosts that
+                    you would like to have included in your ArgoCD server.
+                  type: string
+              type: object
+            kustomizeBuildOptions:
+              description: KustomizeBuildOptions is used to specify build options/parameters
+                to use with `kustomize build`.
+              type: string
+            oidcConfig:
+              description: OIDCConfig is the OIDC configuration as an alternative
+                to dex.
+              type: string
+            prometheus:
+              description: Prometheus defines the Prometheus server options for ArgoCD.
+              properties:
+                enabled:
+                  description: Enabled will toggle Prometheus support globally for
+                    ArgoCD.
+                  type: boolean
+                host:
+                  description: Host is the hostname to use for Ingress/Route resources.
+                  type: string
+                ingress:
+                  description: Ingress defines the desired state for an Ingress for
+                    the Prometheus component.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations is the map of annotations to apply
+                        to the Ingress.
+                      type: object
+                    enabled:
+                      description: Enabled will toggle the creation of the Ingress.
+                      type: boolean
+                    path:
+                      description: Path used for the Ingress resource.
+                      type: string
+                    tls:
+                      description: TLS configuration. Currently the Ingress only supports
+                        a single TLS port, 443. If multiple members of this list specify
+                        different hosts, they will be multiplexed on the same port
+                        according to the hostname specified through the SNI TLS extension,
+                        if the ingress controller fulfilling the ingress supports
+                        SNI.
+                      items:
+                        description: IngressTLS describes the transport layer security
+                          associated with an Ingress.
+                        properties:
+                          hosts:
+                            description: Hosts are a list of hosts included in the
+                              TLS certificate. The values in this list must match
+                              the name/s used in the tlsSecret. Defaults to the wildcard
+                              host setting for the loadbalancer controller fulfilling
+                              this Ingress, if left unspecified.
+                            items:
+                              type: string
+                            type: array
+                          secretName:
+                            description: SecretName is the name of the secret used
+                              to terminate SSL traffic on 443. Field is left optional
+                              to allow SSL routing based on SNI hostname alone. If
+                              the SNI host in a listener conflicts with the "Host"
+                              header field used by an IngressRule, the SNI host is
+                              used for termination and value of the Host header is
+                              used for routing.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - enabled
+                  type: object
+                route:
+                  description: Route defines the desired state for an OpenShift Route
+                    for the Prometheus component.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations is the map of annotations to use for
+                        the Route resource.
+                      type: object
+                    enabled:
+                      description: Enabled will toggle the creation of the OpenShift
+                        Route.
+                      type: boolean
+                    path:
+                      description: Path the router watches for, to route traffic for
+                        to the service.
+                      type: string
+                    tls:
+                      description: TLS provides the ability to configure certificates
+                        and termination for the Route.
+                      properties:
+                        caCertificate:
+                          description: caCertificate provides the cert authority certificate
+                            contents
+                          type: string
+                        certificate:
+                          description: certificate provides certificate contents
+                          type: string
+                        destinationCACertificate:
+                          description: destinationCACertificate provides the contents
+                            of the ca certificate of the final destination.  When
+                            using reencrypt termination this file should be provided
+                            in order to have routers use it for health checks on the
+                            secure connection. If this field is not specified, the
+                            router may provide its own destination CA and perform
+                            hostname validation using the short service name (service.namespace.svc),
+                            which allows infrastructure generated certificates to
+                            automatically verify.
+                          type: string
+                        insecureEdgeTerminationPolicy:
+                          description: "insecureEdgeTerminationPolicy indicates the
+                            desired behavior for insecure connections to a route.
+                            While each router may make its own decisions on which
+                            ports to expose, this is normally port 80. \n * Allow
+                            - traffic is sent to the server on the insecure port (default)
+                            * Disable - no traffic is allowed on the insecure port.
+                            * Redirect - clients are redirected to the secure port."
+                          type: string
+                        key:
+                          description: key provides key file contents
+                          type: string
+                        termination:
+                          description: termination indicates termination type.
+                          type: string
+                      required:
+                      - termination
+                      type: object
+                    wildcardPolicy:
+                      description: WildcardPolicy if any for the route. Currently
+                        only 'Subdomain' or 'None' is allowed.
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                size:
+                  description: Size is the replica count for the Prometheus StatefulSet.
+                  format: int32
+                  type: integer
+              required:
+              - enabled
+              type: object
+            rbac:
+              description: RBAC defines the RBAC configuration for Argo CD.
+              properties:
+                defaultPolicy:
+                  description: DefaultPolicy is the name of the default role which
+                    Argo CD will falls back to, when authorizing API requests (optional).
+                    If omitted or empty, users may be still be able to login, but
+                    will see no apps, projects, etc...
+                  type: string
+                policy:
+                  description: 'Policy is CSV containing user-defined RBAC policies
+                    and role definitions. Policy rules are in the form:   p, subject,
+                    resource, action, object, effect Role definitions and bindings
+                    are in the form:   g, subject, inherited-subject See https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/rbac.md
+                    for additional information.'
+                  type: string
+                scopes:
+                  description: 'Scopes controls which OIDC scopes to examine during
+                    rbac enforcement (in addition to `sub` scope). If omitted, defaults
+                    to: ''[groups]''.'
+                  type: string
+              type: object
+            redis:
+              description: Redis defines the Redis server options for ArgoCD.
+              properties:
+                image:
+                  description: Image is the Redis container image.
+                  type: string
+                resources:
+                  description: Resources defines the Compute Resources required by
+                    the container for Redis.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                version:
+                  description: Version is the Redis container image tag.
+                  type: string
+              type: object
+            repo:
+              description: Repo defines the repo server options for Argo CD.
+              properties:
+                mountsatoken:
+                  description: MountSAToken describes whether you would like to have
+                    the Repo server mount the service account token
+                  type: boolean
+                resources:
+                  description: Resources defines the Compute Resources required by
+                    the container for Redis.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                serviceaccount:
+                  description: ServiceAccount defines the ServiceAccount user that
+                    you would like the Repo server to use
+                  type: string
+              type: object
+            repositoryCredentials:
+              description: RepositoryCredentials are the Git pull credentials to configure
+                Argo CD with upon creation of the cluster.
+              type: string
+            resourceCustomizations:
+              description: 'ResourceCustomizations customizes resource behavior. Keys
+                are in the form: group/Kind.'
+              type: string
+            resourceExclusions:
+              description: ResourceExclusions is used to completely ignore entire
+                classes of resource group/kinds.
+              type: string
+            resourceInclusions:
+              description: ResourceInclusions is used to only include specific group/kinds
+                in the reconciliation process.
+              type: string
+            server:
+              description: Server defines the options for the ArgoCD Server component.
+              properties:
+                autoscale:
+                  description: Autoscale defines the autoscale options for the Argo
+                    CD Server component.
+                  properties:
+                    enabled:
+                      description: Enabled will toggle autoscaling support for the
+                        Argo CD Server component.
+                      type: boolean
+                    hpa:
+                      description: HPA defines the HorizontalPodAutoscaler options
+                        for the Argo CD Server component.
+                      properties:
+                        maxReplicas:
+                          description: upper limit for the number of pods that can
+                            be set by the autoscaler; cannot be smaller than MinReplicas.
+                          format: int32
+                          type: integer
+                        minReplicas:
+                          description: minReplicas is the lower limit for the number
+                            of replicas to which the autoscaler can scale down.  It
+                            defaults to 1 pod.  minReplicas is allowed to be 0 if
+                            the alpha feature gate HPAScaleToZero is enabled and at
+                            least one Object or External metric is configured.  Scaling
+                            is active as long as at least one metric value is available.
+                          format: int32
+                          type: integer
+                        scaleTargetRef:
+                          description: reference to scaled resource; horizontal pod
+                            autoscaler will learn the current resource consumption
+                            and will set the desired number of pods by using its Scale
+                            subresource.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        targetCPUUtilizationPercentage:
+                          description: target average CPU utilization (represented
+                            as a percentage of requested CPU) over all the pods; if
+                            not specified the default autoscaling policy will be used.
+                          format: int32
+                          type: integer
+                      required:
+                      - maxReplicas
+                      - scaleTargetRef
+                      type: object
+                  required:
+                  - enabled
+                  type: object
+                grpc:
+                  description: GRPC defines the state for the Argo CD Server GRPC
+                    options.
+                  properties:
+                    host:
+                      description: Host is the hostname to use for Ingress/Route resources.
+                      type: string
+                    ingress:
+                      description: Ingress defines the desired state for the Argo
+                        CD Server GRPC Ingress.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is the map of annotations to apply
+                            to the Ingress.
+                          type: object
+                        enabled:
+                          description: Enabled will toggle the creation of the Ingress.
+                          type: boolean
+                        path:
+                          description: Path used for the Ingress resource.
+                          type: string
+                        tls:
+                          description: TLS configuration. Currently the Ingress only
+                            supports a single TLS port, 443. If multiple members of
+                            this list specify different hosts, they will be multiplexed
+                            on the same port according to the hostname specified through
+                            the SNI TLS extension, if the ingress controller fulfilling
+                            the ingress supports SNI.
+                          items:
+                            description: IngressTLS describes the transport layer
+                              security associated with an Ingress.
+                            properties:
+                              hosts:
+                                description: Hosts are a list of hosts included in
+                                  the TLS certificate. The values in this list must
+                                  match the name/s used in the tlsSecret. Defaults
+                                  to the wildcard host setting for the loadbalancer
+                                  controller fulfilling this Ingress, if left unspecified.
+                                items:
+                                  type: string
+                                type: array
+                              secretName:
+                                description: SecretName is the name of the secret
+                                  used to terminate SSL traffic on 443. Field is left
+                                  optional to allow SSL routing based on SNI hostname
+                                  alone. If the SNI host in a listener conflicts with
+                                  the "Host" header field used by an IngressRule,
+                                  the SNI host is used for termination and value of
+                                  the Host header is used for routing.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - enabled
+                      type: object
+                  type: object
+                host:
+                  description: Host is the hostname to use for Ingress/Route resources.
+                  type: string
+                ingress:
+                  description: Ingress defines the desired state for an Ingress for
+                    the Argo CD Server component.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations is the map of annotations to apply
+                        to the Ingress.
+                      type: object
+                    enabled:
+                      description: Enabled will toggle the creation of the Ingress.
+                      type: boolean
+                    path:
+                      description: Path used for the Ingress resource.
+                      type: string
+                    tls:
+                      description: TLS configuration. Currently the Ingress only supports
+                        a single TLS port, 443. If multiple members of this list specify
+                        different hosts, they will be multiplexed on the same port
+                        according to the hostname specified through the SNI TLS extension,
+                        if the ingress controller fulfilling the ingress supports
+                        SNI.
+                      items:
+                        description: IngressTLS describes the transport layer security
+                          associated with an Ingress.
+                        properties:
+                          hosts:
+                            description: Hosts are a list of hosts included in the
+                              TLS certificate. The values in this list must match
+                              the name/s used in the tlsSecret. Defaults to the wildcard
+                              host setting for the loadbalancer controller fulfilling
+                              this Ingress, if left unspecified.
+                            items:
+                              type: string
+                            type: array
+                          secretName:
+                            description: SecretName is the name of the secret used
+                              to terminate SSL traffic on 443. Field is left optional
+                              to allow SSL routing based on SNI hostname alone. If
+                              the SNI host in a listener conflicts with the "Host"
+                              header field used by an IngressRule, the SNI host is
+                              used for termination and value of the Host header is
+                              used for routing.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - enabled
+                  type: object
+                insecure:
+                  description: Insecure toggles the insecure flag.
+                  type: boolean
+                resources:
+                  description: Resources defines the Compute Resources required by
+                    the container for the Argo CD server component.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                route:
+                  description: Route defines the desired state for an OpenShift Route
+                    for the Argo CD Server component.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations is the map of annotations to use for
+                        the Route resource.
+                      type: object
+                    enabled:
+                      description: Enabled will toggle the creation of the OpenShift
+                        Route.
+                      type: boolean
+                    path:
+                      description: Path the router watches for, to route traffic for
+                        to the service.
+                      type: string
+                    tls:
+                      description: TLS provides the ability to configure certificates
+                        and termination for the Route.
+                      properties:
+                        caCertificate:
+                          description: caCertificate provides the cert authority certificate
+                            contents
+                          type: string
+                        certificate:
+                          description: certificate provides certificate contents
+                          type: string
+                        destinationCACertificate:
+                          description: destinationCACertificate provides the contents
+                            of the ca certificate of the final destination.  When
+                            using reencrypt termination this file should be provided
+                            in order to have routers use it for health checks on the
+                            secure connection. If this field is not specified, the
+                            router may provide its own destination CA and perform
+                            hostname validation using the short service name (service.namespace.svc),
+                            which allows infrastructure generated certificates to
+                            automatically verify.
+                          type: string
+                        insecureEdgeTerminationPolicy:
+                          description: "insecureEdgeTerminationPolicy indicates the
+                            desired behavior for insecure connections to a route.
+                            While each router may make its own decisions on which
+                            ports to expose, this is normally port 80. \n * Allow
+                            - traffic is sent to the server on the insecure port (default)
+                            * Disable - no traffic is allowed on the insecure port.
+                            * Redirect - clients are redirected to the secure port."
+                          type: string
+                        key:
+                          description: key provides key file contents
+                          type: string
+                        termination:
+                          description: termination indicates termination type.
+                          type: string
+                      required:
+                      - termination
+                      type: object
+                    wildcardPolicy:
+                      description: WildcardPolicy if any for the route. Currently
+                        only 'Subdomain' or 'None' is allowed.
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                service:
+                  description: Service defines the options for the Service backing
+                    the ArgoCD Server component.
+                  properties:
+                    type:
+                      description: Type is the ServiceType to use for the Service
+                        resource.
+                      type: string
+                  required:
+                  - type
+                  type: object
+              type: object
+            statusBadgeEnabled:
+              description: StatusBadgeEnabled toggles application status badge feature.
+              type: boolean
+            tls:
+              description: TLS defines the TLS options for ArgoCD.
+              properties:
+                ca:
+                  description: CA defines the CA options.
+                  properties:
+                    configMapName:
+                      description: ConfigMapName is the name of the ConfigMap containing
+                        the CA Certificate.
+                      type: string
+                    secretName:
+                      description: SecretName is the name of the Secret containing
+                        the CA Certificate and Key.
+                      type: string
+                  type: object
+                initialCerts:
+                  additionalProperties:
+                    type: string
+                  description: InitialCerts defines custom TLS certificates upon creation
+                    of the cluster for connecting Git repositories via HTTPS.
+                  type: object
+              type: object
+            usersAnonymousEnabled:
+              description: UsersAnonymousEnabled toggles anonymous user access. The
+                anonymous users get default role permissions specified argocd-rbac-cm.
+              type: boolean
+            version:
+              description: Version is the tag to use with the ArgoCD container image
+                for all ArgoCD components.
+              type: string
+          type: object
+        status:
+          description: ArgoCDStatus defines the observed state of ArgoCD
+          properties:
+            applicationController:
+              description: 'ApplicationController is a simple, high-level summary
+                of where the Argo CD application controller component is in its lifecycle.
+                There are five possible ApplicationController values: Pending: The
+                Argo CD application controller component has been accepted by the
+                Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                application controller component are in a Ready state. Failed: At
+                least one of the  Argo CD application controller component Pods had
+                a failure. Unknown: For some reason the state of the Argo CD application
+                controller component could not be obtained.'
+              type: string
+            dex:
+              description: 'Dex is a simple, high-level summary of where the Argo
+                CD Dex component is in its lifecycle. There are five possible dex
+                values: Pending: The Argo CD Dex component has been accepted by the
+                Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                Dex component are in a Ready state. Failed: At least one of the  Argo
+                CD Dex component Pods had a failure. Unknown: For some reason the
+                state of the Argo CD Dex component could not be obtained.'
+              type: string
+            phase:
+              description: 'Phase is a simple, high-level summary of where the ArgoCD
+                is in its lifecycle. There are five possible phase values: Pending:
+                The ArgoCD has been accepted by the Kubernetes system, but one or
+                more of the required resources have not been created. Available: All
+                of the resources for the ArgoCD are ready. Failed: At least one resource
+                has experienced a failure. Unknown: For some reason the state of the
+                ArgoCD phase could not be obtained.'
+              type: string
+            redis:
+              description: 'Redis is a simple, high-level summary of where the Argo
+                CD Redis component is in its lifecycle. There are five possible redis
+                values: Pending: The Argo CD Redis component has been accepted by
+                the Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                Redis component are in a Ready state. Failed: At least one of the  Argo
+                CD Redis component Pods had a failure. Unknown: For some reason the
+                state of the Argo CD Redis component could not be obtained.'
+              type: string
+            repo:
+              description: 'Repo is a simple, high-level summary of where the Argo
+                CD Repo component is in its lifecycle. There are five possible repo
+                values: Pending: The Argo CD Repo component has been accepted by the
+                Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                Repo component are in a Ready state. Failed: At least one of the  Argo
+                CD Repo component Pods had a failure. Unknown: For some reason the
+                state of the Argo CD Repo component could not be obtained.'
+              type: string
+            server:
+              description: 'Server is a simple, high-level summary of where the Argo
+                CD server component is in its lifecycle. There are five possible server
+                values: Pending: The Argo CD server component has been accepted by
+                the Kubernetes system, but one or more of the required resources have
+                not been created. Running: All of the required Pods for the Argo CD
+                server component are in a Ready state. Failed: At least one of the  Argo
+                CD server component Pods had a failure. Unknown: For some reason the
+                state of the Argo CD server component could not be obtained.'
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/argocd-operator/argocd-operator.package.yaml
+++ b/deploy/olm-catalog/argocd-operator/argocd-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: argocd-operator.v0.0.15
+- currentCSV: argocd-operator.v0.0.16
   name: alpha
 defaultChannel: alpha
 packageName: argocd-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -84,3 +84,17 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - templates
+  - templateinstances
+  - templateconfigs
+  verbs:
+  - '*'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - '*'

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -38,6 +38,7 @@ Name | Default | Description
 [**ResourceExclusions**](#resource-exclusions) | [Empty] | The configuration to completely ignore entire classes of resource group/kinds.
 [**ResourceInclusions**](#resource-inclusions) | [Empty] | The configuration to configure which resource group/kinds are applied.
 [**Server**](#server-options) | [Object] | Argo CD Server configuration options.
+[**SSO**](#single-sign-on-options) | [Object] | Single sign-on options.
 [**StatusBadgeEnabled**](#status-badge-enabled) | `true` | Enable application status badge feature.
 [**TLS**](#tls-options) | [Object] | TLS configuration options.
 [**UsersAnonymousEnabled**](#users-anonymous-enabled) | `true` | Enable anonymous user access.
@@ -997,6 +998,30 @@ metadata:
     example: status-badge-enabled
 spec:
   statusBadgeEnabled: true
+```
+
+## Single sign-on Options
+
+The following properties are available for configuring the Single sign-on component.
+
+Name | Default | Description
+--- | --- | ---
+Provider | [Empty] | The name of the provider used to configure Single sign-on. For now the only supported option is keycloak.
+
+### Single sign-on Example
+
+The following example uses keycloak as Single sign-on option for Argo CD.
+
+``` yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: status-badge-enabled
+spec:
+  sso:
+    provider: keycloak
 ```
 
 ## TLS Options

--- a/docs/usage/keycloak.md
+++ b/docs/usage/keycloak.md
@@ -1,0 +1,71 @@
+# Usage
+
+Note: This feature is currently supported only in openshift and is currently work-in-progress.
+
+The following example shows the most minimal valid manifest to create a new Argo CD cluster with keycloak as Single sign-on provider.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  sso:
+    provider: keycloak
+```
+
+## Create
+
+Create a new Argo CD cluster in the `argocd` namespace using the provided basic example.
+
+```bash
+kubectl create -n argocd -f examples/argocd-basic.yaml
+```
+
+The above configuration creates a keycloak instance and its relevant resources along with the Argo CD resources. Users can login into the keycloak console using the below commands.
+
+Get the Keycloak Route URL for Login.
+
+```bash
+kubectl -n argocd get route sso
+```
+
+```bash
+NAME   HOST/PORT                                                                PATH   SERVICES   PORT    TERMINATION   WILDCARD
+sso    sso-default.apps.ci-ln-rh7g922-d5d6b.origin-ci-int-aws.dev.rhcloud.com          sso        <all>   reencrypt     None
+```
+
+Get the Keycloak Credentials which are stored as environment variables in the keycloak pod.  
+
+Get the Keycloak Pod name.
+
+```bash
+kubectl -n argocd get pods
+```
+
+```bash
+NAME                                         READY   STATUS             RESTARTS   AGE
+sso-1-2sjcl                                  1/1     Running            0          45m
+```
+
+Get the Keycloak Username.
+
+```bash
+kubectl -n argocd exec sso-1-2sjcl -- "env" | grep SSO_ADMIN_USERNAME
+```
+
+```bash
+SSO_ADMIN_USERNAME=Cqid54Ih
+```
+
+Get the Keycloak Password.
+
+```bash
+kubectl -n argocd exec sso-1-2sjcl -- "env" | grep SSO_ADMIN_PASSWORD
+```
+
+```bash
+SSO_ADMIN_PASSWORD=GVXxHifH
+```

--- a/examples/argocd-keycloak.yaml
+++ b/examples/argocd-keycloak.yaml
@@ -1,0 +1,12 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: route
+spec:
+  sso:
+    provider: keycloak
+  server:
+    route:
+      enabled: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,12 +22,14 @@ nav:
     - OpenShift: install/openshift.md
     - Operator Lifecycle Manager: install/olm.md
     - Manual Installation: install/manual.md
+    - Kustomize Installation: install/kustomize.md
   - Usage: 
     - Basics: usage/basics.md
     - Export: usage/export.md
     - High Availability: usage/ha.md
     - Ingress: usage/ingress.md
     - Insights: usage/insights.md
+    - SSO: usage/keycloak.md
     - Routes: usage/routes.md
   - Reference:
     - ArgoCD: reference/argocd.md

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -333,6 +333,21 @@ type ArgoCDServerServiceSpec struct {
 	Type corev1.ServiceType `json:"type"`
 }
 
+// SSOProviderType string defines the type of SSO provider.
+type SSOProviderType string
+
+const (
+	// SSOProviderTypeKeycloak means keycloak will be Installed and Integrated with Argo CD. A new realm with name argocd
+	// will be created in this keycloak. This realm will have a client with name argocd that uses OpenShift v4 as Identity Provider.
+	SSOProviderTypeKeycloak SSOProviderType = "keycloak"
+)
+
+// ArgoCDSSOSpec defines SSO provider.
+type ArgoCDSSOSpec struct {
+	// Provider installs and configures the given SSO Provider with Argo CD.
+	Provider SSOProviderType `json:"provider,omitempty"`
+}
+
 // ArgoCDSpec defines the desired state of ArgoCD
 // +k8s:openapi-gen=true
 type ArgoCDSpec struct {
@@ -418,6 +433,9 @@ type ArgoCDSpec struct {
 
 	// Server defines the options for the ArgoCD Server component.
 	Server ArgoCDServerSpec `json:"server,omitempty"`
+
+	// SSO defines the Single Sign-on configuration for Argo CD
+	SSO *ArgoCDSSOSpec `json:"sso,omitempty"`
 
 	// StatusBadgeEnabled toggles application status badge feature.
 	StatusBadgeEnabled bool `json:"statusBadgeEnabled,omitempty"`

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -160,6 +160,12 @@ const (
 	// ArgoCDDefaultKustomizeBuildOptions is the default kustomize build options.
 	ArgoCDDefaultKustomizeBuildOptions = ""
 
+	// ArgoCDKeycloakImageName is the default Keycloak Image used when not specified.
+	ArgoCDKeycloakImageName = "sso74-openshift-rhel8"
+
+	// ArgoCDKeycloakVersion is the default Keycloak version used when not specified.
+	ArgoCDKeycloakVersion = "7.4"
+
 	// ArgoCDDefaultOIDCConfig is the default OIDC configuration.
 	ArgoCDDefaultOIDCConfig = ""
 

--- a/pkg/controller/argocd/keycloak.go
+++ b/pkg/controller/argocd/keycloak.go
@@ -1,0 +1,385 @@
+// Copyright 2021 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocd
+
+import (
+	json "encoding/json"
+
+	"github.com/argoproj-labs/argocd-operator/pkg/common"
+	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
+	appsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	template "github.com/openshift/api/template/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	privilegedMode bool  = false
+	graceTime      int64 = 75
+	portTLS        int32 = 8443
+)
+
+// getKeycloakContainerImage will return the container image for Keycloak.
+func getKeycloakContainerImage(img string, ver string) string {
+	return argoutil.CombineImageTag(img, ver)
+}
+
+func getKeycloakConfigMapTemplate(ns string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"description": "ConfigMap providing service ca bundle",
+				"service.beta.openshift.io/inject-cabundle": "true",
+			},
+			Labels: map[string]string{
+				"application": "${APPLICATION_NAME}",
+			},
+			Name:      "${APPLICATION_NAME}-service-ca",
+			Namespace: ns,
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+	}
+}
+
+func getKeycloakContainer() corev1.Container {
+	return corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: "SSO_HOSTNAME", Value: "${SSO_HOSTNAME}"},
+			{Name: "DB_MIN_POOL_SIZE", Value: "${DB_MIN_POOL_SIZE}"},
+			{Name: "DB_MAX_POOL_SIZE", Value: "${DB_MAX_POOL_SIZE}"},
+			{Name: "DB_TX_ISOLATION", Value: "${DB_TX_ISOLATION}"},
+			{Name: "JGROUPS_PING_PROTOCOL", Value: "openshift.DNS_PING"},
+			{Name: "OPENSHIFT_DNS_PING_SERVICE_NAME", Value: "${APPLICATION_NAME}-ping"},
+			{Name: "OPENSHIFT_DNS_PING_SERVICE_PORT", Value: "8888"},
+			{Name: "X509_CA_BUNDLE", Value: "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
+			{Name: "JGROUPS_CLUSTER_PASSWORD", Value: "${JGROUPS_CLUSTER_PASSWORD}"},
+			{Name: "SSO_ADMIN_USERNAME", Value: "${SSO_ADMIN_USERNAME}"},
+			{Name: "SSO_ADMIN_PASSWORD", Value: "${SSO_ADMIN_PASSWORD}"},
+			{Name: "SSO_REALM", Value: "${SSO_REALM}"},
+			{Name: "SSO_SERVICE_USERNAME", Value: "${SSO_SERVICE_USERNAME}"},
+			{Name: "SSO_SERVICE_PASSWORD", Value: "${SSO_SERVICE_PASSWORD}"},
+		},
+		Image:           "",
+		ImagePullPolicy: "Always",
+		LivenessProbe: &corev1.Probe{
+			FailureThreshold: 3,
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						"/opt/eap/bin/livenessProbe.sh",
+					},
+				},
+			},
+			InitialDelaySeconds: 60,
+		},
+		Name: "${APPLICATION_NAME}",
+		Ports: []corev1.ContainerPort{
+			{ContainerPort: 8778, Name: "jolokia", Protocol: "TCP"},
+			{ContainerPort: 8080, Name: "http", Protocol: "TCP"},
+			{ContainerPort: 8443, Name: "https", Protocol: "TCP"},
+			{ContainerPort: 8888, Name: "ping", Protocol: "TCP"},
+		},
+		ReadinessProbe: &corev1.Probe{
+			FailureThreshold: 10,
+			Handler: corev1.Handler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"/bin/bash",
+						"-c",
+						"/opt/eap/bin/readinessProbe.sh",
+					},
+				},
+			},
+			InitialDelaySeconds: 60,
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"memory": resource.Quantity{
+					Format: "${MEMORY_LIMIT}",
+				},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				MountPath: "/etc/x509/https",
+				Name:      "sso-x509-https-volume",
+				ReadOnly:  true,
+			},
+			{
+				MountPath: "/etc/x509/jgroups",
+				Name:      "sso-x509-jgroups-volume",
+				ReadOnly:  true,
+			},
+			{
+				MountPath: "/var/run/configmaps/service-ca",
+				Name:      "service-ca",
+				ReadOnly:  true,
+			},
+		},
+	}
+}
+
+func getKeycloakDeploymentConfigTemplate(ns string) *appsv1.DeploymentConfig {
+	keycloakContainer := getKeycloakContainer()
+	keycloakImage := common.ArgoCDKeycloakImageName
+	keycloakVersion := common.ArgoCDKeycloakVersion
+
+	return &appsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    map[string]string{"application": "${APPLICATION_NAME}"},
+			Name:      "${APPLICATION_NAME}",
+			Namespace: ns,
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "DeploymentConfig"},
+		Spec: appsv1.DeploymentConfigSpec{
+			Replicas: 1,
+			Selector: map[string]string{"deploymentConfig": "${APPLICATION_NAME}"},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: "Recreate",
+			},
+			Template: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"application":      "${APPLICATION_NAME}",
+						"deploymentConfig": "${APPLICATION_NAME}",
+					},
+					Name: "${APPLICATION_NAME}",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						keycloakContainer,
+					},
+					TerminationGracePeriodSeconds: &graceTime,
+					Volumes: []corev1.Volume{
+						{
+							Name: "sso-x509-https-volume",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "sso-x509-https-secret",
+								},
+							},
+						},
+						{
+							Name: "sso-x509-jgroups-volume",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "sso-x509-https-secret",
+								},
+							},
+						},
+						{
+							Name: "service-ca",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "${APPLICATION_NAME}-service-ca",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Triggers: appsv1.DeploymentTriggerPolicies{
+				appsv1.DeploymentTriggerPolicy{
+					Type: "ImageChange",
+					ImageChangeParams: &appsv1.DeploymentTriggerImageChangeParams{
+						Automatic:      true,
+						ContainerNames: []string{"${APPLICATION_NAME}"},
+						From: corev1.ObjectReference{
+							Kind:      "ImageStreamTag",
+							Name:      getKeycloakContainerImage(keycloakImage, keycloakVersion),
+							Namespace: "${IMAGE_STREAM_NAMESPACE}",
+						},
+					},
+				},
+				appsv1.DeploymentTriggerPolicy{
+					Type: "ConfigChange",
+				},
+			},
+		},
+	}
+}
+
+func getKeycloakServiceTemplate(ns string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    map[string]string{"application": "${APPLICATION_NAME}"},
+			Name:      "${APPLICATION_NAME}",
+			Namespace: ns,
+			Annotations: map[string]string{
+				"description": "The web server's https port",
+				"service.alpha.openshift.io/serving-cert-secret-name": "sso-x509-https-secret",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Port: portTLS, TargetPort: intstr.FromInt(int(portTLS))},
+			},
+			Selector: map[string]string{
+				"deploymentConfig": "${APPLICATION_NAME}",
+			},
+		},
+	}
+}
+
+func getKeycloakPingServiceTemplate(ns string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:    map[string]string{"application": "${APPLICATION_NAME}"},
+			Name:      "${APPLICATION_NAME}" + "-ping",
+			Namespace: ns,
+			Annotations: map[string]string{
+				"description": "The JGroups ping port for clustering",
+				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+				"service.alpha.openshift.io/serving-cert-secret-name":    "sso-x509-jgroups-secret",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Ports: []corev1.ServicePort{
+				{Name: "ping", Port: 8888},
+			},
+			Selector: map[string]string{
+				"deploymentConfig": "${APPLICATION_NAME}",
+			},
+		},
+	}
+}
+
+func getKeycloakRouteTemplate(ns string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      map[string]string{"application": "${APPLICATION_NAME}"},
+			Name:        "${APPLICATION_NAME}",
+			Namespace:   ns,
+			Annotations: map[string]string{"description": "Route for application's https service"},
+		},
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Route"},
+		Spec: routev1.RouteSpec{
+			TLS: &routev1.TLSConfig{
+				Termination: "reencrypt",
+			},
+			To: routev1.RouteTargetReference{
+				Name: "${APPLICATION_NAME}",
+			},
+		},
+	}
+}
+
+func newKeycloakTemplateInstance(ns string) (*template.TemplateInstance, error) {
+	tpl, err := newKeycloakTemplate(ns)
+	if err != nil {
+		return &template.TemplateInstance{}, err
+	}
+	return &template.TemplateInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhsso",
+			Namespace: ns,
+		},
+		Spec: template.TemplateInstanceSpec{
+			Template: tpl,
+		},
+	}, nil
+}
+
+func newKeycloakTemplate(ns string) (template.Template, error) {
+	tmpl := template.Template{}
+	configMapTemplate := getKeycloakConfigMapTemplate(ns)
+	deploymentConfigTemplate := getKeycloakDeploymentConfigTemplate(ns)
+	serviceTemplate := getKeycloakServiceTemplate(ns)
+	pingServiceTemplate := getKeycloakPingServiceTemplate(ns)
+	routeTemplate := getKeycloakRouteTemplate(ns)
+
+	configMap, err := json.Marshal(configMapTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	deploymentConfig, err := json.Marshal(deploymentConfigTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	service, err := json.Marshal(serviceTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	pingService, err := json.Marshal(pingServiceTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	route, err := json.Marshal(routeTemplate)
+	if err != nil {
+		return tmpl, err
+	}
+
+	tmpl = template.Template{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"description":               "RH-SSO Template for Installing keycloak",
+				"iconClass":                 "icon-sso",
+				"openshift.io/display-name": "Keycloak",
+				"tags":                      "keycloak",
+				"version":                   "9.0.4-SNAPSHOT",
+			},
+			Name:      "rhsso",
+			Namespace: ns,
+		},
+		Objects: []runtime.RawExtension{
+			{
+				Raw: json.RawMessage(configMap),
+			},
+			{
+				Raw: json.RawMessage(deploymentConfig),
+			},
+			{
+				Raw: json.RawMessage(service),
+			},
+			{
+				Raw: json.RawMessage(pingService),
+			},
+			{
+				Raw: json.RawMessage(route),
+			},
+		},
+		Parameters: []template.Parameter{
+			{Name: "APPLICATION_NAME", Value: "sso", Required: true},
+			{Name: "SSO_HOSTNAME"},
+			{Name: "JGROUPS_CLUSTER_PASSWORD", Generate: "expression", From: "[a-zA-Z0-9]{32}", Required: true},
+			{Name: "DB_MIN_POOL_SIZE"},
+			{Name: "DB_MAX_POOL_SIZE"},
+			{Name: "DB_TX_ISOLATION"},
+			{Name: "IMAGE_STREAM_NAMESPACE", Value: "openshift", Required: true},
+			{Name: "SSO_ADMIN_USERNAME", Generate: "expression", From: "[a-zA-Z0-9]{8}", Required: true},
+			{Name: "SSO_ADMIN_PASSWORD", Generate: "expression", From: "[a-zA-Z0-9]{8}", Required: true},
+			{Name: "SSO_REALM", DisplayName: "RH-SSO Realm"},
+			{Name: "SSO_SERVICE_USERNAME", DisplayName: "RH-SSO Service Username"},
+			{Name: "SSO_SERVICE_PASSWORD", DisplayName: "RH-SSO Service Password"},
+			{Name: "MEMORY_LIMIT", Value: "1Gi"},
+		},
+	}
+	return tmpl, err
+}

--- a/pkg/controller/argocd/keycloak_test.go
+++ b/pkg/controller/argocd/keycloak_test.go
@@ -1,0 +1,129 @@
+// Copyright 2021 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocd
+
+import (
+	"testing"
+
+	appsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	fakeNs             = "foo"
+	fakeReplicas int32 = 1
+	fakeVolumes        = []corev1.Volume{
+		{
+			Name: "sso-x509-https-volume",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "sso-x509-https-secret",
+				},
+			},
+		},
+		{
+			Name: "sso-x509-jgroups-volume",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "sso-x509-https-secret",
+				},
+			},
+		},
+		{
+			Name: "service-ca",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "${APPLICATION_NAME}-service-ca",
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestKeycloakContainerImage(t *testing.T) {
+	testImage := getKeycloakContainerImage("sso-74-image", "7.4")
+	assert.Equal(t, testImage, "sso-74-image:7.4")
+
+	testImage = getKeycloakContainerImage("sso-74-image", "SHA256:cbb1222787986dfs999")
+	assert.Equal(t, testImage, "sso-74-image@SHA256:cbb1222787986dfs999")
+}
+
+func TestNewKeycloakTemplateInstance(t *testing.T) {
+	tmplInstance, err := newKeycloakTemplateInstance(fakeNs)
+	assert.NilError(t, err)
+
+	assert.Equal(t, tmplInstance.Name, "rhsso")
+	assert.Equal(t, tmplInstance.Namespace, fakeNs)
+}
+
+func TestNewKeycloakTemplate(t *testing.T) {
+	tmpl, err := newKeycloakTemplate(fakeNs)
+	assert.NilError(t, err)
+
+	assert.Equal(t, tmpl.Name, "rhsso")
+	assert.Equal(t, tmpl.Namespace, fakeNs)
+}
+
+func TestNewKeycloakTemplate_testDeploymentConfig(t *testing.T) {
+	dc := getKeycloakDeploymentConfigTemplate(fakeNs)
+
+	assert.Equal(t, dc.Spec.Replicas, fakeReplicas)
+	assert.DeepEqual(t, dc.Spec.Strategy, appsv1.DeploymentStrategy{Type: "Recreate"})
+	assert.Equal(t, dc.Spec.Template.ObjectMeta.Name, "${APPLICATION_NAME}")
+	assert.DeepEqual(t, dc.Spec.Template.Spec.Volumes, fakeVolumes)
+}
+
+func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
+	kc := getKeycloakContainer()
+	assert.Equal(t, kc.Image, "")
+	assert.Equal(t, kc.ImagePullPolicy, corev1.PullAlways)
+	assert.Equal(t, kc.Name, "${APPLICATION_NAME}")
+}
+
+func TestNewKeycloakTemplate_testConfigmap(t *testing.T) {
+	cm := getKeycloakConfigMapTemplate(fakeNs)
+	assert.Equal(t, cm.Name, "${APPLICATION_NAME}-service-ca")
+	assert.Equal(t, cm.Namespace, fakeNs)
+}
+
+func TestNewKeycloakTemplate_testService(t *testing.T) {
+	svc := getKeycloakServiceTemplate(fakeNs)
+	assert.Equal(t, svc.Name, "${APPLICATION_NAME}")
+	assert.Equal(t, svc.Namespace, fakeNs)
+	assert.DeepEqual(t, svc.Spec.Selector, map[string]string{
+		"deploymentConfig": "${APPLICATION_NAME}"})
+}
+
+func TestNewKeycloakTemplate_testPingService(t *testing.T) {
+	svc := getKeycloakPingServiceTemplate(fakeNs)
+	assert.Equal(t, svc.Name, "${APPLICATION_NAME}-ping")
+	assert.Equal(t, svc.Namespace, fakeNs)
+	assert.DeepEqual(t, svc.Spec.Selector, map[string]string{
+		"deploymentConfig": "${APPLICATION_NAME}"})
+}
+
+func TestNewKeycloakTemplate_testRoute(t *testing.T) {
+	route := getKeycloakRouteTemplate(fakeNs)
+	assert.Equal(t, route.Name, "${APPLICATION_NAME}")
+	assert.Equal(t, route.Namespace, fakeNs)
+	assert.DeepEqual(t, route.Spec.To,
+		routev1.RouteTargetReference{Name: "${APPLICATION_NAME}"})
+	assert.DeepEqual(t, route.Spec.TLS,
+		&routev1.TLSConfig{Termination: "reencrypt"})
+}

--- a/pkg/controller/argocd/sso.go
+++ b/pkg/controller/argocd/sso.go
@@ -1,0 +1,64 @@
+// Copyright 2021 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocd
+
+import (
+	"context"
+
+	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
+	template "github.com/openshift/api/template/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var templateAPIFound = false
+
+// IsTemplateAPIAvailable returns true if the template API is present.
+func IsTemplateAPIAvailable() bool {
+	return templateAPIFound
+}
+
+// verifyTemplateAPI will verify that the template API is present.
+func verifyTemplateAPI() error {
+	found, err := argoutil.VerifyAPI(template.SchemeGroupVersion.Group, template.SchemeGroupVersion.Version)
+	if err != nil {
+		return err
+	}
+	templateAPIFound = found
+	return nil
+}
+
+func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
+	if cr.Spec.SSO.Provider == argoprojv1a1.SSOProviderTypeKeycloak {
+		// TemplateAPI is available, Install keycloack using openshift templates.
+		if IsTemplateAPIAvailable() {
+			templateInstanceRef, err := newKeycloakTemplateInstance(cr.Namespace)
+			if err != nil {
+				return err
+			}
+			existingTemplateInstance := template.TemplateInstance{}
+			err = r.client.Get(context.TODO(), types.NamespacedName{Name: templateInstanceRef.Name, Namespace: templateInstanceRef.Namespace}, &existingTemplateInstance)
+			if err != nil && errors.IsNotFound(err) {
+				log.Info("Creating a new keycloak template instance")
+				err = r.client.Create(context.TODO(), templateInstanceRef)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/controller/argocd/sso_test.go
+++ b/pkg/controller/argocd/sso_test.go
@@ -1,0 +1,66 @@
+// Copyright 2021 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	argoappv1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	argov1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	templatev1 "github.com/openshift/api/template/v1"
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func makeFakeReconciler(t *testing.T, acd *argov1alpha1.ArgoCD, objs ...runtime.Object) *ReconcileArgoCD {
+	t.Helper()
+	s := scheme.Scheme
+	// Register template scheme
+	s.AddKnownTypes(templatev1.SchemeGroupVersion, objs...)
+	templatev1.Install(s)
+
+	cl := fake.NewFakeClientWithScheme(s, objs...)
+	return &ReconcileArgoCD{
+		client: cl,
+		scheme: s,
+	}
+}
+
+func TestReconcile_testKeycloakTemplateInstance(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD()
+	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
+		Provider: "keycloak",
+	}
+
+	templateAPIFound = true
+	r := makeFakeReconciler(t, a)
+
+	assert.NilError(t, r.reconcileSSO(a))
+
+	templateInstance := &templatev1.TemplateInstance{}
+	assert.NilError(t, r.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      "rhsso",
+			Namespace: a.Namespace,
+		},
+		templateInstance))
+}

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -589,6 +589,10 @@ func InspectCluster() error {
 	if err := verifyRouteAPI(); err != nil {
 		return err
 	}
+
+	if err := verifyTemplateAPI(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -697,6 +701,13 @@ func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
 	if cr.Spec.ApplicationSet != nil {
 		log.Info("reconciling ApplicationSet controller")
 		if err := r.reconcileApplicationSetController(cr); err != nil {
+			return err
+		}
+	}
+
+	if cr.Spec.SSO != nil {
+		log.Info("reconciling SSO")
+		if err := r.reconcileSSO(cr); err != nil {
 			return err
 		}
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ package version
 
 var (
 	// Version is the ArgoCD Operator version.
-	Version = "0.0.15"
+	Version = "0.0.16"
 )


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
This PR adds `sso provider` in CR.   The reconciler installs Keycloack/RHSSO using OpenShift Templates.   This PR does not configure.  This PR also does not delete installed Keycloak.

**Have you updated the necessary documentation?**
Added

**Which issue(s) this PR fixes**:

Fixes #?
This PR address installing keycloak for openshift of #312


**How to test changes / Special notes to the reviewer**:
Deploy the example argocd CR
```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: route
spec:
  sso:
    provider: keycloak
  server:
    route:
      enabled: true
```

or add the below section to your existing argocd CR Spec
```
  sso:
    provider: keycloak
```

* Get the SSO hostname or url. It can only be accessed using https://<hostname>

```
oc get route | grep sso
NAME                    HOST/PORT                                                                                  PATH   SERVICES                PORT    TERMINATION            WILDCARD
sso                     sso-default.apps.ci-ln-0ckf2vb-d5d6b.origin-ci-int-aws.dev.rhcloud.com                            sso                     <all>   reencrypt              None
```

* Get User and Password from the SSO pod name
```
oc exec sso-1-<> -- "env" | grep SSO_ADMIN_USERNAME
oc exec sso-1-<> -- "env" | grep SSO_ADMIN_PASSWORD
```

