### PR TITLE
FIX: remove RBACs from target-namespace when ArgoCD instance is deleted

### DIFF
--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -103,7 +103,7 @@ func (r *ReconcileArgoCD) Reconcile(request reconcile.Request) (reconcile.Result
 				return reconcile.Result{}, fmt.Errorf("failed to delete ClusterResources: %w", err)
 			}
 
-			if err := r.removeManagedByLabelFromNamespace(argocd.Namespace); err != nil {
+			if err := r.removeManagedByLabelFromNamespaces(argocd.Namespace); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to remove label from namespace[%v], error: %w", argocd.Namespace, err)
 			}
 

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -798,7 +798,7 @@ func (r *ReconcileArgoCD) deleteClusterResources(cr *argoprojv1a1.ArgoCD) error 
 	return nil
 }
 
-func (r *ReconcileArgoCD) removeManagedByLabelFromNamespace(namespace string) error {
+func (r *ReconcileArgoCD) removeManagedByLabelFromNamespaces(namespace string) error {
 	nsList := &corev1.NamespaceList{}
 	listOption := client.MatchingLabels{
 		common.ArgoCDManagedByLabel: namespace,

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -799,16 +799,32 @@ func (r *ReconcileArgoCD) deleteClusterResources(cr *argoprojv1a1.ArgoCD) error 
 }
 
 func (r *ReconcileArgoCD) removeManagedByLabelFromNamespace(namespace string) error {
-	ns := &corev1.Namespace{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: namespace}, ns); err != nil {
+	nsList := &corev1.NamespaceList{}
+	selector := labels.NewSelector()
+	requirement, err := labels.NewRequirement(common.ArgoCDManagedByLabel, selection.Equals, []string{namespace})
+	if err != nil {
+		return fmt.Errorf("failed to create a requirement for %w", err)
+	}
+	selector.Add(*requirement)
+	if err := r.client.List(context.TODO(), nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
 		return err
 	}
 
-	if ns.Labels == nil {
-		return nil
+	for _, n := range nsList.Items {
+		ns := &corev1.Namespace{}
+		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: n.Name}, ns); err != nil {
+			return err
+		}
+
+		if ns.Labels == nil {
+			return nil
+		}
+		delete(ns.Labels, common.ArgoCDManagedByLabel)
+		if err = r.client.Update(context.TODO(), ns); err != nil {
+			log.Error(err, fmt.Sprintf("failed to remove label from namespace [%s]", ns.Name))
+		}
 	}
-	delete(ns.Labels, common.ArgoCDManagedByLabel)
-	return r.client.Update(context.TODO(), ns)
+	return nil
 }
 
 func filterObjectsBySelector(c client.Client, objectList runtime.Object, selector labels.Selector) error {

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -800,13 +800,10 @@ func (r *ReconcileArgoCD) deleteClusterResources(cr *argoprojv1a1.ArgoCD) error 
 
 func (r *ReconcileArgoCD) removeManagedByLabelFromNamespace(namespace string) error {
 	nsList := &corev1.NamespaceList{}
-	selector := labels.NewSelector()
-	requirement, err := labels.NewRequirement(common.ArgoCDManagedByLabel, selection.Equals, []string{namespace})
-	if err != nil {
-		return fmt.Errorf("failed to create a requirement for %w", err)
+	listOption := client.MatchingLabels{
+		common.ArgoCDManagedByLabel: namespace,
 	}
-	selector.Add(*requirement)
-	if err := r.client.List(context.TODO(), nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+	if err := r.client.List(context.TODO(), nsList, listOption); err != nil {
 		return err
 	}
 
@@ -817,10 +814,14 @@ func (r *ReconcileArgoCD) removeManagedByLabelFromNamespace(namespace string) er
 		}
 
 		if ns.Labels == nil {
-			return nil
+			continue
+		}
+
+		if n, ok := ns.Labels[common.ArgoCDManagedByLabel]; !ok || n != namespace {
+			continue
 		}
 		delete(ns.Labels, common.ArgoCDManagedByLabel)
-		if err = r.client.Update(context.TODO(), ns); err != nil {
+		if err := r.client.Update(context.TODO(), ns); err != nil {
 			log.Error(err, fmt.Sprintf("failed to remove label from namespace [%s]", ns.Name))
 		}
 	}

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -479,7 +479,7 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	assert.DeepEqual(t, string(s.Data["namespaces"]), "testNamespace2")
 }
 
-func TestRemoveManagedByLabelFromNamespace(t *testing.T) {
+func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t)
 
@@ -513,7 +513,7 @@ func TestRemoveManagedByLabelFromNamespace(t *testing.T) {
 	err = r.client.Create(context.TODO(), ns3)
 	assert.NilError(t, err)
 
-	err = r.removeManagedByLabelFromNamespace(a.Namespace)
+	err = r.removeManagedByLabelFromNamespaces(a.Namespace)
 	assert.NilError(t, err)
 
 	nsList := &v1.NamespaceList{}

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/argoproj-labs/argocd-operator/pkg/common"
 	"github.com/argoproj-labs/argocd-operator/pkg/controller/argoutil"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
@@ -476,4 +477,55 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	s, err := testClient.CoreV1().Secrets(a.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, string(s.Data["namespaces"]), "testNamespace2")
+}
+
+func TestRemoveManagedByLabelFromNamespace(t *testing.T) {
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t)
+
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "testNamespace",
+		Labels: map[string]string{
+			common.ArgoCDManagedByLabel: a.Namespace,
+		}},
+	}
+
+	err := r.client.Create(context.TODO(), ns)
+	assert.NilError(t, err)
+
+	ns2 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "testNamespace2",
+		Labels: map[string]string{
+			common.ArgoCDManagedByLabel: a.Namespace,
+		}},
+	}
+
+	err = r.client.Create(context.TODO(), ns2)
+	assert.NilError(t, err)
+
+	ns3 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "testNamespace3",
+		Labels: map[string]string{
+			common.ArgoCDManagedByLabel: "newNamespace",
+		}},
+	}
+
+	err = r.client.Create(context.TODO(), ns3)
+	assert.NilError(t, err)
+
+	err = r.removeManagedByLabelFromNamespace(a.Namespace)
+	assert.NilError(t, err)
+
+	nsList := &v1.NamespaceList{}
+	err = r.client.List(context.TODO(), nsList)
+	assert.NilError(t, err)
+	for _, n := range nsList.Items {
+		if n.Name == ns3.Name {
+			_, ok := n.Labels[common.ArgoCDManagedByLabel]
+			assert.Equal(t, ok, true)
+			continue
+		}
+		_, ok := n.Labels[common.ArgoCDManagedByLabel]
+		assert.Equal(t, ok, false)
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
When the ArgoCD instance is deleted from the source namespace, operator would remove the managed-by label from all the namespaces that were managed by this particular argocd instance.
The operator currently already has the logic to remove the RBACs from the namespaces from which the label is being removed, so it takes care of removing the RBACs as soon as the labels is removed.
This ensures there are no redundant roles/role_bindings/labels are present for a namespace.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
> https://issues.redhat.com/browse/GITOPS-1228

**How to test changes / Special notes to the reviewer**:
BUILD for testing - create a catalog source using the following yaml:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: argocd-operator-catalog
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/shuagarw/argocd-operator-registry:v1.2.1-1228
  displayName: Argo CD Operators
  publisher: Red Hat Developer
```

Steps to test - 
- Deploy the above provided build and install the argocd-operator
- Create an argocd instance in namespace `foo`. Wait for the instance to be in an available state.
- Create 2 namespaces `bar1` and `bar2`.
- Label both namespaces with the managed-by label - `argocd.argoproj.io/managed-by: foo`
- Make sure the correct Roles/RoleBindings were created for the namespaces. 
- Delete the ArgoCD instance in foo namespace. 
- Make sure the created Role/RoleBindings and Labels were removed from the namespaces. 