### PR TITLE
fix: Invalid Image location for ApplicationSets

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -46,7 +46,7 @@ const (
 	ArgoCDDefaultAdminPasswordNumSymbols = 0
 
 	// ArgoCDDefaultApplicationSetImage is the Argo CD Application Set container image to use when not specified.
-	ArgoCDDefaultApplicationSetImage = "quay.io/argocdapplicationset/argocd-applicationset"
+	ArgoCDDefaultApplicationSetImage = "quay.io/argoproj/argocd-applicationset"
 
 	// ArgoCDDefaultApplicationSetVersion is the Argo CD Application Set image tag to use when not specified.
 	ArgoCDDefaultApplicationSetVersion = "v0.2.0"


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Fixes #445

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
#445 

**How to test changes / Special notes to the reviewer**:
**Steps to reproduce the behavior:**
1. Run the operator locally using `make install && make run`
2. Create an Argo CD CR with the below configuration.
```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  namespace: foo
spec:
  applicationSet:
    resources:
      limits:
        cpu: "2"
        memory: 1Gi
      requests:
        cpu: 250m
        memory: 512Mi
  server:
    route:
      enabled: true
```
3. Verify that the application set pod moves in to `ImagePullBackoff` state.
