### PR TITLE
[Release v0.2.1] fix argocd-tls-certs-cm overwritting and CVE 2022-24348

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,5 +1,5 @@
-# Argo CD v2.2.2
-FROM quay.io/argoproj/argocd@sha256:358c244c96313ca3bf9f588dc870d8123fc22ffa5c231c57da10f77b8d671c66
+# Argo CD v2.2.5
+FROM quay.io/argoproj/argocd@sha256:0cdf5aac80f0a77307cbb288a0c1e5e39d4bac0cafb3c285a6d3c656b9f8e910
 
 USER root
 

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -58,7 +58,7 @@ const (
 	ArgoCDDefaultArgoImage = "quay.io/argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:358c244c96313ca3bf9f588dc870d8123fc22ffa5c231c57da10f77b8d671c66" // v2.2.2
+	ArgoCDDefaultArgoVersion = "sha256:0cdf5aac80f0a77307cbb288a0c1e5e39d4bac0cafb3c285a6d3c656b9f8e910" // v2.2.5
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -680,17 +680,16 @@ func (r *ReconcileArgoCD) reconcileSSHKnownHosts(cr *argoprojv1a1.ArgoCD) error 
 // reconcileTLSCerts will ensure that the ArgoCD TLS Certs ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileTLSCerts(cr *argoprojv1a1.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDTLSCertsConfigMapName, cr)
-
-	if !argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
-		cm.Data = getInitialTLSCerts(cr)
-		if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
-			return err
-		}
-		return r.Client.Create(context.TODO(), cm)
+	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
+		return nil // ConfigMap found, move along...
 	}
 
 	cm.Data = getInitialTLSCerts(cr)
-	return r.Client.Update(context.TODO(), cm)
+
+	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
+		return err
+	}
+	return r.Client.Create(context.TODO(), cm)
 }
 
 // reconcileGPGKeysConfigMap creates a gpg-keys config map

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -625,3 +625,14 @@ func TestSetManagedNamespaces(t *testing.T) {
 		}
 	}
 }
+
+func generateEncodedPEM(t *testing.T, host string) []byte {
+	key, err := argoutil.NewPrivateKey()
+	assert.NoError(t, err)
+
+	cert, err := argoutil.NewSelfSignedCACertificate(key)
+	assert.NoError(t, err)
+
+	encoded := argoutil.EncodeCertificatePEM(cert)
+	return encoded
+}

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -43,7 +43,7 @@ Name | Default | Description
 [**StatusBadgeEnabled**](#status-badge-enabled) | `true` | Enable application status badge feature.
 [**TLS**](#tls-options) | [Object] | TLS configuration options.
 [**UsersAnonymousEnabled**](#users-anonymous-enabled) | `true` | Enable anonymous user access.
-[**Version**](#version) | v2.2.2 (SHA) | The tag to use with the container image for all Argo CD components.
+[**Version**](#version) | v2.2.5 (SHA) | The tag to use with the container image for all Argo CD components.
 
 ## Application Instance Label Key
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1157,6 +1157,28 @@ spec:
     initialCerts: []
 ```
 
+### IntialCerts Example
+
+Initial set of repository certificates to be configured in Argo CD upon creation of the cluster.
+
+This property maps directly to the data field in the argocd-tls-certs-cm ConfigMap. Updating this property after the cluster has been created has no affect and should be used only as a means to initialize the cluster with the value provided. Updating new certificates should then be made through the Argo CD web UI or CLI.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: intialCerts
+spec:
+  tls:
+    ca: {}
+    initialCerts:
+      test.example.com: |
+        -----BEGIN CERTIFICATE-----
+        -----END CERTIFICATE-----
+```
+
 ## Users Anonymous Enabled
 
 Enables anonymous user access. The anonymous users get default role permissions specified `argocd-rbac-cm`.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-operator
 go 1.16
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.2.2
+	github.com/argoproj/argo-cd/v2 v2.2.5
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj/argo-cd/v2 v2.2.2 h1:sKfiJuGiG85dBRYZz20n+y3tqs+F7yuLAKkxTH0Y260=
-github.com/argoproj/argo-cd/v2 v2.2.2/go.mod h1:J51If+krhtBEbNP/Y/l9sh9HctPHiiGueqPAkfFXXBo=
+github.com/argoproj/argo-cd/v2 v2.2.5 h1:Amthb2SRNixwl6q/1dk+3SbfXouNApk+eS0Zy9TsYqc=
+github.com/argoproj/argo-cd/v2 v2.2.5/go.mod h1:J51If+krhtBEbNP/Y/l9sh9HctPHiiGueqPAkfFXXBo=
 github.com/argoproj/gitops-engine v0.5.2/go.mod h1:K2RYpGXh11VdFwDksS23SyFTOJaPcsF+MVJ/FHlqEOE=
 github.com/argoproj/pkg v0.11.1-0.20211203175135-36c59d8fafe0/go.mod h1:ra+bQPmbVAoEL+gYSKesuigt4m49i3Qa3mE/xQcjCiA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
> For example, `> /kind bug` would simply become: `/kind bug`
> /kind bug

**What does this PR do / why we need it**:
1. cherrypicks #553 
2. fixes CVE 2022-24348 by upgrading Argo CD to v2.2.5

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
#552 
CVE 2022-24348

Fixes #552 
CVE 2022-24348

**How to test changes / Special notes to the reviewer**:
#552  is a clean cherry-pick from master branch. There is no additional testing required.

Steps to test CVE 2022-24348:

- Create namespace helm-guestbook
- Create ArgoCD instance somewhere
- Create application with this manifest
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: helm-guestbook
  namespace: <argo namespace>
spec:
  destination:
    namespace: helm-guestbook
    server: https://kubernetes.default.svc/
  project: default
  source:
    helm:
      valueFiles:
      - /foo.yaml
    path: helm-guestbook
    repoURL: https://github.com/argoproj/argocd-example-apps
    targetRevision: HEAD
```
- Try to sync application
-  Inspect helm-guestbook Application. If it has the below condition the fix is not working.
```
  conditions:
  - lastTransitionTime: "2022-02-16T19:20:22Z"
    message: 'rpc error: code = Unknown desc = `helm template . --name-template ........
```