### PR TITLE
chore:  simplify env merge logic

### DIFF
--- a/controllers/argoutil/env.go
+++ b/controllers/argoutil/env.go
@@ -25,16 +25,15 @@ func EnvMerge(existing []corev1.EnvVar, merge []corev1.EnvVar, override bool) []
 		}
 	}
 
-	// sort final by keys
-	keys := make([]string, 0, len(final))
-	for k := range final {
-		keys = append(keys, k)
+	for _, v := range final {
+		ret = append(ret, v)
 	}
-	sort.Strings(keys)
 
-	for _, v := range keys {
-		ret = append(ret, final[v])
-	}
+	// sort result slice by env name
+	sort.SliceStable(ret,
+		func(i, j int) bool {
+			return ret[i].Name < ret[j].Name
+		})
 
 	return ret
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
/kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
https://github.com/argoproj-labs/argocd-operator/pull/467 introduced environment merge logic that should be simplified.
* eliminated an unnecessary for-loop
* use go library sort function

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
Test covered by env_test.go
