### PR TITLE
fix: use operator sdk naming conventions for resources

### DIFF
--- a/bundle/manifests/argocd-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/argocd-operator-controller-manager-metrics-service_v1_service.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     control-plane: controller-manager
-  name: controller-manager-metrics-service
+  name: argocd-operator-controller-manager-metrics-service
 spec:
   ports:
   - name: https

--- a/bundle/manifests/argocd-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/argocd-operator-manager-config_v1_configmap.yaml
@@ -14,4 +14,4 @@ data:
       resourceName: b674928d.argoproj.io
 kind: ConfigMap
 metadata:
-  name: manager-config
+  name: argocd-operator-manager-config

--- a/bundle/manifests/argocd-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/argocd-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: metrics-reader
+  name: argocd-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -914,9 +914,9 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: argocd-operator
+        serviceAccountName: argocd-operator-controller-manager
       deployments:
-      - name: controller-manager
+      - name: argocd-operator-controller-manager
         spec:
           replicas: 1
           selector:
@@ -970,7 +970,7 @@ spec:
                   allowPrivilegeEscalation: false
               securityContext:
                 runAsNonRoot: true
-              serviceAccountName: argocd-operator
+              serviceAccountName: argocd-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
@@ -1005,7 +1005,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: argocd-operator
+        serviceAccountName: argocd-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: true

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: argocd-operator-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-# namePrefix: argocd-operator-
+namePrefix: argocd-operator-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,5 +50,5 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
-      serviceAccountName: argocd-operator
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: argocd-operator
+  name: controller-manager
   namespace: system

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: argocd-operator
+  name: controller-manager
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: argocd-operator
+  name: controller-manager
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: argocd-operator
+  name: controller-manager
   namespace: system


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**

> /kind cleanup

**What does this PR do / why we need it**:

Adds the prefix `argocd-operator-` to all resources belonging to the operator, so that they won't have generic names like `controller-manager`

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

Install the operator and check that the names of the operator's resources are correct.
