### PR TITLE
Update Base Image to the Latest Version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
-# RHEL 8 Universal Base Image created 2020-09-01T19:43:18.550354Z
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
+# RHEL 8 Universal Base Image created 2021-05-04T17:20:18.408117Z
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:fc75532a20c1e7eb0512a03feac46554278bce946cf454a78e11433e39a66d2d
 
 ENV OPERATOR=/usr/local/bin/argocd-operator \
     USER_UID=1001 \


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

This PR updates the operator base image to the latest version.

**Which issue(s) this PR fixes**:

The current release image is failing the quay.io security scans, as the base image is quite old at this point. 

https://quay.io/repository/argoprojlabs/argocd-operator/manifest/sha256:38254c8d53172993cb51c0b4c72645757ba36e7e8e3b1251683b00cede47fa7c?tab=vulnerabilities

The updated image is passing.

https://quay.io/repository/jmckind/argocd-operator/manifest/sha256:ab70a593a4f40bd035c25d9756cd189262b3bff3d5c54842479fae2bdbe79207?tab=vulnerabilities 
