### PR TITLE
fix: update bundle manifest with ExecTimeout

### DIFF
--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -703,6 +703,10 @@ spec:
                       can currently be: - openshift - Use the OpenShift service CA
                       to request TLS config'
                     type: string
+                  execTimeout:
+                    description: ExecTimeout specifies the timeout in seconds for
+                      tool execution
+                    type: integer
                   image:
                     description: Image is the ArgoCD Repo Server container image.
                     type: string


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:

Adds the updated `bundle/manifests/argoproj.io_argocds.yaml` file which was missing from PR #415. This file is generated by running `make bundle`.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.
