### PR TITLE
feat: add permissions to manage monitoring resources

### DIFF
--- a/controllers/openshift/openshift.go
+++ b/controllers/openshift/openshift.go
@@ -99,6 +99,17 @@ func getPolicyRuleForApplicationController() []rbacv1.PolicyRule {
 				"watch",
 			},
 		},
+		{
+			APIGroups: []string{
+				"monitoring.coreos.com",
+			},
+			Resources: []string{
+				"*",
+			},
+			Verbs: []string{
+				"*",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
 /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
Adds permissions for managing `monitoring.coreos.com` resources to the `argocd-application-controller` role in order for argocd-operator to create `prometheusRules` (if there is one included in any application that is being managed by any argo-cd instance controlled by the argocd-operator)

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-1638

**How to test changes / Special notes to the reviewer**:

- build operator out of this branch
- create Argo CD instance
- use https://github.com/jaideepr97/gitops-examples/tree/master/bgd-k8s to create an application within argo-cd and sync it
- application should be sync'd and healthy 
