### PR TITLE
chore: Ignore transient build artifacts in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,7 @@ vendor/
 *.swo
 *~
 
+# transient build artifacts
+build/_output
+
 kubeconfig


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

New Operator SDK creates `build/_output` for transient build artifacts. We should ignore it for Git.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
