### PR TITLE
fix: Remove trailing newline from admin.password

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -299,14 +299,17 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 	changed := false
 
 	if hasArgoAdminPasswordChanged(secret, clusterSecret) {
-		hashedPassword, err := argopass.HashPassword(string(clusterSecret.Data[common.ArgoCDKeyAdminPassword]))
-		if err != nil {
-			return err
-		}
+		pwBytes, ok := clusterSecret.Data[common.ArgoCDKeyAdminPassword]
+		if ok {
+			hashedPassword, err := argopass.HashPassword(strings.TrimRight(string(pwBytes), "\n"))
+			if err != nil {
+				return err
+			}
 
-		secret.Data[common.ArgoCDKeyAdminPassword] = []byte(hashedPassword)
-		secret.Data[common.ArgoCDKeyAdminPasswordMTime] = nowBytes()
-		changed = true
+			secret.Data[common.ArgoCDKeyAdminPassword] = []byte(hashedPassword)
+			secret.Data[common.ArgoCDKeyAdminPasswordMTime] = nowBytes()
+			changed = true
+		}
 	}
 
 	if hasArgoTLSChanged(secret, tlsSecret) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

The Operator reconciles the admin password for Argo CD from the `<instance>-cluster` secret, which stores a base64 encoded version of the password in its `admin.password` field. Users tend to encode base64 data like this: `echo foobar | base64`. This also encodes the final newline from `echo` into the base64 data, which effectively makes the password useless (users will not be able to login).

This change removes any trailing newline from the decoded value in `admin.password`, so users won't shoot themselves in the foot.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

* Run Operator locally
* Create new Argo CD instance
* Create new password with trailing newline: `echo foobar | base64`
* Set new password by c&p from above: `oc patch secret argocd-cluster --type merge --patch '{"data":{"admin.password":"Zm9vYmFyCg=="}}'`
* Log into Argo CD using user "admin" and password "foobar"