### PR TITLE
Revert Keycloak image name and version update in #349

### DIFF
--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -161,10 +161,10 @@ const (
 	ArgoCDDefaultKustomizeBuildOptions = ""
 
 	// ArgoCDKeycloakImageName is the default Keycloak Image used when not specified.
-	ArgoCDKeycloakImageName = "quay.io/keycloak/keycloak"
+	ArgoCDKeycloakImageName = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8"
 
 	// ArgoCDKeycloakVersion is the default Keycloak version used when not specified.
-	ArgoCDKeycloakVersion = "sha256:828e92baa29aee2fdf30cca0e0aeefdf77ca458d6818ebbd08bf26f1c5c6a7cf"
+	ArgoCDKeycloakVersion = "sha256:39d752173fc97c29373cd44477b48bcb078531def0a897ee81a60e8d1d0212cc"
 
 	// ArgoCDDefaultOIDCConfig is the default OIDC configuration.
 	ArgoCDDefaultOIDCConfig = ""

--- a/pkg/controller/argocd/keycloak_test.go
+++ b/pkg/controller/argocd/keycloak_test.go
@@ -62,7 +62,7 @@ func TestKeycloakContainerImage(t *testing.T) {
 	// When both cr.spec.sso.Image and ArgoCDKeycloakImageEnvName are not set.
 	testImage := getKeycloakContainerImage(cr)
 	assert.Equal(t, testImage,
-		"quay.io/keycloak/keycloak@sha256:828e92baa29aee2fdf30cca0e0aeefdf77ca458d6818ebbd08bf26f1c5c6a7cf")
+		"registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:39d752173fc97c29373cd44477b48bcb078531def0a897ee81a60e8d1d0212cc")
 
 	// When ENV variable is set.
 	err := os.Setenv(common.ArgoCDKeycloakImageEnvName, "envImage:latest")
@@ -124,7 +124,7 @@ func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
 	}
 	kc := getKeycloakContainer(a)
 	assert.Equal(t, kc.Image,
-		"quay.io/keycloak/keycloak@sha256:828e92baa29aee2fdf30cca0e0aeefdf77ca458d6818ebbd08bf26f1c5c6a7cf")
+		"registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:39d752173fc97c29373cd44477b48bcb078531def0a897ee81a60e8d1d0212cc")
 	assert.Equal(t, kc.ImagePullPolicy, corev1.PullAlways)
 	assert.Equal(t, kc.Name, "${APPLICATION_NAME}")
 }


### PR DESCRIPTION
**What type of PR is this?**
This PR addresses the issue that was created due to PR #349. I have unintentionally updated the Keycloak Image in PR #349, changing it back to the original state.

> /kind bug

**What does this PR do / why we need it**:
Revert the  Keycloak Image name and version that was updated in #349 

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Run the operator using `operator-sdk run local`
2. Create an Argo CD instance
3. Update the Argo CD CR Spec with
```
    sso:
       provider: keycloak
```
4. Verify that the Keycloak pods are up and running.
