### PR TITLE
feat: bump cronjob api to v1

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -42,7 +42,7 @@ func init() {
 //+operator-sdk:csv:customresourcedefinitions:resources={{ArgoCD,v1alpha1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{ArgoCDExport,v1alpha1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{ConfigMap,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{CronJob,v1beta1,""}}
+//+operator-sdk:csv:customresourcedefinitions:resources={{CronJob,v1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{Ingress,v1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{Job,v1,""}}

--- a/api/v1alpha1/argocdexport_types.go
+++ b/api/v1alpha1/argocdexport_types.go
@@ -33,7 +33,7 @@ import (
 //+operator-sdk:csv:customresourcedefinitions:resources={{ArgoCD,v1alpha1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{ArgoCDExport,v1alpha1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{ConfigMap,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{CronJob,v1beta1,""}}
+//+operator-sdk:csv:customresourcedefinitions:resources={{CronJob,v1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{Ingress,v1,""}}
 //+operator-sdk:csv:customresourcedefinitions:resources={{Job,v1,""}}

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -170,7 +170,7 @@ spec:
         version: v1
       - kind: CronJob
         name: ""
-        version: v1beta1
+        version: v1
       - kind: Deployment
         name: ""
         version: v1
@@ -253,7 +253,7 @@ spec:
         version: v1
       - kind: CronJob
         name: ""
-        version: v1beta1
+        version: v1
       - kind: Deployment
         name: ""
         version: v1

--- a/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ spec:
         version: v1
       - kind: CronJob
         name: ""
-        version: v1beta1
+        version: v1
       - kind: Deployment
         name: ""
         version: v1
@@ -130,7 +130,7 @@ spec:
         version: v1
       - kind: CronJob
         name: ""
-        version: v1beta1
+        version: v1
       - kind: Deployment
         name: ""
         version: v1

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1b1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -152,8 +151,8 @@ func newJob(cr *argoprojv1a1.ArgoCDExport) *batchv1.Job {
 }
 
 // newCronJob returns a new CronJob instance for the given ArgoCDExport.
-func newCronJob(cr *argoprojv1a1.ArgoCDExport) *batchv1b1.CronJob {
-	return &batchv1b1.CronJob{
+func newCronJob(cr *argoprojv1a1.ArgoCDExport) *batchv1.CronJob {
+	return &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind cleanup
> /kind failing-test
 /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
batch/v1beta1 version of cronjob is set to be deprecated in k8s v1.25. We should upgrade it in our code base before it becomes too late and causes bigger problems as we have seen it can in the past 

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
