### PR TITLE
chore: Fix small typo in reference docs (kustomizeBuildOptions -> oidcConfig)

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -590,7 +590,7 @@ OIDC configuration as an alternative to dex (optional). This property maps direc
 
 ### OIDC Config Example
 
-The following example sets a value in the `argocd-cm` ConfigMap using the `KustomizeBuildOptions` property on the `ArgoCD` resource.
+The following example sets a value in the `argocd-cm` ConfigMap using the `oidcConfig` property on the `ArgoCD` resource.
 
 ``` yaml
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation



**What does this PR do / why we need it**:
This fixes a small docs typo that referenced kustomizeBuildOptions instead of oidcConfig

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR.
* [X] Documentation has been updated.

**Which issue(s) this PR fixes**:
N/A

**How to test changes / Special notes to the reviewer**:
Nothing to test, just a doc fix.