### PR TITLE
fix: panic when missing init containers

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1060,24 +1060,6 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 			existing.Spec.Template.Spec.InitContainers = deploy.Spec.Template.Spec.InitContainers
 			changed = true
 		}
-		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].VolumeMounts,
-			existing.Spec.Template.Spec.InitContainers[0].VolumeMounts) {
-			existing.Spec.Template.Spec.InitContainers[0].VolumeMounts = deploy.Spec.Template.Spec.InitContainers[0].VolumeMounts
-			changed = true
-		}
-		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].Env,
-			existing.Spec.Template.Spec.InitContainers[0].Env) {
-			existing.Spec.Template.Spec.InitContainers[0].Env = deploy.Spec.Template.Spec.InitContainers[0].Env
-			changed = true
-		}
-		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].Resources, existing.Spec.Template.Spec.InitContainers[0].Resources) {
-			existing.Spec.Template.Spec.InitContainers[0].Resources = deploy.Spec.Template.Spec.InitContainers[0].Resources
-			changed = true
-		}
-		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].Command, existing.Spec.Template.Spec.InitContainers[0].Command) {
-			existing.Spec.Template.Spec.InitContainers[0].Command = deploy.Spec.Template.Spec.InitContainers[0].Command
-			changed = true
-		}
 		if !reflect.DeepEqual(deploy.Spec.Replicas, existing.Spec.Replicas) {
 			existing.Spec.Replicas = deploy.Spec.Replicas
 			changed = true

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1056,6 +1056,10 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 				deploy.Spec.Template.Spec.Containers[1:]...)
 			changed = true
 		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers, existing.Spec.Template.Spec.InitContainers) {
+			existing.Spec.Template.Spec.InitContainers = deploy.Spec.Template.Spec.InitContainers
+			changed = true
+		}
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].VolumeMounts,
 			existing.Spec.Template.Spec.InitContainers[0].VolumeMounts) {
 			existing.Spec.Template.Spec.InitContainers[0].VolumeMounts = deploy.Spec.Template.Spec.InitContainers[0].VolumeMounts
@@ -1072,12 +1076,6 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 		}
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].Command, existing.Spec.Template.Spec.InitContainers[0].Command) {
 			existing.Spec.Template.Spec.InitContainers[0].Command = deploy.Spec.Template.Spec.InitContainers[0].Command
-			changed = true
-		}
-		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[1:],
-			existing.Spec.Template.Spec.InitContainers[1:]) {
-			existing.Spec.Template.Spec.InitContainers = append(existing.Spec.Template.Spec.InitContainers[0:1],
-				deploy.Spec.Template.Spec.InitContainers[1:]...)
 			changed = true
 		}
 		if !reflect.DeepEqual(deploy.Spec.Replicas, existing.Spec.Replicas) {


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

Fixes a bug with CMP 2.0 support where the reconciler would panic if there was an existing argocd repo deployment without any init containers

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #586

**How to test**

* Install the operator.
* Install an Argo CD instance
* Edit the repo server deployment and delete the init container
  `kubectl edit deployments.apps argocd-repo-server `
* The operator should not panic. Edit the repo server deployment again and check that the init container was added back

