### PR TITLE
feat: Support for custom roles using env variables

### DIFF
--- a/common/keys.go
+++ b/common/keys.go
@@ -210,4 +210,10 @@ const (
 
 	// ArgoCDManagedByLabel is needed to identify namespace managed by an instance on ArgoCD
 	ArgoCDManagedByLabel = "argocd.argoproj.io/managed-by"
+
+	// ArgoCDControllerClusterRoleEnvName is an environment variable to specify a custom cluster role for Argo CD application controller
+	ArgoCDControllerClusterRoleEnvName = "CONTROLLER_CLUSTER_ROLE"
+
+	// ArgoCDServerClusterRoleEnvName is an environment variable to specify a custom cluster role for Argo CD server
+	ArgoCDServerClusterRoleEnvName = "SERVER_CLUSTER_ROLE"
 )

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -104,11 +104,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 
 	// create policy rules for each namespace
 	for _, namespace := range namespaces.Items {
-		var useCustomRole bool
-		if customRole := getCustomRoleName(name); customRole != "" {
-			useCustomRole = true
-		}
-
+		customRole := getCustomRoleName(name)
 		role := newRole(name, policyRules, cr)
 		if err := applyReconcilerHook(cr, role, ""); err != nil {
 			return nil, err
@@ -120,7 +116,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 			if !errors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to reconcile the role for the service account associated with %s : %s", name, err)
 			}
-			if useCustomRole {
+			if customRole != "" {
 				continue // skip creating default role if custom cluster role is provided
 			}
 			roles = append(roles, role)
@@ -140,7 +136,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 			continue
 		}
 
-		if useCustomRole {
+		if customRole != "" {
 			// Delete the existing default role if custom role is specified
 			if err := r.Client.Delete(context.TODO(), &existingRole); err != nil {
 				return nil, err

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -8,6 +8,7 @@ import (
 
 	"gotest.tools/assert"
 	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -124,4 +125,44 @@ func TestReconcileArgoCD_RoleHooks(t *testing.T) {
 	role = roles[0]
 	assert.NilError(t, err)
 	assert.DeepEqual(t, role.Rules, []v1.PolicyRule{})
+}
+
+func TestReconcileArgoCD_reconcileRole_custom_role(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+	assert.NilError(t, createNamespace(r, a.Namespace, ""))
+	assert.NilError(t, createNamespace(r, "namespace-custom-role", a.Namespace))
+
+	workloadIdentifier := "argocd-application-controller"
+	expectedRules := policyRuleForApplicationController()
+	_, err := r.reconcileRole(workloadIdentifier, expectedRules, a)
+	assert.NilError(t, err)
+
+	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
+	reconciledRole := &v1.Role{}
+	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.DeepEqual(t, expectedRules, reconciledRole.Rules)
+
+	// check if roles are created for the new namespace as well
+	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "namespace-custom-role"}, reconciledRole))
+	assert.DeepEqual(t, expectedRules, reconciledRole.Rules)
+
+	// set the custom role as env variable
+	assert.NilError(t, os.Setenv(common.ArgoCDControllerClusterRoleEnvName, "custom-role"))
+	defer os.Unsetenv(common.ArgoCDControllerClusterRoleEnvName)
+
+	_, err = r.reconcileRole(workloadIdentifier, expectedRules, a)
+	assert.NilError(t, err)
+
+	// check if the default cluster roles are removed
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
+	if err == nil || !errors.IsNotFound(err) {
+		t.Fatal(err)
+	}
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "namespace-custom-role"}, reconciledRole)
+	if err == nil || !errors.IsNotFound(err) {
+		t.Fatal(err)
+	}
 }

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
@@ -87,22 +88,33 @@ func (r *ReconcileArgoCD) reconcileRoleBindings(cr *argoprojv1a1.ArgoCD) error {
 // reconcileRoleBinding, creates RoleBindings for every role and associates it with the right ServiceAccount.
 // This would create RoleBindings for all the namespaces managed by the ArgoCD instance.
 func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
-	var roles []*v1.Role
 	var sa *corev1.ServiceAccount
 	var error error
+
+	namespaces := corev1.NamespaceList{}
+	listOption := client.MatchingLabels{
+		common.ArgoCDManagedByLabel: cr.Namespace,
+	}
+
+	// get the list of namespaces managed by the ArgoCD instance
+	if err := r.Client.List(context.TODO(), &namespaces, listOption); err != nil {
+		return err
+	}
+
+	namespaces.Items = append(namespaces.Items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cr.Namespace}})
 
 	if sa, error = r.reconcileServiceAccount(name, cr); error != nil {
 		return error
 	}
 
-	if roles, error = r.reconcileRole(name, rules, cr); error != nil {
+	if _, error = r.reconcileRole(name, rules, cr); error != nil {
 		return error
 	}
 
-	for _, role := range roles {
+	for _, namespace := range namespaces.Items {
 		// get expected name
 		roleBinding := newRoleBindingWithname(name, cr)
-		roleBinding.Namespace = role.Namespace
+		roleBinding.Namespace = namespace.Name
 
 		// fetch existing rolebinding by name
 		existingRoleBinding := &v1.RoleBinding{}
@@ -125,10 +137,20 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 				Namespace: sa.Namespace,
 			},
 		}
-		roleBinding.RoleRef = v1.RoleRef{
-			APIGroup: v1.GroupName,
-			Kind:     "Role",
-			Name:     role.Name,
+
+		customRoleName := getCustomRoleName(name)
+		if customRoleName != "" {
+			roleBinding.RoleRef = v1.RoleRef{
+				APIGroup: v1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     customRoleName,
+			}
+		} else {
+			roleBinding.RoleRef = v1.RoleRef{
+				APIGroup: v1.GroupName,
+				Kind:     "Role",
+				Name:     generateResourceName(name, cr),
+			}
 		}
 
 		if roleBindingExists {
@@ -141,7 +163,7 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 			}
 
 			// if the RoleRef changes, delete the existing role binding and create a new one
-			if !reflect.DeepEqual(roleBinding.RoleRef, existingRoleBinding.RoleRef) {
+			if customRoleName != "" || !reflect.DeepEqual(roleBinding.RoleRef, existingRoleBinding.RoleRef) {
 				if err = r.Client.Delete(context.TODO(), existingRoleBinding); err != nil {
 					return err
 				}
@@ -165,6 +187,16 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 		}
 	}
 	return nil
+}
+
+func getCustomRoleName(name string) string {
+	if name == applicationController {
+		return os.Getenv(common.ArgoCDControllerClusterRoleEnvName)
+	}
+	if name == server {
+		return os.Getenv(common.ArgoCDServerClusterRoleEnvName)
+	}
+	return ""
 }
 
 func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.ClusterRole, sa *corev1.ServiceAccount, cr *argoprojv1a1.ArgoCD) error {

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -163,7 +163,7 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 			}
 
 			// if the RoleRef changes, delete the existing role binding and create a new one
-			if customRoleName != "" || !reflect.DeepEqual(roleBinding.RoleRef, existingRoleBinding.RoleRef) {
+			if !reflect.DeepEqual(roleBinding.RoleRef, existingRoleBinding.RoleRef) {
 				if err = r.Client.Delete(context.TODO(), existingRoleBinding); err != nil {
 					return err
 				}

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -104,35 +104,43 @@ func TestReconcileArgoCD_reconcileRoleBinding_custom_role(t *testing.T) {
 	assert.NilError(t, createNamespace(r, a.Namespace, ""))
 
 	workloadIdentifier := "argocd-application-controller"
-	roleBinding := &rbacv1.RoleBinding{}
 	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
-
-	expectedRoleRef := rbacv1.RoleRef{
-		APIGroup: rbacv1.GroupName,
-		Kind:     "ClusterRole",
-		Name:     "custom-role",
-	}
 
 	namespaceWithCustomRole := "namespace-with-custom-role"
 	assert.NilError(t, createNamespace(r, namespaceWithCustomRole, a.Namespace))
 	assert.NilError(t, r.reconcileRoleBinding(workloadIdentifier, p, a))
 
 	// check if the default rolebindings are created
-	roleBinding = &rbacv1.RoleBinding{}
-	expectedName = fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
-	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, roleBinding))
+	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, &rbacv1.RoleBinding{}))
 
-	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: namespaceWithCustomRole}, roleBinding))
+	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: namespaceWithCustomRole}, &rbacv1.RoleBinding{}))
 
-	// specify the custom cluster role
-	assert.NilError(t, os.Setenv(common.ArgoCDControllerClusterRoleEnvName, "custom-role"))
+	checkForUpdatedRoleRef := func(t *testing.T, roleName, expectedName string) {
+		t.Helper()
+		expectedRoleRef := rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		}
+		roleBinding := &rbacv1.RoleBinding{}
+		assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, roleBinding))
+		assert.DeepEqual(t, roleBinding.RoleRef, expectedRoleRef)
+
+		assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: namespaceWithCustomRole}, roleBinding))
+		assert.DeepEqual(t, roleBinding.RoleRef, expectedRoleRef)
+	}
+
+	assert.NilError(t, os.Setenv(common.ArgoCDControllerClusterRoleEnvName, "custom-controller-role"))
 	defer os.Unsetenv(common.ArgoCDControllerClusterRoleEnvName)
-	assert.NilError(t, r.reconcileRoleBinding(workloadIdentifier, p, a))
+	assert.NilError(t, r.reconcileRoleBinding(applicationController, p, a))
 
-	// check if the role ref is updated with cluster role
-	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, roleBinding))
-	assert.DeepEqual(t, roleBinding.RoleRef, expectedRoleRef)
+	expectedName = fmt.Sprintf("%s-%s", a.Name, "argocd-application-controller")
+	checkForUpdatedRoleRef(t, "custom-controller-role", expectedName)
 
-	assert.NilError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: namespaceWithCustomRole}, roleBinding))
-	assert.DeepEqual(t, roleBinding.RoleRef, expectedRoleRef)
+	assert.NilError(t, os.Setenv(common.ArgoCDServerClusterRoleEnvName, "custom-server-role"))
+	defer os.Unsetenv(common.ArgoCDServerClusterRoleEnvName)
+	assert.NilError(t, r.reconcileRoleBinding("argocd-server", p, a))
+
+	expectedName = fmt.Sprintf("%s-%s", a.Name, "argocd-server")
+	checkForUpdatedRoleRef(t, "custom-server-role", expectedName)
 }

--- a/docs/usage/custom_roles.md
+++ b/docs/usage/custom_roles.md
@@ -1,0 +1,40 @@
+# Custom Roles
+
+Admins can configure a common cluster role for all the Argo CD instances running on a cluster by specifying them in environment variables. The operator looks for the environment variable `CONTROLLER_CLUSTER_ROLE` for argocd application controller and `SERVER_CLUSTER_ROLE` for argocd server and refers them in role bindings. In the presence of custom roles, the operator will not create the default role and uses the existing custom role for every Argo CD instance. We can inject these environment variables either in the Subscription OLM object or directly into the operator deployment.
+
+Example: Custom role environment variables in operator Subscription:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: argocd-operator
+  namespace: argocd
+spec:
+  config:
+    env:
+    - name: CONTROLLER_CLUSTER_ROLE
+      value: custom-controller-role
+    - name: SERVER_CLUSTER_ROLE
+      value: custom-server-role
+```
+
+Example: Custom role environment variables in operator Deployment:
+
+```yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: argocd-operator-controller-manager
+  namespace: argocd
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+          env:
+          - name: CONTROLLER_CLUSTER_ROLE
+            value: custom-controller-role
+          - name: SERVER_CLUSTER_ROLE
+            value: custom-server-role
+```


### PR DESCRIPTION
Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>

**What type of PR is this?**
> /kind enhancement


**What does this PR do / why we need it**:
1. Introduces the env variables `CONTROLLER_CLUSTER_ROLE` and `SERVER_CLUSTER_ROLE` for specifying the cluster roles for application controller and server respectively.
2. If these env variables are found, the operator will use these roles in the bindings and delete the existing default roles.
3. These roles will be applied to all the namespaces where Argo CD is running or managed by Argo CD using the managed-by label

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.


**How to test changes / Special notes to the reviewer**:
1. Run the operator locally and create multiple Argo CD instances
2. Add the env variables `CONTROLLER_CLUSTER_ROLE` and `SERVER_CLUSTER_ROLE` 
3. Check if the default roles are deleted in all the namespaces
4. Check if the role bindings have an updated role ref i.e. it should refer to a cluster role instead of a role