### PR TITLE
chore: Add descriptions for ArgoCD CRDs in CSV

### DIFF
--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -138,13 +138,20 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: Application
+    - description: An Application is a group of Kubernetes resources as defined by
+        a manifest.
+      displayName: Application
+      kind: Application
       name: applications.argoproj.io
       version: v1alpha1
-    - kind: ApplicationSet
+    - description: An ApplicationSet is a group or set of Application resources.
+      displayName: ApplicationSet
+      kind: ApplicationSet
       name: applicationsets.argoproj.io
       version: v1alpha1
-    - kind: AppProject
+    - description: An AppProject is a logical grouping of Argo CD Applications.
+      displayName: AppProject
+      kind: AppProject
       name: appprojects.argoproj.io
       version: v1alpha1
     - description: ArgoCDExport is the Schema for the argocdexports API

--- a/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
@@ -15,6 +15,22 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: An Application is a group of Kubernetes resources as defined by
+        a manifest.
+      displayName: Application
+      kind: Application
+      name: applications.argoproj.io
+      version: v1alpha1
+    - description: An ApplicationSet is a group or set of Application resources.
+      displayName: ApplicationSet
+      kind: ApplicationSet
+      name: applicationsets.argoproj.io
+      version: v1alpha1
+    - description: An AppProject is a logical grouping of Argo CD Applications.
+      displayName: AppProject
+      kind: AppProject
+      name: appprojects.argoproj.io
+      version: v1alpha1
     - description: ArgoCDExport is the Schema for the argocdexports API
       displayName: Argo CDExport
       kind: ArgoCDExport


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**

> /kind cleanup

**What does this PR do / why we need it**:

Adds descriptions for the ArgoCD CRDs to the argocd-operator's CSV file.  Fixes the *Provided APIs* section of the operator's details page showing *Not Available* as the description.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

Install the operator via the OLM catalog.  The proper descriptions should be shown for each ArgoCD CRD in the *Provided APIs* section