### PR TITLE
feat: Upgrade RH-SSO to v7.5.1 and support kube:admin, ocp groups and proxy env

### DIFF
--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -898,6 +898,18 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - '*'
@@ -915,6 +927,14 @@ spec:
           resources:
           - routes
           - routes/custom-host
+          verbs:
+          - '*'
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - templateconfigs
+          - templateinstances
+          - templates
           verbs:
           - '*'
         - apiGroups:

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -173,8 +173,8 @@ const (
 	ArgoCDKeycloakImage = "quay.io/keycloak/keycloak"
 
 	// ArgoCDKeycloakVersion is the default Keycloak version used for the non-openshift platform when not specified.
-	// Version: 9.0.3
-	ArgoCDKeycloakVersion = "sha256:828e92baa29aee2fdf30cca0e0aeefdf77ca458d6818ebbd08bf26f1c5c6a7cf"
+	// Version: 15.0.2
+	ArgoCDKeycloakVersion = "sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9"
 
 	// ArgoCDKeycloakImageForOpenShift is the default Keycloak Image used for the OpenShift platform when not specified.
 	ArgoCDKeycloakImageForOpenShift = "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8"

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -177,11 +177,11 @@ const (
 	ArgoCDKeycloakVersion = "sha256:828e92baa29aee2fdf30cca0e0aeefdf77ca458d6818ebbd08bf26f1c5c6a7cf"
 
 	// ArgoCDKeycloakImageForOpenShift is the default Keycloak Image used for the OpenShift platform when not specified.
-	ArgoCDKeycloakImageForOpenShift = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8"
+	ArgoCDKeycloakImageForOpenShift = "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8"
 
 	// ArgoCDKeycloakVersionForOpenShift is the default Keycloak version used for the OpenShift platform when not specified.
-	// Version: 7.4.0
-	ArgoCDKeycloakVersionForOpenShift = "sha256:39d752173fc97c29373cd44477b48bcb078531def0a897ee81a60e8d1d0212cc"
+	// Version: 7.5.1
+	ArgoCDKeycloakVersionForOpenShift = "sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3"
 
 	// ArgoCDDefaultOIDCConfig is the default OIDC configuration.
 	ArgoCDDefaultOIDCConfig = ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -101,6 +101,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - '*'
@@ -118,5 +130,13 @@ rules:
   resources:
   - routes
   - routes/custom-host
+  verbs:
+  - '*'
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - templateconfigs
+  - templateinstances
+  - templates
   verbs:
   - '*'

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -59,6 +59,8 @@ var log = logr.Log.WithName("controller_argocd")
 //+kubebuilder:rbac:groups=argoproj.io,resources=applications;appprojects,verbs=*
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=*,verbs=*
 //+kubebuilder:rbac:groups="",resources=pods;pods/log,verbs=get
+//+kubebuilder:rbac:groups=template.openshift.io,resources=templates;templateinstances;templateconfigs,verbs=*
+//+kubebuilder:rbac:groups="oauth.openshift.io",resources=oauthclients,verbs=get;list;watch;create;delete;patch;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -83,7 +83,6 @@ const (
 var (
 	// client secret for keycloak, argocd and openshift-v4 IdP.
 	oAuthClientSecret       = generateRandomString(8)
-	privilegedMode    bool  = false
 	graceTime         int64 = 75
 	portTLS           int32 = 8443
 	httpPort          int32 = 8080

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -109,6 +110,49 @@ type oidcConfig struct {
 	ClientID       string   `json:"clientID"`
 	ClientSecret   string   `json:"clientSecret"`
 	RequestedScope []string `json:"requestedScopes"`
+}
+
+// KeycloakIdentityProviderMapper defines IdentityProvider Mappers
+// issue: https://github.com/keycloak/keycloak-operator/issues/471
+type KeycloakIdentityProviderMapper struct {
+	// Name
+	// +optional
+	Name string `json:"name,omitempty"`
+	// Identity Provider Alias.
+	// +optional
+	IdentityProviderAlias string `json:"identityProviderAlias,omitempty"`
+	// Identity Provider Mapper.
+	// +optional
+	IdentityProviderMapper string `json:"identityProviderMapper,omitempty"`
+	// Identity Provider Mapper config.
+	// +optional
+	Config map[string]string `json:"config,omitempty"`
+}
+
+// CustomKeycloakAPIRealm is an extention type of KeycloakAPIRealm as is it does not
+// support IdentityProvider Mappers
+// issue: https://github.com/keycloak/keycloak-operator/issues/471
+type CustomKeycloakAPIRealm struct {
+	// Realm name.
+	Realm string `json:"realm"`
+	// Realm enabled flag.
+	// +optional
+	Enabled bool `json:"enabled"`
+	// Require SSL
+	// +optional
+	SslRequired string `json:"sslRequired,omitempty"`
+	// A set of Keycloak Clients.
+	// +optional
+	Clients []*keycloakv1alpha1.KeycloakAPIClient `json:"clients,omitempty"`
+	// Client scopes
+	// +optional
+	ClientScopes []keycloakv1alpha1.KeycloakClientScope `json:"clientScopes,omitempty"`
+	// A set of Identity Providers.
+	// +optional
+	IdentityProviders []*keycloakv1alpha1.KeycloakIdentityProvider `json:"identityProviders,omitempty"`
+	// KeycloakIdentityProviderMapper defines IdentityProvider Mappers
+	// issue: https://github.com/keycloak/keycloak-operator/issues/471
+	IdentityProviderMappers []*KeycloakIdentityProviderMapper `json:"identityProviderMappers,omitempty"`
 }
 
 // getKeycloakContainerImage will return the container image for the Keycloak.
@@ -211,21 +255,23 @@ func getKeycloakResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
 }
 
 func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
+	envVars := []corev1.EnvVar{
+		{Name: "SSO_HOSTNAME", Value: "${SSO_HOSTNAME}"},
+		{Name: "DB_MIN_POOL_SIZE", Value: "${DB_MIN_POOL_SIZE}"},
+		{Name: "DB_MAX_POOL_SIZE", Value: "${DB_MAX_POOL_SIZE}"},
+		{Name: "DB_TX_ISOLATION", Value: "${DB_TX_ISOLATION}"},
+		{Name: "OPENSHIFT_DNS_PING_SERVICE_NAME", Value: "${APPLICATION_NAME}-ping"},
+		{Name: "OPENSHIFT_DNS_PING_SERVICE_PORT", Value: "8888"},
+		{Name: "X509_CA_BUNDLE", Value: "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/*.crt"},
+		{Name: "SSO_ADMIN_USERNAME", Value: "${SSO_ADMIN_USERNAME}"},
+		{Name: "SSO_ADMIN_PASSWORD", Value: "${SSO_ADMIN_PASSWORD}"},
+		{Name: "SSO_REALM", Value: "${SSO_REALM}"},
+		{Name: "SSO_SERVICE_USERNAME", Value: "${SSO_SERVICE_USERNAME}"},
+		{Name: "SSO_SERVICE_PASSWORD", Value: "${SSO_SERVICE_PASSWORD}"},
+	}
+
 	return corev1.Container{
-		Env: []corev1.EnvVar{
-			{Name: "SSO_HOSTNAME", Value: "${SSO_HOSTNAME}"},
-			{Name: "DB_MIN_POOL_SIZE", Value: "${DB_MIN_POOL_SIZE}"},
-			{Name: "DB_MAX_POOL_SIZE", Value: "${DB_MAX_POOL_SIZE}"},
-			{Name: "DB_TX_ISOLATION", Value: "${DB_TX_ISOLATION}"},
-			{Name: "OPENSHIFT_DNS_PING_SERVICE_NAME", Value: "${APPLICATION_NAME}-ping"},
-			{Name: "OPENSHIFT_DNS_PING_SERVICE_PORT", Value: "8888"},
-			{Name: "X509_CA_BUNDLE", Value: "/var/run/configmaps/service-ca/service-ca.crt /var/run/secrets/kubernetes.io/serviceaccount/*.crt"},
-			{Name: "SSO_ADMIN_USERNAME", Value: "${SSO_ADMIN_USERNAME}"},
-			{Name: "SSO_ADMIN_PASSWORD", Value: "${SSO_ADMIN_PASSWORD}"},
-			{Name: "SSO_REALM", Value: "${SSO_REALM}"},
-			{Name: "SSO_SERVICE_USERNAME", Value: "${SSO_SERVICE_USERNAME}"},
-			{Name: "SSO_SERVICE_PASSWORD", Value: "${SSO_SERVICE_PASSWORD}"},
-		},
+		Env:             proxyEnvVars(envVars...),
 		Image:           getKeycloakContainerImage(cr),
 		ImagePullPolicy: "Always",
 		LivenessProbe: &corev1.Probe{
@@ -828,7 +874,7 @@ func (r *ReconcileArgoCD) prepareKeycloakConfigForK8s(cr *argoprojv1a1.ArgoCD) (
 // creates a keycloak realm configuration which when posted to keycloak using http client creates a keycloak realm.
 func createRealmConfig(cfg *keycloakConfig) ([]byte, error) {
 
-	ks := &keycloakv1alpha1.KeycloakAPIRealm{
+	ks := &CustomKeycloakAPIRealm{
 		Realm:       keycloakRealm,
 		Enabled:     true,
 		SslRequired: "external",
@@ -862,13 +908,15 @@ func createRealmConfig(cfg *keycloakConfig) ([]byte, error) {
 					{
 						Name:           "groups",
 						Protocol:       "openid-connect",
-						ProtocolMapper: "oidc-group-membership-mapper",
+						ProtocolMapper: "oidc-usermodel-attribute-mapper",
 						Config: map[string]string{
-							"full.path":            "false",
+							"aggregate.attrs":      "false",
+							"multivalued":          "true",
+							"userinfo.token.claim": "true",
+							"user.attribute":       "groups",
 							"id.token.claim":       "true",
 							"access.token.claim":   "true",
 							"claim.name":           "groups",
-							"userinfo.token.claim": "true",
 						},
 					},
 				},
@@ -892,6 +940,14 @@ func createRealmConfig(cfg *keycloakConfig) ([]byte, error) {
 					},
 				},
 			},
+			{
+				Name:     "profile",
+				Protocol: "openid-connect",
+				Attributes: map[string]string{
+					"include.in.token.scope":    "true",
+					"display.on.consent.screen": "true",
+				},
+			},
 		},
 	}
 
@@ -908,6 +964,18 @@ func createRealmConfig(cfg *keycloakConfig) ([]byte, error) {
 					"clientSecret": oAuthClientSecret,
 					"clientId":     getOAuthClient(cfg.ArgoNamespace),
 					"defaultScope": "user:full",
+				},
+			},
+		}
+		ks.IdentityProviderMappers = []*KeycloakIdentityProviderMapper{
+			{
+				Name:                   "groups",
+				IdentityProviderAlias:  "openshift-v4",
+				IdentityProviderMapper: "openshift-v4-user-attribute-mapper",
+				Config: map[string]string{
+					"syncMode":      "INHERIT",
+					"jsonField":     "groups",
+					"userAttribute": "groups",
 				},
 			},
 		}
@@ -1250,7 +1318,10 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoprojv1a1.ArgoCD)
 
 			// Update Realm creation. This will avoid posting of realm configuration on further reconciliations.
 			existingDC.Annotations["argocd.argoproj.io/realm-created"] = "true"
-			err = r.Client.Update(context.TODO(), existingDC)
+			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				return r.Client.Update(context.TODO(), existingDC)
+			})
+
 			if err != nil {
 				return err
 			}

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -1317,6 +1317,11 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoprojv1a1.ArgoCD)
 				cr.Name, cr.Namespace))
 
 			// Update Realm creation. This will avoid posting of realm configuration on further reconciliations.
+			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingDC.Name, Namespace: existingDC.Namespace}, existingDC)
+			if err != nil {
+				return err
+			}
+
 			existingDC.Annotations["argocd.argoproj.io/realm-created"] = "true"
 			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				return r.Client.Update(context.TODO(), existingDC)

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -960,10 +960,11 @@ func createRealmConfig(cfg *keycloakConfig) ([]byte, error) {
 				DisplayName: "Login with OpenShift",
 				ProviderID:  "openshift-v4",
 				Config: map[string]string{
-					"baseUrl":      "https://kubernetes.default.svc.cluster.local",
+					"baseUrl":      getBaseURL(),
 					"clientSecret": oAuthClientSecret,
 					"clientId":     getOAuthClient(cfg.ArgoNamespace),
 					"defaultScope": "user:full",
+					"syncMode":     "IMPORT",
 				},
 			},
 		}

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -954,13 +954,18 @@ func createRealmConfig(cfg *keycloakConfig) ([]byte, error) {
 	// Add OpenShift-v4 as Identity Provider only for OpenShift environment.
 	// No Identity Provider is configured by default for non-openshift environments.
 	if IsTemplateAPIAvailable() {
+		baseURL := "https://kubernetes.default.svc.cluster.local"
+		if isProxyCluster() {
+			baseURL = getOpenShiftAPIURL()
+		}
+
 		ks.IdentityProviders = []*keycloakv1alpha1.KeycloakIdentityProvider{
 			{
 				Alias:       "openshift-v4",
 				DisplayName: "Login with OpenShift",
 				ProviderID:  "openshift-v4",
 				Config: map[string]string{
-					"baseUrl":      getBaseURL(),
+					"baseUrl":      baseURL,
 					"clientSecret": oAuthClientSecret,
 					"clientId":     getOAuthClient(cfg.ArgoNamespace),
 					"defaultScope": "user:full",

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -1226,6 +1226,10 @@ func deleteOAuthClient(cr *argoprojv1a1.ArgoCD) error {
 
 	oa := getOAuthClient(cr.Namespace)
 
+	// TODO: Remove the oauth.OAuthClients().Get and proceed with delete once the issue is resolved.
+	// OAuthClient configuration does not get deleted from previous instances occasionally.
+	// It is safe to verify if OAuthClient exists and perform delete.
+	// https://github.com/openshift/client-go/issues/209
 	_, err = oauth.OAuthClients().Get(context.TODO(), oa, metav1.GetOptions{})
 	if err == nil {
 		err = oauth.OAuthClients().Delete(context.TODO(), oa, deleteOptions)
@@ -1361,8 +1365,10 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoprojv1a1.ArgoCD)
 			log.Info(fmt.Sprintf("Successfully created keycloak realm for ArgoCD %s in namespace %s",
 				cr.Name, cr.Namespace))
 
+			// TODO: Remove the deleteOAuthClient invocation once the issue is resolved.
 			// OAuthClient configuration does not get deleted from previous instances occasionally.
 			// It is safe to delete before updating the OIDC config.
+			// https://github.com/openshift/client-go/issues/209
 			err = deleteOAuthClient(cr)
 			if err != nil {
 				return err

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -969,7 +969,7 @@ func createRealmConfig(cfg *keycloakConfig) ([]byte, error) {
 					"clientSecret": oAuthClientSecret,
 					"clientId":     getOAuthClient(cfg.ArgoNamespace),
 					"defaultScope": "user:full",
-					"syncMode":     "IMPORT",
+					"syncMode":     "FORCE",
 				},
 			},
 		}

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -83,7 +83,7 @@ func TestKeycloakContainerImage(t *testing.T) {
 	templateAPIFound = true
 	testImage = getKeycloakContainerImage(cr)
 	assert.Equal(t, testImage,
-		"registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:39d752173fc97c29373cd44477b48bcb078531def0a897ee81a60e8d1d0212cc")
+		"registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3")
 
 	// When ENV variable is set.
 	err := os.Setenv(common.ArgoCDKeycloakImageEnvName, "envImage:latest")
@@ -160,7 +160,7 @@ func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
 	}
 	kc := getKeycloakContainer(a)
 	assert.Equal(t, kc.Image,
-		"registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:39d752173fc97c29373cd44477b48bcb078531def0a897ee81a60e8d1d0212cc")
+		"registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3")
 	assert.Equal(t, kc.ImagePullPolicy, corev1.PullAlways)
 	assert.Equal(t, kc.Name, "${APPLICATION_NAME}")
 }

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -81,6 +81,8 @@ func TestKeycloakContainerImage(t *testing.T) {
 
 	// For OpenShift Container Platform.
 	templateAPIFound = true
+	defer removeTemplateAPI()
+
 	testImage = getKeycloakContainerImage(cr)
 	assert.Equal(t, testImage,
 		"registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3")
@@ -102,6 +104,10 @@ func TestKeycloakContainerImage(t *testing.T) {
 }
 
 func TestNewKeycloakTemplateInstance(t *testing.T) {
+	// For OpenShift Container Platform.
+	templateAPIFound = true
+	defer removeTemplateAPI()
+
 	a := makeTestArgoCD()
 	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
 		Provider: "keycloak",
@@ -114,6 +120,10 @@ func TestNewKeycloakTemplateInstance(t *testing.T) {
 }
 
 func TestNewKeycloakTemplate(t *testing.T) {
+	// For OpenShift Container Platform.
+	templateAPIFound = true
+	defer removeTemplateAPI()
+
 	a := makeTestArgoCD()
 	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
 		Provider: "keycloak",
@@ -126,6 +136,10 @@ func TestNewKeycloakTemplate(t *testing.T) {
 }
 
 func TestNewKeycloakTemplate_testDeploymentConfig(t *testing.T) {
+	// For OpenShift Container Platform.
+	templateAPIFound = true
+	defer removeTemplateAPI()
+
 	a := makeTestArgoCD()
 	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
 		Provider: "keycloak",
@@ -154,6 +168,10 @@ func TestNewKeycloakTemplate_testDeploymentConfig(t *testing.T) {
 }
 
 func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
+	// For OpenShift Container Platform.
+	templateAPIFound = true
+	defer removeTemplateAPI()
+
 	a := makeTestArgoCD()
 	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
 		Provider: "keycloak",
@@ -208,7 +226,6 @@ func TestNewKeycloakTemplate_testRoute(t *testing.T) {
 }
 
 func TestKeycloak_testRealmConfigCreation(t *testing.T) {
-	templateAPIFound = false
 	cfg := &keycloakConfig{
 		ArgoName:      "foo-argocd",
 		ArgoNamespace: "foo",
@@ -258,4 +275,8 @@ func TestKeycloak_NodeLabelSelector(t *testing.T) {
 	dc := getKeycloakDeploymentConfigTemplate(a)
 	assert.Equal(t, dc.Spec.Template.Spec.NodeSelector, a.Spec.NodePlacement.NodeSelector)
 	assert.Equal(t, dc.Spec.Template.Spec.Tolerations, a.Spec.NodePlacement.Tolerations)
+}
+
+func removeTemplateAPI() {
+	templateAPIFound = false
 }

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -77,7 +77,7 @@ func TestKeycloakContainerImage(t *testing.T) {
 	// When both cr.spec.sso.Image and ArgoCDKeycloakImageEnvName are not set.
 	testImage := getKeycloakContainerImage(cr)
 	assert.Equal(t, testImage,
-		"quay.io/keycloak/keycloak@sha256:828e92baa29aee2fdf30cca0e0aeefdf77ca458d6818ebbd08bf26f1c5c6a7cf")
+		"quay.io/keycloak/keycloak@sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9")
 
 	// For OpenShift Container Platform.
 	templateAPIFound = true
@@ -208,6 +208,7 @@ func TestNewKeycloakTemplate_testRoute(t *testing.T) {
 }
 
 func TestKeycloak_testRealmConfigCreation(t *testing.T) {
+	templateAPIFound = false
 	cfg := &keycloakConfig{
 		ArgoName:      "foo-argocd",
 		ArgoNamespace: "foo",

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -17,6 +17,8 @@ package argocd
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -1364,4 +1366,20 @@ func getOpenShiftAPIURL() string {
 	}
 
 	return out
+}
+
+// generateRandomBytes returns a securely generated random bytes.
+func generateRandomBytes(n int) []byte {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		log.Error(err, "")
+	}
+	return b
+}
+
+// generateRandomString returns a securely generated random string.
+func generateRandomString(s int) string {
+	b := generateRandomBytes(s)
+	return base64.URLEncoding.EncodeToString(b)
 }

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1359,7 +1359,7 @@ func getOpenShiftAPIURL() string {
 	if c, ok := data["clusterInfo"]; ok {
 		ci, _ := c.(map[interface{}]interface{})
 
-		apiURL, _ = ci["masterPublicURL"]
+		apiURL = ci["masterPublicURL"]
 		out = fmt.Sprintf("%v", apiURL)
 	}
 

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1303,3 +1303,11 @@ func (r *ReconcileArgoCD) setManagedNamespaces(cr *argoproj.ArgoCD) error {
 	r.ManagedNamespaces = namespaces
 	return nil
 }
+
+func getBaseURL() string {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		log.Error(err, "")
+	}
+	return cfg.Host
+}

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"os"
 	"reflect"
 	"strings"
@@ -624,6 +625,21 @@ func TestSetManagedNamespaces(t *testing.T) {
 			t.Errorf("Expected namespace %s to be managed by Argo CD instance %s", n.Name, testNamespace)
 		}
 	}
+}
+
+func TestGenerateRandomString(t *testing.T) {
+
+	// verify the creation of unique strings
+	s1 := generateRandomString(20)
+	s2 := generateRandomString(20)
+	assert.NotEqual(t, s1, s2)
+
+	// verify length
+	a, _ := b64.URLEncoding.DecodeString(s1)
+	assert.Len(t, a, 20)
+
+	b, _ := b64.URLEncoding.DecodeString(s2)
+	assert.Len(t, b, 20)
 }
 
 func generateEncodedPEM(t *testing.T, host string) []byte {

--- a/deploy/olm-catalog/argocd-operator/0.2.0/argocd-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.2.0/argocd-operator.v0.2.0.clusterserviceversion.yaml
@@ -898,6 +898,18 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - '*'
@@ -915,6 +927,14 @@ spec:
           resources:
           - routes
           - routes/custom-host
+          verbs:
+          - '*'
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - templateconfigs
+          - templateinstances
+          - templates
           verbs:
           - '*'
         - apiGroups:

--- a/deploy/olm-catalog/argocd-operator/0.2.0/argocd-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.2.0/argocd-operator.v0.2.0.clusterserviceversion.yaml
@@ -898,18 +898,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - oauth.openshift.io
-          resources:
-          - oauthclients
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - '*'
@@ -927,14 +915,6 @@ spec:
           resources:
           - routes
           - routes/custom-host
-          verbs:
-          - '*'
-        - apiGroups:
-          - template.openshift.io
-          resources:
-          - templateconfigs
-          - templateinstances
-          - templates
           verbs:
           - '*'
         - apiGroups:

--- a/deploy/olm-catalog/argocd-operator/0.3.0/argocd-operator.v0.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.3.0/argocd-operator.v0.3.0.clusterserviceversion.yaml
@@ -898,6 +898,18 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - '*'
@@ -915,6 +927,14 @@ spec:
           resources:
           - routes
           - routes/custom-host
+          verbs:
+          - '*'
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - templateconfigs
+          - templateinstances
+          - templates
           verbs:
           - '*'
         - apiGroups:

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1105,11 +1105,11 @@ The following properties are available for configuring the Single sign-on compon
 
 Name | Default | Description
 --- | --- | ---
-Image | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8` | The container image for keycloak. This overrides the `ARGOCD_KEYCLOAK_IMAGE` environment variable.
+Image | OpenShift - `registry.redhat.io/rh-sso-7/sso75-openshift-rhel8` <br/> Kuberentes - `quay.io/keycloak/keycloak` | The container image for keycloak. This overrides the `ARGOCD_KEYCLOAK_IMAGE` environment variable.
 Provider | [Empty] | The name of the provider used to configure Single sign-on. For now the only supported option is keycloak.
 Resources | `Requests`: CPU=500m, Mem=512Mi, `Limits`: CPU=1000m, Mem=1024Mi | The container compute resources.
 VerifyTLS | true | Whether to enforce strict TLS checking when communicating with Keycloak service.
-Version | `sha256:39d752173fc97c29373cd44477b48bcb078531def0a897ee81a60e8d1d0212cc` | The tag to use with the keycloak container image.
+Version | OpenShift - `sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3` (7.5.1) <br/> Kubernetes - `sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9` (15.0.2) | The tag to use with the keycloak container image.
 
 ### Single sign-on Example
 

--- a/docs/usage/keycloak/openshift.md
+++ b/docs/usage/keycloak/openshift.md
@@ -95,12 +95,14 @@ By default any user logged into ArgoCD will have read-only access. User level ac
 
 ### Group Level RBAC
 
-The below example shows how to grant admin access to a group with name `argocd-sig`. More information regarding ArgoCD RBAC can be found [here](https://argoproj.github.io/argo-cd/operator-manual/rbac/)
+The below example shows how to grant admin access to a group with name `system:cluster-admins`. More information regarding ArgoCD RBAC can be found [here](https://argoproj.github.io/argo-cd/operator-manual/rbac/)
 
 ```yaml
 policy.csv: |
-  g, argocd-sig, role:admin
+  g, system:cluster-admins, role:admin
 ```
+
+Note: Currently, group based RBAC only works with the default OpenShift groups(groups that are created at bootstrap like system:masters, system:cluster-admins, system:authenticated, system:admin .....)
 
 ### User Level RBAC
 

--- a/docs/usage/keycloak/openshift.md
+++ b/docs/usage/keycloak/openshift.md
@@ -75,46 +75,6 @@ kubectl -n argocd exec keycloak-1-2sjcl -- "env" | grep SSO_ADMIN_PASSWORD
 SSO_ADMIN_PASSWORD=GVXxHifH
 ```
 
-## Additional Steps for Disconnected OpenShift Clusters
-
-In a [disconnected](https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/planning_your_deployment/disconnected-environment_rhocs) cluster, Keycloak communicates with OpenShift Oauth Server through proxy. Below are some additional steps that needs to followed to get Keycloak integrated with OpenShift Oauth Login.
-
-### Login to the Keycloak Pod
-
-```bash
-oc exec -it dc/keycloak -n argocd -- /bin/bash
-```
-
-### Run JBoss Cli command
-
-```bash
-/opt/eap/bin/jboss-cli.sh
-```
-
-### Start an Embedded Standalone Server
-
-```bash
-embed-server --server-config=standalone-openshift.xml
-```
-
-### Run the below command to setup proxy mappings for OpenShift OAuth Server host
-
-```bash
-/subsystem=keycloak-server/spi=connectionsHttpClient/provider=default:write-attribute(name=properties.proxy-mappings,value=["<oauth-server-hostname>;http://<proxy-server-host>:<proxy-server-port>"])
-```
-
-### Stop the Embedded Server
-
-```bash
-quit
-```
-
-### Reload JBoss
-
-```bash
-/opt/eap/bin/jboss-cli.sh --connect --command=:reload
-```
-
 ## Login
 
 You can see an option to Log in via keycloak apart from the usual ArgoCD login.
@@ -129,13 +89,27 @@ You can create keycloak users by logging in to keycloak admin console using the 
 
 **NOTE:** Keycloak instance takes 2-3 minutes to be up and running. You will see the option **LOGIN VIA KEYCLOAK** only after the keycloak instance is up.
 
-By default any user logged into ArgoCD will have read-only access. User level access can be managed by updating the argocd-rbac-cm configmap.
+## RBAC
 
-The below example show how to grant user foobar with email ID `foobang@example.com` admin access to ArgoCD. More information regarding ArgoCD RBAC can be found [here](https://argoproj.github.io/argo-cd/operator-manual/rbac/)
+By default any user logged into ArgoCD will have read-only access. User level access can be managed by updating the `argocd-rbac-cm` configmap.
+
+### Group Level RBAC
+
+The below example shows how to grant admin access to a group with name `argocd-sig`. More information regarding ArgoCD RBAC can be found [here](https://argoproj.github.io/argo-cd/operator-manual/rbac/)
 
 ```yaml
 policy.csv: |
-  g, foobang@example.com, role:admin
+  g, argocd-sig, role:admin
+```
+
+### User Level RBAC
+
+If you wish to configure RBAC for users instead of groups, consider the below example.
+Example shows how to grant admin access to User foobar with email ID `foobar@example.com`. More information regarding ArgoCD RBAC can be found [here](https://argoproj.github.io/argo-cd/operator-manual/rbac/)
+
+```yaml
+policy.csv: |
+  g, foobar@example.com, role:admin
 ```
 
 ## Change Keycloak Admin Password

--- a/docs/usage/keycloak/openshift.md
+++ b/docs/usage/keycloak/openshift.md
@@ -95,14 +95,12 @@ By default any user logged into ArgoCD will have read-only access. User level ac
 
 ### Group Level RBAC
 
-The below example shows how to grant admin access to a group with name `system:cluster-admins`. More information regarding ArgoCD RBAC can be found [here](https://argoproj.github.io/argo-cd/operator-manual/rbac/)
+The below example shows how to grant admin access to a group with name `cluster-admins`. More information regarding ArgoCD RBAC can be found [here](https://argoproj.github.io/argo-cd/operator-manual/rbac/)
 
 ```yaml
 policy.csv: |
-  g, system:cluster-admins, role:admin
+  g, cluster-admins, role:admin
 ```
-
-Note: Currently, group based RBAC only works with the default OpenShift groups(groups that are created at bootstrap like system:masters, system:cluster-admins, system:authenticated, system:admin .....)
 
 ### User Level RBAC
 

--- a/examples/argocd-keycloak-openshift.yaml
+++ b/examples/argocd-keycloak-openshift.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   sso:
     provider: keycloak
-    verifyTLS: false
+    # uncomment the below line when running operator locally.
+    # verifyTLS: false 
   server:
     route:
       enabled: true

--- a/examples/argocd-keycloak-openshift.yaml
+++ b/examples/argocd-keycloak-openshift.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   sso:
     provider: keycloak
+    verifyTLS: false
   server:
     route:
       enabled: true

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -29,3 +29,11 @@ kubectl delete namespace argocd-e2e
 kubectl create namespace argocd-e2e-cluster-config
 kubectl kuttl test --config kuttl-test-cluster-config.yaml
 kubectl delete namespace argocd-e2e-cluster-config
+
+# Run the below test only on OpenShift Container Platform
+kubectl get crds | grep openshiftapiservers.operator.openshift.io
+if [ $? -eq 0 ]; then
+    kubectl kuttl test --config kuttl-test-rhsso.yaml
+else
+    echo "skipping test rhsso"
+fi

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -30,11 +30,4 @@ kubectl create namespace argocd-e2e-cluster-config
 kubectl kuttl test --config kuttl-test-cluster-config.yaml
 kubectl delete namespace argocd-e2e-cluster-config
 
-# if target cluster is ocp, run kuttl-test-rhsso.yaml
-# else run kuttl-test-keycloak.yaml
-isOCP=$(kubectl get crds | grep "openshiftapiservers.operator.openshift.io" || true)
-if [[ ! -z ${isOCP} ]]; then
-    kubectl kuttl test --config kuttl-test-rhsso.yaml
-else
-    kubectl kuttl test --config kuttl-test-keycloak.yaml
-fi
+kubectl kuttl test --config kuttl-test-keycloak.yaml

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -16,7 +16,7 @@
 #
 # Script to run the operator tests.
 
-set -e
+set -e 
 
 kubectl create namespace argocd-e2e
 kubectl kuttl test
@@ -30,10 +30,11 @@ kubectl create namespace argocd-e2e-cluster-config
 kubectl kuttl test --config kuttl-test-cluster-config.yaml
 kubectl delete namespace argocd-e2e-cluster-config
 
-# Run the below test only on OpenShift Container Platform
-kubectl get crds | grep openshiftapiservers.operator.openshift.io
-if [ $? -eq 0 ]; then
+# if target cluster is ocp, run kuttl-test-rhsso.yaml
+# else run kuttl-test-keycloak.yaml
+isOCP=$(kubectl get crds | grep "openshiftapiservers.operator.openshift.io" || true)
+if [[ ! -z ${isOCP} ]]; then
     kubectl kuttl test --config kuttl-test-rhsso.yaml
 else
-    echo "skipping test rhsso"
+    kubectl kuttl test --config kuttl-test-keycloak.yaml
 fi

--- a/kuttl-test-keycloak.yaml
+++ b/kuttl-test-keycloak.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+- ./tests/e2e-keycloak/
+timeout: 90
+startKIND: false
+namespace: argocd-e2e-keycloak
+commands:
+- command: kubectl create ns argocd-e2e-keycloak
+  ignoreFailure: true

--- a/kuttl-test-rhsso.yaml
+++ b/kuttl-test-rhsso.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+- ./tests/e2e-rhsso/
+timeout: 180
+startKIND: false
+namespace: argocd-e2e-rhsso
+commands:
+- command: kubectl create ns argocd-e2e-rhsso
+  ignoreFailure: true
+

--- a/tests/e2e-keycloak/argocd-tests/01-argocd-keycloak.yaml
+++ b/tests/e2e-keycloak/argocd-tests/01-argocd-keycloak.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd-keycloak
+  labels:
+    example: keycloak
+spec:
+  sso: 
+    provider: keycloak
+    verifyTLS: false # required when running operator locally
+  server:
+    ingress: 
+      enabled: true

--- a/tests/e2e-keycloak/argocd-tests/01-assert.yaml
+++ b/tests/e2e-keycloak/argocd-tests/01-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 180
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd-keycloak
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: keycloak

--- a/tests/e2e-keycloak/argocd-tests/99-delete.yaml
+++ b/tests/e2e-keycloak/argocd-tests/99-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete argocd example-argocd-keycloak -n argocd-e2e-keycloak
+  - command: kubectl delete ns argocd-e2e-keycloak

--- a/tests/e2e-rhsso/argocd-tests/01-argocd-rhsso.yaml
+++ b/tests/e2e-rhsso/argocd-tests/01-argocd-rhsso.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd-keycloak
+  labels:
+    example: keycloak
+spec:
+  sso: 
+    provider: keycloak
+    verifyTLS: false # required when running operator locally
+  server:
+    route: 
+      enabled: true

--- a/tests/e2e-rhsso/argocd-tests/01-assert.yaml
+++ b/tests/e2e-rhsso/argocd-tests/01-assert.yaml
@@ -1,0 +1,88 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 180
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd-keycloak
+status:
+  phase: Available
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: keycloak
+spec:
+  selector:
+    deploymentConfig: keycloak
+  strategy:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        application: keycloak
+        deploymentConfig: keycloak
+      name: keycloak
+    spec:
+      containers:
+      - image: registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /etc/x509/https
+          name: sso-x509-https-volume
+          readOnly: true
+        - mountPath: /var/run/configmaps/service-ca
+          name: service-ca
+          readOnly: true
+      restartPolicy: Always
+      volumes:
+      - name: sso-x509-https-volume
+        secret:
+          defaultMode: 420
+          secretName: sso-x509-https-secret
+      - configMap:
+          defaultMode: 420
+          name: keycloak-service-ca
+        name: service-ca
+  triggers:
+  - type: ConfigChange
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: keycloak
+spec:
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: keycloak
+    weight: 100
+  wildcardPolicy: None
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-secret
+type: Opaque

--- a/tests/e2e-rhsso/argocd-tests/02-sleep.yaml
+++ b/tests/e2e-rhsso/argocd-tests/02-sleep.yaml
@@ -1,0 +1,5 @@
+# wait for operator to create a new keycloak realm and update OIDC configuration.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: sleep 60

--- a/tests/e2e-rhsso/argocd-tests/03-verify-oidc.yaml
+++ b/tests/e2e-rhsso/argocd-tests/03-verify-oidc.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# verify OIDC config
+# verify issuer
+- script: |
+    issuer=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n argocd-e2e-rhsso | grep issuer | awk -F' ' '{print $2}')
+    keycloakRoute=$(kubectl get route keycloak -n argocd-e2e-rhsso -o jsonpath='{.spec.host}')
+    if [[ "${issuer}" == "https://${keycloakRoute}/auth/realms/argocd" ]]; then 
+      echo "issuer matched"
+    else 
+      echo "issuer mismatched"
+      echo "${issuer} not equals ${keycloakRoute}/auth/realms/argocd"
+      exit 1
+    fi  
+# verify oidc config name and clientid
+- script: | 
+    clientid=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n argocd-e2e-rhsso | grep clientid | awk -F' ' '{print $2}')
+    name=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n argocd-e2e-rhsso | grep name | awk -F' ' '{print $2}')
+    
+    if [[ "${clientid}" == "argocd" && "${name}" == "Keycloak" ]]; then 
+      echo "oidc name and clientid matched"
+    else 
+      echo "oidc name and clientid mismatched"
+      echo "${clientid} and ${name}"
+      exit 1
+    fi

--- a/tests/e2e-rhsso/argocd-tests/04-verifyRealmCreation.yaml
+++ b/tests/e2e-rhsso/argocd-tests/04-verifyRealmCreation.yaml
@@ -1,0 +1,45 @@
+# This step is executed after the RHSSO deployment, service, secret, route objects are created and verified.
+# Reads the username and password from keycloak secret.
+# Requests keycloak for an access token.
+# Verifies Realm and Argo CD client creation.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    # Set the needed parameter for the authorization
+    KEYCLOAK_URL=$(oc get route keycloak -n argocd-e2e-rhsso -o jsonpath='{.spec.host}')
+    tenant=argocd
+    USER=$(oc get secret keycloak-secret -n argocd-e2e-rhsso -o jsonpath='{.data.SSO_USERNAME}' | base64 --decode)
+    PASSWORD=$(oc get secret keycloak-secret -n argocd-e2e-rhsso -o jsonpath='{.data.SSO_PASSWORD}' | base64 --decode)
+    GRANT_TYPE=password
+    CLIENT_ID=admin-cli
+    
+    # Execute the CURL command to request the access-token
+    access_token=$(curl -d "client_id=$CLIENT_ID" -d "username=$USER" -d "password=$PASSWORD" -d "grant_type=$GRANT_TYPE" "https://$KEYCLOAK_URL/auth/realms/master/protocol/openid-connect/token" -k | sed -n 's|.*"access_token":"\([^"]*\)".*|\1|p')
+
+    # Execute the CURL command to verify the realm and client creation
+    clientFound=$(curl -H "Content-Type: application/json" -H "Authorization: bearer $access_token" "https://$KEYCLOAK_URL/auth/admin/realms/$tenant/clients" -k | grep '"clientId":"argocd"')
+    if ! [ "$clientFound" = "" ]; then
+      echo "argocd realm and client creation verified"
+    else
+      echo "argocd client not found"
+      exit 1
+    fi
+
+    # Verify OpenShift-v4 IdP creation
+    IdPFound=$(curl -H "Content-Type: application/json" -H "Authorization: bearer $access_token" "https://$KEYCLOAK_URL/auth/admin/realms/$tenant/identity-provider/instances" -k | grep -i OpenShift-v4)
+    if ! [ "$IdPFound" = "" ]; then
+      echo "OpenShift-v4 IdP creation verified"
+    else
+      echo "OpenShift-v4 IdP not found"
+      exit 1
+    fi
+
+    # Verify OpenShift-v4 IdP creation
+    syncModeVerified=$(curl -H "Content-Type: application/json" -H "Authorization: bearer $access_token" "https://$KEYCLOAK_URL/auth/admin/realms/$tenant/identity-provider/instances" -k | grep -i '"syncMode":"FORCE"')
+    if ! [ "$syncModeVerified" = "" ]; then
+      echo "syncMode set to Force, verified"
+    else
+      echo "syncMode not set to Force"
+      exit 1
+    fi

--- a/tests/e2e-rhsso/argocd-tests/99-delete.yaml
+++ b/tests/e2e-rhsso/argocd-tests/99-delete.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: echo 
   - command: oc delete argocd example-argocd-keycloak -n argocd-e2e-rhsso
   - command: oc delete ns argocd-e2e-rhsso

--- a/tests/e2e-rhsso/argocd-tests/99-delete.yaml
+++ b/tests/e2e-rhsso/argocd-tests/99-delete.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: echo 
+  - command: oc delete argocd example-argocd-keycloak -n argocd-e2e-rhsso
+  - command: oc delete ns argocd-e2e-rhsso


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:

**This PR adds the below enhancements.**
-------------------------------------------
* Added missing RBAC annotations in `agocd_controller.go`: `template.openshift.io` and `oauth.openshift.io` api groups. Without these annotations, RBAC manifests won't get generated properly in order to install RHSSO.
* Removed hardcoded OIDC client secrets and replaced them by generated random strings. These client secrets do not need to be stored. 
* Added `KeycloakIdentityProviderMapper` to workaround https://github.com/keycloak/keycloak-operator/issues/471. Without the workaround, tokens can't be translated to credentials that contain the group identity.
* Propagated proxy environment variables from operator to Keycloak containers so that outbound calls can go through cluster proxy if cluste proxy is configured.
* Delete OAuth client using foreground propagation policy to ensure that the garbage collector removes all instantiated objects before the TemplateInstance itself disappears.
* Add extra Delete OAuth client calls to workaround https://github.com/openshift/client-go/issues/209
* Add retries to handle RHSSO image upgrade
* Upgrades the default version of RH-SSO to 7.5.1
* Adds support to login with `kube:admin` OpenShift User.
* With this PR, RH-SSO can fetch the group details of OpenShift Users(You should see the group details of the logged in user in the Argo CD console). This will help admins define Group Level RBAC for their OpenShift groups. 
   https://github.com/keycloak/keycloak/pull/8381
* Kube:admin by default you only have. Not working previously. not an OS user.
   https://github.com/keycloak/keycloak/pull/8428
* RHSSO works in proxy enabled cluster with no additional or manual configuration.
   https://github.com/keycloak/keycloak/pull/8559
*. Upgrades Keycloak version to `15.0.2`. On non-OpenShif Kubernetes clusters, users will see a Keycloak version upgrade from `9.0.3` to `15.0.2`

**Upgrades**
----------------
Whether you are using the Operator on Kubernetes or OpenShift, Version upgrades mentioned above are smooth and does not require any manual intervention other than upgrading the operator to new version(0.3.0) once it's released.

**Have you updated the necessary documentation?**
------------------
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:
-------------------

Kubernetes:
----------------------
1. Deploy the below catalog source
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: argocd-catalog
spec:
  sourceType: grpc
  image: quay.io/aveerama/argocd-operator-index@sha256:bb0db86d3e6e27fe9d9e6891027db62e3b15f2947d65b059de8c7aae3a582eda
  displayName: Argo CD Operators
  publisher: Argo CD Community
```

2. Run the make target to install the CRDs `make install`
3. kubectl create namespace argocd
4. kubectl create -n argocd -f deploy/operator_group.yaml
5. kubectl create -n argocd -f deploy/subscription.yaml
6. kubectl create -n argocd -f examples/argocd-keycloak-k8s.yaml

OpenShift:
---------------
1. Deploy the below catalog source into `openshift-operators` namespace.
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: argocd-catalog
spec:
  sourceType: grpc
  image: quay.io/aveerama/argocd-operator-index@sha256:bb0db86d3e6e27fe9d9e6891027db62e3b15f2947d65b059de8c7aae3a582eda
  displayName: Argo CD Operators
  publisher: Argo CD Community
```
2. Move to Operator Hub to install the Operator.
3. kubectl create namespace argocd
4. kubectl create -n argocd -f examples/argocd-keycloak-openshift.yaml


Testing upgrade:
-------------------

1. Install the `0.2.0` of operator(same for k8s and OpenShift).
2. Create an Argo CD Instance with Keycloak as shown above.
3. Delete the operator but keep the Argo CD Instance and workloads as is.
4. Now, Install the new version of operator and see if the Keycloak pod is recreated and updated.

How to test login with kube:admin
------------------------

On your OpenShift cluster, Go to Networking -> Routes -> Click on the Argo CD route.
1. Click on `Login Via Keycloak` -> `Login with OpenShift` -> Provide `kubeadmin` credentials.
2. Once you login to Argo CD, you can also confirm this by looking into the user profile section.

Run E2E test:
--------------------
Download kuttl on your laptop or server
Run operator locally or through the bundle.
Run the below command to execute rhsso e2e tests
`kubectl kuttl test --config kuttl-test-rhsso.yaml`