### PR TITLE
Filter managed namespaces only once per reconciliation

### DIFF
--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -91,18 +91,6 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 	var sa *corev1.ServiceAccount
 	var error error
 
-	namespaces := corev1.NamespaceList{}
-	listOption := client.MatchingLabels{
-		common.ArgoCDManagedByLabel: cr.Namespace,
-	}
-
-	// get the list of namespaces managed by the ArgoCD instance
-	if err := r.Client.List(context.TODO(), &namespaces, listOption); err != nil {
-		return err
-	}
-
-	namespaces.Items = append(namespaces.Items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cr.Namespace}})
-
 	if sa, error = r.reconcileServiceAccount(name, cr); error != nil {
 		return error
 	}
@@ -111,7 +99,7 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 		return error
 	}
 
-	for _, namespace := range namespaces.Items {
+	for _, namespace := range r.ManagedNamespaces.Items {
 		// get expected name
 		roleBinding := newRoleBindingWithname(name, cr)
 		roleBinding.Namespace = namespace.Name

--- a/controllers/argocd/testing.go
+++ b/controllers/argocd/testing.go
@@ -294,5 +294,10 @@ func createNamespace(r *ReconcileArgoCD, n string, managedBy string) error {
 		ns.Labels = map[string]string{common.ArgoCDManagedByLabel: managedBy}
 	}
 
+	if r.ManagedNamespaces == nil {
+		r.ManagedNamespaces = &corev1.NamespaceList{}
+	}
+	r.ManagedNamespaces.Items = append(r.ManagedNamespaces.Items, *ns)
+
 	return r.Client.Create(context.TODO(), ns)
 }

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -30,6 +30,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
@@ -1261,4 +1262,20 @@ func getLogFormat(logField string) string {
 		return logField
 	}
 	return common.ArgoCDDefaultLogFormat
+}
+
+func (r *ReconcileArgoCD) setManagedNamespaces(cr *argoproj.ArgoCD) error {
+	namespaces := &corev1.NamespaceList{}
+	listOption := client.MatchingLabels{
+		common.ArgoCDManagedByLabel: cr.Namespace,
+	}
+
+	// get the list of namespaces managed by the Argo CD instance
+	if err := r.Client.List(context.TODO(), namespaces, listOption); err != nil {
+		return err
+	}
+
+	namespaces.Items = append(namespaces.Items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cr.Namespace}})
+	r.ManagedNamespaces = namespaces
+	return nil
 }

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -565,3 +565,51 @@ func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {
 		assert.Equal(t, ok, false)
 	}
 }
+
+func TestSetManagedNamespaces(t *testing.T) {
+	a := makeTestArgoCD()
+	nsList := &v1.NamespaceList{
+		Items: []v1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace-1",
+					Labels: map[string]string{
+						common.ArgoCDManagedByLabel: testNamespace,
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace-2",
+					Labels: map[string]string{
+						common.ArgoCDManagedByLabel: testNamespace,
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace-3",
+					Labels: map[string]string{
+						common.ArgoCDManagedByLabel: "random-namespace",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-namespace-4",
+				},
+			},
+		},
+	}
+	r := makeTestReconciler(t, nsList)
+
+	err := r.setManagedNamespaces(a)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(r.ManagedNamespaces.Items), 3)
+	for _, n := range r.ManagedNamespaces.Items {
+		if n.Labels[common.ArgoCDManagedByLabel] != testNamespace && n.Name != testNamespace {
+			t.Errorf("Expected namespace %s to be managed by Argo CD instance %s", n.Name, testNamespace)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind code-refactoring

**What does this PR do / why we need it**:

Filter the list of managed namespaces only once during each reconciliation and reuse them at multiple places. Currently, we list the namespaces while reconciling roles and role bindings. Since RBAC is managed for each argocd component, the operator filters the namespaces more than eight times per reconciliation. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
