### PR TITLE
fix: argocd-tls-certs-cm is overwritten on any change

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -680,17 +680,16 @@ func (r *ReconcileArgoCD) reconcileSSHKnownHosts(cr *argoprojv1a1.ArgoCD) error 
 // reconcileTLSCerts will ensure that the ArgoCD TLS Certs ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileTLSCerts(cr *argoprojv1a1.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDTLSCertsConfigMapName, cr)
-
-	if !argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
-		cm.Data = getInitialTLSCerts(cr)
-		if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
-			return err
-		}
-		return r.Client.Create(context.TODO(), cm)
+	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
+		return nil // ConfigMap found, move along...
 	}
 
 	cm.Data = getInitialTLSCerts(cr)
-	return r.Client.Update(context.TODO(), cm)
+
+	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
+		return err
+	}
+	return r.Client.Create(context.TODO(), cm)
 }
 
 // reconcileGPGKeysConfigMap creates a gpg-keys config map

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -625,3 +625,14 @@ func TestSetManagedNamespaces(t *testing.T) {
 		}
 	}
 }
+
+func generateEncodedPEM(t *testing.T, host string) []byte {
+	key, err := argoutil.NewPrivateKey()
+	assert.NoError(t, err)
+
+	cert, err := argoutil.NewSelfSignedCACertificate(key)
+	assert.NoError(t, err)
+
+	encoded := argoutil.EncodeCertificatePEM(cert)
+	return encoded
+}

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1157,6 +1157,28 @@ spec:
     initialCerts: []
 ```
 
+### IntialCerts Example
+
+Initial set of repository certificates to be configured in Argo CD upon creation of the cluster.
+
+This property maps directly to the data field in the argocd-tls-certs-cm ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Updating new certificates should then be made through the Argo CD web UI or CLI.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: intialCerts
+spec:
+  tls:
+    ca: {}
+    initialCerts:
+      test.example.com: |
+        -----BEGIN CERTIFICATE-----
+        -----END CERTIFICATE-----
+```
+
 ## Users Anonymous Enabled
 
 Enables anonymous user access. The anonymous users get default role permissions specified `argocd-rbac-cm`.


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
#552 

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes #552 

**How to test changes / Special notes to the reviewer**:
1. Create an Argo CD Instance
2. Deploy the below Argo CD CR.
```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: example-argocd
spec:
  server:
    route:
      enabled: true
```
3. Add a cert to argocd-tls-certs-cm configmap.
```
..........
data:
  test.example.com: '-----BEGIN CERTIFICATE-----  -----END CERTIFICATE-----'
```
4. Argo CD controller reconciles the configmap changes and remove the added cert.
