### PR TITLE
chore: Fix typo in the TLS Options Documentation.

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1031,7 +1031,7 @@ spec:
 
 ## TLS Options
 
-The following properties are available for configuring the Grafana component.
+The following properties are available for configuring the TLS settings.
 
 Name | Default | Description
 --- | --- | ---


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind documentation


**What does this PR do / why we need it**:

Fix a documentation issue.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [X] Documentation has been updated.
