### PR TITLE
bug: update workflow to avoid deleting Secrets while reconciling cluster permissions

### DIFF
--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -246,6 +246,6 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	assert.NoError(t, r.reconcileClusterPermissionsSecret(a))
 	//assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret), "not found")
 	//TODO: https://github.com/stretchr/testify/pull/1022 introduced ErrorContains, but is not yet available in a tagged release. Revert to ErrorContains once this becomes available
-	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
-	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret).Error(), "not found")
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
+	assert.Nil(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
 }


### PR DESCRIPTION
**What type of PR is this?**
   /kind bug

**What does this PR do / why we need it**:
While reconciling cluster permissions, every time the Secret was deleted if the secret belongs to a cluster config instance.
In this PR, we are updating the logic to not delete the Secret, but to remove the `namespaces` field from the Secret.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-1777](https://issues.redhat.com/browse/GITOPS-1777)

**How to test changes / Special notes to the reviewer**:
* build operator out of this branch
* create Argo CD instance
* Enable route for Argo CD instance to be able to access UI
* Log in to Argo CD UI -> Settings -> Clusters, edit the existing cluster to see the Secret getting created
* Update ArgoCD instance to add a label `food: pizza` and sync it
* See that the Secret does not get deleted automatically