### PR TITLE
feat: Add ability to configure loglevel for each ArgoCD component

### DIFF
--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -91,7 +91,7 @@ spec:
                   logLevel:
                     description: LogLevel refers to the log level used by the Application
                       Controller component. Defaults to ArgoCDDefaultLogLevel if not
-                      configured.
+                      configured. Valid options are info, error, and warn.
                     type: string
                   processors:
                     description: Processors contains the options for the Application
@@ -687,7 +687,7 @@ spec:
                   logLevel:
                     description: LogLevel describes the log level that should be used
                       by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not
-                      set.
+                      set.  Valid options are info, error, and warn.
                     type: string
                   mountsatoken:
                     description: MountSAToken describes whether you would like to
@@ -929,7 +929,7 @@ spec:
                   logLevel:
                     description: LogLevel refers to the log level to be used by the
                       ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if
-                      not set.
+                      not set.  Valid options are info, error, and warn.
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required

--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -88,6 +88,11 @@ spec:
                       \n Set this to a duration, e.g. 10m or 600s to control the synchronisation
                       frequency."
                     type: string
+                  logLevel:
+                    description: LogLevel refers to the log level used by the Application
+                      Controller component. Defaults to ArgoCDDefaultLogLevel if not
+                      configured.
+                    type: string
                   processors:
                     description: Processors contains the options for the Application
                       Controller processors.
@@ -679,6 +684,11 @@ spec:
                   image:
                     description: Image is the ArgoCD Repo Server container image.
                     type: string
+                  logLevel:
+                    description: LogLevel describes the log level that should be used
+                      by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not
+                      set.
+                    type: string
                   mountsatoken:
                     description: MountSAToken describes whether you would like to
                       have the Repo server mount the service account token
@@ -916,6 +926,11 @@ spec:
                   insecure:
                     description: Insecure toggles the insecure flag.
                     type: boolean
+                  logLevel:
+                    description: LogLevel refers to the log level to be used by the
+                      ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if
+                      not set.
+                    type: string
                   resources:
                     description: Resources defines the Compute Resources required
                       by the container for the Argo CD server component.

--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -45,7 +45,7 @@ spec:
                   logLevel:
                     description: LogLevel describes the log level that should be used
                       by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel
-                      if not set.  Valid options are info, error, and warn.
+                      if not set.  Valid options are debug,info, error, and warn.
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required
@@ -96,7 +96,7 @@ spec:
                   logLevel:
                     description: LogLevel refers to the log level used by the Application
                       Controller component. Defaults to ArgoCDDefaultLogLevel if not
-                      configured. Valid options are info, error, and warn.
+                      configured. Valid options are debug,info, error, and warn.
                     type: string
                   processors:
                     description: Processors contains the options for the Application
@@ -692,7 +692,7 @@ spec:
                   logLevel:
                     description: LogLevel describes the log level that should be used
                       by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not
-                      set.  Valid options are info, error, and warn.
+                      set.  Valid options are debug, info, error, and warn.
                     type: string
                   mountsatoken:
                     description: MountSAToken describes whether you would like to
@@ -934,7 +934,7 @@ spec:
                   logLevel:
                     description: LogLevel refers to the log level to be used by the
                       ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if
-                      not set.  Valid options are info, error, and warn.
+                      not set.  Valid options are debug, info, error, and warn.
                     type: string
                   resources:
                     description: Resources defines the Compute Resources required

--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -42,6 +42,11 @@ spec:
                   image:
                     description: Image is the Argo CD ApplicationSet image (optional)
                     type: string
+                  logLevel:
+                    description: LogLevel describes the log level that should be used
+                      by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel
+                      if not set.  Valid options are info, error, and warn.
+                    type: string
                   resources:
                     description: Resources defines the Compute Resources required
                       by the container for ApplicationSet.

--- a/deploy/crds/argoproj.io_argocds_crd.yaml
+++ b/deploy/crds/argoproj.io_argocds_crd.yaml
@@ -96,7 +96,7 @@ spec:
                   logLevel:
                     description: LogLevel refers to the log level used by the Application
                       Controller component. Defaults to ArgoCDDefaultLogLevel if not
-                      configured. Valid options are debug,info, error, and warn.
+                      configured. Valid options are debug, info, error, and warn.
                     type: string
                   processors:
                     description: Processors contains the options for the Application

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -770,7 +770,7 @@ VerifyTLS | false | Whether to enforce strict TLS checking on all components whe
 AutoTLS | "" | Provider to use for setting up TLS the repo-server's gRPC TLS certificate (one of: `openshift`). Currently only available for OpenShift.
 Image | `argoproj/argocd` | The container image for ArgoCD Repo Server. This overrides the `ARGOCD_REPOSERVER_IMAGE` environment variable.
 Version | v2.0.0 (SHA) | The tag to use with the ArgoCD Repo Server.
-LogLevel | info | The log level to be used by the ArgoCD Repo Server. Valid options are info, error, and warn.
+LogLevel | info | The log level to be used by the ArgoCD Repo Server. Valid options are debug, info, error, and warn.
 
 ### Repo Example
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -123,6 +123,7 @@ Name | Default | Description
 Processors.Operation | 10 | The number of operation processors.
 Processors.Status | 20 | The number of status processors.
 Resources | [Empty] | The container compute resources.
+LogLevel | info | The log level to be used by the ArgoCd Application Controller component.
 
 ### Controller Example
 
@@ -769,6 +770,7 @@ VerifyTLS | false | Whether to enforce strict TLS checking on all components whe
 AutoTLS | "" | Provider to use for setting up TLS the repo-server's gRPC TLS certificate (one of: `openshift`). Currently only available for OpenShift.
 Image | `argoproj/argocd` | The container image for ArgoCD Repo Server. This overrides the `ARGOCD_REPOSERVER_IMAGE` environment variable.
 Version | v2.0.0 (SHA) | The tag to use with the ArgoCD Repo Server.
+LogLevel | info | The log level to be used by the ArgoCD Repo Server.
 
 ### Repo Example
 
@@ -923,6 +925,7 @@ Insecure | false | Toggles the insecure flag for Argo CD Server.
 Resources | [Empty] | The container compute resources.
 [Route](#server-route-options) | [Object] | Route configuration options.
 Service.Type | ClusterIP | The ServiceType to use for the Service resource.
+LogLevel | info | The log level to be used by the ArgoCD Server component.
 
 ### Server Autoscale Options
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -123,7 +123,7 @@ Name | Default | Description
 Processors.Operation | 10 | The number of operation processors.
 Processors.Status | 20 | The number of status processors.
 Resources | [Empty] | The container compute resources.
-LogLevel | info | The log level to be used by the ArgoCd Application Controller component. Valid options are info, error, and warn.
+LogLevel | info | The log level to be used by the ArgoCd Application Controller component. Valid options are debug, info, error, and warn.
 
 ### Controller Example
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -925,7 +925,7 @@ Insecure | false | Toggles the insecure flag for Argo CD Server.
 Resources | [Empty] | The container compute resources.
 [Route](#server-route-options) | [Object] | Route configuration options.
 Service.Type | ClusterIP | The ServiceType to use for the Service resource.
-LogLevel | info | The log level to be used by the ArgoCD Server component. Valid options are info, error, and warn.
+LogLevel | info | The log level to be used by the ArgoCD Server component. Valid options are debug, info, error, and warn.
 
 ### Server Autoscale Options
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -123,7 +123,7 @@ Name | Default | Description
 Processors.Operation | 10 | The number of operation processors.
 Processors.Status | 20 | The number of status processors.
 Resources | [Empty] | The container compute resources.
-LogLevel | info | The log level to be used by the ArgoCd Application Controller component.
+LogLevel | info | The log level to be used by the ArgoCd Application Controller component. Valid options are info, error, and warn.
 
 ### Controller Example
 
@@ -770,7 +770,7 @@ VerifyTLS | false | Whether to enforce strict TLS checking on all components whe
 AutoTLS | "" | Provider to use for setting up TLS the repo-server's gRPC TLS certificate (one of: `openshift`). Currently only available for OpenShift.
 Image | `argoproj/argocd` | The container image for ArgoCD Repo Server. This overrides the `ARGOCD_REPOSERVER_IMAGE` environment variable.
 Version | v2.0.0 (SHA) | The tag to use with the ArgoCD Repo Server.
-LogLevel | info | The log level to be used by the ArgoCD Repo Server.
+LogLevel | info | The log level to be used by the ArgoCD Repo Server. Valid options are info, error, and warn.
 
 ### Repo Example
 
@@ -925,7 +925,7 @@ Insecure | false | Toggles the insecure flag for Argo CD Server.
 Resources | [Empty] | The container compute resources.
 [Route](#server-route-options) | [Object] | Route configuration options.
 Service.Type | ClusterIP | The ServiceType to use for the Service resource.
-LogLevel | info | The log level to be used by the ArgoCD Server component.
+LogLevel | info | The log level to be used by the ArgoCD Server component. Valid options are info, error, and warn.
 
 ### Server Autoscale Options
 

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -84,6 +84,9 @@ type ArgoCDApplicationSet struct {
 
 	// Resources defines the Compute Resources required by the container for ApplicationSet.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// LogLevel describes the log level that should be used by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are info, error, and warn.
+	LogLevel string `json:"logLevel,omitempty"`
 }
 
 // ArgoCDCASpec defines the CA options for ArgCD.

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -58,7 +58,7 @@ type ArgoCDApplicationControllerSpec struct {
 	// Processors contains the options for the Application Controller processors.
 	Processors ArgoCDApplicationControllerProcessorsSpec `json:"processors,omitempty"`
 
-	// LogLevel refers to the log level used by the Application Controller component. Defaults to ArgoCDDefaultLogLevel if not configured. Valid options are debug,info, error, and warn.
+	// LogLevel refers to the log level used by the Application Controller component. Defaults to ArgoCDDefaultLogLevel if not configured. Valid options are debug, info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Application Controller.

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -58,7 +58,7 @@ type ArgoCDApplicationControllerSpec struct {
 	// Processors contains the options for the Application Controller processors.
 	Processors ArgoCDApplicationControllerProcessorsSpec `json:"processors,omitempty"`
 
-	// LogLevel refers to the log level used by the Application Controller component. Defaults to ArgoCDDefaultLogLevel if not configured.
+	// LogLevel refers to the log level used by the Application Controller component. Defaults to ArgoCDDefaultLogLevel if not configured. Valid options are info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Application Controller.
@@ -258,7 +258,7 @@ type ArgoCDRedisSpec struct {
 // ArgoCDRepoSpec defines the desired state for the Argo CD repo server component.
 type ArgoCDRepoSpec struct {
 
-	// LogLevel describes the log level that should be used by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not set.
+	// LogLevel describes the log level that should be used by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// MountSAToken describes whether you would like to have the Repo server mount the service account token
@@ -341,7 +341,7 @@ type ArgoCDServerSpec struct {
 	// Insecure toggles the insecure flag.
 	Insecure bool `json:"insecure,omitempty"`
 
-	// LogLevel refers to the log level to be used by the ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if not set.
+	// LogLevel refers to the log level to be used by the ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Argo CD server component.

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -58,7 +58,7 @@ type ArgoCDApplicationControllerSpec struct {
 	// Processors contains the options for the Application Controller processors.
 	Processors ArgoCDApplicationControllerProcessorsSpec `json:"processors,omitempty"`
 
-	// LogLevel refers to the log level used by the Application Controller component. Defaults to ArgoCDDefaultLogLevel if not configured. Valid options are info, error, and warn.
+	// LogLevel refers to the log level used by the Application Controller component. Defaults to ArgoCDDefaultLogLevel if not configured. Valid options are debug,info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Application Controller.
@@ -85,7 +85,7 @@ type ArgoCDApplicationSet struct {
 	// Resources defines the Compute Resources required by the container for ApplicationSet.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
-	// LogLevel describes the log level that should be used by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are info, error, and warn.
+	// LogLevel describes the log level that should be used by the ApplicationSet controller. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are debug,info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 }
 
@@ -261,7 +261,7 @@ type ArgoCDRedisSpec struct {
 // ArgoCDRepoSpec defines the desired state for the Argo CD repo server component.
 type ArgoCDRepoSpec struct {
 
-	// LogLevel describes the log level that should be used by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are info, error, and warn.
+	// LogLevel describes the log level that should be used by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are debug, info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// MountSAToken describes whether you would like to have the Repo server mount the service account token
@@ -344,7 +344,7 @@ type ArgoCDServerSpec struct {
 	// Insecure toggles the insecure flag.
 	Insecure bool `json:"insecure,omitempty"`
 
-	// LogLevel refers to the log level to be used by the ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are info, error, and warn.
+	// LogLevel refers to the log level to be used by the ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are debug, info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Argo CD server component.

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -58,6 +58,9 @@ type ArgoCDApplicationControllerSpec struct {
 	// Processors contains the options for the Application Controller processors.
 	Processors ArgoCDApplicationControllerProcessorsSpec `json:"processors,omitempty"`
 
+	// LogLevel refers to the log level used by the Application Controller component. Defaults to ArgoCDDefaultLogLevel if not configured.
+	LogLevel string `json:"logLevel,omitempty"`
+
 	// Resources defines the Compute Resources required by the container for the Application Controller.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
@@ -254,6 +257,10 @@ type ArgoCDRedisSpec struct {
 
 // ArgoCDRepoSpec defines the desired state for the Argo CD repo server component.
 type ArgoCDRepoSpec struct {
+
+	// LogLevel describes the log level that should be used by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not set.
+	LogLevel string `json:"logLevel,omitempty"`
+
 	// MountSAToken describes whether you would like to have the Repo server mount the service account token
 	MountSAToken bool `json:"mountsatoken,omitempty"`
 
@@ -333,6 +340,9 @@ type ArgoCDServerSpec struct {
 
 	// Insecure toggles the insecure flag.
 	Insecure bool `json:"insecure,omitempty"`
+
+	// LogLevel refers to the log level to be used by the ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if not set.
+	LogLevel string `json:"logLevel,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Argo CD server component.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/pkg/common/defaults.go
+++ b/pkg/common/defaults.go
@@ -18,6 +18,9 @@ const (
 	// ArgoCDApplicationControllerComponent is the name of the application controller  control plane component
 	ArgoCDApplicationControllerComponent = "argocd-application-controller"
 
+	// ArgoCDDefaultLogLevel is the default log level to be used by all ArgoCD components.
+	ArgoCDDefaultLogLevel = "info"
+
 	// ArgoCDServerComponent is the name of the Dex server control plane component
 	ArgoCDServerComponent = "argocd-server"
 

--- a/pkg/controller/argocd/applicationset.go
+++ b/pkg/controller/argocd/applicationset.go
@@ -31,6 +31,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+
+// getArgoApplicationSetCommand will return the command for the ArgoCD ApplicationSet component.
+func getArgoApplicationSetCommand(cr *argoprojv1a1.ArgoCD) []string {
+	cmd := make([]string, 0)
+
+	cmd = append(cmd, "applicationset-controller")
+
+	cmd = append(cmd, "--argocd-repo-server")
+	cmd = append(cmd, getRepoServerAddress(cr))
+
+	cmd = append(cmd, "--loglevel")
+	cmd = append(cmd, getLogLevel(cr.Spec.ApplicationSet.LogLevel))
+
+	return cmd
+}
+
+
 func (r *ReconcileArgoCD) reconcileApplicationSetController(cr *argoprojv1a1.ArgoCD) error {
 
 	log.Info("reconciling applicationset serviceaccounts")
@@ -117,7 +134,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoprojv1a1.Arg
 	}
 
 	podSpec.Containers = []corev1.Container{{
-		Command: []string{"applicationset-controller", "--argocd-repo-server", getRepoServerAddress(cr)},
+		Command: getArgoApplicationSetCommand(cr),
 		Env: []corev1.EnvVar{{
 			Name: "NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/controller/argocd/applicationset.go
+++ b/pkg/controller/argocd/applicationset.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-
 // getArgoApplicationSetCommand will return the command for the ArgoCD ApplicationSet component.
 func getArgoApplicationSetCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd := make([]string, 0)
@@ -46,7 +45,6 @@ func getArgoApplicationSetCommand(cr *argoprojv1a1.ArgoCD) []string {
 
 	return cmd
 }
-
 
 func (r *ReconcileArgoCD) reconcileApplicationSetController(cr *argoprojv1a1.ArgoCD) error {
 

--- a/pkg/controller/argocd/applicationset_test.go
+++ b/pkg/controller/argocd/applicationset_test.go
@@ -58,7 +58,7 @@ func TestReconcileApplicationSet_Deployments(t *testing.T) {
 	appsetAssertExpectedLabels(t, &deployment.ObjectMeta)
 
 	want := []corev1.Container{{
-		Command: []string{"applicationset-controller", "--argocd-repo-server", getRepoServerAddress(a)},
+		Command: []string{"applicationset-controller", "--argocd-repo-server", getRepoServerAddress(a), "--loglevel", "info"},
 		Env: []corev1.EnvVar{{
 			Name: "NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
@@ -101,7 +101,7 @@ func TestReconcileApplicationSet_Deployments_resourceRequirements(t *testing.T) 
 	appsetAssertExpectedLabels(t, &deployment.ObjectMeta)
 
 	containerWant := []corev1.Container{{
-		Command: []string{"applicationset-controller", "--argocd-repo-server", getRepoServerAddress(a)},
+		Command: []string{"applicationset-controller", "--argocd-repo-server", getRepoServerAddress(a), "--loglevel", "info"},
 		Env: []corev1.EnvVar{{
 			Name: "NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -194,6 +194,10 @@ func getArgoRepoCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd = append(cmd, "--redis")
 	cmd = append(cmd, getRedisServerAddress(cr))
 
+	cmd = append(cmd, "--loglevel")
+
+	cmd = append(cmd, getLogLevel(cr.Spec.Repo.LogLevel))
+
 	return cmd
 }
 
@@ -221,6 +225,8 @@ func getArgoServerCommand(cr *argoprojv1a1.ArgoCD) []string {
 
 	cmd = append(cmd, "--redis")
 	cmd = append(cmd, getRedisServerAddress(cr))
+
+	cmd = append(cmd, getLogLevel(cr.Spec.Server.LogLevel))
 
 	return cmd
 }

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -196,8 +196,6 @@ func getArgoRepoCommand(cr *argoprojv1a1.ArgoCD) []string {
 
 	cmd = append(cmd, "--loglevel "+getLogLevel(cr.Spec.Repo.LogLevel))
 
-	//cmd = append(cmd, getLogLevel(cr.Spec.Repo.LogLevel))
-
 	return cmd
 }
 

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -194,7 +194,8 @@ func getArgoRepoCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd = append(cmd, "--redis")
 	cmd = append(cmd, getRedisServerAddress(cr))
 
-	cmd = append(cmd, "--loglevel "+getLogLevel(cr.Spec.Repo.LogLevel))
+	cmd = append(cmd, "--loglevel")
+	cmd = append(cmd, getLogLevel(cr.Spec.Repo.LogLevel))
 
 	return cmd
 }
@@ -224,7 +225,8 @@ func getArgoServerCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd = append(cmd, "--redis")
 	cmd = append(cmd, getRedisServerAddress(cr))
 
-	cmd = append(cmd, "--loglevel "+getLogLevel(cr.Spec.Server.LogLevel))
+	cmd = append(cmd, "--loglevel")
+	cmd = append(cmd, getLogLevel(cr.Spec.Server.LogLevel))
 
 	return cmd
 }

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -194,9 +194,9 @@ func getArgoRepoCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd = append(cmd, "--redis")
 	cmd = append(cmd, getRedisServerAddress(cr))
 
-	cmd = append(cmd, "--loglevel")
+	cmd = append(cmd, "--loglevel "+getLogLevel(cr.Spec.Repo.LogLevel))
 
-	cmd = append(cmd, getLogLevel(cr.Spec.Repo.LogLevel))
+	//cmd = append(cmd, getLogLevel(cr.Spec.Repo.LogLevel))
 
 	return cmd
 }
@@ -226,7 +226,7 @@ func getArgoServerCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd = append(cmd, "--redis")
 	cmd = append(cmd, getRedisServerAddress(cr))
 
-	cmd = append(cmd, getLogLevel(cr.Spec.Server.LogLevel))
+	cmd = append(cmd, "--loglevel "+getLogLevel(cr.Spec.Server.LogLevel))
 
 	return cmd
 }

--- a/pkg/controller/argocd/deployment_test.go
+++ b/pkg/controller/argocd/deployment_test.go
@@ -73,9 +73,9 @@ func TestReconcileArgoCD_reconcileRepoDeployment_loglevel(t *testing.T) {
 
 		for _, con := range deployment.Spec.Template.Spec.Containers {
 			if con.Name == "argocd-repo-server" {
-				for _, cmd := range con.Command {
-					if strings.HasPrefix(cmd, "--loglevel") {
-						if diff := cmp.Diff(ll, strings.Split(cmd, " ")[1]); diff != "" {
+				for cmdKey, cmd := range con.Command {
+					if cmd == "--loglevel" {
+						if diff := cmp.Diff(ll, con.Command[cmdKey+1]); diff != "" {
 							t.Fatalf("reconcileRepoDeployment failed:\n%s", diff)
 						}
 					}
@@ -579,7 +579,8 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 					"argocd-repo-server.argocd.svc.cluster.local:8081",
 					"--redis",
 					"argocd-redis.argocd.svc.cluster.local:6379",
-					"--loglevel info",
+					"--loglevel",
+					"info",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},
@@ -651,7 +652,8 @@ func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 					"argocd-repo-server.argocd.svc.cluster.local:8081",
 					"--redis",
 					"argocd-redis.argocd.svc.cluster.local:6379",
-					"--loglevel info",
+					"--loglevel",
+					"info",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},
@@ -726,7 +728,8 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 					"argocd-repo-server.argocd.svc.cluster.local:8081",
 					"--redis",
 					"argocd-redis.argocd.svc.cluster.local:6379",
-					"--loglevel info",
+					"--loglevel",
+					"info",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},

--- a/pkg/controller/argocd/deployment_test.go
+++ b/pkg/controller/argocd/deployment_test.go
@@ -38,6 +38,53 @@ var (
 		"argocd-server"}
 )
 
+func TestReconcileArgoCD_reconcileRepoDeployment_loglevel(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	repoDeps := []*argoprojv1alpha1.ArgoCD{
+		makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Repo.LogLevel = "warn"
+		}),
+		makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a.Spec.Repo.LogLevel = "error"
+		}),
+		makeTestArgoCD(),
+	}
+
+	for _, lglv := range repoDeps {
+
+		var ll string
+		if lglv.Spec.Repo.LogLevel == "" {
+			ll = "info"
+		} else {
+			ll = lglv.Spec.Repo.LogLevel
+		}
+
+		r := makeTestReconciler(t, lglv)
+
+		err := r.reconcileRepoDeployment(lglv)
+		assert.NilError(t, err)
+		deployment := &appsv1.Deployment{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{
+			Name:      "argocd-repo-server",
+			Namespace: testNamespace,
+		}, deployment)
+		assert.NilError(t, err)
+
+		for _, con := range deployment.Spec.Template.Spec.Containers {
+			if con.Name == "argocd-repo-server" {
+				for _, cmd := range con.Command {
+					if strings.HasPrefix(cmd, "--loglevel") {
+						if diff := cmp.Diff(ll, strings.Split(cmd, " ")[1]); diff != "" {
+							t.Fatalf("reconcileRepoDeployment failed:\n%s", diff)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
 // TODO: This needs more testing for the rest of the RepoDeployment container
 // fields.
 
@@ -532,6 +579,7 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 					"argocd-repo-server.argocd.svc.cluster.local:8081",
 					"--redis",
 					"argocd-redis.argocd.svc.cluster.local:6379",
+					"--loglevel info",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},
@@ -603,6 +651,7 @@ func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 					"argocd-repo-server.argocd.svc.cluster.local:8081",
 					"--redis",
 					"argocd-redis.argocd.svc.cluster.local:6379",
+					"--loglevel info",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},
@@ -677,6 +726,7 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 					"argocd-repo-server.argocd.svc.cluster.local:8081",
 					"--redis",
 					"argocd-redis.argocd.svc.cluster.local:6379",
+					"--loglevel info",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},

--- a/pkg/controller/argocd/statefulset_test.go
+++ b/pkg/controller/argocd/statefulset_test.go
@@ -107,7 +107,8 @@ func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {
 		"--operation-processors", "10",
 		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
 		"--repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081",
-		"--status-processors", "20"}
+		"--status-processors", "20",
+		"--loglevel info"}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}
@@ -145,7 +146,8 @@ func TestReconcileArgoCD_reconcileApplicationController_withUpdate(t *testing.T)
 		"--operation-processors", "10",
 		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
 		"--repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081",
-		"--status-processors", "30"}
+		"--status-processors", "30",
+		"--loglevel info"}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}

--- a/pkg/controller/argocd/statefulset_test.go
+++ b/pkg/controller/argocd/statefulset_test.go
@@ -108,7 +108,7 @@ func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {
 		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
 		"--repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081",
 		"--status-processors", "20",
-		"--loglevel info"}
+		"--loglevel", "info"}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}
@@ -147,7 +147,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withUpdate(t *testing.T)
 		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
 		"--repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081",
 		"--status-processors", "30",
-		"--loglevel info"}
+		"--loglevel", "info"}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -109,6 +109,9 @@ func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD) []string {
 	if cr.Spec.Controller.AppSync != nil {
 		cmd = append(cmd, "--app-resync", strconv.FormatInt(int64(cr.Spec.Controller.AppSync.Seconds()), 10))
 	}
+
+	cmd = append(cmd, getLogLevel(cr.Spec.Controller.LogLevel))
+
 	return cmd
 }
 
@@ -1203,4 +1206,20 @@ func initK8sClient() (*kubernetes.Clientset, error) {
 	}
 
 	return k8sClient, nil
+}
+
+// getLogLevel returns the log level for a specified component if it is set or returns the default log level if it is not set
+func getLogLevel(logField string) string {
+	
+	if logField == "" {
+		return common.ArgoCDDefaultLogLevel
+	} else {
+		switch(logField) {
+			"info",
+			"warn",
+			"error":
+			return logField
+		}
+		return common.ArgoCDDefaultLogLevel
+	}
 }

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -1215,6 +1215,7 @@ func getLogLevel(logField string) string {
 		return common.ArgoCDDefaultLogLevel
 	} else {
 		switch(logField) {
+	        case
 			"info",
 			"warn",
 			"error":

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -1212,7 +1212,7 @@ func initK8sClient() (*kubernetes.Clientset, error) {
 // getLogLevel returns the log level for a specified component if it is set or returns the default log level if it is not set
 func getLogLevel(logField string) string {
 
-        switch strings.ToLower(logField) {
+	switch strings.ToLower(logField) {
 	case "debug",
 		"info",
 		"warn",

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -110,7 +110,7 @@ func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD) []string {
 		cmd = append(cmd, "--app-resync", strconv.FormatInt(int64(cr.Spec.Controller.AppSync.Seconds()), 10))
 	}
 
-	cmd = append(cmd, getLogLevel(cr.Spec.Controller.LogLevel))
+	cmd = append(cmd, "--loglevel "+getLogLevel(cr.Spec.Controller.LogLevel))
 
 	return cmd
 }
@@ -1210,12 +1210,12 @@ func initK8sClient() (*kubernetes.Clientset, error) {
 
 // getLogLevel returns the log level for a specified component if it is set or returns the default log level if it is not set
 func getLogLevel(logField string) string {
-	
+
 	if logField == "" {
 		return common.ArgoCDDefaultLogLevel
 	} else {
-		switch(logField) {
-	        case
+		switch logField {
+		case
 			"info",
 			"warn",
 			"error":

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -1217,6 +1217,7 @@ func getLogLevel(logField string) string {
 	} else {
 		switch logField {
 		case
+			"debug",
 			"info",
 			"warn",
 			"error":

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -110,7 +110,8 @@ func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD) []string {
 		cmd = append(cmd, "--app-resync", strconv.FormatInt(int64(cr.Spec.Controller.AppSync.Seconds()), 10))
 	}
 
-	cmd = append(cmd, "--loglevel "+getLogLevel(cr.Spec.Controller.LogLevel))
+	cmd = append(cmd, "--loglevel")
+	cmd = append(cmd, getLogLevel(cr.Spec.Controller.LogLevel))
 
 	return cmd
 }

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -1212,17 +1212,12 @@ func initK8sClient() (*kubernetes.Clientset, error) {
 // getLogLevel returns the log level for a specified component if it is set or returns the default log level if it is not set
 func getLogLevel(logField string) string {
 
-	if logField == "" {
-		return common.ArgoCDDefaultLogLevel
-	} else {
-		switch logField {
-		case
-			"debug",
-			"info",
-			"warn",
-			"error":
-			return logField
-		}
-		return common.ArgoCDDefaultLogLevel
+        switch strings.ToLower(logField) {
+	case "debug",
+		"info",
+		"warn",
+		"error":
+		return logField
 	}
+	return common.ArgoCDDefaultLogLevel
 }

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -323,6 +323,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"argocd-repo-server.argocd.svc.cluster.local:8081",
 				"--status-processors",
 				"20",
+				"--loglevel info",
 			},
 		},
 		{
@@ -338,6 +339,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"argocd-repo-server.argocd.svc.cluster.local:8081",
 				"--status-processors",
 				"30",
+				"--loglevel info",
 			},
 		},
 		{
@@ -353,6 +355,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"argocd-repo-server.argocd.svc.cluster.local:8081",
 				"--status-processors",
 				"20",
+				"--loglevel info",
 			},
 		},
 		{
@@ -370,6 +373,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"20",
 				"--app-resync",
 				"600",
+				"--loglevel info",
 			},
 		},
 	}

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -323,7 +323,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"argocd-repo-server.argocd.svc.cluster.local:8081",
 				"--status-processors",
 				"20",
-				"--loglevel info",
+				"--loglevel",
+				"info",
 			},
 		},
 		{
@@ -339,7 +340,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"argocd-repo-server.argocd.svc.cluster.local:8081",
 				"--status-processors",
 				"30",
-				"--loglevel info",
+				"--loglevel",
+				"info",
 			},
 		},
 		{
@@ -355,7 +357,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"argocd-repo-server.argocd.svc.cluster.local:8081",
 				"--status-processors",
 				"20",
-				"--loglevel info",
+				"--loglevel",
+				"info",
 			},
 		},
 		{
@@ -373,7 +376,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"20",
 				"--app-resync",
 				"600",
-				"--loglevel info",
+				"--loglevel",
+				"info",
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

> /kind enhancement

**What does this PR do / why we need it**:
This PR adds the ability to adjust the loglevel of each of the ArgoCD components (controller, repo, server)

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR.
* [X] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #329 

**How to test changes / Special notes to the reviewer**:

After building the operator from this PR branch, you can deploy it with the following to confirm the loglevel functionality:


```yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: basic
spec: 
  server:
    logLevel: "warn"
  repo:
    logLevel: "error"
  controller:
    logLevel: "info"
```

If you don't set any of the above, it will default the loglevel to info (which is the current behavior of each of the components).
