### PR TITLE
chore: Install CRDs as part of `make run` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,10 +93,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
-install-crds: ## Install CRDs
-	kubectl apply -f config/crd/bases/
-
-run: manifests generate fmt vet install-crds ## Run a controller from your host.
+run: manifests generate fmt vet install ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the manager.

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
-run: manifests generate fmt vet ## Run a controller from your host.
+install-crds: ## Install CRDs
+	kubectl apply -f config/crd/bases/
+
+run: manifests generate fmt vet install-crds ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the manager.


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

> For example, `> /kind bug` would simply become: `/kind bug`
> /kind bug

**What does this PR do / why we need it**:
`make run` target fails with below error when the Argo CD related CRDs are not installed on the cluster.  include the `install` target as part of the `make run`.

```
09-06T13:22:17.479+0530	ERROR	setup	problem running manager	{"error": "failed to wait for argocdexport caches to sync: no matches for kind \"ArgoCDExport\" in version \"argoproj.io/v1alpha1\""}
```

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
On a fresh cluster, run `make run` and verify that operator does not fail with the below error.

```
09-06T13:22:17.479+0530	ERROR	setup	problem running manager	{"error": "failed to wait for argocdexport caches to sync: no matches for kind \"ArgoCDExport\" in version \"argoproj.io/v1alpha1\""}
```