### PR TITLE
fix: ArgoCD server resources limit/request changes in ArgoCD CR is not reconcilied

### DIFF
--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -1037,6 +1037,11 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoprojv1a1.ArgoCD) err
 			existing.Spec.Template.Spec.Containers[0].VolumeMounts = deploy.Spec.Template.Spec.Containers[0].VolumeMounts
 			changed = true
 		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].Resources,
+			existing.Spec.Template.Spec.Containers[0].Resources) {
+			existing.Spec.Template.Spec.Containers[0].Resources = deploy.Spec.Template.Spec.Containers[0].Resources
+			changed = true
+		}
 		if changed {
 			return r.client.Update(context.TODO(), existing)
 		}


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Users can modify argocd server container resource limit/request in the ArgoCD CR.  The operator should apply/reconcile the changes to the cluster.   However, reconciler is not checking for changes in ArgoCD CR against the running state due to a bug.
This PR adds a check in the reconcile function to check for changes in ArgoCD CR on argocd server container resource limit/request against the cluster and set the "changed" flag accordingly.

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Create ArgoCD CR in the foo namespace.
2. Record the resource limit/request on the running argocd server pod 
2. Update the ArgoCD Server container resource request/limits to different values
3. Verify that the resource request/limits changes have been applied to the cluster not updated on the container.
