### PR TITLE
FIX: remove RBACs from target-namespace when ArgoCD instance is deleted

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -92,7 +92,7 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 				return reconcile.Result{}, fmt.Errorf("failed to delete ClusterResources: %w", err)
 			}
 
-			if err := r.removeManagedByLabelFromNamespace(argocd.Namespace); err != nil {
+			if err := r.removeManagedByLabelFromNamespaces(argocd.Namespace); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to remove label from namespace[%v], error: %w", argocd.Namespace, err)
 			}
 


### PR DESCRIPTION
Cherry-picked the fix added to rhos-v1.2 branch -> https://github.com/argoproj-labs/argocd-operator/pull/404