### PR TITLE
fix readthedocs build issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
-mkdocs-material
+mkdocs==1.1.2
+mkdocs-material==7.1.7
 pygments==2.7.4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Argo CD Operator
+site_url: ""
 repo_url: https://github.com/argoproj-labs/argocd-operator
 strict: true
 theme:


### PR DESCRIPTION
**What type of PR is this?**
fixes #332 

> /kind bug

**What does this PR do / why we need it**:
Currently the docs requirements.txt is not defined with versions of required modules. Add the exact module versions as dependencies.

Also, update the site_url to empty string as defined in the error message.

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
fixes #332 

Fixes #?
#332 

**How to test changes / Special notes to the reviewer**:
Install mkdocs locally and run `mkdocs serve`