### PR TITLE
fix: Do not restart argocd-server on changes to argocd-tls

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -320,10 +320,6 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 		if err := r.Client.Update(context.TODO(), secret); err != nil {
 			return err
 		}
-
-		// Trigger rollout of Argo Server Deployment
-		deploy := newDeploymentWithSuffix("server", "server", cr)
-		return r.triggerRollout(deploy, "secret.changed")
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This bug fixes a reconciliation loop and race condition between the Argo CD Operator and Argo CD.

Argo CD usually picks up changes from `argocd-secret` without the need to restart. This is also true for changes to `tls.key` and `tls.crt` fields, as Argo CD would just restart the TLS listener with the new configuration on this occasion.

The Operator instructs the `argocd-server` deployment to restart after a change to `tls.crt` or `tls.key` in the `-tls` secret. This will, for some reason, trigger Argo CD to generate a new key in `tls.key` of `argocd-secret`, which leads to the reconciliation loop and the constant restarts.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #? GITOPS-1300

**How to test changes / Special notes to the reviewer**:
