### PR TITLE
feat: Publish latest operator image after push to master branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,7 @@ jobs:
 
     env:
       ARGOCD_OPERATOR_IMAGE_BUILDER: docker
+      ARGOCD_OPERATOR_IMAGE: ${{ secrets.REGISTRY_URL }}/argocd-operator:latest
 
     steps:
 
@@ -38,9 +39,7 @@ jobs:
           make install
 
       - name: Build operator and Tag Latest
-        run: | 
-          bash hack/build.sh
-          bash hack/tag.sh
+        run: bash hack/build.sh
 
       - name: Login to Registry
         uses: docker/login-action@v1
@@ -50,7 +49,4 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Push latest operator
-        env:
-          ARGOCD_OPERATOR_IMAGE=${{ secrets.REGISTRY_URL }}/argocd-operator:latest
-        run: |
-          bash hack/push.sh
+        run: bash hack/push.sh

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,56 @@
+name: Publish latest operator build 
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+
+  publish-latest-operator:
+    runs-on: ubuntu-latest
+
+    env:
+      ARGOCD_OPERATOR_IMAGE_BUILDER: docker
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Restore go build cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-v1-${{ github.run_id }}
+
+      - name: Install operator-sdk
+        run: |
+          sudo apt-get install git -y
+          git clone https://github.com/operator-framework/operator-sdk ~/go/src/github.com/operator-framework/operator-sdk
+          cd ~/go/src/github.com/operator-framework/operator-sdk
+          git checkout v0.19.4
+          make tidy
+          make install
+
+      - name: Build operator and Tag Latest
+        run: | 
+          bash hack/build.sh
+          bash hack/tag.sh
+
+      - name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push latest operator
+        env:
+          ARGOCD_OPERATOR_IMAGE=${{ secrets.REGISTRY_URL }}/argocd-operator:latest
+        run: |
+          bash hack/push.sh


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind enhancement

**What does this PR do / why we need it**:
This PR adds a GHA workflow to build and publish the latest code to a container registry with the tag `:latest`. It requires three secrets to be created in the repository:
- `REGISTRY_URL` - The registry to publish the image to (i.e. `quay.io/<reponame>`)
- `REGISTRY_USERNAME` - The user to authenticate as
- `REGISTRY_PASSWORD` - The password/token to use to authenticate

This workflow will only run on push/merge to the `master` branch.

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR.
* [X] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #325 

**How to test changes / Special notes to the reviewer**:
No great way to test this. But you can see this in action here:

https://github.com/tylerauerbeck/argocd-operator/actions/runs/1024920750