### PR TITLE
fix: reposerver, server and controller pods restart continuously when multiple env vars are set

### DIFF
--- a/controllers/argoutil/env.go
+++ b/controllers/argoutil/env.go
@@ -1,13 +1,14 @@
 package argoutil
 
 import (
+	"sort"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 // EnvMerge merges two slices of EnvVar entries into a single one. If existing
 // has an EnvVar with same Name attribute as one in merge, the EnvVar is not
-// merged unless override is set to true. The resulting slice is not guaranteed
-// to be in the same order than the existing input.
+// merged unless override is set to true.
 func EnvMerge(existing []corev1.EnvVar, merge []corev1.EnvVar, override bool) []corev1.EnvVar {
 	ret := []corev1.EnvVar{}
 	final := map[string]corev1.EnvVar{}
@@ -24,8 +25,15 @@ func EnvMerge(existing []corev1.EnvVar, merge []corev1.EnvVar, override bool) []
 		}
 	}
 
-	for _, v := range final {
-		ret = append(ret, v)
+	// sort final by keys
+	keys := make([]string, 0, len(final))
+	for k := range final {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, v := range keys {
+		ret = append(ret, final[v])
 	}
 
 	return ret


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Sort the Env vars before adding to the workloads.
Fixes #466 

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:

Fixes #466 

**How to test changes / Special notes to the reviewer**:
NA
