### PR TITLE
fix: Do not copy all labels from ArgoCD CR to resources we create

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -672,3 +672,13 @@ func (argocd *ArgoCD) IsDeletionFinalizerPresent() bool {
 	}
 	return false
 }
+
+// ApplicationInstanceLabelKey returns either the custom application instance
+// label key if set, or the default value.
+func (a *ArgoCD) ApplicationInstanceLabelKey() string {
+	if a.Spec.ApplicationInstanceLabelKey != "" {
+		return a.Spec.ApplicationInstanceLabelKey
+	} else {
+		return common.ArgoCDDefaultApplicationInstanceLabelKey
+	}
+}

--- a/api/v1alpha1/argocd_types_test.go
+++ b/api/v1alpha1/argocd_types_test.go
@@ -1,0 +1,17 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/argoproj-labs/argocd-operator/common"
+)
+
+func Test_ArgoCD_ApplicationInstanceLabelKey(t *testing.T) {
+	cr := &ArgoCD{}
+	cr.Spec.ApplicationInstanceLabelKey = "my.corp/instance"
+	assert.Equal(t, cr.ApplicationInstanceLabelKey(), "my.corp/instance")
+	cr = &ArgoCD{}
+	assert.Equal(t, cr.ApplicationInstanceLabelKey(), common.ArgoCDDefaultApplicationInstanceLabelKey)
+}

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -49,7 +49,7 @@ const (
 	ArgoCDDefaultApplicationSetVersion = "v0.1.0"
 
 	// ArgoCDDefaultApplicationInstanceLabelKey is the default app name as a tracking label.
-	ArgoCDDefaultApplicationInstanceLabelKey = "mycompany.com/appname"
+	ArgoCDDefaultApplicationInstanceLabelKey = "app.kubernetes.io/instance"
 
 	// ArgoCDDefaultArgoImage is the ArgoCD container image to use when not specified.
 	ArgoCDDefaultArgoImage = "argoproj/argocd"

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -284,3 +284,20 @@ ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4Nak
 vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
 `
 )
+
+// DefaultLabels returns the default set of labels for controllers.
+func DefaultLabels(name string) map[string]string {
+	return map[string]string{
+		ArgoCDKeyName:      name,
+		ArgoCDKeyPartOf:    ArgoCDAppName,
+		ArgoCDKeyManagedBy: name,
+	}
+}
+
+// DefaultAnnotations returns the default set of annotations for child resources of ArgoCD
+func DefaultAnnotations(name string, namespace string) map[string]string {
+	return map[string]string{
+		AnnotationName:      name,
+		AnnotationNamespace: namespace,
+	}
+}

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -223,7 +223,7 @@ func newConfigMap(cr *argoprojv1a1.ArgoCD) *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }
@@ -287,7 +287,7 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoprojv1a1.ArgoCD) error {
 		return nil // ConfigMap found, do nothing
 	}
 
-	caSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, common.ArgoCDCASuffix, cr.ApplicationInstanceLabelKey())
+	caSecret := argoutil.NewSecretWithSuffix(cr, common.ArgoCDCASuffix)
 	if !argoutil.IsObjectFound(r.Client, cr.Namespace, caSecret.Name, caSecret) {
 		log.Info(fmt.Sprintf("ca secret [%s] not found, waiting to reconcile ca configmap [%s]", caSecret.Name, cm.Name))
 		return nil
@@ -506,7 +506,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoprojv1a1.ArgoCD)
 		return nil // ConfigMap found, do nothing
 	}
 
-	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "grafana", cr.ApplicationInstanceLabelKey())
+	secret := argoutil.NewSecretWithSuffix(cr, "grafana")
 	secret, err := argoutil.FetchSecret(r.Client, cr.ObjectMeta, secret.Name)
 	if err != nil {
 		return err

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -287,7 +287,7 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoprojv1a1.ArgoCD) error {
 		return nil // ConfigMap found, do nothing
 	}
 
-	caSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, common.ArgoCDCASuffix)
+	caSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, common.ArgoCDCASuffix, cr.ApplicationInstanceLabelKey())
 	if !argoutil.IsObjectFound(r.Client, cr.Namespace, caSecret.Name, caSecret) {
 		log.Info(fmt.Sprintf("ca secret [%s] not found, waiting to reconcile ca configmap [%s]", caSecret.Name, cm.Name))
 		return nil
@@ -506,7 +506,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoprojv1a1.ArgoCD)
 		return nil // ConfigMap found, do nothing
 	}
 
-	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "grafana")
+	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "grafana", cr.ApplicationInstanceLabelKey())
 	secret, err := argoutil.FetchSecret(r.Client, cr.ObjectMeta, secret.Name)
 	if err != nil {
 		return err

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -99,7 +99,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 	assert.NilError(t, err)
 
 	want := map[string]string{
-		"application.instanceLabelKey": "mycompany.com/appname",
+		"application.instanceLabelKey": common.ArgoCDDefaultApplicationInstanceLabelKey,
 		"admin.enabled":                "true",
 		"configManagementPlugins":      "",
 		"dex.config":                   "",
@@ -224,7 +224,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 		}},
 	}
 
-	secret := argoutil.NewSecretWithName(metav1.ObjectMeta{Name: "token", Namespace: "argocd"}, "token", "")
+	secret := argoutil.NewSecretWithName(a, "token")
 	r := makeTestReconciler(t, a, sa, secret)
 	err := r.reconcileArgoConfigMap(a)
 	assert.NilError(t, err)

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -224,7 +224,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 		}},
 	}
 
-	secret := argoutil.NewSecretWithName(metav1.ObjectMeta{Name: "token", Namespace: "argocd"}, "token")
+	secret := argoutil.NewSecretWithName(metav1.ObjectMeta{Name: "token", Namespace: "argocd"}, "token", "")
 	r := makeTestReconciler(t, a, sa, secret)
 	err := r.reconcileArgoConfigMap(a)
 	assert.NilError(t, err)

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -247,7 +247,7 @@ func newDeployment(cr *argoprojv1a1.ArgoCD) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }

--- a/controllers/argocd/hpa.go
+++ b/controllers/argocd/hpa.go
@@ -30,7 +30,7 @@ func newHorizontalPodAutoscaler(cr *argoprojv1a1.ArgoCD) *autoscaling.Horizontal
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }

--- a/controllers/argocd/ingress.go
+++ b/controllers/argocd/ingress.go
@@ -50,7 +50,7 @@ func newIngress(cr *argoprojv1a1.ArgoCD) *extv1beta1.Ingress {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }

--- a/controllers/argocd/prometheus.go
+++ b/controllers/argocd/prometheus.go
@@ -89,7 +89,7 @@ func newPrometheus(cr *argoprojv1a1.ArgoCD) *monitoringv1.Prometheus {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }
@@ -100,7 +100,7 @@ func newServiceMonitor(cr *argoprojv1a1.ArgoCD) *monitoringv1.ServiceMonitor {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -15,6 +15,7 @@ import (
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 const (
@@ -30,7 +31,7 @@ func newRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.Ro
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateResourceName(name, cr),
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 		Rules: rules,
 	}
@@ -49,8 +50,8 @@ func newClusterRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD)
 	return &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        GenerateUniqueResourceName(name, cr),
-			Labels:      labelsForCluster(cr),
-			Annotations: annotationsForCluster(cr),
+			Labels:      argoutil.LabelsForCluster(cr),
+			Annotations: argoutil.AnnotationsForCluster(cr),
 		},
 		Rules: rules,
 	}

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -15,6 +15,7 @@ import (
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // newClusterRoleBinding returns a new ClusterRoleBinding instance.
@@ -22,8 +23,8 @@ func newClusterRoleBinding(name string, cr *argoprojv1a1.ArgoCD) *v1.ClusterRole
 	return &v1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Name,
-			Labels:      labelsForCluster(cr),
-			Annotations: annotationsForCluster(cr),
+			Labels:      argoutil.LabelsForCluster(cr),
+			Annotations: argoutil.AnnotationsForCluster(cr),
 		},
 	}
 }
@@ -45,8 +46,8 @@ func newRoleBinding(cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
 	return &v1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Name,
-			Labels:      labelsForCluster(cr),
-			Annotations: annotationsForCluster(cr),
+			Labels:      argoutil.LabelsForCluster(cr),
+			Annotations: argoutil.AnnotationsForCluster(cr),
 			Namespace:   cr.Namespace,
 		},
 	}

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -51,7 +51,7 @@ func newRoute(cr *argoprojv1a1.ArgoCD) *routev1.Route {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -85,7 +85,7 @@ func nowNano() string {
 
 // newCASecret creates a new CA secret with the given suffix for the given ArgoCD.
 func newCASecret(cr *argoprojv1a1.ArgoCD) (*corev1.Secret, error) {
-	secret := argoutil.NewTLSSecret(cr.ObjectMeta, "ca", cr.ApplicationInstanceLabelKey())
+	secret := argoutil.NewTLSSecret(cr, "ca")
 
 	key, err := argoutil.NewPrivateKey()
 	if err != nil {
@@ -109,7 +109,7 @@ func newCASecret(cr *argoprojv1a1.ArgoCD) (*corev1.Secret, error) {
 
 // newCertificateSecret creates a new secret using the given name suffix for the given TLS certificate.
 func newCertificateSecret(suffix string, caCert *x509.Certificate, caKey *rsa.PrivateKey, cr *argoprojv1a1.ArgoCD) (*corev1.Secret, error) {
-	secret := argoutil.NewTLSSecret(cr.ObjectMeta, suffix, cr.ApplicationInstanceLabelKey())
+	secret := argoutil.NewTLSSecret(cr, suffix)
 
 	key, err := argoutil.NewPrivateKey()
 	if err != nil {
@@ -151,15 +151,15 @@ func newCertificateSecret(suffix string, caCert *x509.Certificate, caKey *rsa.Pr
 
 // reconcileArgoSecret will ensure that the Argo CD Secret is present.
 func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
-	clusterSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "cluster", cr.ApplicationInstanceLabelKey())
-	secret := argoutil.NewSecretWithName(cr.ObjectMeta, common.ArgoCDSecretName, cr.ApplicationInstanceLabelKey())
+	clusterSecret := argoutil.NewSecretWithSuffix(cr, "cluster")
+	secret := argoutil.NewSecretWithName(cr, common.ArgoCDSecretName)
 
 	if !argoutil.IsObjectFound(r.Client, cr.Namespace, clusterSecret.Name, clusterSecret) {
 		log.Info(fmt.Sprintf("cluster secret [%s] not found, waiting to reconcile argo secret [%s]", clusterSecret.Name, secret.Name))
 		return nil
 	}
 
-	tlsSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "tls", cr.ApplicationInstanceLabelKey())
+	tlsSecret := argoutil.NewSecretWithSuffix(cr, "tls")
 	if !argoutil.IsObjectFound(r.Client, cr.Namespace, tlsSecret.Name, tlsSecret) {
 		log.Info(fmt.Sprintf("tls secret [%s] not found, waiting to reconcile argo secret [%s]", tlsSecret.Name, secret.Name))
 		return nil
@@ -196,7 +196,7 @@ func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
 
 // reconcileClusterMainSecret will ensure that the main Secret is present for the Argo CD cluster.
 func (r *ReconcileArgoCD) reconcileClusterMainSecret(cr *argoprojv1a1.ArgoCD) error {
-	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "cluster", cr.ApplicationInstanceLabelKey())
+	secret := argoutil.NewSecretWithSuffix(cr, "cluster")
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, secret.Name, secret) {
 		return nil // Secret found, do nothing
 	}
@@ -218,12 +218,12 @@ func (r *ReconcileArgoCD) reconcileClusterMainSecret(cr *argoprojv1a1.ArgoCD) er
 
 // reconcileClusterTLSSecret ensures the TLS Secret is created for the ArgoCD cluster.
 func (r *ReconcileArgoCD) reconcileClusterTLSSecret(cr *argoprojv1a1.ArgoCD) error {
-	secret := argoutil.NewTLSSecret(cr.ObjectMeta, "tls", cr.ApplicationInstanceLabelKey())
+	secret := argoutil.NewTLSSecret(cr, "tls")
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, secret.Name, secret) {
 		return nil // Secret found, do nothing
 	}
 
-	caSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "ca", cr.ApplicationInstanceLabelKey())
+	caSecret := argoutil.NewSecretWithSuffix(cr, "ca")
 	caSecret, err := argoutil.FetchSecret(r.Client, cr.ObjectMeta, caSecret.Name)
 	if err != nil {
 		return err
@@ -253,7 +253,7 @@ func (r *ReconcileArgoCD) reconcileClusterTLSSecret(cr *argoprojv1a1.ArgoCD) err
 
 // reconcileClusterCASecret ensures the CA Secret is created for the ArgoCD cluster.
 func (r *ReconcileArgoCD) reconcileClusterCASecret(cr *argoprojv1a1.ArgoCD) error {
-	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "ca", cr.ApplicationInstanceLabelKey())
+	secret := argoutil.NewSecretWithSuffix(cr, "ca")
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, secret.Name, secret) {
 		return nil // Secret found, do nothing
 	}
@@ -335,8 +335,8 @@ func (r *ReconcileArgoCD) reconcileGrafanaSecret(cr *argoprojv1a1.ArgoCD) error 
 		return nil // Grafana not enabled, do nothing.
 	}
 
-	clusterSecret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "cluster", cr.ApplicationInstanceLabelKey())
-	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "grafana", cr.ApplicationInstanceLabelKey())
+	clusterSecret := argoutil.NewSecretWithSuffix(cr, "cluster")
+	secret := argoutil.NewSecretWithSuffix(cr, "grafana")
 
 	if !argoutil.IsObjectFound(r.Client, cr.Namespace, clusterSecret.Name, clusterSecret) {
 		log.Info(fmt.Sprintf("cluster secret [%s] not found, waiting to reconcile grafana secret [%s]", clusterSecret.Name, secret.Name))
@@ -394,7 +394,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaSecret(cr *argoprojv1a1.ArgoCD) error 
 // reconcileClusterPermissionsSecret ensures ArgoCD instance is namespace-scoped
 func (r *ReconcileArgoCD) reconcileClusterPermissionsSecret(cr *argoprojv1a1.ArgoCD) error {
 	var clusterConfigInstance bool
-	secret := argoutil.NewSecretWithSuffix(cr.ObjectMeta, "default-cluster-config", cr.ApplicationInstanceLabelKey())
+	secret := argoutil.NewSecretWithSuffix(cr, "default-cluster-config")
 	secret.Labels[common.ArgoCDSecretTypeLabel] = "cluster"
 	dataBytes, _ := json.Marshal(map[string]interface{}{
 		"tlsClientConfig": map[string]interface{}{

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -214,7 +214,7 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	r := makeTestReconciler(t, a)
 	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
 
-	testSecret := argoutil.NewSecretWithSuffix(a.ObjectMeta, "default-cluster-config", a.ApplicationInstanceLabelKey())
+	testSecret := argoutil.NewSecretWithSuffix(a, "default-cluster-config")
 	assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret), "not found")
 
 	assert.NilError(t, r.reconcileClusterPermissionsSecret(a))

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -214,7 +214,7 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	r := makeTestReconciler(t, a)
 	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
 
-	testSecret := argoutil.NewSecretWithSuffix(a.ObjectMeta, "default-cluster-config")
+	testSecret := argoutil.NewSecretWithSuffix(a.ObjectMeta, "default-cluster-config", a.ApplicationInstanceLabelKey())
 	assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret), "not found")
 
 	assert.NilError(t, r.reconcileClusterPermissionsSecret(a))

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -42,7 +42,7 @@ func newService(cr *argoprojv1a1.ArgoCD) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -41,7 +41,7 @@ func newServiceAccount(cr *argoprojv1a1.ArgoCD) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -43,7 +43,7 @@ func newStatefulSet(cr *argoprojv1a1.ArgoCD) *appsv1.StatefulSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 }

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -335,7 +335,7 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoprojv1a1.ArgoCD) (*str
 	}
 
 	// Fetch the secret to obtain the token
-	secret := argoutil.NewSecretWithName(cr.ObjectMeta, tokenSecret.Name, cr.ApplicationInstanceLabelKey())
+	secret := argoutil.NewSecretWithName(cr, tokenSecret.Name)
 	if err := argoutil.FetchObject(r.Client, cr.Namespace, secret.Name, secret); err != nil {
 		return nil, err
 	}
@@ -846,24 +846,6 @@ func removeString(slice []string, s string) []string {
 	return result
 }
 
-// labelsForCluster returns the labels for all cluster resources.
-func labelsForCluster(cr *argoprojv1a1.ArgoCD) map[string]string {
-	labels := argoutil.DefaultLabels(cr.Name)
-	for key, val := range cr.ObjectMeta.Labels {
-		labels[key] = val
-	}
-	return labels
-}
-
-// annotationsForCluster returns the annotations for all cluster resources.
-func annotationsForCluster(cr *argoprojv1a1.ArgoCD) map[string]string {
-	annotations := argoutil.DefaultAnnotations(cr)
-	for key, val := range cr.ObjectMeta.Annotations {
-		annotations[key] = val
-	}
-	return annotations
-}
-
 // setResourceWatches will register Watches for each of the supported Resources.
 func setResourceWatches(bldr *builder.Builder, clusterResourceMapper, tlsSecretMapper, namespaceResourceMapper handler.MapFunc) *builder.Builder {
 
@@ -993,7 +975,7 @@ func setResourceWatches(bldr *builder.Builder, clusterResourceMapper, tlsSecretM
 
 // withClusterLabels will add the given labels to the labels for the cluster and return the result.
 func withClusterLabels(cr *argoprojv1a1.ArgoCD, addLabels map[string]string) map[string]string {
-	labels := labelsForCluster(cr)
+	labels := argoutil.LabelsForCluster(cr)
 	for key, val := range addLabels {
 		labels[key] = val
 	}

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -335,7 +335,7 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoprojv1a1.ArgoCD) (*str
 	}
 
 	// Fetch the secret to obtain the token
-	secret := argoutil.NewSecretWithName(cr.ObjectMeta, tokenSecret.Name)
+	secret := argoutil.NewSecretWithName(cr.ObjectMeta, tokenSecret.Name, cr.ApplicationInstanceLabelKey())
 	if err := argoutil.FetchObject(r.Client, cr.Namespace, secret.Name, secret); err != nil {
 		return nil, err
 	}

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -427,7 +427,7 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	_, err = testClient.RbacV1().RoleBindings(testNameSpace).Create(context.TODO(), roleBinding2, metav1.CreateOptions{})
 	assert.NilError(t, err)
 
-	secret := argoutil.NewSecretWithSuffix(a.ObjectMeta, "xyz", a.ApplicationInstanceLabelKey())
+	secret := argoutil.NewSecretWithSuffix(a, "xyz")
 	secret.Labels = map[string]string{common.ArgoCDSecretTypeLabel: "cluster"}
 	secret.Data = map[string][]byte{
 		"server":     []byte(common.ArgoCDDefaultServer),

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -427,7 +427,7 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	_, err = testClient.RbacV1().RoleBindings(testNameSpace).Create(context.TODO(), roleBinding2, metav1.CreateOptions{})
 	assert.NilError(t, err)
 
-	secret := argoutil.NewSecretWithSuffix(a.ObjectMeta, "xyz")
+	secret := argoutil.NewSecretWithSuffix(a.ObjectMeta, "xyz", a.ApplicationInstanceLabelKey())
 	secret.Labels = map[string]string{common.ArgoCDSecretTypeLabel: "cluster"}
 	secret.Data = map[string][]byte{
 		"server":     []byte(common.ArgoCDDefaultServer),

--- a/controllers/argocdexport/export.go
+++ b/controllers/argocdexport/export.go
@@ -62,7 +62,7 @@ func (r *ReconcileArgoCDExport) reconcileExport(cr *argoprojv1a1.ArgoCDExport) e
 // reconcileExportSecret will ensure that the Secret used for the export process is present.
 func (r *ReconcileArgoCDExport) reconcileExportSecret(cr *argoprojv1a1.ArgoCDExport) error {
 	name := argoutil.FetchStorageSecretName(cr)
-	secret := argoutil.NewSecretWithName(cr.ObjectMeta, name)
+	secret := argoutil.NewSecretWithName(cr.ObjectMeta, name, "")
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, name, secret) {
 		backupKey := secret.Data[common.ArgoCDKeyBackupKey]
 		if len(backupKey) <= 0 {

--- a/controllers/argocdexport/export.go
+++ b/controllers/argocdexport/export.go
@@ -62,7 +62,10 @@ func (r *ReconcileArgoCDExport) reconcileExport(cr *argoprojv1a1.ArgoCDExport) e
 // reconcileExportSecret will ensure that the Secret used for the export process is present.
 func (r *ReconcileArgoCDExport) reconcileExportSecret(cr *argoprojv1a1.ArgoCDExport) error {
 	name := argoutil.FetchStorageSecretName(cr)
-	secret := argoutil.NewSecretWithName(cr.ObjectMeta, name, "")
+	// Dummy CR to retrieve secret
+	a := &argoprojv1a1.ArgoCD{}
+	a.ObjectMeta = cr.ObjectMeta
+	secret := argoutil.NewSecretWithName(a, name)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, name, secret) {
 		backupKey := secret.Data[common.ArgoCDKeyBackupKey]
 		if len(backupKey) <= 0 {

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -146,7 +146,7 @@ func newJob(cr *argoprojv1a1.ArgoCDExport) *batchv1.Job {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    argoutil.DefaultLabels(cr.Name),
+			Labels:    common.DefaultLabels(cr.Name),
 		},
 	}
 }
@@ -157,7 +157,7 @@ func newCronJob(cr *argoprojv1a1.ArgoCDExport) *batchv1b1.CronJob {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    argoutil.DefaultLabels(cr.Name),
+			Labels:    common.DefaultLabels(cr.Name),
 		},
 	}
 }
@@ -189,7 +189,7 @@ func newPodTemplateSpec(cr *argoprojv1a1.ArgoCDExport) corev1.PodTemplateSpec {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    argoutil.DefaultLabels(cr.Name),
+			Labels:    common.DefaultLabels(cr.Name),
 		},
 		Spec: newExportPodSpec(cr),
 	}

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -65,23 +65,6 @@ func CreateEvent(client client.Client, action string, message string, reason str
 	return client.Create(context.TODO(), event)
 }
 
-// DefaultLabels returns the default set of labels for controllers.
-func DefaultLabels(name string) map[string]string {
-	return map[string]string{
-		common.ArgoCDKeyName:      name,
-		common.ArgoCDKeyPartOf:    common.ArgoCDAppName,
-		common.ArgoCDKeyManagedBy: name,
-	}
-}
-
-// DefaultAnnotations returns the default set of annotations for child resources of ArgoCD
-func DefaultAnnotations(cr *argoprojv1a1.ArgoCD) map[string]string {
-	return map[string]string{
-		common.AnnotationName:      cr.Name,
-		common.AnnotationNamespace: cr.Namespace,
-	}
-}
-
 // FetchObject will retrieve the object with the given namespace and name using the Kubernetes API.
 // The result will be stored in the given object.
 func FetchObject(client client.Client, namespace string, name string, obj client.Object) error {
@@ -115,4 +98,19 @@ func newEvent(meta metav1.ObjectMeta) *corev1.Event {
 	event.ObjectMeta.Labels = meta.Labels
 	event.ObjectMeta.Namespace = meta.Namespace
 	return event
+}
+
+// LabelsForCluster returns the labels for all cluster resources.
+func LabelsForCluster(cr *argoprojv1a1.ArgoCD) map[string]string {
+	labels := common.DefaultLabels(cr.Name)
+	return labels
+}
+
+// annotationsForCluster returns the annotations for all cluster resources.
+func AnnotationsForCluster(cr *argoprojv1a1.ArgoCD) map[string]string {
+	annotations := common.DefaultAnnotations(cr.Name, cr.Namespace)
+	for key, val := range cr.ObjectMeta.Annotations {
+		annotations[key] = val
+	}
+	return annotations
 }

--- a/controllers/argoutil/resource_test.go
+++ b/controllers/argoutil/resource_test.go
@@ -21,6 +21,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 func TestDefaultAnnotations(t *testing.T) {
@@ -50,7 +51,7 @@ func TestDefaultAnnotations(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultAnnotations(tt.args.cr); !reflect.DeepEqual(got, tt.want) {
+			if got := common.DefaultAnnotations(tt.args.cr.Name, tt.args.cr.Namespace); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DefaultAnnotations() = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/argoutil/secret.go
+++ b/controllers/argoutil/secret.go
@@ -21,50 +21,48 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 // FetchSecret will retrieve the object with the given Name using the provided client.
 // The result will be returned.
 func FetchSecret(client client.Client, meta metav1.ObjectMeta, name string) (*corev1.Secret, error) {
-	secret := NewSecretWithName(meta, name, "")
+	a := &argoprojv1a1.ArgoCD{}
+	a.ObjectMeta = meta
+	secret := NewSecretWithName(a, name)
 	return secret, FetchObject(client, meta.Namespace, name, secret)
 }
 
 // NewTLSSecret returns a new TLS Secret based on the given metadata with the provided suffix on the Name.
-func NewTLSSecret(meta metav1.ObjectMeta, suffix string, instanceLabelKey string) *corev1.Secret {
-	secret := NewSecretWithSuffix(meta, suffix, instanceLabelKey)
+func NewTLSSecret(cr *argoprojv1a1.ArgoCD, suffix string) *corev1.Secret {
+	secret := NewSecretWithSuffix(cr, suffix)
 	secret.Type = corev1.SecretTypeTLS
 	return secret
 }
 
 // NewSecret returns a new Secret based on the given metadata.
-func NewSecret(meta metav1.ObjectMeta) *corev1.Secret {
+func NewSecret(cr *argoprojv1a1.ArgoCD) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      meta.Name,
-			Namespace: meta.Namespace,
-			Labels:    AppendStringMap(DefaultLabels(meta.Name), meta.Labels),
+			Labels: LabelsForCluster(cr),
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
 }
 
 // NewSecretWithName returns a new Secret based on the given metadata with the provided Name.
-func NewSecretWithName(meta metav1.ObjectMeta, name string, instanceLabelKey string) *corev1.Secret {
-	secret := NewSecret(meta)
+func NewSecretWithName(cr *argoprojv1a1.ArgoCD, name string) *corev1.Secret {
+	secret := NewSecret(cr)
 
 	secret.ObjectMeta.Name = name
+	secret.ObjectMeta.Namespace = cr.Namespace
 	secret.ObjectMeta.Labels[common.ArgoCDKeyName] = name
-	// Make sure our instance label is not on the created resource, to prevent Argo CD from believing it manages this secret
-	if instanceLabelKey != "" {
-		delete(secret.ObjectMeta.Labels, instanceLabelKey)
-	}
 
 	return secret
 }
 
 // NewSecretWithSuffix returns a new Secret based on the given metadata with the provided suffix on the Name.
-func NewSecretWithSuffix(meta metav1.ObjectMeta, suffix string, instanceLabelKey string) *corev1.Secret {
-	return NewSecretWithName(meta, fmt.Sprintf("%s-%s", meta.Name, suffix), instanceLabelKey)
+func NewSecretWithSuffix(cr *argoprojv1a1.ArgoCD, suffix string) *corev1.Secret {
+	return NewSecretWithName(cr, fmt.Sprintf("%s-%s", cr.Name, suffix))
 }

--- a/controllers/argoutil/volume.go
+++ b/controllers/argoutil/volume.go
@@ -59,7 +59,7 @@ func NewPersistentVolumeClaim(meta metav1.ObjectMeta) *corev1.PersistentVolumeCl
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      meta.Name,
 			Namespace: meta.Namespace,
-			Labels:    DefaultLabels(meta.Name),
+			Labels:    common.DefaultLabels(meta.Name),
 		},
 	}
 }

--- a/controllers/openshift/clusterconfig_test.go
+++ b/controllers/openshift/clusterconfig_test.go
@@ -133,7 +133,7 @@ func newStatefulSet(cr *argoprojv1alpha1.ArgoCD) *appsv1.StatefulSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
-			Labels:    labelsForCluster(cr),
+			Labels:    argoutil.LabelsForCluster(cr),
 		},
 	}
 
@@ -239,12 +239,4 @@ func newStatefulSet(cr *argoprojv1alpha1.ArgoCD) *appsv1.StatefulSet {
 	}}
 
 	return &ss
-}
-
-func labelsForCluster(cr *argoprojv1alpha1.ArgoCD) map[string]string {
-	labels := argoutil.DefaultLabels(cr.Name)
-	for key, val := range cr.ObjectMeta.Labels {
-		labels[key] = val
-	}
-	return labels
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Currently, when we create resources, we inherit all labels from the `ArgoCD` CR to those resources. If the `ArgoCD` CR was created by Argo CD itself from Git, it will have an instance label (`app.kubernetes.io/instance` by default), indicating that the resource is managed by that particular Argo CD instance/application. However, this label will also be inherited on the resources that the Operator creates, and that are not managed through Argo CD (but through the Operator). This confuses Argo CD, as it thinks it might be managing these resources.

IMHO, we don't need to copy the labels from the `ArgoCD` CR at all, and just set some default labels on the resources we create to be able to identify it.

Also, this PR includes a slight refactor of methods used for labeling and annotating our resources.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

* Create a YAML [0] containing `ArgoCD` spec, and have some labels in the metadata, for example
* Apply YAML to some namespace: `kubectl apply -n some-ns -f argocd-cr.yaml`
* Wait for reconciliation
* Inspect metadata of any resources created by the Operator. In none of these, the labels `foo: bar` or `bar: foo` should be visible. Only the default labels `app.kubernetes.io/name`, `app.kubernetes.io/part-of` and `app.kubernetes.io/managed-by` should be there.
  * `kubectl get -n some-ns secret argocd-secret -o jsonpath='{.metadata.labels}' `
  * `kubectl get -n some-ns secret argocd-default-cluster -o jsonpath='{.metadata.labels}' `
  * `kubectl get -n some-ns deployment argocd-server -o jsonpath='{.metadata.labels}' `

> [0] argocd-cr.yaml

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: argocd
  labels:
    foo: bar
    bar: foo
spec:
  route:
     enabled: true
```