### PR TITLE
feat: Add ability to apply additional labels to generated routes

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -288,6 +288,12 @@ spec:
                         description: Enabled will toggle the creation of the OpenShift
                           Route.
                         type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is the map of labels to use for the Route
+                          resource
+                        type: object
                       path:
                         description: Path the router watches for, to route traffic
                           for to the service.
@@ -520,6 +526,12 @@ spec:
                         description: Enabled will toggle the creation of the OpenShift
                           Route.
                         type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is the map of labels to use for the Route
+                          resource
+                        type: object
                       path:
                         description: Path the router watches for, to route traffic
                           for to the service.
@@ -928,6 +940,12 @@ spec:
                         description: Enabled will toggle the creation of the OpenShift
                           Route.
                         type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is the map of labels to use for the Route
+                          resource
+                        type: object
                       path:
                         description: Path the router watches for, to route traffic
                           for to the service.

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -290,6 +290,7 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to use for the Ingress resource.
 Enabled | `false` | Toggle creation of an Ingress resource.
+Labels | [Empty] | The map of labels to add to the Route.
 Path | `/` | Path to use for Ingress resources.
 TLS | [Empty] | TLS configuration for the Ingress.
 
@@ -642,6 +643,7 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to add to the Route.
 Enabled | `false` | Toggles the creation of a Route for the Prometheus component.
+Labels | [Empty] | The map of labels to add to the Route.
 Path | `/` | The path for the Route.
 TLS | [Object] | The TLSConfig for the Route.
 WildcardPolicy| `None` | The wildcard policy for the Route. Can be one of `Subdomain` or `None`.
@@ -940,6 +942,7 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to add to the Route.
 Enabled | `false` | Toggles the creation of a Route for the Argo CD Server component.
+Labels | [Empty] | The map of labels to add to the Route.
 Path | `/` | The path for the Route.
 TLS | [Object] | The TLSConfig for the Route.
 WildcardPolicy| `None` | The wildcard policy for the Route. Can be one of `Subdomain` or `None`.

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -290,7 +290,6 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to use for the Ingress resource.
 Enabled | `false` | Toggle creation of an Ingress resource.
-Labels | [Empty] | The map of labels to add to the Route.
 Path | `/` | Path to use for Ingress resources.
 TLS | [Empty] | TLS configuration for the Ingress.
 
@@ -302,6 +301,7 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to add to the Route.
 Enabled | `false` | Toggles the creation of a Route for the Grafana component.
+Labels | [Empty] | The map of labels to add to the Route.
 Path | `/` | The path for the Route.
 TLS | [Object] | The TLSConfig for the Route.
 WildcardPolicy| `None` | The wildcard policy for the Route. Can be one of `Subdomain` or `None`.

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -283,6 +283,9 @@ type ArgoCDRouteSpec struct {
 	// Annotations is the map of annotations to use for the Route resource.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// Labels is the map of labels to use for the Route resource
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// Enabled will toggle the creation of the OpenShift Route.
 	Enabled bool `json:"enabled"`
 

--- a/pkg/apis/argoproj/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/argoproj/v1alpha1/zz_generated.deepcopy.go
@@ -551,6 +551,13 @@ func (in *ArgoCDRouteSpec) DeepCopyInto(out *ArgoCDRouteSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.TLS != nil {
 		in, out := &in.TLS, &out.TLS
 		*out = new(routev1.TLSConfig)

--- a/pkg/controller/argocd/route.go
+++ b/pkg/controller/argocd/route.go
@@ -108,6 +108,15 @@ func (r *ReconcileArgoCD) reconcileGrafanaRoute(cr *argoprojv1a1.ArgoCD) error {
 		route.Annotations = cr.Spec.Grafana.Route.Annotations
 	}
 
+	// Allow override of the Labels for the Route.
+	if len(cr.Spec.Grafana.Route.Labels) > 0 {
+		labels := route.Labels
+		for key, val := range cr.Spec.Grafana.Route.Labels {
+			labels[key] = val
+		}
+		route.Labels = labels
+	}
+
 	// Allow override of the Host for the Route.
 	if len(cr.Spec.Grafana.Host) > 0 {
 		route.Spec.Host = cr.Spec.Grafana.Host // TODO: What additional role needed for this?
@@ -161,6 +170,15 @@ func (r *ReconcileArgoCD) reconcilePrometheusRoute(cr *argoprojv1a1.ArgoCD) erro
 		route.Annotations = cr.Spec.Prometheus.Route.Annotations
 	}
 
+	// Allow override of the Labels for the Route.
+	if len(cr.Spec.Prometheus.Route.Labels) > 0 {
+		labels := route.Labels
+		for key, val := range cr.Spec.Prometheus.Route.Labels {
+			labels[key] = val
+		}
+		route.Labels = labels
+	}
+
 	// Allow override of the Host for the Route.
 	if len(cr.Spec.Prometheus.Host) > 0 {
 		route.Spec.Host = cr.Spec.Prometheus.Host // TODO: What additional role needed for this?
@@ -208,6 +226,15 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoprojv1a1.ArgoCD) error {
 	// Allow override of the Annotations for the Route.
 	if len(cr.Spec.Server.Route.Annotations) > 0 {
 		route.Annotations = cr.Spec.Server.Route.Annotations
+	}
+
+	// Allow override of the Labels for the Route.
+	if len(cr.Spec.Server.Route.Labels) > 0 {
+		labels := route.Labels
+		for key, val := range cr.Spec.Server.Route.Labels {
+			labels[key] = val
+		}
+		route.Labels = labels
 	}
 
 	// Allow override of the Host for the Route.


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
This PR enables the ability to add additional labels to a generated route. This can be useful in a number of scenarios including router sharding, etc.

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR.
* [X] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #359 

**How to test changes / Special notes to the reviewer**:

This can be tested by building the operator from the PR branch and deploying an ArgoCD instance with the following CR:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: route
spec:
  grafana:
    enabled: true
    route:
      enabled: true
  prometheus:
    enabled: true
    route:
      enabled: true
  server:
    route:
      enabled: true
      labels:
        shard: my-shard
```

You can see from the above CR that different labels can be applied to each route (server, prometheus, grafana) individually and that applying a label to one does not apply it to them all. The PR also makes sure that the default labels that are applied across all ArgoCD objects are kept in place.