### PR TITLE
fix: operator crashes on reconciliation when existing Argo CD configmap is empty

### DIFF
--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -396,6 +396,10 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 func (r *ReconcileArgoCD) reconcileExistingArgoConfigMap(cm *corev1.ConfigMap, cr *argoprojv1a1.ArgoCD) error {
 	changed := false
 
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+
 	if cm.Data[common.ArgoCDKeyAdminEnabled] == fmt.Sprintf("%t", cr.Spec.DisableAdmin) {
 		cm.Data[common.ArgoCDKeyAdminEnabled] = fmt.Sprintf("%t", !cr.Spec.DisableAdmin)
 		changed = true

--- a/pkg/controller/argocd/configmap_test.go
+++ b/pkg/controller/argocd/configmap_test.go
@@ -122,6 +122,33 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 	}
 }
 
+func TestReconcileArgoCD_reconcileEmptyArgoConfigMap(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+
+	// An empty Argo CD Configmap
+	emptyArgoConfigmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: a.Namespace,
+		},
+	}
+
+	err := r.client.Create(context.TODO(), emptyArgoConfigmap)
+	assert.NilError(t, err)
+
+	err = r.reconcileArgoConfigMap(a)
+	assert.NilError(t, err)
+
+	cm := &corev1.ConfigMap{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      common.ArgoCDConfigMapName,
+		Namespace: testNamespace,
+	}, cm)
+	assert.NilError(t, err)
+}
+
 func TestReconcileArgoCDCM_withRepoCredentials(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
 I have observed an unexpected crash of the operator when the operator is trying to reconcile an empty Argo CD configmap.

I can reproduce this issue by creating an empty Argo CD configmap (argocd-cm) in a namespace and then creating an Argo CD CR. Noticed that operator crashed while reconciling the empty configmap.

Error:
```
goroutine 1873 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1769d40, 0x1b43340)
/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.18.3/pkg/util/runtime/runtime.go:74 +0xa6
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
/remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.18.3/pkg/util/runtime/runtime.go:48 +0x86
panic(0x1769d40, 0x1b43340)
/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
github.com/argoproj-labs/argocd-operator/pkg/controller/argocd.(*ReconcileArgoCD).reconcileExistingArgoConfigMap(0xc0008f4000, 0xc008c18780, 0xc00850e000, 0x0, 0x0)
/remote-source/deps/gomod/pkg/mod/github.com/argoproj-labs/argocd-operator@v0.0.16-0.20210715041124-bb75775953f8/pkg/controller/argocd/configmap.go:420 +0x53e
github.com/argoproj-labs/argocd-operator/pkg/controller/argocd.(*ReconcileArgoCD).reconcileArgoConfigMap(0xc0008f4000, 0xc00850e000, 0x0, 0x0)
/remote-source/deps/gomod/pkg/mod/github.com/argoproj-labs/argocd-operator@v0.0.16-0.20210715041124-bb75775953f8/pkg/controller/argocd/configmap.go:312 +0x11af
github.com/argoproj-labs/argocd-operator/pkg/controller/argocd.(*ReconcileArgoCD).reconcileConfigMaps(0xc0008f4000, 0xc00850e000, 0x17, 0x0)
/remote-source/deps/gomod/pkg/mod/github.com/argoproj-labs/argocd-operator@v0.0.16-0.20210715041124-bb75775953f8/pkg/controller/argocd/configmap.go:250 +0x39
github.com/argoproj-labs/argocd-operator/pkg/controller/argocd.(*ReconcileArgoCD).reconcileResources(0xc0008f4000, 0xc00850e000, 0xc000042068, 0xc000ec8680)
runtime@v0.6.0/pkg/internal/controller/controller.go:193 +0x32d
panic: assignment to entry in nil map [recovered]
panic: assignment to entry in nil map
```

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Create a empty configmap with name `argocd-cm`.
2. Run the operator.
3. Create a Argo CD CR to crete Argo CD instance.

or

1. Run the operator locally `operator-sdk run local`
2. Create Argo CD CR to create Argo CD instance.
3. Wait for the operator to create all the workloads.
4. remove the data section of argocd-cm configmap.
