### PR TITLE
fix: fix broken argocd export (cherry-pick to master) (#490)

### DIFF
--- a/build/util/util.sh
+++ b/build/util/util.sh
@@ -32,7 +32,7 @@ export_argocd () {
 
 create_backup () {
     echo "creating argo-cd backup"
-    argocd-util export > ${BACKUP_EXPORT_LOCATION}
+    argocd admin export > ${BACKUP_EXPORT_LOCATION}
 }
 
 encrypt_backup () {
@@ -148,7 +148,7 @@ decrypt_backup () {
 
 load_backup () {
     echo "loading argo-cd backup"
-    argocd-util import - < ${BACKUP_EXPORT_LOCATION}
+    argocd admin import - < ${BACKUP_EXPORT_LOCATION}
 }
 
 usage () {

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -113,7 +113,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/argoprojlabs/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:0c779eea3f08ffa75fe9d06852b9ab7aed445cb5ac96831c2429b0ed98444324" // v0.1.0
+	ArgoCDDefaultExportJobVersion = "sha256:1e708f786cffc444ebbcb1ecfc4188a2a1cd3c333bdaab60c69f5a86858587cb" // dev-485
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"

--- a/tests/e2e/argocd-tests/04-assert.yaml
+++ b/tests/e2e/argocd-tests/04-assert.yaml
@@ -1,0 +1,19 @@
+# Increase the timeout for this test because it needs to download
+# a large container image
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 720
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: example-argocdexport
+status:
+  succeeded: 1

--- a/tests/e2e/argocd-tests/04-export.yaml
+++ b/tests/e2e/argocd-tests/04-export.yaml
@@ -1,0 +1,27 @@
+# Delete previous cluster
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: argoproj.io/v1alpha1
+  kind: ArgoCD
+  name: example-argocd
+commands:
+  # Sleep to allow resources to be completely deleted
+  - command: sleep 30s
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: export
+spec: {}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCDExport
+metadata:
+  name: example-argocdexport
+  labels:
+    example: basic
+spec:
+  argocd: example-argocd


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:

Fixes the export function of the argocd operator Cherry picks the fix for this bug from the release-0.1 branch to master.

There were three problems that required fixing

1. The name of the service account has changed.  It is now prefixed by the name of the argocd instance it belongs to.
2. The argocd command to invoke the export function has changed from `argocd-util export` to `argocd admin export`
3. On OpenShift, the SCC that OpenShift assigns to the export job pod has changed from `restricted` to `anyuid`.  The effect of this is that the pod no longer has permissions to write the export data to the PV.  The fix for this is to specify the correct `runAsUser`, `runaAsGroup` and `fsGroup` values for the export job pod.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #485

**How to test changes / Special notes to the reviewer**:

Install the operator, create an argocd instance, create an argocdexport resource in the same namespace, ensure that the job pod completes successfully and that the logs indicate all went well, for example
```
% kubectl logs -n argocd example-argocdexport-hzwtw 
exporting argo-cd
creating argo-cd backup
encrypting argo-cd backup
argo-cd export complete
```
