### PR TITLE
fix: add missing bundle updates from #534

### DIFF
--- a/deploy/olm-catalog/argocd-operator/0.3.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.3.0/argoproj.io_argocds.yaml
@@ -82,6 +82,20 @@ spec:
                       (optional)
                     type: string
                 type: object
+              banner:
+                description: Banner defines an additional banner to be displayed in
+                  Argo CD UI
+                properties:
+                  content:
+                    description: Content defines the banner message content to display
+                    type: string
+                  url:
+                    description: URL defines an optional URL to be used as banner
+                      message link
+                    type: string
+                required:
+                - content
+                type: object
               configManagementPlugins:
                 description: ConfigManagementPlugins is used to specify additional
                   config management plugins.


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
PR #534 did not add changes into bundle. To be specific `deploy/olm-catalog/argocd-operator/0.3.0/argoproj.io_argocds.yaml` file. This is causing CI on the other PR's fail.

Run `make bundle` to regenerate outdated manifests.

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
Fixes PR #534 

**How to test changes / Special notes to the reviewer**:
This should unblock the CI failures on other PRs.