### PR TITLE
fix: Set subject on CA cert used for signing self-signed certs

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -92,7 +92,7 @@ func newCASecret(cr *argoprojv1a1.ArgoCD) (*corev1.Secret, error) {
 		return nil, err
 	}
 
-	cert, err := argoutil.NewSelfSignedCACertificate(key)
+	cert, err := argoutil.NewSelfSignedCACertificate(cr.Name, key)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/argocd/testing.go
+++ b/controllers/argocd/testing.go
@@ -217,7 +217,7 @@ func initialCerts(t *testing.T, host string) argoCDOpt {
 	return func(a *argoprojv1alpha1.ArgoCD) {
 		key, err := argoutil.NewPrivateKey()
 		assert.NoError(t, err)
-		cert, err := argoutil.NewSelfSignedCACertificate(key)
+		cert, err := argoutil.NewSelfSignedCACertificate(a.Name, key)
 		assert.NoError(t, err)
 		encoded := argoutil.EncodeCertificatePEM(cert)
 

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -630,7 +630,7 @@ func generateEncodedPEM(t *testing.T, host string) []byte {
 	key, err := argoutil.NewPrivateKey()
 	assert.NoError(t, err)
 
-	cert, err := argoutil.NewSelfSignedCACertificate(key)
+	cert, err := argoutil.NewSelfSignedCACertificate("foo", key)
 	assert.NoError(t, err)
 
 	encoded := argoutil.EncodeCertificatePEM(cert)

--- a/controllers/argoutil/tls.go
+++ b/controllers/argoutil/tls.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"time"
@@ -71,7 +72,7 @@ func ParsePEMEncodedPrivateKey(pemdata []byte) (*rsa.PrivateKey, error) {
 
 // NewSelfSignedCACertificate returns a self-signed CA certificate based on given configuration and private key.
 // The certificate has one-year lease.
-func NewSelfSignedCACertificate(key *rsa.PrivateKey) (*x509.Certificate, error) {
+func NewSelfSignedCACertificate(name string, key *rsa.PrivateKey) (*x509.Certificate, error) {
 	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
 	if err != nil {
 		return nil, err
@@ -84,6 +85,7 @@ func NewSelfSignedCACertificate(key *rsa.PrivateKey) (*x509.Certificate, error) 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
+		Subject:               pkix.Name{CommonName: fmt.Sprintf("argocd-operator@%s", name)},
 	}
 	certDERBytes, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, key.Public(), key)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

See https://github.com/redhat-developer/gitops-operator/issues/277

Recent versions of Firefox refuse to process TLS certificates that are signed by an unnamed CA. The Operator uses a CA certificate that's created without a X509 `Subject`, and thus, Firefox chokes.

For an existing installation, the `argocd-tls` and `argocd-ca` secrets must be deleted and reconciled back by the Operator.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/redhat-developer/gitops-operator/issues/277

**How to test changes / Special notes to the reviewer**:

* Install a recent version of Firefox (I used 97.0.1 (64-bit), installed via Flatpak)
* Create simple ArgoCD for the Operator to reconcile and to create a new Argo CD instance. If you use `route`, make sure that `.server.route.tls.termination` is set to `passthrough` (or left blank, because `passthrough` is the default)
* Point Firefox to the Argo CD UI
* Connection should be successful (the unknown certificate message is expected, but should be skippable)