### PR TITLE
fix: crash when no .data exists in argocd-secret

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -306,6 +306,10 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 				return err
 			}
 
+			if secret.Data == nil {
+				secret.Data = make(map[string][]byte)
+			}
+
 			secret.Data[common.ArgoCDKeyAdminPassword] = []byte(hashedPassword)
 			secret.Data[common.ArgoCDKeyAdminPasswordMTime] = nowBytes()
 			changed = true


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
Previously when a user deleted the information under `.data` in argocd-secret, an error would occur that caused pods to crash (error was from an `assignment to entry in nil map`). This PR adds a check that will see if `.data == nil`, and if it is, it will repopulate it with new data. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR. 
* [ ] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

Verifying the error behavior: 
- checkout to recent version of master branch `git checkout master`
- Run `make docker-build`, `make docker-push` and login to a cluster and then run `make deploy`
- Add the Argo CD instance: 
```
cat <<EOF | kubectl apply -f -                                                                    
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: argocd
spec: {}
EOF                 
```
- go to OpenShift console and under Administrator View, set namespace as `default` and navigate to Secrets > `argocd-secret`. View the yaml for this secret and delete the entire `.data` section, then save. You should be able to see that the secret remains missing (ie, this section does not regenerate), and if you navigate to Workloads > Deployments in the `argocd-operator-system` namspace, the pod `argocd-operator-controller-manager` has crashed. 

Testing the fix: 
- checkout to this PR
- Go to Makefile and change the version # (just to something else) and change image base tag to `IMAGE_TAG_BASE ?= quay.io/{your quay or docker username}/argocd-operator`
- Run `make docker-build`, `make docker-push` and `make deploy` again
- go back to the OpenShift console and still under Administrator View, set namespace as `default` and go again to Secrets > `argocd-secret`
- add the argocd instance again, and try deleting the secret again the same way as before. This time when you delete it and hit save, you should see that the secret regenerates and when inspecting the deployment `argocd-operator-controller-manager` you will see that it hasn't crashed like before. 