### PR TITLE
fix: handle deletion of managed ns in cluster secret and update unit test

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1100,6 +1100,30 @@ func namespaceFilterPredicate() predicate.Predicate {
 				} else {
 					log.Info(fmt.Sprintf("Successfully removed the RBACs for namespace: %s", e.ObjectOld.GetName()))
 				}
+
+				// Delete managed namespace from cluster secret
+				if err = deleteManagedNamespaceFromClusterSecret(ns, e.ObjectOld.GetName(), k8sClient); err != nil {
+					log.Error(err, fmt.Sprintf("unable to delete namespace %s from cluster secret", e.ObjectOld.GetName()))
+				} else {
+					log.Info(fmt.Sprintf("Successfully deleted namespace %s from cluster secret", e.ObjectOld.GetName()))
+				}
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if ns, ok := e.Object.GetLabels()[common.ArgoCDManagedByLabel]; ok && ns != "" {
+				k8sClient, err := initK8sClient()
+
+				if err != nil {
+					return false
+				}
+				// Delete managed namespace from cluster secret
+				err = deleteManagedNamespaceFromClusterSecret(ns, e.Object.GetName(), k8sClient)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("unable to delete namespace %s from cluster secret", e.Object.GetName()))
+				} else {
+					log.Info(fmt.Sprintf("Successfully deleted namespace %s from cluster secret", e.Object.GetName()))
+				}
 			}
 			return false
 		},
@@ -1141,8 +1165,12 @@ func deleteRBACsForNamespace(ownerNS, sourceNS string, k8sClient kubernetes.Inte
 		}
 	}
 
+	return nil
+}
+
+func deleteManagedNamespaceFromClusterSecret(ownerNS, sourceNS string, k8sClient kubernetes.Interface) error {
 	// Get the cluster secret used for configuring ArgoCD
-	labelSelector = metav1.LabelSelector{MatchLabels: map[string]string{common.ArgoCDSecretTypeLabel: "cluster"}}
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{common.ArgoCDSecretTypeLabel: "cluster"}}
 	secrets, err := k8sClient.CoreV1().Secrets(ownerNS).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.Set(labelSelector.MatchLabels).String()})
 	if err != nil {
 		log.Error(err, fmt.Sprintf("failed to retrieve secrets for namespace: %s", ownerNS))

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -465,17 +465,6 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	_, err = testClient.RbacV1().RoleBindings(testNameSpace).Create(context.TODO(), roleBinding2, metav1.CreateOptions{})
 	assert.NilError(t, err)
 
-	secret := argoutil.NewSecretWithSuffix(a, "xyz")
-	secret.Labels = map[string]string{common.ArgoCDSecretTypeLabel: "cluster"}
-	secret.Data = map[string][]byte{
-		"server":     []byte(common.ArgoCDDefaultServer),
-		"namespaces": []byte(strings.Join([]string{testNameSpace, "testNamespace2"}, ",")),
-	}
-
-	// create secret with the label
-	_, err = testClient.CoreV1().Secrets(a.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
-	assert.NilError(t, err)
-
 	// run deleteRBACsForNamespace
 	assert.NilError(t, deleteRBACsForNamespace(a.Namespace, testNameSpace, testClient))
 
@@ -492,6 +481,26 @@ func TestDeleteRBACsForNamespace(t *testing.T) {
 	// roleBinding without the label should still exists, no error
 	_, err = testClient.RbacV1().Roles(testNameSpace).Get(context.TODO(), roleBinding2.Name, metav1.GetOptions{})
 	assert.NilError(t, err)
+}
+
+func TestRemoveManagedNamespaceFromClusterSecretAfterDeletion(t *testing.T) {
+	a := makeTestArgoCD()
+	testClient := testclient.NewSimpleClientset()
+	testNameSpace := "testNameSpace"
+
+	secret := argoutil.NewSecretWithSuffix(a, "xyz")
+	secret.Labels = map[string]string{common.ArgoCDSecretTypeLabel: "cluster"}
+	secret.Data = map[string][]byte{
+		"server":     []byte(common.ArgoCDDefaultServer),
+		"namespaces": []byte(strings.Join([]string{testNameSpace, "testNamespace2"}, ",")),
+	}
+
+	// create secret with the label
+	_, err := testClient.CoreV1().Secrets(a.Namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	// run deleteManagedNamespaceFromClusterSecret
+	assert.NilError(t, deleteManagedNamespaceFromClusterSecret(a.Namespace, testNameSpace, testClient))
 
 	// secret should still exists with updated list of namespaces
 	s, err := testClient.CoreV1().Secrets(a.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
Porting https://github.com/argoproj-labs/argocd-operator/pull/479 into release-0.1 branch
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #478 

**How to test changes / Special notes to the reviewer**:
