### PR TITLE
fix: reconcile argocd cr changes for resouce inclusions in argocd-cm config map

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -471,6 +471,11 @@ func (r *ReconcileArgoCD) reconcileExistingArgoConfigMap(cm *corev1.ConfigMap, c
 		changed = true
 	}
 
+	if cm.Data[common.ArgoCDKeyResourceInclusions] != cr.Spec.ResourceInclusions {
+		cm.Data[common.ArgoCDKeyResourceInclusions] = cr.Spec.ResourceInclusions
+		changed = true
+	}
+
 	uri := r.getArgoServerURI(cr)
 	if cm.Data[common.ArgoCDKeyServerURL] != uri {
 		cm.Data[common.ArgoCDKeyServerURL] = uri

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -345,6 +345,8 @@ func TestReconcileArgoCD_reconcileGPGKeysConfigMap(t *testing.T) {
 func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceInclusions(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	customizations := "testing: testing"
+	updatedCustomizations := "updated-testing: updated-testing"
+
 	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
 		a.Spec.ResourceInclusions = customizations
 	})
@@ -363,6 +365,21 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceInclusions(t *testin
 	if c := cm.Data["resource.inclusions"]; c != customizations {
 		t.Fatalf("reconcileArgoConfigMap failed got %q, want %q", c, customizations)
 	}
+
+	a.Spec.ResourceInclusions = updatedCustomizations
+	err = r.reconcileArgoConfigMap(a)
+	assert.NilError(t, err)
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      common.ArgoCDConfigMapName,
+		Namespace: testNamespace,
+	}, cm)
+	assert.NilError(t, err)
+
+	if c := cm.Data["resource.inclusions"]; c != updatedCustomizations {
+		t.Fatalf("reconcileArgoConfigMap failed got %q, want %q", c, updatedCustomizations)
+	}
+
 }
 
 func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceCustomizations(t *testing.T) {


### PR DESCRIPTION
…g map

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`
 /kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
Adds reconciliation logic for resourceInclusions from argocd CR to `argocd-cm` config map

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #471 

**How to test changes / Special notes to the reviewer**:

1. Deploy operator
2. Update the argo-cd CR resource inclusions
3. wait for config map to be reconciled
4. config map should reflect changes in resource inclusions
