### PR TITLE
Fix: managed-by label reset to source namespace

### DIFF
--- a/deploy/olm-catalog/argocd-operator/0.0.16/argocd-operator.v0.0.16.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.0.16/argocd-operator.v0.0.16.clusterserviceversion.yaml
@@ -741,6 +741,12 @@ spec:
           - pods/log
           verbs:
           - get
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - update
         serviceAccountName: argocd-operator
       - rules:
         - apiGroups:

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -19,12 +19,8 @@ import (
 	"fmt"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/pkg/apis/argoproj/v1alpha1"
-	"github.com/argoproj-labs/argocd-operator/pkg/common"
-
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -116,21 +112,6 @@ func (r *ReconcileArgoCD) Reconcile(request reconcile.Request) (reconcile.Result
 
 	if !argocd.IsDeletionFinalizerPresent() {
 		if err := r.addDeletionFinalizer(argocd); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-
-	namespace := &corev1.Namespace{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: request.Namespace}, namespace); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if val, ok := namespace.Labels[common.ArgoCDManagedByLabel]; !ok || val != argocd.Namespace {
-		if namespace.Labels == nil {
-			namespace.Labels = make(map[string]string)
-		}
-		namespace.Labels[common.ArgoCDManagedByLabel] = argocd.Namespace
-		if err = r.client.Update(context.TODO(), namespace); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller/argocd/argocd_controller_test.go
+++ b/pkg/controller/argocd/argocd_controller_test.go
@@ -91,13 +91,6 @@ func TestReconcileArgoCD_Reconcile(t *testing.T) {
 		t.Fatal("reconcile requeued request")
 	}
 
-	// check if namespace label was added
-	ns := &corev1.Namespace{}
-	assert.NilError(t, r.client.Get(context.TODO(), types.NamespacedName{Name: a.Namespace}, ns))
-	if _, ok := ns.Labels[common.ArgoCDManagedByLabel]; !ok {
-		t.Errorf("Expected the namespace[%v] to be labelled with[%v]", a.Namespace, common.ArgoCDManagedByLabel)
-	}
-
 	deployment := &appsv1.Deployment{}
 	if err = r.client.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-redis",
@@ -121,7 +114,7 @@ func TestReconcileArgoCD_CleanUp(t *testing.T) {
 	resources := []runtime.Object{a}
 	resources = append(resources, clusterResources(a)...)
 	r := makeTestReconciler(t, resources...)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/controller/argocd/role.go
+++ b/pkg/controller/argocd/role.go
@@ -98,6 +98,8 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 		return nil, err
 	}
 
+	namespaces.Items = append(namespaces.Items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cr.Namespace}})
+
 	// create policy rules for each namespace
 	for _, namespace := range namespaces.Items {
 		role := newRole(name, policyRules, cr)

--- a/pkg/controller/argocd/role_test.go
+++ b/pkg/controller/argocd/role_test.go
@@ -17,7 +17,7 @@ func TestReconcileArgoCD_reconcileRole(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 	assert.NilError(t, createNamespace(r, "newNamespaceTest", a.Namespace))
 
 	workloadIdentifier := "x"
@@ -49,7 +49,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	rules := policyRuleForDexServer()
 	role := newRole(dexServer, rules, a)
@@ -111,7 +111,7 @@ func TestReconcileArgoCD_RoleHooks(t *testing.T) {
 	defer resetHooks()()
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 	Register(testRoleHook)
 
 	roles, err := r.reconcileRole(applicationController, []v1.PolicyRule{}, a)

--- a/pkg/controller/argocd/rolebinding_test.go
+++ b/pkg/controller/argocd/rolebinding_test.go
@@ -20,7 +20,7 @@ func TestReconcileArgoCD_reconcileRoleBinding(t *testing.T) {
 	r := makeTestReconciler(t, a)
 	p := policyRuleForApplicationController()
 
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 	assert.NilError(t, createNamespace(r, "newTestNamespace", a.Namespace))
 
 	workloadIdentifier := "xrb"
@@ -48,7 +48,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	rules := policyRuleForDexServer()
 	rb := newRoleBindingWithname(dexServer, a)

--- a/pkg/controller/argocd/route_test.go
+++ b/pkg/controller/argocd/route_test.go
@@ -35,7 +35,7 @@ func TestReconcileRouteSetLabels(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
-	assert.NilError(t, createNamespace(r, argoCD.Namespace, argoCD.Namespace))
+	assert.NilError(t, createNamespace(r, argoCD.Namespace, ""))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -67,7 +67,7 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
-	assert.NilError(t, createNamespace(r, argoCD.Namespace, argoCD.Namespace))
+	assert.NilError(t, createNamespace(r, argoCD.Namespace, ""))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -139,7 +139,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
-	assert.NilError(t, createNamespace(r, argoCD.Namespace, argoCD.Namespace))
+	assert.NilError(t, createNamespace(r, argoCD.Namespace, ""))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/controller/argocd/secret.go
+++ b/pkg/controller/argocd/secret.go
@@ -414,6 +414,9 @@ func (r *ReconcileArgoCD) reconcileClusterPermissionsSecret(cr *argoprojv1a1.Arg
 		namespaces = append(namespaces, namespace.Name)
 	}
 
+	if !containsString(namespaces, cr.Namespace) {
+		namespaces = append(namespaces, cr.Namespace)
+	}
 	sort.Strings(namespaces)
 
 	secret.Data = map[string][]byte{

--- a/pkg/controller/argocd/secret_test.go
+++ b/pkg/controller/argocd/secret_test.go
@@ -211,7 +211,7 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	testSecret := argoutil.NewSecretWithSuffix(a.ObjectMeta, "default-cluster-config")
 	assert.ErrorContains(t, r.client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret), "not found")

--- a/pkg/controller/argocd/service_account_test.go
+++ b/pkg/controller/argocd/service_account_test.go
@@ -31,7 +31,7 @@ func TestReconcileArgoCD_reconcileServiceAccountPermissions(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	// objective is to verify if the right rule associations have happened.
 
@@ -126,7 +126,7 @@ func TestReconcileArgoCD_reconcileServiceAccount_dex_disabled(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	// Dex is enabled, creates a new Service Account for it
 	sa, err := r.reconcileServiceAccount(dexServer, a)

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -807,6 +807,7 @@ func (r *ReconcileArgoCD) removeManagedByLabelFromNamespaces(namespace string) e
 		return err
 	}
 
+	nsList.Items = append(nsList.Items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 	for _, n := range nsList.Items {
 		ns := &corev1.Namespace{}
 		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: n.Name}, ns); err != nil {

--- a/pkg/controller/argocd/util_test.go
+++ b/pkg/controller/argocd/util_test.go
@@ -482,6 +482,11 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t)
+	nsArgocd := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: a.Namespace,
+	}}
+	err := r.client.Create(context.TODO(), nsArgocd)
+	assert.NilError(t, err)
 
 	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "testNamespace",
@@ -490,7 +495,7 @@ func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {
 		}},
 	}
 
-	err := r.client.Create(context.TODO(), ns)
+	err = r.client.Create(context.TODO(), ns)
 	assert.NilError(t, err)
 
 	ns2 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR fixes the issue with the `managed-by` label getting reset to the source namespace. This happened only for the namespaces where ArgoCD instance is installed. 

Earlier the operator would by default label the namespace where the argocd instance is installed with the managed-by label as the source namespace. The fix is to not label the namespace explicitly while making sure the required RBACs are created/deleted for the namespace. This is done by appending the source namesapce to the list of namespaces retrieved using the label. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes - https://issues.redhat.com/browse/GITOPS-1247

**How to test changes / Special notes to the reviewer**:
Catalog source to test the operator changes - 
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: argocd-catalog-1247
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/shuagarw/argocd-operator-registry:v1.2.1-1247
  displayName: Argo CD Operators
  publisher: Red Hat Developer
```

Steps to test - 
refer - https://github.com/pittar-sandbox/gitops-1247#how-to-reproduce-this-issue