### PR TITLE
fix: fix broken argocd export

### DIFF
--- a/build/util/util.sh
+++ b/build/util/util.sh
@@ -32,7 +32,7 @@ export_argocd () {
 
 create_backup () {
     echo "creating argo-cd backup"
-    argocd-util export > ${BACKUP_EXPORT_LOCATION}
+    argocd admin export > ${BACKUP_EXPORT_LOCATION}
 }
 
 encrypt_backup () {
@@ -148,7 +148,7 @@ decrypt_backup () {
 
 load_backup () {
     echo "loading argo-cd backup"
-    argocd-util import - < ${BACKUP_EXPORT_LOCATION}
+    argocd admin import - < ${BACKUP_EXPORT_LOCATION}
 }
 
 usage () {

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -113,7 +113,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/argoprojlabs/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:0c779eea3f08ffa75fe9d06852b9ab7aed445cb5ac96831c2429b0ed98444324" // v0.1.0
+	ArgoCDDefaultExportJobVersion = "sha256:1e708f786cffc444ebbcb1ecfc4188a2a1cd3c333bdaab60c69f5a86858587cb" // dev-485
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -17,8 +17,9 @@ package argocdexport
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1b1 "k8s.io/api/batch/v1beta1"

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -16,6 +16,8 @@ package argocdexport
 
 import (
 	"context"
+	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -162,7 +164,7 @@ func newCronJob(cr *argoprojv1a1.ArgoCDExport) *batchv1b1.CronJob {
 	}
 }
 
-func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport) corev1.PodSpec {
+func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string) corev1.PodSpec {
 	pod := corev1.PodSpec{}
 
 	pod.Containers = []corev1.Container{{
@@ -175,23 +177,32 @@ func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport) corev1.PodSpec {
 	}}
 
 	pod.RestartPolicy = corev1.RestartPolicyOnFailure
-	pod.ServiceAccountName = "argocd-application-controller"
+	pod.ServiceAccountName = fmt.Sprintf("%s-%s", argocdName, "argocd-application-controller")
 	pod.Volumes = []corev1.Volume{
 		getArgoStorageVolume("backup-storage", cr),
 		getArgoSecretVolume("secret-storage", cr),
 	}
 
+	// Configure runAsUser, runAsGroup and fsGroup so that the job can write to the PV
+	// 999 is the uid/gid of the argocd user that the container runs as
+	id := int64(999)
+	pod.SecurityContext = &corev1.PodSecurityContext{
+		RunAsUser:  &id,
+		RunAsGroup: &id,
+		FSGroup:    &id,
+	}
+
 	return pod
 }
 
-func newPodTemplateSpec(cr *argoprojv1a1.ArgoCDExport) corev1.PodTemplateSpec {
+func newPodTemplateSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
 			Labels:    common.DefaultLabels(cr.Name),
 		},
-		Spec: newExportPodSpec(cr),
+		Spec: newExportPodSpec(cr, argocdName),
 	}
 }
 
@@ -212,8 +223,15 @@ func (r *ReconcileArgoCDExport) reconcileCronJob(cr *argoprojv1a1.ArgoCDExport) 
 
 	cj.Spec.Schedule = *cr.Spec.Schedule
 
+	// To create the job, we need the name of the argocd instance.  Although the argocd export cr contains a field with
+	// the argocd instance name, it's never used anywhere, and so there may be existing argocd export resources with the
+	// wrong name. To avoid these breaking, we look up the name of the argocd instance in the namespace of the export cr.
+	argocdName, err := r.argocdName(cr.Namespace)
+	if err != nil {
+		return err
+	}
 	job := newJob(cr)
-	job.Spec.Template = newPodTemplateSpec(cr)
+	job.Spec.Template = newPodTemplateSpec(cr, argocdName)
 
 	cj.Spec.JobTemplate.Spec = job.Spec
 
@@ -239,10 +257,29 @@ func (r *ReconcileArgoCDExport) reconcileJob(cr *argoprojv1a1.ArgoCDExport) erro
 		return nil // Job not complete, move along...
 	}
 
-	job.Spec.Template = newPodTemplateSpec(cr)
+	// To create the job, we need the name of the argocd instance.  Although the argocd export cr contains a field with
+	// the argocd instance name, it's never used anywhere, and so there may be existing argocd export resources with the
+	// wrong name. To avoid these breaking, we look up the name of the argocd instance in the namespace of the export cr.
+	argocdName, err := r.argocdName(cr.Namespace)
+	if err != nil {
+		return err
+	}
+	job.Spec.Template = newPodTemplateSpec(cr, argocdName)
 
 	if err := controllerutil.SetControllerReference(cr, job, r.Scheme); err != nil {
 		return err
 	}
 	return r.Client.Create(context.TODO(), job)
+}
+
+func (r *ReconcileArgoCDExport) argocdName(namespace string) (string, error) {
+	argocds := &argoprojv1a1.ArgoCDList{}
+	if err := r.Client.List(context.TODO(), argocds, &client.ListOptions{Namespace: namespace}); err != nil {
+		return "", err
+	}
+	if len(argocds.Items) != 1 {
+		return "", fmt.Errorf("No Argo CD instance found in namespace %s", namespace)
+	}
+	argocd := argocds.Items[0]
+	return argocd.Name, nil
 }

--- a/tests/e2e/argocd-tests/04-assert.yaml
+++ b/tests/e2e/argocd-tests/04-assert.yaml
@@ -1,0 +1,19 @@
+# Increase the timeout for this test because it needs to download
+# a large container image
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 720
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: example-argocdexport
+status:
+  succeeded: 1

--- a/tests/e2e/argocd-tests/04-export.yaml
+++ b/tests/e2e/argocd-tests/04-export.yaml
@@ -1,0 +1,27 @@
+# Delete previous cluster
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: argoproj.io/v1alpha1
+  kind: ArgoCD
+  name: example-argocd
+commands:
+  # Sleep to allow resources to be completely deleted
+  - command: sleep 30s
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: export
+spec: {}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCDExport
+metadata:
+  name: example-argocdexport
+  labels:
+    example: basic
+spec:
+  argocd: example-argocd


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:

Fixes the export function of the argocd operator

There were three problems that required fixing

1. The name of the service account has changed.  It is now prefixed by the name of the argocd instance it belongs to.
2. The argocd command to invoke the export function has changed from `argocd-util export` to `argocd admin export`
3. On OpenShift, the SCC that OpenShift assigns to the export job pod has changed from `restricted` to `anyuid`.  The effect of this is that the pod no longer has permissions to write the export data to the PV.  The fix for this is to specify the correct `runAsUser`, `runaAsGroup` and `fsGroup` values for the export job pod.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #485

**How to test changes / Special notes to the reviewer**:

Install the operator, create an argocd instance, create an argocdexport resource in the same namespace, ensure that the job pod completes successfully and that the logs indicate all went well, for example
```
% kubectl logs -n argocd example-argocdexport-hzwtw 
exporting argo-cd
creating argo-cd backup
encrypting argo-cd backup
argo-cd export complete
```
