### PR TITLE
allow operator to manage permissions based on namespace labels

### DIFF
--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -201,6 +201,6 @@ const (
 	// ArgoCDSecretTypeLabel is needed for cluster secrets
 	ArgoCDSecretTypeLabel = "argocd.argoproj.io/secret-type"
 
-	// ArgoCDManagedNamespaceLabel is needed to identify namespace managed by an instance on ArgoCD
-	ArgoCDManagedNamespaceLabel = "argocd.argoproj.io/managed-by"
+	// ArgoCDManagedByLabel is needed to identify namespace managed by an instance on ArgoCD
+	ArgoCDManagedByLabel = "argocd.argoproj.io/managed-by"
 )

--- a/pkg/common/keys.go
+++ b/pkg/common/keys.go
@@ -200,4 +200,7 @@ const (
 
 	// ArgoCDSecretTypeLabel is needed for cluster secrets
 	ArgoCDSecretTypeLabel = "argocd.argoproj.io/secret-type"
+
+	// ArgoCDManagedNamespaceLabel is needed to identify namespace managed by an instance on ArgoCD
+	ArgoCDManagedNamespaceLabel = "argocd.argoproj.io/managed-by"
 )

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -17,16 +17,18 @@ package argocd
 import (
 	"context"
 	"fmt"
+	argoproj "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/pkg/common"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-
-	argoproj "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 )
 
 // blank assignment to verify that ReconcileArgoCD implements reconcile.Reconciler
@@ -57,7 +59,7 @@ func add(mgr manager.Manager, r *ReconcileArgoCD) error {
 	}
 
 	// Register watches for all controller resources
-	if err := watchResources(c, r.clusterResourceMapper, r.tlsSecretMapper); err != nil {
+	if err := watchResources(c, r.clusterResourceMapper, r.tlsSecretMapper, r.namespaceResourceMapper); err != nil {
 		return err
 	}
 
@@ -92,6 +94,18 @@ func (r *ReconcileArgoCD) Reconcile(request reconcile.Request) (reconcile.Result
 		}
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
+	}
+
+	namespace := &corev1.Namespace{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: request.Namespace}, namespace); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if val, ok := namespace.Labels[common.ArgoCDManagedNamespaceLabel]; !ok || val != argocd.Namespace {
+		namespace.Labels[common.ArgoCDManagedNamespaceLabel] = argocd.Namespace
+		if err = r.client.Update(context.TODO(), namespace); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	if argocd.GetDeletionTimestamp() != nil {

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -102,6 +102,9 @@ func (r *ReconcileArgoCD) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 
 	if val, ok := namespace.Labels[common.ArgoCDManagedNamespaceLabel]; !ok || val != argocd.Namespace {
+		if namespace.Labels == nil {
+			namespace.Labels = make(map[string]string)
+		}
 		namespace.Labels[common.ArgoCDManagedNamespaceLabel] = argocd.Namespace
 		if err = r.client.Update(context.TODO(), namespace); err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/argocd/argocd_controller_test.go
+++ b/pkg/controller/argocd/argocd_controller_test.go
@@ -47,6 +47,7 @@ func TestReconcileArgoCD_Reconcile_with_deleted(t *testing.T) {
 	a := makeTestArgoCD(deletedAt(time.Now()))
 
 	r := makeTestReconciler(t, a)
+	createNamespace(r, a.Namespace, false)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -74,6 +75,7 @@ func TestReconcileArgoCD_Reconcile(t *testing.T) {
 	a := makeTestArgoCD()
 
 	r := makeTestReconciler(t, a)
+	createNamespace(r, a.Namespace, false)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -111,6 +113,7 @@ func TestReconcileArgoCD_CleanUp(t *testing.T) {
 	resources := []runtime.Object{a}
 	resources = append(resources, clusterResources(a)...)
 	r := makeTestReconciler(t, resources...)
+	createNamespace(r, a.Namespace, false)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/controller/argocd/custommapper.go
+++ b/pkg/controller/argocd/custommapper.go
@@ -3,15 +3,15 @@ package argocd
 import (
 	"context"
 	"fmt"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"strings"
 
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/pkg/common"
+
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 func (r *ReconcileArgoCD) clusterResourceMapper(o handler.MapObject) []reconcile.Request {
@@ -98,11 +98,13 @@ func (r *ReconcileArgoCD) tlsSecretMapper(o handler.MapObject) []reconcile.Reque
 	return result
 }
 
+// namespaceResourceMapper maps a watch event on a namespace, back to the
+// ArgoCD object that we want to reconcile.
 func (r *ReconcileArgoCD) namespaceResourceMapper(o handler.MapObject) []reconcile.Request {
 	var result = []reconcile.Request{}
 
 	labels := o.Meta.GetLabels()
-	if v, ok := labels[common.ArgoCDManagedNamespaceLabel]; ok {
+	if v, ok := labels[common.ArgoCDManagedByLabel]; ok {
 		argocds := &argoprojv1alpha1.ArgoCDList{}
 		if err := r.client.List(context.TODO(), argocds, &client.ListOptions{Namespace: v}); err != nil {
 			return result

--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -6,6 +6,8 @@ import (
 	"os"
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/pkg/common"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,19 +57,19 @@ func newClusterRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD)
 
 // reconcileRoles will ensure that all ArgoCD Service Accounts are configured.
 func (r *ReconcileArgoCD) reconcileRoles(cr *argoprojv1a1.ArgoCD) (role *v1.Role, err error) {
-	if role, err := r.reconcileRole(applicationController, policyRuleForApplicationController(), cr); err != nil {
+	if _, err := r.reconcileRole(applicationController, policyRuleForApplicationController(), cr); err != nil {
 		return role, err
 	}
 
-	if role, err := r.reconcileRole(dexServer, policyRuleForDexServer(), cr); err != nil {
+	if _, err := r.reconcileRole(dexServer, policyRuleForDexServer(), cr); err != nil {
 		return role, err
 	}
 
-	if role, err := r.reconcileRole(server, policyRuleForServer(), cr); err != nil {
+	if _, err := r.reconcileRole(server, policyRuleForServer(), cr); err != nil {
 		return role, err
 	}
 
-	if role, err := r.reconcileRole(redisHa, policyRuleForRedisHa(cr), cr); err != nil {
+	if _, err := r.reconcileRole(redisHa, policyRuleForRedisHa(cr), cr); err != nil {
 		return role, err
 	}
 
@@ -83,30 +85,52 @@ func (r *ReconcileArgoCD) reconcileRoles(cr *argoprojv1a1.ArgoCD) (role *v1.Role
 }
 
 // reconcileRole
-func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) (*v1.Role, error) {
-	role := newRole(name, policyRules, cr)
-	if err := applyReconcilerHook(cr, role, ""); err != nil {
+func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) ([]*v1.Role, error) {
+	var roles []*v1.Role
+	namespaces := corev1.NamespaceList{}
+	listOption := client.MatchingLabels{
+		common.ArgoCDManagedNamespaceLabel: cr.Namespace,
+	}
+	if err := r.client.List(context.TODO(), &namespaces, listOption); err != nil {
 		return nil, err
 	}
-	existingRole := v1.Role{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: cr.Namespace}, &existingRole)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to reconcile the role for the service account associated with %s : %s", name, err)
-		}
-		if name == dexServer && isDexDisabled() {
-			return role, nil // Dex is disabled, do nothing
-		}
-		controllerutil.SetControllerReference(cr, role, r.scheme)
-		return role, r.client.Create(context.TODO(), role)
-	}
 
-	if name == dexServer && isDexDisabled() {
-		// Delete any existing Role created for Dex
-		return role, r.client.Delete(context.TODO(), role)
+	for _, namespace := range namespaces.Items {
+		role := newRole(name, policyRules, cr)
+		if err := applyReconcilerHook(cr, role, ""); err != nil {
+			return nil, err
+		}
+		role.Namespace = namespace.Name
+		existingRole := v1.Role{}
+		err := r.client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, &existingRole)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to reconcile the role for the service account associated with %s : %s", name, err)
+			}
+			if name == dexServer && isDexDisabled() {
+				continue // Dex is disabled, do nothing
+			}
+			controllerutil.SetControllerReference(cr, role, r.scheme)
+			if err := r.client.Create(context.TODO(), role); err != nil {
+				return nil, err
+			}
+			roles = append(roles, role)
+			continue
+		}
+
+		if name == dexServer && isDexDisabled() {
+			// Delete any existing Role created for Dex
+			if err := r.client.Delete(context.TODO(), role); err != nil {
+				return nil, err
+			}
+		}
+		existingRole.Rules = role.Rules
+		if err := r.client.Update(context.TODO(), &existingRole); err != nil {
+			return nil, err
+		}
+		roles = append(roles, &existingRole)
 	}
-	existingRole.Rules = role.Rules
-	return &existingRole, r.client.Update(context.TODO(), &existingRole)
+	return roles, nil
 }
 
 func (r *ReconcileArgoCD) reconcileClusterRole(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) (*v1.ClusterRole, error) {

--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -123,6 +123,8 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 			if err := r.client.Delete(context.TODO(), role); err != nil {
 				return nil, err
 			}
+			roles = append(roles, role)
+			continue
 		}
 		existingRole.Rules = role.Rules
 		if err := r.client.Update(context.TODO(), &existingRole); err != nil {

--- a/pkg/controller/argocd/role_test.go
+++ b/pkg/controller/argocd/role_test.go
@@ -106,11 +106,13 @@ func TestReconcileArgoCD_RoleHooks(t *testing.T) {
 	r := makeTestReconciler(t)
 	Register(testRoleHook)
 
-	role, err := r.reconcileRole(applicationController, []v1.PolicyRule{}, a)
+	roles, err := r.reconcileRole(applicationController, []v1.PolicyRule{}, a)
+	role := roles[0]
 	assert.NilError(t, err)
 	assert.DeepEqual(t, role.Rules, testRules())
 
-	role, err = r.reconcileRole("test", []v1.PolicyRule{}, a)
+	roles, err = r.reconcileRole("test", []v1.PolicyRule{}, a)
+	role = roles[0]
 	assert.NilError(t, err)
 	assert.DeepEqual(t, role.Rules, []v1.PolicyRule{})
 }

--- a/pkg/controller/argocd/role_test.go
+++ b/pkg/controller/argocd/role_test.go
@@ -17,6 +17,7 @@ func TestReconcileArgoCD_reconcileRole(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
+	createNamespace(r, a.Namespace, true)
 
 	workloadIdentifier := "x"
 	expectedRules := policyRuleForApplicationController()
@@ -43,6 +44,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
+	createNamespace(r, a.Namespace, true)
 
 	rules := policyRuleForDexServer()
 	role := newRole(dexServer, rules, a)
@@ -104,6 +106,7 @@ func TestReconcileArgoCD_RoleHooks(t *testing.T) {
 	defer resetHooks()()
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t)
+	createNamespace(r, a.Namespace, true)
 	Register(testRoleHook)
 
 	roles, err := r.reconcileRole(applicationController, []v1.PolicyRule{}, a)

--- a/pkg/controller/argocd/role_test.go
+++ b/pkg/controller/argocd/role_test.go
@@ -17,7 +17,8 @@ func TestReconcileArgoCD_reconcileRole(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	createNamespace(r, a.Namespace, true)
+	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, "newNamespaceTest", a.Namespace))
 
 	workloadIdentifier := "x"
 	expectedRules := policyRuleForApplicationController()
@@ -27,6 +28,10 @@ func TestReconcileArgoCD_reconcileRole(t *testing.T) {
 	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
 	reconciledRole := &v1.Role{}
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.DeepEqual(t, expectedRules, reconciledRole.Rules)
+
+	// check if roles are created for the new namespace as well
+	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "newNamespaceTest"}, reconciledRole))
 	assert.DeepEqual(t, expectedRules, reconciledRole.Rules)
 
 	// update reconciledRole policy rules to RedisHa policy rules
@@ -44,7 +49,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	createNamespace(r, a.Namespace, true)
+	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
 
 	rules := policyRuleForDexServer()
 	role := newRole(dexServer, rules, a)
@@ -106,7 +111,7 @@ func TestReconcileArgoCD_RoleHooks(t *testing.T) {
 	defer resetHooks()()
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t)
-	createNamespace(r, a.Namespace, true)
+	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
 	Register(testRoleHook)
 
 	roles, err := r.reconcileRole(applicationController, []v1.PolicyRule{}, a)

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -82,6 +82,8 @@ func (r *ReconcileArgoCD) reconcileRoleBindings(cr *argoprojv1a1.ArgoCD) error {
 	return nil
 }
 
+// reconcileRoleBinding, creates RoleBindings for every role and associates it with the right ServiceAccount.
+// This would create RoleBindings for all the namespaces managed by the ArgoCD instance.
 func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
 	var roles []*v1.Role
 	var sa *corev1.ServiceAccount

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -83,68 +83,79 @@ func (r *ReconcileArgoCD) reconcileRoleBindings(cr *argoprojv1a1.ArgoCD) error {
 }
 
 func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
-	var role *v1.Role
+	var roles []*v1.Role
 	var sa *corev1.ServiceAccount
 	var error error
-
-	if role, error = r.reconcileRole(name, rules, cr); error != nil {
-		return error
-	}
 
 	if sa, error = r.reconcileServiceAccount(name, cr); error != nil {
 		return error
 	}
 
-	// get expected name
-	roleBinding := newRoleBindingWithname(name, cr)
-
-	// fetch existing rolebinding by name
-	existingRoleBinding := &v1.RoleBinding{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: cr.Namespace}, existingRoleBinding)
-	roleBindingExists := true
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get the rolebinding associated with %s : %s", name, err)
-		}
-		if name == dexServer && isDexDisabled() {
-			return nil // Dex is disabled, do nothing
-		}
-		roleBindingExists = false
-		roleBinding = newRoleBindingWithname(name, cr)
+	if roles, error = r.reconcileRole(name, rules, cr); error != nil {
+		return error
 	}
 
-	roleBinding.Subjects = []v1.Subject{
-		{
-			Kind:      v1.ServiceAccountKind,
-			Name:      sa.Name,
-			Namespace: sa.Namespace,
-		},
-	}
-	roleBinding.RoleRef = v1.RoleRef{
-		APIGroup: v1.GroupName,
-		Kind:     "Role",
-		Name:     role.Name,
-	}
+	for _, role := range roles {
+		// get expected name
+		roleBinding := newRoleBindingWithname(name, cr)
+		roleBinding.Namespace = role.Namespace
 
-	if roleBindingExists {
-		if name == dexServer && isDexDisabled() {
-			// Delete any existing RoleBinding created for Dex
-			return r.client.Delete(context.TODO(), roleBinding)
-		}
-
-		// if the RoleRef changes, delete the existing role binding and create a new one
-		if !reflect.DeepEqual(roleBinding.RoleRef, existingRoleBinding.RoleRef) {
-			if err = r.client.Delete(context.TODO(), existingRoleBinding); err != nil {
-				return err
+		// fetch existing rolebinding by name
+		existingRoleBinding := &v1.RoleBinding{}
+		err := r.client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, existingRoleBinding)
+		roleBindingExists := true
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to get the rolebinding associated with %s : %s", name, err)
 			}
-		} else {
-			existingRoleBinding.Subjects = roleBinding.Subjects
-			return r.client.Update(context.TODO(), existingRoleBinding)
+			if name == dexServer && isDexDisabled() {
+				continue // Dex is disabled, do nothing
+			}
+			roleBindingExists = false
+		}
+
+		roleBinding.Subjects = []v1.Subject{
+			{
+				Kind:      v1.ServiceAccountKind,
+				Name:      sa.Name,
+				Namespace: sa.Namespace,
+			},
+		}
+		roleBinding.RoleRef = v1.RoleRef{
+			APIGroup: v1.GroupName,
+			Kind:     "Role",
+			Name:     role.Name,
+		}
+
+		if roleBindingExists {
+			if name == dexServer && isDexDisabled() {
+				// Delete any existing RoleBinding created for Dex
+				if err = r.client.Delete(context.TODO(), existingRoleBinding); err != nil {
+					return err
+				}
+				continue
+			}
+
+			// if the RoleRef changes, delete the existing role binding and create a new one
+			if !reflect.DeepEqual(roleBinding.RoleRef, existingRoleBinding.RoleRef) {
+				if err = r.client.Delete(context.TODO(), existingRoleBinding); err != nil {
+					return err
+				}
+			} else {
+				existingRoleBinding.Subjects = roleBinding.Subjects
+				if err = r.client.Update(context.TODO(), existingRoleBinding); err != nil {
+					return err
+				}
+				continue
+			}
+		}
+
+		controllerutil.SetControllerReference(cr, roleBinding, r.scheme)
+		if err = r.client.Create(context.TODO(), roleBinding); err != nil {
+			return err
 		}
 	}
-
-	controllerutil.SetControllerReference(cr, roleBinding, r.scheme)
-	return r.client.Create(context.TODO(), roleBinding)
+	return nil
 }
 
 func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.ClusterRole, sa *corev1.ServiceAccount, cr *argoprojv1a1.ArgoCD) error {

--- a/pkg/controller/argocd/rolebinding_test.go
+++ b/pkg/controller/argocd/rolebinding_test.go
@@ -59,6 +59,8 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 	os.Setenv("DISABLE_DEX", "true")
 	defer os.Unsetenv("DISABLE_DEX")
 
+	_, err := r.reconcileRole(dexServer, rules, a)
+	assert.NilError(t, err)
 	assert.NilError(t, r.reconcileRoleBinding(dexServer, rules, a))
 	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Name: rb.Name, Namespace: a.Namespace}, rb), "not found")
 }

--- a/pkg/controller/argocd/rolebinding_test.go
+++ b/pkg/controller/argocd/rolebinding_test.go
@@ -20,7 +20,8 @@ func TestReconcileArgoCD_reconcileRoleBinding(t *testing.T) {
 	r := makeTestReconciler(t, a)
 	p := policyRuleForApplicationController()
 
-	createNamespace(r, a.Namespace, true)
+	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, "newTestNamespace", a.Namespace))
 
 	workloadIdentifier := "xrb"
 
@@ -29,6 +30,7 @@ func TestReconcileArgoCD_reconcileRoleBinding(t *testing.T) {
 	roleBinding := &rbacv1.RoleBinding{}
 	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, roleBinding))
+	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "newTestNamespace"}, roleBinding))
 
 	// update role reference and subject of the rolebinding
 	roleBinding.RoleRef.Name = "not-xrb"
@@ -46,7 +48,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	createNamespace(r, a.Namespace, true)
+	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
 
 	rules := policyRuleForDexServer()
 	rb := newRoleBindingWithname(dexServer, a)

--- a/pkg/controller/argocd/rolebinding_test.go
+++ b/pkg/controller/argocd/rolebinding_test.go
@@ -20,6 +20,8 @@ func TestReconcileArgoCD_reconcileRoleBinding(t *testing.T) {
 	r := makeTestReconciler(t, a)
 	p := policyRuleForApplicationController()
 
+	createNamespace(r, a.Namespace, true)
+
 	workloadIdentifier := "xrb"
 
 	assert.NilError(t, r.reconcileRoleBinding(workloadIdentifier, p, a))
@@ -44,6 +46,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
+	createNamespace(r, a.Namespace, true)
 
 	rules := policyRuleForDexServer()
 	rb := newRoleBindingWithname(dexServer, a)

--- a/pkg/controller/argocd/route_test.go
+++ b/pkg/controller/argocd/route_test.go
@@ -32,6 +32,7 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
+	createNamespace(r, argoCD.Namespace, true)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -103,6 +104,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
+	createNamespace(r, argoCD.Namespace, true)
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/controller/argocd/route_test.go
+++ b/pkg/controller/argocd/route_test.go
@@ -32,7 +32,7 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
-	createNamespace(r, argoCD.Namespace, true)
+	assert.NilError(t, createNamespace(r, argoCD.Namespace, argoCD.Namespace))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -104,7 +104,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
-	createNamespace(r, argoCD.Namespace, true)
+	assert.NilError(t, createNamespace(r, argoCD.Namespace, argoCD.Namespace))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/controller/argocd/secret.go
+++ b/pkg/controller/argocd/secret.go
@@ -452,10 +452,10 @@ func (r *ReconcileArgoCD) reconcileClusterPermissionsSecret(cr *argoprojv1a1.Arg
 					if !containsString(ns, strings.TrimSpace(n)) {
 						ns = append(ns, strings.TrimSpace(n))
 					}
-					sort.Strings(ns)
-					s.Data["namespaces"] = []byte(strings.Join(ns, ","))
-					return r.client.Update(context.TODO(), &s)
 				}
+				sort.Strings(ns)
+				s.Data["namespaces"] = []byte(strings.Join(ns, ","))
+				return r.client.Update(context.TODO(), &s)
 			}
 		}
 	}

--- a/pkg/controller/argocd/secret.go
+++ b/pkg/controller/argocd/secret.go
@@ -403,7 +403,7 @@ func (r *ReconcileArgoCD) reconcileClusterPermissionsSecret(cr *argoprojv1a1.Arg
 
 	namespaceList := corev1.NamespaceList{}
 	listOption := client.MatchingLabels{
-		common.ArgoCDManagedNamespaceLabel: cr.Namespace,
+		common.ArgoCDManagedByLabel: cr.Namespace,
 	}
 	if err := r.client.List(context.TODO(), &namespaceList, listOption); err != nil {
 		return err

--- a/pkg/controller/argocd/service_account_test.go
+++ b/pkg/controller/argocd/service_account_test.go
@@ -31,6 +31,7 @@ func TestReconcileArgoCD_reconcileServiceAccountPermissions(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
+	createNamespace(r, a.Namespace, true)
 
 	// objective is to verify if the right rule associations have happened.
 
@@ -125,6 +126,7 @@ func TestReconcileArgoCD_reconcileServiceAccount_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
+	createNamespace(r, a.Namespace, true)
 
 	// Dex is enabled, creates a new Service Account for it
 	sa, err := r.reconcileServiceAccount(dexServer, a)

--- a/pkg/controller/argocd/service_account_test.go
+++ b/pkg/controller/argocd/service_account_test.go
@@ -31,7 +31,7 @@ func TestReconcileArgoCD_reconcileServiceAccountPermissions(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	createNamespace(r, a.Namespace, true)
+	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
 
 	// objective is to verify if the right rule associations have happened.
 
@@ -126,7 +126,7 @@ func TestReconcileArgoCD_reconcileServiceAccount_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	createNamespace(r, a.Namespace, true)
+	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
 
 	// Dex is enabled, creates a new Service Account for it
 	sa, err := r.reconcileServiceAccount(dexServer, a)

--- a/pkg/controller/argocd/testing.go
+++ b/pkg/controller/argocd/testing.go
@@ -254,10 +254,10 @@ func makeTestDexResources() *corev1.ResourceRequirements {
 	}
 }
 
-func createNamespace(r *ReconcileArgoCD, n string, withLabel bool) error {
+func createNamespace(r *ReconcileArgoCD, n string, managedBy string) error {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: n}}
-	if withLabel {
-		ns.Labels = map[string]string{common.ArgoCDManagedByLabel: n}
+	if managedBy != "" {
+		ns.Labels = map[string]string{common.ArgoCDManagedByLabel: managedBy}
 	}
 
 	return r.client.Create(context.TODO(), ns)

--- a/pkg/controller/argocd/testing.go
+++ b/pkg/controller/argocd/testing.go
@@ -257,7 +257,7 @@ func makeTestDexResources() *corev1.ResourceRequirements {
 func createNamespace(r *ReconcileArgoCD, n string, withLabel bool) error {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: n}}
 	if withLabel {
-		ns.Labels = map[string]string{common.ArgoCDManagedNamespaceLabel: n}
+		ns.Labels = map[string]string{common.ArgoCDManagedByLabel: n}
 	}
 
 	return r.client.Create(context.TODO(), ns)

--- a/pkg/controller/argocd/testing.go
+++ b/pkg/controller/argocd/testing.go
@@ -15,6 +15,8 @@
 package argocd
 
 import (
+	"context"
+	"github.com/argoproj-labs/argocd-operator/pkg/common"
 	"sort"
 	"testing"
 
@@ -250,4 +252,13 @@ func makeTestDexResources() *corev1.ResourceRequirements {
 			corev1.ResourceCPU:    resourcev1.MustParse("500m"),
 		},
 	}
+}
+
+func createNamespace(r *ReconcileArgoCD, n string, withLabel bool) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: n}}
+	if withLabel {
+		ns.Labels = map[string]string{common.ArgoCDManagedNamespaceLabel: n}
+	}
+
+	return r.client.Create(context.TODO(), ns)
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
This PR addresses the need to manually provide the permissions to ArgoCD instance for managing a new namespace. This feature would allow the user to simply label a namespace with the label `argocd.argoproj.io/managed-by: <namespace of argocd>` and the operator would create the required permissions. 

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes  #352

**How to test changes / Special notes to the reviewer**:
// TODO

- [x] Add Unit Tests
