### PR TITLE
fix: add nodePlacement check in applicationSet reconciler

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -179,7 +179,9 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoprojv1a1.Arg
 			existingSpec.ServiceAccountName != podSpec.ServiceAccountName ||
 			!reflect.DeepEqual(existing.Labels, deploy.Labels) ||
 			!reflect.DeepEqual(existing.Spec.Template.Labels, deploy.Spec.Template.Labels) ||
-			!reflect.DeepEqual(existing.Spec.Selector, deploy.Spec.Selector)
+			!reflect.DeepEqual(existing.Spec.Selector, deploy.Spec.Selector) ||
+			!reflect.DeepEqual(existing.Spec.Template.Spec.NodeSelector, deploy.Spec.Template.Spec.NodeSelector) ||
+			!reflect.DeepEqual(existing.Spec.Template.Spec.Tolerations, deploy.Spec.Template.Spec.Tolerations)
 
 		// If the Deployment already exists, make sure the values we care about are up-to-date
 		if deploymentsDifferent {
@@ -189,6 +191,8 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoprojv1a1.Arg
 			existing.Labels = deploy.Labels
 			existing.Spec.Template.Labels = deploy.Spec.Template.Labels
 			existing.Spec.Selector = deploy.Spec.Selector
+			existing.Spec.Template.Spec.NodeSelector = deploy.Spec.Template.Spec.NodeSelector
+			existing.Spec.Template.Spec.Tolerations = deploy.Spec.Template.Spec.Tolerations
 			return r.Client.Update(context.TODO(), existing)
 		}
 		return nil // Deployment found with nothing to do, move along...


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug


**What does this PR do / why we need it**:
This PR adds check for nodeSelector and tolerations in applicationSet reconciler so that the pod can reschedule on correct nodes

**Which issue(s) this PR fixes**:

Fixes #450 

**How to test changes / Special notes to the reviewer**:
`make install`, `make run` and then in argoCD CR spec add , verify that all pods now have nodeSelectors and tolerations
```
spec:
  applicationSet: {}
  nodePlacement:
    nodeSelector:
      abc: abc
    tolerations:
      - effect: NoSchedule
        key: abc
        value: abc
```