### PR TITLE
add route/ingress URL to .status

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -702,6 +702,9 @@ type ArgoCDStatus struct {
 
 	// RepoTLSChecksum contains the SHA256 checksum of the latest known state of tls.crt and tls.key in the argocd-repo-server-tls secret.
 	RepoTLSChecksum string `json:"repoTLSChecksum,omitempty"`
+
+	// Host is the hostname of the Ingress.
+	Host string `json:"host,omitempty"`
 }
 
 // ArgoCDTLSSpec defines the TLS options for ArgCD.

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -4354,6 +4354,9 @@ spec:
                   of the  Argo CD Dex component Pods had a failure. Unknown: For some
                   reason the state of the Argo CD Dex component could not be obtained.'
                 type: string
+              host:
+                description: Host is the hostname of the Ingress.
+                type: string
               phase:
                 description: 'Phase is a simple, high-level summary of where the ArgoCD
                   is in its lifecycle. There are five possible phase values: Pending:

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -4356,6 +4356,9 @@ spec:
                   of the  Argo CD Dex component Pods had a failure. Unknown: For some
                   reason the state of the Argo CD Dex component could not be obtained.'
                 type: string
+              host:
+                description: Host is the hostname of the Ingress.
+                type: string
               phase:
                 description: 'Phase is a simple, high-level summary of where the ArgoCD
                   is in its lifecycle. There are five possible phase values: Pending:

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -17,6 +17,10 @@ package argocd
 import (
 	"context"
 	"reflect"
+	"strings"
+
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
@@ -51,6 +55,11 @@ func (r *ReconcileArgoCD) reconcileStatus(cr *argoprojv1a1.ArgoCD) error {
 	if err := r.reconcileStatusServer(cr); err != nil {
 		return err
 	}
+
+	if err := r.reconcileStatusHost(cr); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -211,4 +220,71 @@ func (r *ReconcileArgoCD) reconcileStatusServer(cr *argoprojv1a1.ArgoCD) error {
 		return r.Client.Status().Update(context.TODO(), cr)
 	}
 	return nil
+}
+
+// reconcileStatusHost will ensure that the host status is updated for the given ArgoCD.
+func (r *ReconcileArgoCD) reconcileStatusHost(cr *argoprojv1a1.ArgoCD) error {
+	cr.Status.Host = ""
+	cr.Status.Phase = "Available"
+	if cr.Spec.Server.Route.Enabled {
+		if !IsRouteAPIAvailable() {
+			log.Info("Routes not available in non-OpenShift environments, please use Ingresses instead")
+			return nil
+		}
+		route := newRouteWithSuffix("server", cr)
+		if !argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route) {
+			log.Info("argocd-server route requested but not found on cluster")
+			return nil
+		} else {
+			// status.ingress not available
+			if route.Status.Ingress == nil {
+				cr.Status.Host = ""
+				cr.Status.Phase = "Pending"
+			} else {
+				// conditions exist and type is RouteAdmitted
+				if len(route.Status.Ingress[0].Conditions) > 0 && route.Status.Ingress[0].Conditions[0].Type == routev1.RouteAdmitted {
+					if route.Status.Ingress[0].Conditions[0].Status == corev1.ConditionTrue {
+						cr.Status.Host = route.Status.Ingress[0].Host
+						cr.Status.Phase = "Available"
+					} else {
+						cr.Status.Host = ""
+						cr.Status.Phase = "Pending"
+					}
+				} else {
+					// no conditions are available
+					if route.Status.Ingress[0].Host != "" {
+						cr.Status.Host = route.Status.Ingress[0].Host
+						cr.Status.Phase = "Available"
+					} else {
+						cr.Status.Host = "Unavailable"
+						cr.Status.Phase = "Pending"
+					}
+				}
+			}
+		}
+	} else if cr.Spec.Server.Ingress.Enabled {
+		ingress := newIngressWithSuffix("server", cr)
+		if !argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
+			log.Info("argocd-server ingress requested but not found on cluster")
+			return nil
+		} else {
+			if !reflect.DeepEqual(ingress.Status.LoadBalancer, corev1.LoadBalancerStatus{}) && len(ingress.Status.LoadBalancer.Ingress) > 0 {
+				var s []string
+				var hosts string
+				for _, ingressElement := range ingress.Status.LoadBalancer.Ingress {
+					if ingressElement.Hostname != "" {
+						s = append(s, ingressElement.Hostname)
+						continue
+					} else if ingressElement.IP != "" {
+						s = append(s, ingressElement.IP)
+						continue
+					}
+				}
+				hosts = strings.Join(s, ", ")
+				cr.Status.Host = hosts
+				cr.Status.Phase = "Available"
+			}
+		}
+	}
+	return r.Client.Status().Update(context.TODO(), cr)
 }

--- a/controllers/argocd/status_test.go
+++ b/controllers/argocd/status_test.go
@@ -1,9 +1,17 @@
 package argocd
 
 import (
+	"context"
 	"testing"
 
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -42,4 +50,115 @@ func TestReconcileArgoCD_reconcileStatusSSOConfig_no_sso_configured(t *testing.T
 	r := makeTestReconciler(t, a)
 	assert.NoError(t, r.reconcileStatusSSOConfig(a))
 	assert.Equal(t, a.Status.SSOConfig, "Unknown")
+}
+
+func TestReconcileArgoCD_reconcileStatusHost(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	tests := []struct {
+		name              string
+		routeEnabled      bool
+		testRouteAPIFound bool
+		ingressEnabled    bool
+		expectedNil       bool
+		expectedHost      bool
+		host              string
+		phase             string
+	}{
+		{
+			name:              "",
+			routeEnabled:      true,
+			testRouteAPIFound: true,
+			ingressEnabled:    false,
+			expectedNil:       false,
+			host:              "argocd",
+			phase:             "Available",
+		},
+		{
+			name:              "",
+			routeEnabled:      false,
+			testRouteAPIFound: false,
+			ingressEnabled:    true,
+			expectedNil:       false,
+			host:              "argocd, 12.0.0.5",
+			phase:             "Available",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			routeAPIFound = test.testRouteAPIFound
+
+			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+				a.Spec.Server.Route.Enabled = test.routeEnabled
+				a.Spec.Server.Ingress.Enabled = test.ingressEnabled
+			})
+
+			objs := []runtime.Object{
+				a,
+			}
+
+			route := &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testArgoCDName + "-server",
+					Namespace: testNamespace,
+				},
+				Spec: routev1.RouteSpec{
+					Host: "argocd",
+				},
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Host: "argocd",
+							Conditions: []routev1.RouteIngressCondition{
+								{
+									Type:   routev1.RouteAdmitted,
+									Status: "True",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ingress := &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testArgoCDName + "-server",
+					Namespace: testNamespace,
+				},
+				Status: networkingv1.IngressStatus{
+					LoadBalancer: v1.LoadBalancerStatus{
+						Ingress: []v1.LoadBalancerIngress{
+							{
+								IP:       "12.0.0.1",
+								Hostname: "argocd",
+								Ports:    []v1.PortStatus{},
+							},
+							{
+								IP:       "12.0.0.5",
+								Hostname: "",
+							},
+						},
+					},
+				},
+			}
+
+			r := makeReconciler(t, a, objs...)
+			if test.routeEnabled {
+				err := r.Client.Create(context.TODO(), route)
+				assert.NoError(t, err)
+
+			} else if test.ingressEnabled {
+				err := r.Client.Create(context.TODO(), ingress)
+				assert.NoError(t, err)
+				assert.NotEqual(t, "Pending", a.Status.Phase)
+			}
+
+			err := r.reconcileStatusHost(a)
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.host, a.Status.Host)
+			assert.Equal(t, test.phase, a.Status.Phase)
+		})
+	}
 }

--- a/deploy/olm-catalog/argocd-operator/0.2.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.2.0/argoproj.io_argocds.yaml
@@ -4354,6 +4354,9 @@ spec:
                   of the  Argo CD Dex component Pods had a failure. Unknown: For some
                   reason the state of the Argo CD Dex component could not be obtained.'
                 type: string
+              host:
+                description: Host is the hostname of the Ingress.
+                type: string
               phase:
                 description: 'Phase is a simple, high-level summary of where the ArgoCD
                   is in its lifecycle. There are five possible phase values: Pending:

--- a/docs/reference/api.html.md
+++ b/docs/reference/api.html.md
@@ -2214,6 +2214,17 @@ Failed: At least one of the  Argo CD server component Pods had a failure.
 Unknown: For some reason the state of the Argo CD server component could not be obtained.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>url</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>URL is the url for the hostname to use for Ingress/Route resources</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="argoproj.io/v1alpha1.ArgoCDTLSSpec">ArgoCDTLSSpec

--- a/tests/e2e/argocd-tests/02-ingress-available.yaml
+++ b/tests/e2e/argocd-tests/02-ingress-available.yaml
@@ -29,3 +29,24 @@ spec:
     ingress:
       enabled: true
     insecure: true
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-argocd-server
+spec:
+  rules:
+  - host: argocd
+    http:
+      paths:
+      - backend:
+          service:
+            name: argocd-server
+            port:
+              name: http
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - argocd
+    secretName: argocd-secret


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement

**What does this PR do / why we need it**:
This would add a new field, `.host`, to `.status` of `ArgoCD`. When route or ingress is enabled (priority given to route) then the route will be displayed in the new URL field. 

When no URL exists from a route or ingress, the field will not be displayed. 

When on a non-OpenShift cluster (meaning the Route API is not available), if the user chooses to enable Route, they will only get a log saying that Routes are not available in non-OpenShift environments and to please use Ingresses instead. The state of the application controller and of the URL will not be affected. 

When the route or ingress is configured, but the corresponding controller has not yet set it up properly (i.e. is not in Ready state or does not propagate its URL), this is indicated in the Operand as well in the value of `.status.url` as Pending instead of the URL. Also, if `.status.url` is Pending, this affects the overall status for the Operand by making it Pending instead of Available.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes #246 

**How to test changes / Special notes to the reviewer**:
Note: this was tested with an OpenShift cluster
1. Get cluster and log in.

2. In your cloned repo on this branch, go to Makefile and change the version # (just to something else) and change image base tag to `IMAGE_TAG_BASE ?= quay.io/{your quay or docker username}/argocd-operator`. Then run `make docker-build`, `make docker-push`and login to a cluster and then run `make deploy`
3. Add the Argo CD instance:
```
cat <<EOF | kubectl apply -f -                                                                    
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: argocd
spec: {}
EOF   
```
4. Edit the ArgoCD instance so that ingress and route (or at least just route if you're on an OpenShift cluster) is enabled with `oc edit argocd argocd`. `spec.server` should look something like: 
```
  server:
    autoscale:
      enabled: false
    grpc:
      ingress:
        enabled: false
    ingress:
      enabled: true
    route:
      enabled: true
    service:
      type: ""
  tls:
    ca: {}
```
Save your changes. 
5. Wait a second for it to update, and then check back on your CR `oc get argocd argocd -o yaml`. You should see that the URL has been added to the `.status` field. 
```
status:
  applicationController: Running
  dex: Running
  phase: Available
  redis: Running
  repo: Running
  server: Running
  ssoConfig: Unknown
  host: argocd-server-default.apps.app-svc-4.8-120914.devcluster.openshift.com
```
