### PR TITLE
feat: Add log format for ArgoCD components

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -82,6 +82,9 @@ type ArgoCDApplicationControllerSpec struct {
 	// LogLevel refers to the log level used by the Application Controller component. Defaults to ArgoCDDefaultLogLevel if not configured. Valid options are debug, info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
+	// LogFormat refers to the log format used by the Application Controller component. Defaults to ArgoCDDefaultLogFormat if not configured. Valid options are text or json.
+	LogFormat string `json:"logFormat,omitempty"`
+
 	// Resources defines the Compute Resources required by the container for the Application Controller.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
@@ -323,6 +326,9 @@ type ArgoCDRepoSpec struct {
 	// LogLevel describes the log level that should be used by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are debug, info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
 
+	// LogFormat describes the log format that should be used by the Repo Server. Defaults to ArgoCDDefaultLogFormat if not configured. Valid options are text or json.
+	LogFormat string `json:"logFormat,omitempty"`
+
 	// MountSAToken describes whether you would like to have the Repo server mount the service account token
 	MountSAToken bool `json:"mountsatoken,omitempty"`
 
@@ -415,6 +421,9 @@ type ArgoCDServerSpec struct {
 
 	// LogLevel refers to the log level to be used by the ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if not set.  Valid options are debug, info, error, and warn.
 	LogLevel string `json:"logLevel,omitempty"`
+
+	// LogFormat refers to the log level to be used by the ArgoCD Server component. Defaults to ArgoCDDefaultLogFormat if not configured. Valid options are text or json.
+	LogFormat string `json:"logFormat,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Argo CD server component.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -951,7 +951,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/argoprojlabs/argocd-operator:v0.1.0
+                image: quay.io/argoprojlabs/argocd-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -96,6 +96,11 @@ spec:
                       \n Set this to a duration, e.g. 10m or 600s to control the synchronisation
                       frequency."
                     type: string
+                  logFormat:
+                    description: LogFormat refers to the log format used by the Application
+                      Controller component. Defaults to ArgoCDDefaultLogFormat if
+                      not configured. Valid options are text or json.
+                    type: string
                   logLevel:
                     description: LogLevel refers to the log level used by the Application
                       Controller component. Defaults to ArgoCDDefaultLogLevel if not
@@ -710,6 +715,11 @@ spec:
                   image:
                     description: Image is the ArgoCD Repo Server container image.
                     type: string
+                  logFormat:
+                    description: LogFormat describes the log format that should be
+                      used by the Repo Server. Defaults to ArgoCDDefaultLogFormat
+                      if not configured. Valid options are text or json.
+                    type: string
                   logLevel:
                     description: LogLevel describes the log level that should be used
                       by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not
@@ -952,6 +962,11 @@ spec:
                   insecure:
                     description: Insecure toggles the insecure flag.
                     type: boolean
+                  logFormat:
+                    description: LogFormat refers to the log level to be used by the
+                      ArgoCD Server component. Defaults to ArgoCDDefaultLogFormat
+                      if not configured. Valid options are text or json.
+                    type: string
                   logLevel:
                     description: LogLevel refers to the log level to be used by the
                       ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -24,6 +24,9 @@ const (
 	// ArgoCDDefaultLogLevel is the default log level to be used by all ArgoCD components.
 	ArgoCDDefaultLogLevel = "info"
 
+	// ArgoCDDefaultLogFormat is the default log format to be used by all ArgoCD components.
+	ArgoCDDefaultLogFormat = "text"
+
 	// ArgoCDServerComponent is the name of the Dex server control plane component
 	ArgoCDServerComponent = "argocd-server"
 

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -98,6 +98,11 @@ spec:
                       \n Set this to a duration, e.g. 10m or 600s to control the synchronisation
                       frequency."
                     type: string
+                  logFormat:
+                    description: LogFormat refers to the log format used by the Application
+                      Controller component. Defaults to ArgoCDDefaultLogFormat if
+                      not configured. Valid options are text or json.
+                    type: string
                   logLevel:
                     description: LogLevel refers to the log level used by the Application
                       Controller component. Defaults to ArgoCDDefaultLogLevel if not
@@ -712,6 +717,11 @@ spec:
                   image:
                     description: Image is the ArgoCD Repo Server container image.
                     type: string
+                  logFormat:
+                    description: LogFormat describes the log format that should be
+                      used by the Repo Server. Defaults to ArgoCDDefaultLogFormat
+                      if not configured. Valid options are text or json.
+                    type: string
                   logLevel:
                     description: LogLevel describes the log level that should be used
                       by the Repo Server. Defaults to ArgoCDDefaultLogLevel if not
@@ -954,6 +964,11 @@ spec:
                   insecure:
                     description: Insecure toggles the insecure flag.
                     type: boolean
+                  logFormat:
+                    description: LogFormat refers to the log level to be used by the
+                      ArgoCD Server component. Defaults to ArgoCDDefaultLogFormat
+                      if not configured. Valid options are text or json.
+                    type: string
                   logLevel:
                     description: LogLevel refers to the log level to be used by the
                       ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/argoprojlabs/argocd-operator
-  newTag: v0.1.0
+  newTag: latest

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -197,6 +197,9 @@ func getArgoRepoCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd = append(cmd, "--loglevel")
 	cmd = append(cmd, getLogLevel(cr.Spec.Repo.LogLevel))
 
+	cmd = append(cmd, "--logformat")
+	cmd = append(cmd, getLogFormat(cr.Spec.Repo.LogFormat))
+
 	return cmd
 }
 
@@ -227,6 +230,9 @@ func getArgoServerCommand(cr *argoprojv1a1.ArgoCD) []string {
 
 	cmd = append(cmd, "--loglevel")
 	cmd = append(cmd, getLogLevel(cr.Spec.Server.LogLevel))
+
+	cmd = append(cmd, "--logformat")
+	cmd = append(cmd, getLogFormat(cr.Spec.Server.LogFormat))
 
 	return cmd
 }

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -636,6 +636,8 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 					"argocd-redis.argocd.svc.cluster.local:6379",
 					"--loglevel",
 					"info",
+					"--logformat",
+					"text",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},
@@ -709,6 +711,8 @@ func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 					"argocd-redis.argocd.svc.cluster.local:6379",
 					"--loglevel",
 					"info",
+					"--logformat",
+					"text",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},
@@ -785,6 +789,8 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 					"argocd-redis.argocd.svc.cluster.local:6379",
 					"--loglevel",
 					"info",
+					"--logformat",
+					"text",
 				},
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8080},

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -111,7 +111,8 @@ func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {
 		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
 		"--repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081",
 		"--status-processors", "20",
-		"--loglevel", "info"}
+		"--loglevel", "info",
+		"--logformat", "text"}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}
@@ -150,7 +151,8 @@ func TestReconcileArgoCD_reconcileApplicationController_withUpdate(t *testing.T)
 		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
 		"--repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081",
 		"--status-processors", "30",
-		"--loglevel", "info"}
+		"--loglevel", "info",
+		"--logformat", "text"}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -114,6 +114,9 @@ func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD) []string {
 	cmd = append(cmd, "--loglevel")
 	cmd = append(cmd, getLogLevel(cr.Spec.Controller.LogLevel))
 
+	cmd = append(cmd, "--logformat")
+	cmd = append(cmd, getLogFormat(cr.Spec.Controller.LogFormat))
+
 	return cmd
 }
 
@@ -1187,4 +1190,14 @@ func getLogLevel(logField string) string {
 		return logField
 	}
 	return common.ArgoCDDefaultLogLevel
+}
+
+// getLogFormat returns the log format for a specified component if it is set or returns the default log format if it is not set
+func getLogFormat(logField string) string {
+	switch strings.ToLower(logField) {
+	case "text",
+		"json":
+		return logField
+	}
+	return common.ArgoCDDefaultLogFormat
 }

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -326,6 +326,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"20",
 				"--loglevel",
 				"info",
+				"--logformat",
+				"text",
 			},
 		},
 		{
@@ -343,6 +345,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"30",
 				"--loglevel",
 				"info",
+				"--logformat",
+				"text",
 			},
 		},
 		{
@@ -360,6 +364,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"20",
 				"--loglevel",
 				"info",
+				"--logformat",
+				"text",
 			},
 		},
 		{
@@ -379,6 +385,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 				"600",
 				"--loglevel",
 				"info",
+				"--logformat",
+				"text",
 			},
 		},
 	}

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -75,6 +75,7 @@ Image | `quay.io/argocdapplicationset/argocd-applicationset` | The container ima
 Version | *(recent ApplicationSet version)* | The tag to use with the ApplicationSet container image.
 Resources | [Empty] | The container compute resources.
 LogLevel | info | The log level to be used by the ArgoCD Application Controller component. Valid options are debug, info, error, and warn.
+LogFormat | text | The log format to be used by the ArgoCD Application Controller component. Valid options are text or json.
 
 ### ApplicationSet Controller Example
 
@@ -776,6 +777,7 @@ AutoTLS | "" | Provider to use for setting up TLS the repo-server's gRPC TLS cer
 Image | `argoproj/argocd` | The container image for ArgoCD Repo Server. This overrides the `ARGOCD_REPOSERVER_IMAGE` environment variable.
 Version | v2.0.0 (SHA) | The tag to use with the ArgoCD Repo Server.
 LogLevel | info | The log level to be used by the ArgoCD Repo Server. Valid options are debug, info, error, and warn.
+LogFormat | text | The log format to be used by the ArgoCD Repo Server. Valid options are text or json.
 
 ### Repo Example
 
@@ -931,6 +933,7 @@ Resources | [Empty] | The container compute resources.
 [Route](#server-route-options) | [Object] | Route configuration options.
 Service.Type | ClusterIP | The ServiceType to use for the Service resource.
 LogLevel | info | The log level to be used by the ArgoCD Server component. Valid options are debug, info, error, and warn.
+LogFormat | text | The log format to be used by the ArgoCD Server component. Valid options are text or json.
 
 ### Server Autoscale Options
 


### PR DESCRIPTION
Signed-off-by: Tyler Auerbeck <tauerbec@redhat.com>

**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

This PR provides the ability to set the logformat of ArgoCD components. By default (if nothing is set), it will use text format. Otherwise, if you specify json it will cause the specified component to use json format.

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR.
* [X] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #180 

**How to test changes / Special notes to the reviewer**:

You can test this change by running the operator from this PR branch with the follow resource:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: basic
spec:
  controller:
    logFormat: json
  server:
    logFormat: json
  repo:
    logFormat: json
```

**Note**: ApplicationSets don't currently support logformat per https://github.com/argoproj-labs/applicationset/issues/57
