### PR TITLE
Add a hook to enable serving cert annotation to argocd server

### DIFF
--- a/pkg/controller/argocd/service_test.go
+++ b/pkg/controller/argocd/service_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"testing"
 
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
 	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
@@ -44,4 +46,68 @@ func TestReconcileArgoCD_reconcileDexService_Dex_Disabled(t *testing.T) {
 	// Service for Dex should not be created on reconciliation when disabled
 	assert.NilError(t, r.reconcileDexService(a))
 	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: s.Namespace, Name: s.Name}, s), "not found")
+}
+
+func TestReconcileArgoCD_reconcileServerServiceHooks(t *testing.T) {
+	defer resetHooks()()
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+	certAnn := "cert.kubernetes"
+	Register(func(cr *argoprojv1alpha1.ArgoCD, v interface{}, s string) error {
+		switch o := v.(type) {
+		case *corev1.Service:
+			if o.Name == cr.Name+"-server" {
+				if o.Annotations == nil {
+					o.Annotations = map[string]string{}
+				}
+				o.Annotations[certAnn] = o.Name
+			}
+		}
+		return nil
+	})
+
+	err := r.reconcileServerService(a)
+	assert.NilError(t, err)
+
+	t.Run("annotation added", func(t *testing.T) {
+		svc := newServiceWithSuffix("server", "server", a)
+		assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, svc))
+		value, found := svc.Annotations[certAnn]
+		assert.Equal(t, found, true)
+		assert.Equal(t, value, svc.Name)
+	})
+
+	t.Run("other annotations are persisted", func(t *testing.T) {
+		// add new annotations to service
+		anns := map[string]string{"a": "1", "b": "2"}
+		svc := newServiceWithSuffix("server", "server", a)
+		assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, svc))
+		svc.Annotations = anns
+		assert.NilError(t, r.client.Update(context.TODO(), svc))
+
+		err := r.reconcileServerService(a)
+		assert.NilError(t, err)
+
+		// check if the old annotations are still present
+		assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, svc))
+		anns[certAnn] = svc.Name
+		assert.DeepEqual(t, anns, svc.Annotations)
+	})
+
+	t.Run("duplicate annotations are overwritten", func(t *testing.T) {
+		// add new annotations to service
+		anns := map[string]string{certAnn: "test-value", "b": "2"}
+		svc := newServiceWithSuffix("server", "server", a)
+		assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, svc))
+		svc.Annotations = anns
+		assert.NilError(t, r.client.Update(context.TODO(), svc))
+
+		err := r.reconcileServerService(a)
+		assert.NilError(t, err)
+
+		// check if the annotation with the duplicate key is overwritten
+		assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, svc))
+		anns[certAnn] = svc.Name
+		assert.DeepEqual(t, anns, svc.Annotations)
+	})
 }

--- a/pkg/reconciler/openshift/openshift.go
+++ b/pkg/reconciler/openshift/openshift.go
@@ -23,6 +23,10 @@ func init() {
 	argocd.Register(reconcilerHook)
 }
 
+const (
+	certAnnotationKey = "service.beta.openshift.io/serving-cert-secret-name"
+)
+
 func reconcilerHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, hint string) error {
 
 	logv := log.WithValues("ArgoCD Namespace", cr.Namespace, "ArgoCD Name", cr.Name)
@@ -84,6 +88,13 @@ func reconcilerHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, hint string) err
 			policyRules := getPolicyRuleForApplicationController()
 			policyRules = append(policyRules, clusterRole.Rules...)
 			o.Rules = policyRules
+		}
+	case *corev1.Service:
+		if o.Name == cr.Name+"-server" {
+			if o.Annotations == nil {
+				o.Annotations = map[string]string{}
+			}
+			o.Annotations[certAnnotationKey] = o.Name
 		}
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement


**What does this PR do / why we need it**:
This PR adds an OpenShift hook to add cert annotation to the argocd server service. OpenShift looks for this annotation and creates a secret in the same namespace with certs  


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
