### PR TITLE
add docs for host field in .status

### DIFF
--- a/docs/usage/ingress.md
+++ b/docs/usage/ingress.md
@@ -193,3 +193,41 @@ kubectl delete -n argocd -f examples/argocd-ingress.yaml
 
 [install_olm]:../install/olm.md
 [docs_argo]:https://argoproj.github.io/argo-cd/getting_started/#creating-apps-via-cli
+
+### Host for Ingress in Argo CD Status
+
+When setting up access to Argo CD via an Ingress, one can easily retrieve hostnames used for accessing the Argo CD installation through the ArgoCD Operand's `status` field. To expose the `host` field, run `kubectl edit argocd argocd` and then edit the Argo CD instance server to have ingress enabled as `true`, like so: 
+
+```yaml
+server:
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: true
+    route:
+      enabled: false
+    service:
+      type: ""
+  tls:
+    ca: {}
+```
+If an ingress is found, hostname(s) of the ingress can now be accessed by inspecting your Argo CD instance. This data could be the hostname and/or the IP address(es), depending on what data is available. It will look like the following: 
+
+```yaml
+status:
+  applicationController: Running
+  dex: Running
+  host: 172.24.0.7
+  phase: Available
+  redis: Running
+  repo: Running
+  server: Running
+  ssoConfig: Unknown
+```
+
+If both Route and Ingress are enabled in the Argo CD spec and a route is available, the status for the Route will be prioritized over the Ingress's. In that case, the `host` for the Ingress is not shown in the `status`. 
+
+Unlike with Routes, an Ingress does not go to pending status.  Hence, this will not affect the overall status of the Operand.

--- a/docs/usage/routes.md
+++ b/docs/usage/routes.md
@@ -120,4 +120,40 @@ spec:
         termination: reencrypt
         insecureEdgeTerminationPolicy: Redirect
 ```
+### Host for Route in Argo CD Status
 
+When setting up access to Argo CD via a Route, one can easily retrieve the hostname used for accessing the Argo CD installation through the ArgoCD Operand's `status` field. To expose the `host` field, run `kubectl edit argocd argocd` and then edit the Argo CD instance server to have route enabled as `true`, like so: 
+
+```yaml
+server:
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: true
+    service:
+      type: ""
+  tls:
+    ca: {}
+```
+If a route is found, your hostname can now be accessed by inspecting your Argo CD instance. It will look like the following: 
+
+```yaml
+status:
+  applicationController: Running
+  dex: Running
+  host: argocd-server-default.my-cluster-url.openshift.com
+  phase: Available
+  redis: Running
+  repo: Running
+  server: Running
+  ssoConfig: Unknown
+```
+
+If the status of the Route is pending, this will affect the overall status of the Operand by making it `Pending` instead of `Available`. Once the Route is available, the status of the Operand should change to `Available`.
+
+Note that Routes are specific to OpenShift clusters, so in non-OpenShift clusters enabling Route will yield no results.  


### PR DESCRIPTION
**What type of PR is this?**
 /kind documentation

**What does this PR do / why we need it**:
Adds documentation about how to utilize the `.host` field under the Argo CD operand's `.status` field that was added in PR https://github.com/argoproj-labs/argocd-operator/pull/514 
