### PR TITLE
GITOPS-1550 removed unnecessary roles/rolebindings for target namespace

### DIFF
--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -91,6 +91,10 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 
 	// create policy rules for each namespace
 	for _, namespace := range r.ManagedNamespaces.Items {
+		// only create dexServer and redisHa roles for the namespace where the argocd instance is deployed
+		if cr.ObjectMeta.Namespace != namespace.Name && (name == dexServer || name == redisHa) {
+			break
+		}
 		customRole := getCustomRoleName(name)
 		role := newRole(name, policyRules, cr)
 		if err := applyReconcilerHook(cr, role, ""); err != nil {

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -100,6 +100,10 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 	}
 
 	for _, namespace := range r.ManagedNamespaces.Items {
+		// only create dexServer and redisHa rolebindings for the namespace where the argocd instance is deployed
+		if cr.ObjectMeta.Namespace != namespace.Name && (name == dexServer || name == redisHa) {
+			break
+		}
 		// get expected name
 		roleBinding := newRoleBindingWithname(name, cr)
 		roleBinding.Namespace = namespace.Name


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What does this PR do / why we need it**:
When creating a namespace with the manage-by label it creates unnecessary dexServer and redisHa roles and roleBindings on the new namespace. The below namespace test doesn't need these roles/rolebindings.

~~~
apiVersion: v1
kind: Namespace
metadata:
   name: test
   labels:
     argocd.argoproj.io/managed-by: openshift-gitops
~~~

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes GITOPS-1550

**How to test changes / Special notes to the reviewer**:
1. Create a target namespace with managed-by label of the namespace where Argo CD instance is deployed.
2. Run
`$ oc get roles -n <target-namespace>`
`$ oc get rolebindings -n <target-namespace>`
3. Confirm that no desServer and redisHa roles/rolebindings are listed for the target namespace