### PR TITLE
fix: Remove managed namespace from cluster secret after deletion

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1112,22 +1112,30 @@ func namespaceFilterPredicate() predicate.Predicate {
 				} else {
 					log.Info(fmt.Sprintf("Successfully removed the RBACs for namespace: %s", e.ObjectOld.GetName()))
 				}
+
+				// Delete managed namespace from cluster secret
+				if err = deleteManagedNamespaceFromClusterSecret(ns, e.ObjectOld.GetName(), k8sClient); err != nil {
+					log.Error(err, fmt.Sprintf("unable to delete namespace %s from cluster secret", e.ObjectOld.GetName()))
+				} else {
+					log.Info(fmt.Sprintf("Successfully deleted namespace %s from cluster secret", e.ObjectOld.GetName()))
+				}
+
 			}
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			if argoCDNs, ok := e.Object.GetLabels()[common.ArgoCDManagedByLabel]; ok && argoCDNs != "" {
+			if ns, ok := e.Object.GetLabels()[common.ArgoCDManagedByLabel]; ok && ns != "" {
 				k8sClient, err := initK8sClient()
-				managedNs := e.Object.GetName()
+
 				if err != nil {
 					return false
 				}
 				// Delete managed namespace from cluster secret
-				err = deleteManagedNamespaceFromClusterSecret(argoCDNs, managedNs, k8sClient)
+				err = deleteManagedNamespaceFromClusterSecret(ns, e.Object.GetName(), k8sClient)
 				if err != nil {
-					log.Error(err, fmt.Sprintf("unable to delete namespace %s from cluster secret", managedNs))
+					log.Error(err, fmt.Sprintf("unable to delete namespace %s from cluster secret", e.Object.GetName()))
 				} else {
-					log.Info(fmt.Sprintf("Successfully deleted namespace %s from cluster secret", managedNs))
+					log.Info(fmt.Sprintf("Successfully deleted namespace %s from cluster secret", e.Object.GetName()))
 				}
 			}
 			return false
@@ -1168,12 +1176,6 @@ func deleteRBACsForNamespace(ownerNS, sourceNS string, k8sClient kubernetes.Inte
 		if err != nil {
 			log.Error(err, fmt.Sprintf("failed to delete role binding for namespace: %s", sourceNS))
 		}
-	}
-
-	// Delete managed namespace from cluster secret
-	err = deleteManagedNamespaceFromClusterSecret(ownerNS, sourceNS, k8sClient)
-	if err != nil {
-		log.Error(err, fmt.Sprintf("unable to delete %s namespace from cluster secret", sourceNS))
 	}
 
 	return nil

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -465,17 +465,6 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	_, err = testClient.RbacV1().RoleBindings(testNameSpace).Create(context.TODO(), roleBinding2, metav1.CreateOptions{})
 	assert.NilError(t, err)
 
-	secret := argoutil.NewSecretWithSuffix(a, "xyz")
-	secret.Labels = map[string]string{common.ArgoCDSecretTypeLabel: "cluster"}
-	secret.Data = map[string][]byte{
-		"server":     []byte(common.ArgoCDDefaultServer),
-		"namespaces": []byte(strings.Join([]string{testNameSpace, "testNamespace2"}, ",")),
-	}
-
-	// create secret with the label
-	_, err = testClient.CoreV1().Secrets(a.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
-	assert.NilError(t, err)
-
 	// run deleteRBACsForNamespace
 	assert.NilError(t, deleteRBACsForNamespace(a.Namespace, testNameSpace, testClient))
 
@@ -493,10 +482,32 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	_, err = testClient.RbacV1().Roles(testNameSpace).Get(context.TODO(), roleBinding2.Name, metav1.GetOptions{})
 	assert.NilError(t, err)
 
+}
+
+func TestRemoveManagedNamespaceFromClusterSecretAfterDeletion(t *testing.T) {
+	a := makeTestArgoCD()
+	testClient := testclient.NewSimpleClientset()
+	testNameSpace := "testNameSpace"
+
+	secret := argoutil.NewSecretWithSuffix(a, "xyz")
+	secret.Labels = map[string]string{common.ArgoCDSecretTypeLabel: "cluster"}
+	secret.Data = map[string][]byte{
+		"server":     []byte(common.ArgoCDDefaultServer),
+		"namespaces": []byte(strings.Join([]string{testNameSpace, "testNamespace2"}, ",")),
+	}
+
+	// create secret with the label
+	_, err := testClient.CoreV1().Secrets(a.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	// run deleteManagedNamespaceFromClusterSecret
+	assert.NilError(t, deleteManagedNamespaceFromClusterSecret(a.Namespace, testNameSpace, testClient))
+
 	// secret should still exists with updated list of namespaces
 	s, err := testClient.CoreV1().Secrets(a.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
 	assert.NilError(t, err)
 	assert.DeepEqual(t, string(s.Data["namespaces"]), "testNamespace2")
+
 }
 
 func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
Adds logic to remove namespaces that were managed by an argo-cd instance (i.e, they contained the managed-by label) from that instance's cluster secret after the namespace has been deleted 

Currently, argocd-operator only handles cases where managed namespaces are updated, but doesn't handle the scenario where managed namespaces are deleted

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #478

**How to test changes / Special notes to the reviewer**:

Steps to reproduce the behavior:

1. Deply an application scoped ArgoCD via the CR:

```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
 name: argocd #name of the Argo CD instance
 namespace: foo #namespace where you want to deploy argocd instance
spec:
 server:
   route:
     enabled: true #creates an openshift route to access Argo CD UI
 ```
     
2. Create two new namespaces and label them

```
kubectl create namespace to-delete
kubectl label namespace/to-delete argocd.argoproj.io/managed-by=foo
kubectl create namespace sample-app
kubectl label namespace/sample-app argocd.argoproj.io/managed-by=foo
```

3. Delete the first namespace

```
kubectl delete namespace/to-delete
```

4. Apply an application to second namespace

```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: sample-app #app CR name
  namespace: foo #argocd instance namespace
spec:
  destination:
    namespace: sample-app #namespace where app is deployed
    server: 'https://kubernetes.default.svc'
  source:
    path: app
    repoURL: 'https://github.com/redhat-developer/openshift-gitops-getting-started'
    targetRevision: HEAD
  project: default
```

5. Application should sync successfully 

6. No errors under cluster settings should be observed