### PR TITLE
fix comment for verifyRouteAPI in route.go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 Anyone interested in contributing to the Argo CD operator is welcomes and 
 should start by reviewing the [development][docs_dev] documentation.
 
-[docs_dev]:./docs/development.md
+[docs_dev]:./docs/contribute/development.md

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -35,7 +35,7 @@ func IsRouteAPIAvailable() bool {
 	return routeAPIFound
 }
 
-// verifyRouteAPI will verify that the Prometheus API is present.
+// verifyRouteAPI will verify that the Route API is present.
 func verifyRouteAPI() error {
 	found, err := argoutil.VerifyAPI(routev1.GroupName, routev1.GroupVersion.Version)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation


**What does this PR do / why we need it**:
This PR aims to eliminate confusing as to what verifyRouteAPI is actually user for. The comment currently says since `Prometheus` which is confusing, since this method is for verifying the existence of the OpenShift Routes API within a cluster. Also this PR updates the link in the Contributing.md to point to the proper file location to make it easier for new comers to find the document.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
N/A
**How to test changes / Special notes to the reviewer**:
N/A