### PR TITLE
fix: managed namespace not getting properly removed from argocd instance cluster secret 

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1085,6 +1085,13 @@ func namespaceFilterPredicate() predicate.Predicate {
 					} else {
 						log.Info(fmt.Sprintf("Successfully removed the RBACs for namespace: %s", e.ObjectOld.GetName()))
 					}
+
+					// Delete namespace from cluster secret of previously managing argocd instance
+					if err = deleteManagedNamespaceFromClusterSecret(valOld, e.ObjectOld.GetName(), k8sClient); err != nil {
+						log.Error(err, fmt.Sprintf("unable to delete namespace %s from cluster secret", e.ObjectOld.GetName()))
+					} else {
+						log.Info(fmt.Sprintf("Successfully deleted namespace %s from cluster secret", e.ObjectOld.GetName()))
+					}
 				}
 				return true
 			}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
fixes a bug where a managed namespace was not being removed from the managing argocd instance's cluster secret after that namespace was updated to be managed by a different argocd instance 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-1644

**How to test changes / Special notes to the reviewer**:

1. Install Gitops-operator 
2. Create namespaces: `test-target`, `test-argo1`, `test-argo2`
3. Label `test-target` with `argocd.argoproj.io/managed-by=test-argo1`
4. Create ns-scoped argocd instances in `test-argo1` and `test-argo2`
5. Create sample application in `test-argo1`:
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: guestbook
  namespace: test-argo1
spec:
  project: default
  source:
    repoURL: https://github.com/redhat-developer/gitops-operator
    path: ./test/examples/nginx
    targetRevision: HEAD
  destination:
    server: https://kubernetes.default.svc
    namespace: test-target
  syncPolicy:
    automated: {}
    retry:
      limit: 1

```
6. Check that `guestbook` app in `test-argo1` is "healthy" and "synced" 
7. Create `guestbook` app in `test-argo2`
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: guestbook
  namespace: test-argo2
spec:
  project: default
  source:
    repoURL: https://github.com/redhat-developer/gitops-operator
    path: ./test/examples/nginx
    targetRevision: HEAD
  destination:
    server: https://kubernetes.default.svc
    namespace: test-target
  syncPolicy:
    automated: {}
    retry:
      limit: 1

```
8. Update label on `test-target` ns to: `arogcd.argoproj.io/managed-by=test-argo2`
9. Refresh `guestbook` app in `test-argo1`
10. Check that `guestbook` app in `test-argo1` is now "missing" and "unknown" and that `guestbook` app in `test-argo2` is now "healthy" and "synced"