### PR TITLE
FIX: remove RBACs from target-namespace when ArgoCD instance is deleted

### DIFF
--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/argoproj-labs/argocd-operator/pkg/common"
 	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
@@ -459,4 +460,55 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	s, err := testClient.CoreV1().Secrets(a.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, string(s.Data["namespaces"]), "testNamespace2")
+}
+
+func TestRemoveManagedByLabelFromNamespace(t *testing.T) {
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t)
+
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "testNamespace",
+		Labels: map[string]string{
+			common.ArgoCDManagedByLabel: a.Namespace,
+		}},
+	}
+
+	err := r.client.Create(context.TODO(), ns)
+	assert.NilError(t, err)
+
+	ns2 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "testNamespace2",
+		Labels: map[string]string{
+			common.ArgoCDManagedByLabel: a.Namespace,
+		}},
+	}
+
+	err = r.client.Create(context.TODO(), ns2)
+	assert.NilError(t, err)
+
+	ns3 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "testNamespace3",
+		Labels: map[string]string{
+			common.ArgoCDManagedByLabel: "newNamespace",
+		}},
+	}
+
+	err = r.client.Create(context.TODO(), ns3)
+	assert.NilError(t, err)
+
+	err = r.removeManagedByLabelFromNamespace(a.Namespace)
+	assert.NilError(t, err)
+
+	nsList := &v1.NamespaceList{}
+	err = r.client.List(context.TODO(), nsList)
+	assert.NilError(t, err)
+	for _, n := range nsList.Items {
+		if n.Name == ns3.Name {
+			_, ok := n.Labels[common.ArgoCDManagedByLabel]
+			assert.Equal(t, ok, true)
+			continue
+		}
+		_, ok := n.Labels[common.ArgoCDManagedByLabel]
+		assert.Equal(t, ok, false)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
When the ArgoCD instance is deleted from the source namespace, operator would remove the `managed-by` label from all the namespaces that were managed by this particular argocd instance. 
The operator currently already has the logic to remove the RBACs from the namespaces from which the label is being removed, so it takes care of removing the RBACs as soon as the labels is removed. 
This ensures there are no redundant roles/role_bindings/labels are present for a namespace. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
> https://issues.redhat.com/browse/GITOPS-1228

**How to test changes / Special notes to the reviewer**:
TODO
