### PR TITLE
fix: Keycloak fails to update OIDC config in argocd-cm intermittently

### DIFF
--- a/pkg/controller/argocd/keycloak.go
+++ b/pkg/controller/argocd/keycloak.go
@@ -673,7 +673,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoprojv1a1.ArgoCD, kRo
 	}
 
 	// Update ArgoCD instance for OIDC Config with Keycloakrealm URL
-	o, _ := yaml.Marshal(oidcConfig{
+	o, err := yaml.Marshal(oidcConfig{
 		Name: "Keycloak",
 		Issuer: fmt.Sprintf("%s/auth/realms/%s",
 			kRouteURL, keycloakRealm),
@@ -681,6 +681,10 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoprojv1a1.ArgoCD, kRo
 		ClientSecret:   "$oidc.keycloak.clientSecret",
 		RequestedScope: []string{"openid", "profile", "email", "groups"},
 	})
+
+	if err != nil {
+		return err
+	}
 
 	argoCDCM := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: argoCDCM.Name, Namespace: argoCDCM.Namespace}, argoCDCM)


### PR DESCRIPTION
> For example, `> /kind bug` would simply become: `/kind bug`
> /kind bug

**What does this PR do / why we need it**:
#366  introduced a new bug which does not allow operator to update the keycloak related OIDC configuration intermittently. 

Reason for failure:
A user can choose to override Keycloak container resource requests/limits from Argo CD CR (Please refer #366 ). When a user does not provide Keycloak container resource requests/limits in Argo CD CR, operator overrides the default values and updates the Keycloak deployment config with new resource requirements.

#366 fails to get the new version(modified) deployment config to update the OIDC configuration. 

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Run the operator either locally or using operator hub.
2. Patch the Argo CD CR to enable Login with Keycloak.
```
spec:
   sso:
     provider: keycloak
```
3. Wait for the operator to reconcile keycloak changes. Keycloak may take a couple of minutes to start.
4. Intermittently you will see operator cannot update argocd-cm with OIDC config. which mean intermittently you will see  that "Login with Keycloak" option is not enabled in the previous build, Which is fixed.
5. on the Argo CD login page, you should see "Login Via Keycloak"