### PR TITLE
Fix: managed-by label reset to source namespace

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -23,12 +23,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	"github.com/argoproj-labs/argocd-operator/common"
-
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -105,21 +101,6 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 
 	if !argocd.IsDeletionFinalizerPresent() {
 		if err := r.addDeletionFinalizer(argocd); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-
-	namespace := &corev1.Namespace{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: request.Namespace}, namespace); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if val, ok := namespace.Labels[common.ArgoCDManagedByLabel]; !ok || val != argocd.Namespace {
-		if namespace.Labels == nil {
-			namespace.Labels = make(map[string]string)
-		}
-		namespace.Labels[common.ArgoCDManagedByLabel] = argocd.Namespace
-		if err = r.Client.Update(ctx, namespace); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/controllers/argocd/argocd_controller_test.go
+++ b/controllers/argocd/argocd_controller_test.go
@@ -93,13 +93,6 @@ func TestReconcileArgoCD_Reconcile(t *testing.T) {
 		t.Fatal("reconcile requeued request")
 	}
 
-	// check if namespace label was added
-	ns := &corev1.Namespace{}
-	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: a.Namespace}, ns))
-	if _, ok := ns.Labels[common.ArgoCDManagedByLabel]; !ok {
-		t.Errorf("Expected the namespace[%v] to be labelled with[%v]", a.Namespace, common.ArgoCDManagedByLabel)
-	}
-
 	deployment := &appsv1.Deployment{}
 	if err = r.Client.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-redis",
@@ -123,7 +116,7 @@ func TestReconcileArgoCD_CleanUp(t *testing.T) {
 	resources := []runtime.Object{a}
 	resources = append(resources, clusterResources(a)...)
 	r := makeTestReconciler(t, resources...)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -100,6 +100,8 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 		return nil, err
 	}
 
+	namespaces.Items = append(namespaces.Items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cr.Namespace}})
+
 	// create policy rules for each namespace
 	for _, namespace := range namespaces.Items {
 		role := newRole(name, policyRules, cr)

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -18,7 +18,7 @@ func TestReconcileArgoCD_reconcileRole(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 	assert.NilError(t, createNamespace(r, "newNamespaceTest", a.Namespace))
 
 	workloadIdentifier := "x"
@@ -50,7 +50,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	rules := policyRuleForDexServer()
 	role := newRole(dexServer, rules, a)
@@ -112,7 +112,7 @@ func TestReconcileArgoCD_RoleHooks(t *testing.T) {
 	defer resetHooks()()
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 	Register(testRoleHook)
 
 	roles, err := r.reconcileRole(applicationController, []v1.PolicyRule{}, a)

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -20,7 +20,7 @@ func TestReconcileArgoCD_reconcileRoleBinding(t *testing.T) {
 	r := makeTestReconciler(t, a)
 	p := policyRuleForApplicationController()
 
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 	assert.NilError(t, createNamespace(r, "newTestNamespace", a.Namespace))
 
 	workloadIdentifier := "xrb"
@@ -48,7 +48,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	rules := policyRuleForDexServer()
 	rb := newRoleBindingWithname(dexServer, a)

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -36,7 +36,7 @@ func TestReconcileRouteSetLabels(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
-	assert.NilError(t, createNamespace(r, argoCD.Namespace, argoCD.Namespace))
+	assert.NilError(t, createNamespace(r, argoCD.Namespace, ""))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -68,7 +68,7 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
-	assert.NilError(t, createNamespace(r, argoCD.Namespace, argoCD.Namespace))
+	assert.NilError(t, createNamespace(r, argoCD.Namespace, ""))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -140,7 +140,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 		argoCD,
 	}
 	r := makeReconciler(t, argoCD, objs...)
-	assert.NilError(t, createNamespace(r, argoCD.Namespace, argoCD.Namespace))
+	assert.NilError(t, createNamespace(r, argoCD.Namespace, ""))
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -414,6 +414,9 @@ func (r *ReconcileArgoCD) reconcileClusterPermissionsSecret(cr *argoprojv1a1.Arg
 		namespaces = append(namespaces, namespace.Name)
 	}
 
+	if !containsString(namespaces, cr.Namespace) {
+		namespaces = append(namespaces, cr.Namespace)
+	}
 	sort.Strings(namespaces)
 
 	secret.Data = map[string][]byte{

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -212,7 +212,7 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	testSecret := argoutil.NewSecretWithSuffix(a, "default-cluster-config")
 	assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret), "not found")

--- a/controllers/argocd/service_account_test.go
+++ b/controllers/argocd/service_account_test.go
@@ -31,7 +31,7 @@ func TestReconcileArgoCD_reconcileServiceAccountPermissions(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	// objective is to verify if the right rule associations have happened.
 
@@ -126,7 +126,7 @@ func TestReconcileArgoCD_reconcileServiceAccount_dex_disabled(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NilError(t, createNamespace(r, a.Namespace, a.Namespace))
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	// Dex is enabled, creates a new Service Account for it
 	sa, err := r.reconcileServiceAccount(dexServer, a)

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -806,6 +806,7 @@ func (r *ReconcileArgoCD) removeManagedByLabelFromNamespaces(namespace string) e
 		return err
 	}
 
+	nsList.Items = append(nsList.Items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 	for _, n := range nsList.Items {
 		ns := &corev1.Namespace{}
 		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: n.Name}, ns); err != nil {

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -473,6 +473,11 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t)
+	nsArgocd := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: a.Namespace,
+	}}
+	err := r.Client.Create(context.TODO(), nsArgocd)
+	assert.NilError(t, err)
 
 	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "testNamespace",
@@ -481,7 +486,7 @@ func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {
 		}},
 	}
 
-	err := r.Client.Create(context.TODO(), ns)
+	err = r.Client.Create(context.TODO(), ns)
 	assert.NilError(t, err)
 
 	ns2 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Backport the changes from branch `rhos-v1.2` to `master`. 
Cherry picks the following change -> https://github.com/argoproj-labs/argocd-operator/pull/424
Fix: GITOPS-1247 (https://issues.redhat.com/browse/GITOPS-1247)