### PR TITLE
feat: remove option to disable the dex installation

### DIFF
--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -343,17 +343,15 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 	cm.Data[common.ArgoCDKeyServerURL] = r.getArgoServerURI(cr)
 	cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] = fmt.Sprint(cr.Spec.UsersAnonymousEnabled)
 
-	if !isDexDisabled() {
-		dexConfig := getDexConfig(cr)
-		if dexConfig == "" && cr.Spec.Dex.OpenShiftOAuth {
-			cfg, err := r.getOpenShiftDexConfig(cr)
-			if err != nil {
-				return err
-			}
-			dexConfig = cfg
+	dexConfig := getDexConfig(cr)
+	if dexConfig == "" && cr.Spec.Dex.OpenShiftOAuth {
+		cfg, err := r.getOpenShiftDexConfig(cr)
+		if err != nil {
+			return err
 		}
-		cm.Data[common.ArgoCDKeyDexConfig] = dexConfig
+		dexConfig = cfg
 	}
+	cm.Data[common.ArgoCDKeyDexConfig] = dexConfig
 
 	if err := controllerutil.SetControllerReference(cr, cm, r.scheme); err != nil {
 		return err

--- a/pkg/controller/argocd/configmap_test.go
+++ b/pkg/controller/argocd/configmap_test.go
@@ -17,7 +17,6 @@ package argocd
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -251,28 +250,6 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 	dexConnector := connectors.([]interface{})[0].(map[interface{}]interface{})
 	config := dexConnector["config"]
 	assert.Equal(t, config.(map[interface{}]interface{})["clientID"], "system:serviceaccount:argocd:argocd-argocd-dex-server")
-}
-
-func TestReconcileArgoCD_reconcileArgoConfigMap_withDexDisabled(t *testing.T) {
-	restoreEnv(t)
-	logf.SetLogger(logf.ZapLogger(true))
-	a := makeTestArgoCD()
-	r := makeTestReconciler(t, a)
-
-	os.Setenv("DISABLE_DEX", "true")
-	err := r.reconcileArgoConfigMap(a)
-	assert.NilError(t, err)
-
-	cm := &corev1.ConfigMap{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{
-		Name:      common.ArgoCDConfigMapName,
-		Namespace: testNamespace,
-	}, cm)
-	assert.NilError(t, err)
-
-	if c, ok := cm.Data["dex.config"]; ok {
-		t.Fatalf("reconcileArgoConfigMap failed, dex.config = %q", c)
-	}
 }
 
 func TestReconcileArgoCD_reconcileArgoConfigMap_withKustomizeVersions(t *testing.T) {

--- a/pkg/controller/argocd/deployment_test.go
+++ b/pkg/controller/argocd/deployment_test.go
@@ -131,48 +131,6 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 	}
 }
 
-func TestReconcileArgoCD_reconcileDexDeployment_with_dex_disabled(t *testing.T) {
-	restoreEnv(t)
-	logf.SetLogger(logf.ZapLogger(true))
-	a := makeTestArgoCD()
-	r := makeTestReconciler(t, a)
-
-	os.Setenv("DISABLE_DEX", "true")
-	assert.NilError(t, r.reconcileDexDeployment(a))
-
-	deployment := &appsv1.Deployment{}
-	assertNotFound(t, r.client.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      "argocd-dex-server",
-			Namespace: a.Namespace,
-		},
-		deployment))
-}
-
-// When Dex is disabled, the Dex Deployment should be removed.
-func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *testing.T) {
-	restoreEnv(t)
-	logf.SetLogger(logf.ZapLogger(true))
-	a := makeTestArgoCD()
-	r := makeTestReconciler(t, a)
-	os.Setenv("DISABLE_DEX", "true")
-
-	assert.NilError(t, r.reconcileDexDeployment(a))
-
-	a = makeTestArgoCD()
-	assert.NilError(t, r.reconcileDexDeployment(a))
-
-	deployment := &appsv1.Deployment{}
-	assertNotFound(t, r.client.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      "argocd-dex-server",
-			Namespace: a.Namespace,
-		},
-		deployment))
-}
-
 func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
 	restoreEnv(t)
 

--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -112,19 +112,8 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 				return nil, fmt.Errorf("failed to reconcile the role for the service account associated with %s : %s", name, err)
 			}
 			roles = append(roles, role)
-			if name == dexServer && isDexDisabled() {
-				continue // Dex is disabled, do nothing
-			}
 			controllerutil.SetControllerReference(cr, role, r.scheme)
 			if err := r.client.Create(context.TODO(), role); err != nil {
-				return nil, err
-			}
-			continue
-		}
-
-		if name == dexServer && isDexDisabled() {
-			// Delete any existing Role created for Dex
-			if err := r.client.Delete(context.TODO(), &existingRole); err != nil {
 				return nil, err
 			}
 			continue

--- a/pkg/controller/argocd/role_test.go
+++ b/pkg/controller/argocd/role_test.go
@@ -45,30 +45,6 @@ func TestReconcileArgoCD_reconcileRole(t *testing.T) {
 	assert.DeepEqual(t, expectedRules, reconciledRole.Rules)
 }
 
-func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-	a := makeTestArgoCD()
-	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
-
-	rules := policyRuleForDexServer()
-	role := newRole(dexServer, rules, a)
-
-	// Dex is enabled
-	_, err := r.reconcileRole(dexServer, rules, a)
-	assert.NilError(t, err)
-	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: a.Namespace}, role))
-	assert.DeepEqual(t, rules, role.Rules)
-
-	// Disable Dex
-	os.Setenv("DISABLE_DEX", "true")
-	defer os.Unsetenv("DISABLE_DEX")
-
-	_, err = r.reconcileRole(dexServer, rules, a)
-	assert.NilError(t, err)
-	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: a.Namespace}, role), "not found")
-}
-
 func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()

--- a/pkg/controller/argocd/rolebinding.go
+++ b/pkg/controller/argocd/rolebinding.go
@@ -110,9 +110,6 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 			if !errors.IsNotFound(err) {
 				return fmt.Errorf("failed to get the rolebinding associated with %s : %s", name, err)
 			}
-			if name == dexServer && isDexDisabled() {
-				continue // Dex is disabled, do nothing
-			}
 			roleBindingExists = false
 		}
 
@@ -130,14 +127,6 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 		}
 
 		if roleBindingExists {
-			if name == dexServer && isDexDisabled() {
-				// Delete any existing RoleBinding created for Dex
-				if err = r.client.Delete(context.TODO(), existingRoleBinding); err != nil {
-					return err
-				}
-				continue
-			}
-
 			// if the RoleRef changes, delete the existing role binding and create a new one
 			if !reflect.DeepEqual(roleBinding.RoleRef, existingRoleBinding.RoleRef) {
 				if err = r.client.Delete(context.TODO(), existingRoleBinding); err != nil {

--- a/pkg/controller/argocd/rolebinding_test.go
+++ b/pkg/controller/argocd/rolebinding_test.go
@@ -3,7 +3,6 @@ package argocd
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"gotest.tools/assert"
@@ -42,29 +41,6 @@ func TestReconcileArgoCD_reconcileRoleBinding(t *testing.T) {
 
 	roleBinding = &rbacv1.RoleBinding{}
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, roleBinding))
-}
-
-func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-	a := makeTestArgoCD()
-	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
-
-	rules := policyRuleForDexServer()
-	rb := newRoleBindingWithname(dexServer, a)
-
-	// Dex is enabled, creates a role binding
-	assert.NilError(t, r.reconcileRoleBinding(dexServer, rules, a))
-	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: rb.Name, Namespace: a.Namespace}, rb))
-
-	// Disable Dex, deletes the existing role binding
-	os.Setenv("DISABLE_DEX", "true")
-	defer os.Unsetenv("DISABLE_DEX")
-
-	_, err := r.reconcileRole(dexServer, rules, a)
-	assert.NilError(t, err)
-	assert.NilError(t, r.reconcileRoleBinding(dexServer, rules, a))
-	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Name: rb.Name, Namespace: a.Namespace}, rb), "not found")
 }
 
 func TestReconcileArgoCD_reconcileClusterRoleBinding(t *testing.T) {

--- a/pkg/controller/argocd/service.go
+++ b/pkg/controller/argocd/service.go
@@ -68,15 +68,7 @@ func newServiceWithSuffix(suffix string, component string, cr *argoprojv1a1.Argo
 func (r *ReconcileArgoCD) reconcileDexService(cr *argoprojv1a1.ArgoCD) error {
 	svc := newServiceWithSuffix("dex-server", "dex-server", cr)
 	if argoutil.IsObjectFound(r.client, cr.Namespace, svc.Name, svc) {
-		if isDexDisabled() {
-			// Service exists but enabled flag has been set to false, delete the Service
-			return r.client.Delete(context.TODO(), svc)
-		}
 		return nil
-	}
-
-	if isDexDisabled() {
-		return nil // Dex is disabled, do nothing
 	}
 
 	svc.Spec.Selector = map[string]string{

--- a/pkg/controller/argocd/service_account.go
+++ b/pkg/controller/argocd/service_account.go
@@ -156,16 +156,9 @@ func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoprojv1a1.
 		if !errors.IsNotFound(err) {
 			return nil, err
 		}
-		if name == dexServer && isDexDisabled() {
-			return sa, nil // Dex is disabled, do nothing
-		}
 		exists = false
 	}
 	if exists {
-		if name == dexServer && isDexDisabled() {
-			// Delete any existing Service Account created for Dex
-			return sa, r.client.Delete(context.TODO(), sa)
-		}
 		return sa, nil
 	}
 

--- a/pkg/controller/argocd/service_account_test.go
+++ b/pkg/controller/argocd/service_account_test.go
@@ -122,26 +122,6 @@ func TestReconcileArgoCD_reconcileServiceAccountClusterPermissions(t *testing.T)
 	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRoleName}, reconcileClusterRole), "not found")
 }
 
-func TestReconcileArgoCD_reconcileServiceAccount_dex_disabled(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-	a := makeTestArgoCD()
-	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
-
-	// Dex is enabled, creates a new Service Account for it
-	sa, err := r.reconcileServiceAccount(dexServer, a)
-	assert.NilError(t, err)
-	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: a.Namespace}, sa))
-
-	//Disable dex, deletes any existing Service Account for it
-	os.Setenv("DISABLE_DEX", "true")
-	defer os.Unsetenv("DISABLE_DEX")
-
-	sa, err = r.reconcileServiceAccount(dexServer, a)
-	assert.NilError(t, err)
-	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: a.Namespace}, sa), "not found")
-}
-
 func testRules() []v1.PolicyRule {
 	return []v1.PolicyRule{
 		{

--- a/pkg/controller/argocd/service_test.go
+++ b/pkg/controller/argocd/service_test.go
@@ -2,7 +2,6 @@ package argocd
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"gotest.tools/assert"
@@ -19,29 +18,4 @@ func TestReconcileArgoCD_reconcileDexService_Dex_Enabled(t *testing.T) {
 
 	assert.NilError(t, r.reconcileDexService(a))
 	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: s.Namespace, Name: s.Name}, s))
-}
-
-func TestReconcileArgoCD_reconcileDexService_Dex_Disabled(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
-	a := makeTestArgoCD()
-	r := makeTestReconciler(t, a)
-
-	s := newServiceWithSuffix("dex-server", "dex-server", a)
-
-	// Create Service for Dex
-	assert.NilError(t, r.reconcileDexService(a))
-	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: s.Namespace, Name: s.Name}, s))
-
-	// Disable Dex, existing service should be deleted
-	os.Setenv("DISABLE_DEX", "true")
-	t.Cleanup(func() {
-		os.Unsetenv("DISABLE_DEX")
-	})
-
-	assert.NilError(t, r.reconcileDexService(a))
-	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: s.Namespace, Name: s.Name}, s), "not found")
-
-	// Service for Dex should not be created on reconciliation when disabled
-	assert.NilError(t, r.reconcileDexService(a))
-	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: s.Namespace, Name: s.Name}, s), "not found")
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
In the current code, we can skip the dex installation using an environmental variable "DISABLE_DEX". It does not make any sense to maintain such wrappers/conditions in the upstream operator. Any downstream operator implementing the argocd-operator should handle such cases if needed.

Dex should be a default installation.

**Have you updated the necessary documentation?**
#393 

**Which issue(s) this PR fixes**:
#393 

Fixes #?
#393 

**How to test changes / Special notes to the reviewer**:
1. Build the operator or run it locally using `operator-sdk run local`
2. Verify the dex installation -> Check for running dex pods.