### PR TITLE
fix: Properly setup edge termination for server route

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -942,6 +942,13 @@ Path | `/` | The path for the Route.
 TLS | [Object] | The TLSConfig for the Route.
 WildcardPolicy| `None` | The wildcard policy for the Route. Can be one of `Subdomain` or `None`.
 
+If the route is enabled, it will use a default termination policy of `edge`
+for handling requests. With edge termination, the `Server.Insecure` setting
+will be automatically set to `true`. This will terminate TLS at the edge of
+your cluster, but the communication between the route and Argo CD will be
+unencrypted. You can change the way TLS is handled by defining an alternate
+TLS termination policy for the server route.
+
 ### Server Example
 
 The following example shows all properties set to the default values.

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -202,7 +202,8 @@ func getArgoServerCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd := make([]string, 0)
 	cmd = append(cmd, "argocd-server")
 
-	if getArgoServerInsecure(cr) {
+	// The --insecure flag is implicit for when using route with edge termination
+	if getArgoServerInsecure(cr) || serverRouteIsEdgeTermination(cr) {
 		cmd = append(cmd, "--insecure")
 	}
 

--- a/pkg/controller/argocd/route.go
+++ b/pkg/controller/argocd/route.go
@@ -264,5 +264,5 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoprojv1a1.ArgoCD) error {
 // routeIsEdgeTermination returns true whether user has configured the edge
 // termination for the server route.
 func serverRouteIsEdgeTermination(cr *argoprojv1a1.ArgoCD) bool {
-	return cr.Spec.Server.Route.TLS == nil || cr.Spec.Server.Route.TLS.Termination == routev1.TLSTerminationEdge
+	return cr.Spec.Server.Route.Enabled && (cr.Spec.Server.Route.TLS == nil || cr.Spec.Server.Route.TLS.Termination == routev1.TLSTerminationEdge)
 }

--- a/pkg/controller/argocd/route_test.go
+++ b/pkg/controller/argocd/route_test.go
@@ -209,3 +209,45 @@ func testNamespacedName(name string) types.NamespacedName {
 		Namespace: testNamespace,
 	}
 }
+
+func TestServerRouteTermination(t *testing.T) {
+	t.Run("Route properties not set, edge is default", func(t *testing.T) {
+		cr := &argov1alpha1.ArgoCD{}
+		if !serverRouteIsEdgeTermination(cr) {
+			t.Fatalf("edge termination should be false, but is true")
+		}
+	})
+	t.Run("Route properties set to edge termination policy", func(t *testing.T) {
+		cr := &argov1alpha1.ArgoCD{
+			Spec: argov1alpha1.ArgoCDSpec{
+				Server: argov1alpha1.ArgoCDServerSpec{
+					Route: argov1alpha1.ArgoCDRouteSpec{
+						TLS: &routev1.TLSConfig{
+							Termination: routev1.TLSTerminationEdge,
+						},
+					},
+				},
+			},
+		}
+		if !serverRouteIsEdgeTermination(cr) {
+			t.Fatalf("edge termination should be true, but is false")
+		}
+	})
+	t.Run("Route properties set to another termination policy", func(t *testing.T) {
+		cr := &argov1alpha1.ArgoCD{
+			Spec: argov1alpha1.ArgoCDSpec{
+				Server: argov1alpha1.ArgoCDServerSpec{
+					Route: argov1alpha1.ArgoCDRouteSpec{
+						TLS: &routev1.TLSConfig{
+							Termination: routev1.TLSTerminationReencrypt,
+						},
+					},
+				},
+			},
+		}
+		if serverRouteIsEdgeTermination(cr) {
+			t.Fatalf("edge termination should be false, but is true")
+		}
+	})
+
+}


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:

This PR properly sets up the route of the server for edge termination. It changes behavior as follows:

1. The default route termination policy will now be `edge`, regardless of `.spec.Server.Insecure` setting
2. If the policy is `edge` (either _implicit_ or _explicit_), `argocd-server` workload will be started with `--insecure` flag

**ATTN**

This is a slightly breaking change, as it changes the default route termination policy from `passthrough` to `edge`. 

We do believe that it's better to have `edge` termination as the default, instead of `passthrough`, as `passthrough` by default uses a self-signed certificate on the Argo CD server endpoint. `edge` will terminate at the cluster, and route traffic within the cluster as plain text to Argo CD components.

The behavior previous to this PR is:
* If `.spec.server.route.enabled`  is set to `true`, and `.spec.server.route.tls` is not set, `passthrough` termination will be the default, serving a self-signed TLS certificate
* User has to set `.spec.server.insecure: true` to enable `edge` termination policy (`.spec.server.insecure` was the leading knob)

The behavior after this PR will be:
* Changing `.spec.server.insecure` manually will be discouraged, it will have no effect on route configuration
* If `.spec.server.route.enabled`  is set to `true`, and `.spec.server.route.tls` is not set, `edge` termination will be the default and the server workload will be _implicitly_ set to run _with_ `--insecure`
*  If `.spec.server.route.enabled`  is set to `true`, and `.spec.server.route.tls.termination` is set to either `passthrough` or `reencrypt`, the server workload will be _implicitly_ set to run _without_ `--insecure`

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1. Create `ArgoCD` with a configuration that enables the route, e.g.
```yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: argocd
spec:
  server:
    route:
      enabled: true
```
2. Have the operator reconcile the CR
3. Check that a route has been created, and that `edge` termination policy is set and the target port is set to `http` (*not* `https`): `oc get route argocd-server`
4. Check that the `argocd-server` deployment has been configured with the `--insecure` flag: `oc describe deployment argocd-server`
4. Navigate to the URL of the route with your browser
5. Argo CD login page should appear

Then, change the route's TLS properties to enable `passthrough` mode:

1. `oc patch argocd argocd --type merge --patch '{"spec":{"server":{"route":{"tls":{"termination": "passthrough"}}}}}''`
2. Check the route has been changed to `passthrough` policy and target port has changed to `https`: `oc get route argocd-server`

Then, switch back to `edge` mode:

1. `oc patch argocd argocd --type merge --patch '{"spec":{"server":{"route":{"tls":{"termination": "edge"}}}}}''`
2. Check the route has been changed to `edge` policy, target port has changed to `http`: `oc get route argocd-server`
3. Check that the `argocd-server` deployment has been re-configured with the `--insecure` flag: `oc describe deployment argocd-server`
