### PR TITLE
fix: Only set ownerReferences for roles & rolebindings in CR's namespace

### DIFF
--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -153,10 +153,11 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 			}
 		}
 
-		if err = controllerutil.SetControllerReference(cr, roleBinding, r.Scheme); err != nil {
-			// TODO handle this error properly
-			// return fmt.Errorf("failed to set ArgoCD CR \"%s\" as owner for roleBinding \"%s\": %s", cr.Name, roleBinding.Name, err)
-			log.Error(err, fmt.Sprintf("failed to set ArgoCD CR \"%s\" as owner for roleBinding \"%s\"", cr.Name, roleBinding.Name))
+		// Only set ownerReferences for role bindings in same namespaces as Argo CD CR
+		if cr.Namespace == roleBinding.Namespace {
+			if err = controllerutil.SetControllerReference(cr, roleBinding, r.Scheme); err != nil {
+				return fmt.Errorf("failed to set ArgoCD CR \"%s\" as owner for roleBinding \"%s\": %s", cr.Name, roleBinding.Name, err)
+			}
 		}
 		if err = r.Client.Create(context.TODO(), roleBinding); err != nil {
 			return err

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -203,11 +203,12 @@ func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.Clus
 		Name:     GenerateUniqueResourceName(name, cr),
 	}
 
-	if err = controllerutil.SetControllerReference(cr, roleBinding, r.Scheme); err != nil {
-		// TODO handle this error properly
-		// return fmt.Errorf("failed to set ArgoCD CR \"%s\" as owner for roleBinding \"%s\": %s", cr.Name, roleBinding.Name, err)
-		log.Error(err, fmt.Sprintf("failed to set ArgoCD CR \"%s\" as owner for roleBinding \"%s\"", cr.Name, roleBinding.Name))
+	if cr.Namespace == roleBinding.Namespace {
+		if err = controllerutil.SetControllerReference(cr, roleBinding, r.Scheme); err != nil {
+			return fmt.Errorf("failed to set ArgoCD CR \"%s\" as owner for roleBinding \"%s\": %s", cr.Name, roleBinding.Name, err)
+		}
 	}
+
 	if roleBindingExists {
 		return r.Client.Update(context.TODO(), roleBinding)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This prevents setting ("illegal" cross-namespace) `ownerReferences` to role and rolebindings created from the `managed-by` feature. We only set up `ownerReferences` for resources in the same namespace as the ArgoCD CR.

Since this may change the behaviour of Argo CD's drift detection in certain situations (because we do apply all labels from the ArgoCD CR to the resources we create), a second PR that fixes this behavior will be coming soon.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #408 

**How to test changes / Special notes to the reviewer**:

* Create `ArgoCD` CR in namespace `ns-one`
* Create namespace `ns-two`
* Apply `managed-by` label to `ns-two`: `kubectl label ns ns-two argocd.argoproj.io/managed-by=ns-one`
* Observe no errors in the Operator's log
* Ensure that roles created in `ns-two` have no `ownerReferences` applied to them