### PR TITLE
[0.3.0] upgrades appsets to v0.4.1

### DIFF
--- a/bundle/manifests/argoproj.io_applicationsets.yaml
+++ b/bundle/manifests/argoproj.io_applicationsets.yaml
@@ -20,71 +20,32 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ApplicationSet is a set of Application resources
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ApplicationSetSpec represents a class of application set
-              state.
             properties:
               generators:
                 items:
-                  description: ApplicationSetGenerator include list item info
                   properties:
                     clusterDecisionResource:
-                      description: DuckType defines a generator to match against clusters
-                        registered with ArgoCD.
                       properties:
                         configMapRef:
-                          description: ConfigMapRef is a ConfigMap with the duck type
-                            definitions needed to retreive the data              this
-                            includes apiVersion(group/version), kind, matchKey and
-                            validation settings Name is the resource name of the kind,
-                            group and version, defined in the ConfigMapRef RequeueAfterSeconds
-                            is how long before the duckType will be rechecked for
-                            a change
                           type: string
                         labelSelector:
-                          description: A label selector is a label query over a set
-                            of resources. The result of matchLabels and matchExpressions
-                            are ANDed. An empty label selector matches all objects.
-                            A null label selector matches no objects.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -96,11 +57,6 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         name:
@@ -109,12 +65,8 @@ spec:
                           format: int64
                           type: integer
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -134,40 +86,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -181,6 +111,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -190,9 +124,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -205,58 +136,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -270,18 +167,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -296,91 +186,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -395,77 +247,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -476,82 +291,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -568,46 +341,22 @@ spec:
                         values:
                           additionalProperties:
                             type: string
-                          description: Values contains key/value pairs which are passed
-                            directly as parameters to the template
                           type: object
                       required:
                       - configMapRef
                       type: object
                     clusters:
-                      description: ClusterGenerator defines a generator to match against
-                        clusters registered with ArgoCD.
                       properties:
                         selector:
-                          description: Selector defines a label selector to match
-                            against all clusters registered with ArgoCD. Clusters
-                            today are stored as Kubernetes Secrets, thus the Secret
-                            labels will be used for matching the selector.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -619,20 +368,11 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -652,40 +392,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -699,6 +417,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -708,9 +430,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -723,58 +442,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -788,18 +473,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -814,91 +492,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -913,77 +553,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -994,82 +597,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -1086,8 +647,6 @@ spec:
                         values:
                           additionalProperties:
                             type: string
-                          description: Values contains key/value pairs which are passed
-                            directly as parameters to the template
                           type: object
                       type: object
                     git:
@@ -1120,12 +679,8 @@ spec:
                         revision:
                           type: string
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1145,40 +700,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -1192,6 +725,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -1201,9 +738,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -1216,58 +750,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1281,18 +781,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1307,91 +800,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -1406,77 +861,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -1487,82 +905,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -1581,19 +957,14 @@ spec:
                       - revision
                       type: object
                     list:
-                      description: ListGenerator include items info
                       properties:
                         elements:
                           items:
                             x-kubernetes-preserve-unknown-fields: true
                           type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1613,40 +984,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -1660,6 +1009,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -1669,9 +1022,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -1684,58 +1034,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1749,18 +1065,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1775,91 +1084,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -1874,77 +1145,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -1955,82 +1189,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -2048,63 +1240,24 @@ spec:
                       - elements
                       type: object
                     matrix:
-                      description: MatrixGenerator include Other generators
                       properties:
                         generators:
                           items:
-                            description: ApplicationSetBaseGenerator include list
-                              item info CRD dosn't support recursive types so we need
-                              a different type for the matrix generator https://github.com/kubernetes-sigs/controller-tools/issues/477
                             properties:
                               clusterDecisionResource:
-                                description: DuckType defines a generator to match
-                                  against clusters registered with ArgoCD.
                                 properties:
                                   configMapRef:
-                                    description: ConfigMapRef is a ConfigMap with
-                                      the duck type definitions needed to retreive
-                                      the data              this includes apiVersion(group/version),
-                                      kind, matchKey and validation settings Name
-                                      is the resource name of the kind, group and
-                                      version, defined in the ConfigMapRef RequeueAfterSeconds
-                                      is how long before the duckType will be rechecked
-                                      for a change
                                     type: string
                                   labelSelector:
-                                    description: A label selector is a label query
-                                      over a set of resources. The result of matchLabels
-                                      and matchExpressions are ANDed. An empty label
-                                      selector matches all objects. A null label selector
-                                      matches no objects.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2116,12 +1269,6 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   name:
@@ -2130,14 +1277,8 @@ spec:
                                     format: int64
                                     type: integer
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -2157,44 +1298,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -2208,6 +1323,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -2217,9 +1336,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -2232,67 +1348,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2306,19 +1379,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2333,106 +1398,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -2447,88 +1459,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -2539,92 +1503,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -2641,51 +1553,22 @@ spec:
                                   values:
                                     additionalProperties:
                                       type: string
-                                    description: Values contains key/value pairs which
-                                      are passed directly as parameters to the template
                                     type: object
                                 required:
                                 - configMapRef
                                 type: object
                               clusters:
-                                description: ClusterGenerator defines a generator
-                                  to match against clusters registered with ArgoCD.
                                 properties:
                                   selector:
-                                    description: Selector defines a label selector
-                                      to match against all clusters registered with
-                                      ArgoCD. Clusters today are stored as Kubernetes
-                                      Secrets, thus the Secret labels will be used
-                                      for matching the selector.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2697,23 +1580,11 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -2733,44 +1604,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -2784,6 +1629,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -2793,9 +1642,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -2808,67 +1654,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2882,19 +1685,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2909,106 +1704,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -3023,88 +1765,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -3115,92 +1809,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -3217,8 +1859,6 @@ spec:
                                   values:
                                     additionalProperties:
                                       type: string
-                                    description: Values contains key/value pairs which
-                                      are passed directly as parameters to the template
                                     type: object
                                 type: object
                               git:
@@ -3251,14 +1891,8 @@ spec:
                                   revision:
                                     type: string
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -3278,44 +1912,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -3329,6 +1937,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -3338,9 +1950,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -3353,67 +1962,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3427,19 +1993,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3454,106 +2012,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -3568,88 +2073,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -3660,92 +2117,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -3764,21 +2169,14 @@ spec:
                                 - revision
                                 type: object
                               list:
-                                description: ListGenerator include items info
                                 properties:
                                   elements:
                                     items:
                                       x-kubernetes-preserve-unknown-fields: true
                                     type: array
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -3798,44 +2196,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -3849,6 +2221,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -3858,9 +2234,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -3873,67 +2246,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3947,19 +2277,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3974,106 +2296,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -4088,88 +2357,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -4180,92 +2401,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -4282,62 +2451,25 @@ spec:
                                 required:
                                 - elements
                                 type: object
-                              scmProvider:
-                                description: SCMProviderGenerator defines a generator
-                                  that scrapes a SCMaaS API to find candidate repos.
+                              matrix:
+                                x-kubernetes-preserve-unknown-fields: true
+                              merge:
+                                x-kubernetes-preserve-unknown-fields: true
+                              pullRequest:
                                 properties:
-                                  cloneProtocol:
-                                    description: Which protocol to use for the SCM
-                                      URL. Default is provider-specific but ssh if
-                                      possible. Not all providers necessarily support
-                                      all protocols.
-                                    type: string
-                                  filters:
-                                    description: Filters for which repos should be
-                                      considered.
-                                    items:
-                                      description: SCMProviderGeneratorFilter is a
-                                        single repository filter. If multiple filter
-                                        types are set on a single struct, they will
-                                        be AND'd together. All filters must pass for
-                                        a repo to be included.
-                                      properties:
-                                        branchMatch:
-                                          description: A regex which must match the
-                                            branch name.
-                                          type: string
-                                        labelMatch:
-                                          description: A regex which must match at
-                                            least one label.
-                                          type: string
-                                        pathsExist:
-                                          description: An array of paths, all of which
-                                            must exist.
-                                          items:
-                                            type: string
-                                          type: array
-                                        repositoryMatch:
-                                          description: A regex for repo names.
-                                          type: string
-                                      type: object
-                                    type: array
                                   github:
-                                    description: Which provider to use and config
-                                      for it.
                                     properties:
-                                      allBranches:
-                                        description: Scan all branches instead of
-                                          just the default branch.
-                                        type: boolean
                                       api:
-                                        description: The GitHub API URL to talk to.
-                                          If blank, use https://api.github.com/.
                                         type: string
-                                      organization:
-                                        description: GitHub org to scan. Required.
+                                      labels:
+                                        items:
+                                          type: string
+                                        type: array
+                                      owner:
+                                        type: string
+                                      repo:
                                         type: string
                                       tokenRef:
-                                        description: Authentication token reference.
                                         properties:
                                           key:
                                             type: string
@@ -4348,56 +2480,15 @@ spec:
                                         - secretName
                                         type: object
                                     required:
-                                    - organization
-                                    type: object
-                                  gitlab:
-                                    description: SCMProviderGeneratorGitlab defines
-                                      a connection info specific to Gitlab.
-                                    properties:
-                                      allBranches:
-                                        description: Scan all branches instead of
-                                          just the default branch.
-                                        type: boolean
-                                      api:
-                                        description: The Gitlab API URL to talk to.
-                                        type: string
-                                      group:
-                                        description: Gitlab group to scan. Required.  You
-                                          can use either the project id (recommended)
-                                          or the full namespaced path.
-                                        type: string
-                                      includeSubgroups:
-                                        description: Recurse through subgroups (true)
-                                          or scan only the base group (false).  Defaults
-                                          to "false"
-                                        type: boolean
-                                      tokenRef:
-                                        description: Authentication token reference.
-                                        properties:
-                                          key:
-                                            type: string
-                                          secretName:
-                                            type: string
-                                        required:
-                                        - key
-                                        - secretName
-                                        type: object
-                                    required:
-                                    - group
+                                    - owner
+                                    - repo
                                     type: object
                                   requeueAfterSeconds:
-                                    description: Standard parameters.
                                     format: int64
                                     type: integer
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -4417,44 +2508,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -4468,6 +2533,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -4477,9 +2546,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -4492,67 +2558,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -4566,19 +2589,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -4593,106 +2608,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -4707,88 +2669,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -4799,92 +2713,381 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
+                              scmProvider:
+                                properties:
+                                  cloneProtocol:
+                                    type: string
+                                  filters:
+                                    items:
+                                      properties:
+                                        branchMatch:
+                                          type: string
+                                        labelMatch:
+                                          type: string
+                                        pathsExist:
+                                          items:
+                                            type: string
+                                          type: array
+                                        repositoryMatch:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  github:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      organization:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - organization
+                                    type: object
+                                  gitlab:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      group:
+                                        type: string
+                                      includeSubgroups:
+                                        type: boolean
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - group
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
                                                 items:
                                                   type: string
                                                 type: array
@@ -4902,12 +3105,8 @@ spec:
                             type: object
                           type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -4927,40 +3126,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -4974,6 +3151,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -4983,9 +3164,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -4998,58 +3176,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5063,18 +3207,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5089,91 +3226,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -5188,77 +3287,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -5269,82 +3331,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -5361,114 +3381,1878 @@ spec:
                       required:
                       - generators
                       type: object
-                    scmProvider:
-                      description: SCMProviderGenerator defines a generator that scrapes
-                        a SCMaaS API to find candidate repos.
+                    merge:
                       properties:
-                        cloneProtocol:
-                          description: Which protocol to use for the SCM URL. Default
-                            is provider-specific but ssh if possible. Not all providers
-                            necessarily support all protocols.
-                          type: string
-                        filters:
-                          description: Filters for which repos should be considered.
+                        generators:
                           items:
-                            description: SCMProviderGeneratorFilter is a single repository
-                              filter. If multiple filter types are set on a single
-                              struct, they will be AND'd together. All filters must
-                              pass for a repo to be included.
                             properties:
-                              branchMatch:
-                                description: A regex which must match the branch name.
-                                type: string
-                              labelMatch:
-                                description: A regex which must match at least one
-                                  label.
-                                type: string
-                              pathsExist:
-                                description: An array of paths, all of which must
-                                  exist.
-                                items:
-                                  type: string
-                                type: array
-                              repositoryMatch:
-                                description: A regex for repo names.
-                                type: string
+                              clusterDecisionResource:
+                                properties:
+                                  configMapRef:
+                                    type: string
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  name:
+                                    type: string
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                  values:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                required:
+                                - configMapRef
+                                type: object
+                              clusters:
+                                properties:
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                  values:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              git:
+                                properties:
+                                  directories:
+                                    items:
+                                      properties:
+                                        exclude:
+                                          type: boolean
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                  files:
+                                    items:
+                                      properties:
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                  repoURL:
+                                    type: string
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  revision:
+                                    type: string
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                required:
+                                - repoURL
+                                - revision
+                                type: object
+                              list:
+                                properties:
+                                  elements:
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                required:
+                                - elements
+                                type: object
+                              matrix:
+                                x-kubernetes-preserve-unknown-fields: true
+                              merge:
+                                x-kubernetes-preserve-unknown-fields: true
+                              pullRequest:
+                                properties:
+                                  github:
+                                    properties:
+                                      api:
+                                        type: string
+                                      labels:
+                                        items:
+                                          type: string
+                                        type: array
+                                      owner:
+                                        type: string
+                                      repo:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - owner
+                                    - repo
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
+                              scmProvider:
+                                properties:
+                                  cloneProtocol:
+                                    type: string
+                                  filters:
+                                    items:
+                                      properties:
+                                        branchMatch:
+                                          type: string
+                                        labelMatch:
+                                          type: string
+                                        pathsExist:
+                                          items:
+                                            type: string
+                                          type: array
+                                        repositoryMatch:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  github:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      organization:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - organization
+                                    type: object
+                                  gitlab:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      group:
+                                        type: string
+                                      includeSubgroups:
+                                        type: boolean
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - group
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
                             type: object
                           type: array
-                        github:
-                          description: Which provider to use and config for it.
-                          properties:
-                            allBranches:
-                              description: Scan all branches instead of just the default
-                                branch.
-                              type: boolean
-                            api:
-                              description: The GitHub API URL to talk to. If blank,
-                                use https://api.github.com/.
-                              type: string
-                            organization:
-                              description: GitHub org to scan. Required.
-                              type: string
-                            tokenRef:
-                              description: Authentication token reference.
-                              properties:
-                                key:
-                                  type: string
-                                secretName:
-                                  type: string
-                              required:
-                              - key
-                              - secretName
-                              type: object
-                          required:
-                          - organization
-                          type: object
-                        gitlab:
-                          description: SCMProviderGeneratorGitlab defines a connection
-                            info specific to Gitlab.
-                          properties:
-                            allBranches:
-                              description: Scan all branches instead of just the default
-                                branch.
-                              type: boolean
-                            api:
-                              description: The Gitlab API URL to talk to.
-                              type: string
-                            group:
-                              description: Gitlab group to scan. Required.  You can
-                                use either the project id (recommended) or the full
-                                namespaced path.
-                              type: string
-                            includeSubgroups:
-                              description: Recurse through subgroups (true) or scan
-                                only the base group (false).  Defaults to "false"
-                              type: boolean
-                            tokenRef:
-                              description: Authentication token reference.
-                              properties:
-                                key:
-                                  type: string
-                                secretName:
-                                  type: string
-                              required:
-                              - key
-                              - secretName
-                              type: object
-                          required:
-                          - group
-                          type: object
-                        requeueAfterSeconds:
-                          description: Standard parameters.
-                          format: int64
-                          type: integer
+                        mergeKeys:
+                          items:
+                            type: string
+                          type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -5488,40 +5272,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -5535,6 +5297,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -5544,9 +5310,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -5559,58 +5322,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5624,18 +5353,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5650,91 +5372,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -5749,77 +5433,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -5830,82 +5477,690 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      required:
+                      - generators
+                      - mergeKeys
+                      type: object
+                    pullRequest:
+                      properties:
+                        github:
+                          properties:
+                            api:
+                              type: string
+                            labels:
+                              items:
+                                type: string
+                              type: array
+                            owner:
+                              type: string
+                            repo:
+                              type: string
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - owner
+                          - repo
+                          type: object
+                        requeueAfterSeconds:
+                          format: int64
+                          type: integer
+                        template:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              properties:
+                                destination:
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    server:
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  items:
+                                    properties:
+                                      group:
+                                        type: string
+                                      jqPathExpressions:
+                                        items:
+                                          type: string
+                                        type: array
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  type: string
+                                revisionHistoryLimit:
+                                  format: int64
+                                  type: integer
+                                source:
+                                  properties:
+                                    chart:
+                                      type: string
+                                    directory:
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        include:
+                                          type: string
+                                        jsonnet:
+                                          properties:
+                                            extVars:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      properties:
+                                        fileParameters:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              path:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
+                                        parameters:
+                                          items:
+                                            properties:
+                                              forceString:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          type: boolean
+                                        releaseName:
+                                          type: string
+                                        skipCrds:
+                                          type: boolean
+                                        valueFiles:
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      properties:
+                                        environment:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        forceCommonAnnotations:
+                                          type: boolean
+                                        forceCommonLabels:
+                                          type: boolean
+                                        images:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          type: string
+                                        nameSuffix:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    path:
+                                      type: string
+                                    plugin:
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      type: string
+                                    targetRevision:
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  properties:
+                                    automated:
+                                      properties:
+                                        allowEmpty:
+                                          type: boolean
+                                        prune:
+                                          type: boolean
+                                        selfHeal:
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      properties:
+                                        backoff:
+                                          properties:
+                                            duration:
+                                              type: string
+                                            factor:
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              type: string
+                                          type: object
+                                        limit:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      type: object
+                    scmProvider:
+                      properties:
+                        cloneProtocol:
+                          type: string
+                        filters:
+                          items:
+                            properties:
+                              branchMatch:
+                                type: string
+                              labelMatch:
+                                type: string
+                              pathsExist:
+                                items:
+                                  type: string
+                                type: array
+                              repositoryMatch:
+                                type: string
+                            type: object
+                          type: array
+                        github:
+                          properties:
+                            allBranches:
+                              type: boolean
+                            api:
+                              type: string
+                            organization:
+                              type: string
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - organization
+                          type: object
+                        gitlab:
+                          properties:
+                            allBranches:
+                              type: boolean
+                            api:
+                              type: string
+                            group:
+                              type: string
+                            includeSubgroups:
+                              type: boolean
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - group
+                          type: object
+                        requeueAfterSeconds:
+                          format: int64
+                          type: integer
+                        template:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              properties:
+                                destination:
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    server:
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  items:
+                                    properties:
+                                      group:
+                                        type: string
+                                      jqPathExpressions:
+                                        items:
+                                          type: string
+                                        type: array
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  type: string
+                                revisionHistoryLimit:
+                                  format: int64
+                                  type: integer
+                                source:
+                                  properties:
+                                    chart:
+                                      type: string
+                                    directory:
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        include:
+                                          type: string
+                                        jsonnet:
+                                          properties:
+                                            extVars:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      properties:
+                                        fileParameters:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              path:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
+                                        parameters:
+                                          items:
+                                            properties:
+                                              forceString:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          type: boolean
+                                        releaseName:
+                                          type: string
+                                        skipCrds:
+                                          type: boolean
+                                        valueFiles:
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      properties:
+                                        environment:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        forceCommonAnnotations:
+                                          type: boolean
+                                        forceCommonLabels:
+                                          type: boolean
+                                        images:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          type: string
+                                        nameSuffix:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    path:
+                                      type: string
+                                    plugin:
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      type: string
+                                    targetRevision:
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  properties:
+                                    automated:
+                                      properties:
+                                        allowEmpty:
+                                          type: boolean
+                                        prune:
+                                          type: boolean
+                                        selfHeal:
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      properties:
+                                        backoff:
+                                          properties:
+                                            duration:
+                                              type: string
+                                            factor:
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              type: string
+                                          type: object
+                                        limit:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
                                       items:
                                         type: string
                                       type: array
@@ -5923,22 +6178,13 @@ spec:
                   type: object
                 type: array
               syncPolicy:
-                description: ApplicationSetSyncPolicy configures how generated Applications
-                  will relate to their ApplicationSet.
                 properties:
                   preserveResourcesOnDeletion:
-                    description: PreserveResourcesOnDeletion will preserve resources
-                      on deletion. If PreserveResourcesOnDeletion is set to true,
-                      these Applications will not be deleted.
                     type: boolean
                 type: object
               template:
-                description: ApplicationSetTemplate represents argocd ApplicationSpec
                 properties:
                   metadata:
-                    description: ApplicationSetTemplateMeta represents the Argo CD
-                      application fields that may be used for Applications generated
-                      from the ApplicationSet (based on metav1.ObjectMeta)
                     properties:
                       annotations:
                         additionalProperties:
@@ -5958,36 +6204,18 @@ spec:
                         type: string
                     type: object
                   spec:
-                    description: ApplicationSpec represents desired application state.
-                      Contains link to repository with application definition and
-                      additional parameters link definition revision.
                     properties:
                       destination:
-                        description: Destination is a reference to the target Kubernetes
-                          server and namespace
                         properties:
                           name:
-                            description: Name is an alternate way of specifying the
-                              target cluster by its symbolic name
                             type: string
                           namespace:
-                            description: Namespace specifies the target namespace
-                              for the application's resources. The namespace will
-                              only be set for namespace-scoped resources that have
-                              not set a value for .metadata.namespace
                             type: string
                           server:
-                            description: Server specifies the URL of the target cluster
-                              and must be set to the Kubernetes control plane API
                             type: string
                         type: object
                       ignoreDifferences:
-                        description: IgnoreDifferences is a list of resources and
-                          their fields which should be ignored during comparison
                         items:
-                          description: ResourceIgnoreDifferences contains resource
-                            filter and list of json paths which should be ignored
-                            during comparison with live state.
                           properties:
                             group:
                               type: string
@@ -6001,6 +6229,10 @@ spec:
                               type: array
                             kind:
                               type: string
+                            managedFieldsManagers:
+                              items:
+                                type: string
+                              type: array
                             name:
                               type: string
                             namespace:
@@ -6010,8 +6242,6 @@ spec:
                           type: object
                         type: array
                       info:
-                        description: Info contains a list of information (URLs, email
-                          addresses, and plain text) that relates to the application
                         items:
                           properties:
                             name:
@@ -6024,51 +6254,24 @@ spec:
                           type: object
                         type: array
                       project:
-                        description: Project is a reference to the project this application
-                          belongs to. The empty string means that application belongs
-                          to the 'default' project.
                         type: string
                       revisionHistoryLimit:
-                        description: RevisionHistoryLimit limits the number of items
-                          kept in the application's revision history, which is used
-                          for informational purposes as well as for rollbacks to previous
-                          versions. This should only be changed in exceptional circumstances.
-                          Setting to zero will store no history. This will reduce
-                          storage used. Increasing will increase the space used to
-                          store the history, so we do not recommend increasing it.
-                          Default is 10.
                         format: int64
                         type: integer
                       source:
-                        description: Source is a reference to the location of the
-                          application's manifests or chart
                         properties:
                           chart:
-                            description: Chart is a Helm chart name, and must be specified
-                              for applications sourced from a Helm repo.
                             type: string
                           directory:
-                            description: Directory holds path/directory specific options
                             properties:
                               exclude:
-                                description: Exclude contains a glob pattern to match
-                                  paths against that should be explicitly excluded
-                                  from being used during manifest generation
                                 type: string
                               include:
-                                description: Include contains a glob pattern to match
-                                  paths against that should be explicitly included
-                                  during manifest generation
                                 type: string
                               jsonnet:
-                                description: Jsonnet holds options specific to Jsonnet
                                 properties:
                                   extVars:
-                                    description: ExtVars is a list of Jsonnet External
-                                      Variables
                                     items:
-                                      description: JsonnetVar represents a variable
-                                        to be passed to jsonnet during manifest generation
                                       properties:
                                         code:
                                           type: boolean
@@ -6082,16 +6285,11 @@ spec:
                                       type: object
                                     type: array
                                   libs:
-                                    description: Additional library search dirs
                                     items:
                                       type: string
                                     type: array
                                   tlas:
-                                    description: TLAS is a list of Jsonnet Top-level
-                                      Arguments
                                     items:
-                                      description: JsonnetVar represents a variable
-                                        to be passed to jsonnet during manifest generation
                                       properties:
                                         code:
                                           type: boolean
@@ -6106,84 +6304,53 @@ spec:
                                     type: array
                                 type: object
                               recurse:
-                                description: Recurse specifies whether to scan a directory
-                                  recursively for manifests
                                 type: boolean
                             type: object
                           helm:
-                            description: Helm holds helm specific options
                             properties:
                               fileParameters:
-                                description: FileParameters are file parameters to
-                                  the helm template
                                 items:
-                                  description: HelmFileParameter is a file parameter
-                                    that's passed to helm template during manifest
-                                    generation
                                   properties:
                                     name:
-                                      description: Name is the name of the Helm parameter
                                       type: string
                                     path:
-                                      description: Path is the path to the file containing
-                                        the values for the Helm parameter
                                       type: string
                                   type: object
                                 type: array
+                              ignoreMissingValueFiles:
+                                type: boolean
                               parameters:
-                                description: Parameters is a list of Helm parameters
-                                  which are passed to the helm template command upon
-                                  manifest generation
                                 items:
-                                  description: HelmParameter is a parameter that's
-                                    passed to helm template during manifest generation
                                   properties:
                                     forceString:
-                                      description: ForceString determines whether
-                                        to tell Helm to interpret booleans and numbers
-                                        as strings
                                       type: boolean
                                     name:
-                                      description: Name is the name of the Helm parameter
                                       type: string
                                     value:
-                                      description: Value is the value for the Helm
-                                        parameter
                                       type: string
                                   type: object
                                 type: array
+                              passCredentials:
+                                type: boolean
                               releaseName:
-                                description: ReleaseName is the Helm release name
-                                  to use. If omitted it will use the application name
                                 type: string
+                              skipCrds:
+                                type: boolean
                               valueFiles:
-                                description: ValuesFiles is a list of Helm value files
-                                  to use when generating a template
                                 items:
                                   type: string
                                 type: array
                               values:
-                                description: Values specifies Helm values to be passed
-                                  to helm template, typically defined as a block
                                 type: string
                               version:
-                                description: Version is the Helm version to use for
-                                  templating (either "2" or "3")
                                 type: string
                             type: object
                           ksonnet:
-                            description: Ksonnet holds ksonnet specific options
                             properties:
                               environment:
-                                description: Environment is a ksonnet application
-                                  environment name
                                 type: string
                               parameters:
-                                description: Parameters are a list of ksonnet component
-                                  parameter override values
                                 items:
-                                  description: KsonnetParameter is a ksonnet component
-                                    parameter
                                   properties:
                                     component:
                                       type: string
@@ -6198,72 +6365,40 @@ spec:
                                 type: array
                             type: object
                           kustomize:
-                            description: Kustomize holds kustomize specific options
                             properties:
                               commonAnnotations:
                                 additionalProperties:
                                   type: string
-                                description: CommonAnnotations is a list of additional
-                                  annotations to add to rendered manifests
                                 type: object
                               commonLabels:
                                 additionalProperties:
                                   type: string
-                                description: CommonLabels is a list of additional
-                                  labels to add to rendered manifests
                                 type: object
                               forceCommonAnnotations:
-                                description: ForceCommonAnnotations specifies whether
-                                  to force applying common annotations to resources
-                                  for Kustomize apps
                                 type: boolean
                               forceCommonLabels:
-                                description: ForceCommonLabels specifies whether to
-                                  force applying common labels to resources for Kustomize
-                                  apps
                                 type: boolean
                               images:
-                                description: Images is a list of Kustomize image override
-                                  specifications
                                 items:
-                                  description: KustomizeImage represents a Kustomize
-                                    image definition in the format [old_image_name=]<image_name>:<image_tag>
                                   type: string
                                 type: array
                               namePrefix:
-                                description: NamePrefix is a prefix appended to resources
-                                  for Kustomize apps
                                 type: string
                               nameSuffix:
-                                description: NameSuffix is a suffix appended to resources
-                                  for Kustomize apps
                                 type: string
                               version:
-                                description: Version controls which version of Kustomize
-                                  to use for rendering manifests
                                 type: string
                             type: object
                           path:
-                            description: Path is a directory path within the Git repository,
-                              and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
                             properties:
                               env:
-                                description: Env is a list of environment variable
-                                  entries
                                 items:
-                                  description: EnvEntry represents an entry in the
-                                    application's environment
                                   properties:
                                     name:
-                                      description: Name is the name of the variable,
-                                        usually expressed in uppercase
                                       type: string
                                     value:
-                                      description: Value is the value of the variable
                                       type: string
                                   required:
                                   - name
@@ -6274,73 +6409,40 @@ spec:
                                 type: string
                             type: object
                           repoURL:
-                            description: RepoURL is the URL to the repository (Git
-                              or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
                             type: string
                         required:
                         - repoURL
                         type: object
                       syncPolicy:
-                        description: SyncPolicy controls when and how a sync will
-                          be performed
                         properties:
                           automated:
-                            description: Automated will keep an application synced
-                              to the target revision
                             properties:
                               allowEmpty:
-                                description: 'AllowEmpty allows apps have zero live
-                                  resources (default: false)'
                                 type: boolean
                               prune:
-                                description: 'Prune specifies whether to delete resources
-                                  from the cluster that are not found in the sources
-                                  anymore as part of automated sync (default: false)'
                                 type: boolean
                               selfHeal:
-                                description: 'SelfHeal specifes whether to revert
-                                  resources back to their desired state upon modification
-                                  in the cluster (default: false)'
                                 type: boolean
                             type: object
                           retry:
-                            description: Retry controls failed sync retry behavior
                             properties:
                               backoff:
-                                description: Backoff controls how to backoff on subsequent
-                                  retries of failed syncs
                                 properties:
                                   duration:
-                                    description: Duration is the amount to back off.
-                                      Default unit is seconds, but could also be a
-                                      duration (e.g. "2m", "1h")
                                     type: string
                                   factor:
-                                    description: Factor is a factor to multiply the
-                                      base duration after each failed retry
                                     format: int64
                                     type: integer
                                   maxDuration:
-                                    description: MaxDuration is the maximum amount
-                                      of time allowed for the backoff strategy
                                     type: string
                                 type: object
                               limit:
-                                description: Limit is the maximum number of attempts
-                                  for retrying a failed sync. If set to 0, no retries
-                                  will be performed.
                                 format: int64
                                 type: integer
                             type: object
                           syncOptions:
-                            description: Options allow you to specify whole app sync-options
                             items:
                               type: string
                             type: array
@@ -6359,7 +6461,28 @@ spec:
             - template
             type: object
           status:
-            description: ApplicationSetStatus defines the observed state of ApplicationSet
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
             type: object
         required:
         - metadata
@@ -6367,6 +6490,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -49,7 +49,7 @@ const (
 	ArgoCDDefaultApplicationSetImage = "quay.io/argoproj/argocd-applicationset"
 
 	// ArgoCDDefaultApplicationSetVersion is the Argo CD Application Set image tag to use when not specified.
-	ArgoCDDefaultApplicationSetVersion = "v0.2.0"
+	ArgoCDDefaultApplicationSetVersion = "v0.4.1"
 
 	// ArgoCDDefaultApplicationInstanceLabelKey is the default app name as a tracking label.
 	ArgoCDDefaultApplicationInstanceLabelKey = "app.kubernetes.io/instance"

--- a/config/crd/bases/argoproj.io_applicationsets.yaml
+++ b/config/crd/bases/argoproj.io_applicationsets.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22,71 +21,32 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ApplicationSet is a set of Application resources
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ApplicationSetSpec represents a class of application set
-              state.
             properties:
               generators:
                 items:
-                  description: ApplicationSetGenerator include list item info
                   properties:
                     clusterDecisionResource:
-                      description: DuckType defines a generator to match against clusters
-                        registered with ArgoCD.
                       properties:
                         configMapRef:
-                          description: ConfigMapRef is a ConfigMap with the duck type
-                            definitions needed to retreive the data              this
-                            includes apiVersion(group/version), kind, matchKey and
-                            validation settings Name is the resource name of the kind,
-                            group and version, defined in the ConfigMapRef RequeueAfterSeconds
-                            is how long before the duckType will be rechecked for
-                            a change
                           type: string
                         labelSelector:
-                          description: A label selector is a label query over a set
-                            of resources. The result of matchLabels and matchExpressions
-                            are ANDed. An empty label selector matches all objects.
-                            A null label selector matches no objects.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -98,11 +58,6 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         name:
@@ -111,12 +66,8 @@ spec:
                           format: int64
                           type: integer
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -136,40 +87,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -183,6 +112,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -192,9 +125,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -207,58 +137,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -272,18 +168,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -298,91 +187,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -397,77 +248,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -478,82 +292,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -570,46 +342,22 @@ spec:
                         values:
                           additionalProperties:
                             type: string
-                          description: Values contains key/value pairs which are passed
-                            directly as parameters to the template
                           type: object
                       required:
                       - configMapRef
                       type: object
                     clusters:
-                      description: ClusterGenerator defines a generator to match against
-                        clusters registered with ArgoCD.
                       properties:
                         selector:
-                          description: Selector defines a label selector to match
-                            against all clusters registered with ArgoCD. Clusters
-                            today are stored as Kubernetes Secrets, thus the Secret
-                            labels will be used for matching the selector.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -621,20 +369,11 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -654,40 +393,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -701,6 +418,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -710,9 +431,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -725,58 +443,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -790,18 +474,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -816,91 +493,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -915,77 +554,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -996,82 +598,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -1088,8 +648,6 @@ spec:
                         values:
                           additionalProperties:
                             type: string
-                          description: Values contains key/value pairs which are passed
-                            directly as parameters to the template
                           type: object
                       type: object
                     git:
@@ -1122,12 +680,8 @@ spec:
                         revision:
                           type: string
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1147,40 +701,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -1194,6 +726,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -1203,9 +739,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -1218,58 +751,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1283,18 +782,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1309,91 +801,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -1408,77 +862,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -1489,82 +906,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -1583,19 +958,14 @@ spec:
                       - revision
                       type: object
                     list:
-                      description: ListGenerator include items info
                       properties:
                         elements:
                           items:
                             x-kubernetes-preserve-unknown-fields: true
                           type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1615,40 +985,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -1662,6 +1010,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -1671,9 +1023,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -1686,58 +1035,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1751,18 +1066,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1777,91 +1085,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -1876,77 +1146,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -1957,82 +1190,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -2050,63 +1241,24 @@ spec:
                       - elements
                       type: object
                     matrix:
-                      description: MatrixGenerator include Other generators
                       properties:
                         generators:
                           items:
-                            description: ApplicationSetBaseGenerator include list
-                              item info CRD dosn't support recursive types so we need
-                              a different type for the matrix generator https://github.com/kubernetes-sigs/controller-tools/issues/477
                             properties:
                               clusterDecisionResource:
-                                description: DuckType defines a generator to match
-                                  against clusters registered with ArgoCD.
                                 properties:
                                   configMapRef:
-                                    description: ConfigMapRef is a ConfigMap with
-                                      the duck type definitions needed to retreive
-                                      the data              this includes apiVersion(group/version),
-                                      kind, matchKey and validation settings Name
-                                      is the resource name of the kind, group and
-                                      version, defined in the ConfigMapRef RequeueAfterSeconds
-                                      is how long before the duckType will be rechecked
-                                      for a change
                                     type: string
                                   labelSelector:
-                                    description: A label selector is a label query
-                                      over a set of resources. The result of matchLabels
-                                      and matchExpressions are ANDed. An empty label
-                                      selector matches all objects. A null label selector
-                                      matches no objects.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2118,12 +1270,6 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   name:
@@ -2132,14 +1278,8 @@ spec:
                                     format: int64
                                     type: integer
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -2159,44 +1299,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -2210,6 +1324,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -2219,9 +1337,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -2234,67 +1349,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2308,19 +1380,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2335,106 +1399,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -2449,88 +1460,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -2541,92 +1504,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -2643,51 +1554,22 @@ spec:
                                   values:
                                     additionalProperties:
                                       type: string
-                                    description: Values contains key/value pairs which
-                                      are passed directly as parameters to the template
                                     type: object
                                 required:
                                 - configMapRef
                                 type: object
                               clusters:
-                                description: ClusterGenerator defines a generator
-                                  to match against clusters registered with ArgoCD.
                                 properties:
                                   selector:
-                                    description: Selector defines a label selector
-                                      to match against all clusters registered with
-                                      ArgoCD. Clusters today are stored as Kubernetes
-                                      Secrets, thus the Secret labels will be used
-                                      for matching the selector.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2699,23 +1581,11 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -2735,44 +1605,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -2786,6 +1630,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -2795,9 +1643,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -2810,67 +1655,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2884,19 +1686,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2911,106 +1705,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -3025,88 +1766,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -3117,92 +1810,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -3219,8 +1860,6 @@ spec:
                                   values:
                                     additionalProperties:
                                       type: string
-                                    description: Values contains key/value pairs which
-                                      are passed directly as parameters to the template
                                     type: object
                                 type: object
                               git:
@@ -3253,14 +1892,8 @@ spec:
                                   revision:
                                     type: string
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -3280,44 +1913,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -3331,6 +1938,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -3340,9 +1951,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -3355,67 +1963,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3429,19 +1994,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3456,106 +2013,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -3570,88 +2074,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -3662,92 +2118,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -3766,21 +2170,14 @@ spec:
                                 - revision
                                 type: object
                               list:
-                                description: ListGenerator include items info
                                 properties:
                                   elements:
                                     items:
                                       x-kubernetes-preserve-unknown-fields: true
                                     type: array
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -3800,44 +2197,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -3851,6 +2222,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -3860,9 +2235,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -3875,67 +2247,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3949,19 +2278,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3976,106 +2297,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -4090,88 +2358,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -4182,92 +2402,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -4284,62 +2452,25 @@ spec:
                                 required:
                                 - elements
                                 type: object
-                              scmProvider:
-                                description: SCMProviderGenerator defines a generator
-                                  that scrapes a SCMaaS API to find candidate repos.
+                              matrix:
+                                x-kubernetes-preserve-unknown-fields: true
+                              merge:
+                                x-kubernetes-preserve-unknown-fields: true
+                              pullRequest:
                                 properties:
-                                  cloneProtocol:
-                                    description: Which protocol to use for the SCM
-                                      URL. Default is provider-specific but ssh if
-                                      possible. Not all providers necessarily support
-                                      all protocols.
-                                    type: string
-                                  filters:
-                                    description: Filters for which repos should be
-                                      considered.
-                                    items:
-                                      description: SCMProviderGeneratorFilter is a
-                                        single repository filter. If multiple filter
-                                        types are set on a single struct, they will
-                                        be AND'd together. All filters must pass for
-                                        a repo to be included.
-                                      properties:
-                                        branchMatch:
-                                          description: A regex which must match the
-                                            branch name.
-                                          type: string
-                                        labelMatch:
-                                          description: A regex which must match at
-                                            least one label.
-                                          type: string
-                                        pathsExist:
-                                          description: An array of paths, all of which
-                                            must exist.
-                                          items:
-                                            type: string
-                                          type: array
-                                        repositoryMatch:
-                                          description: A regex for repo names.
-                                          type: string
-                                      type: object
-                                    type: array
                                   github:
-                                    description: Which provider to use and config
-                                      for it.
                                     properties:
-                                      allBranches:
-                                        description: Scan all branches instead of
-                                          just the default branch.
-                                        type: boolean
                                       api:
-                                        description: The GitHub API URL to talk to.
-                                          If blank, use https://api.github.com/.
                                         type: string
-                                      organization:
-                                        description: GitHub org to scan. Required.
+                                      labels:
+                                        items:
+                                          type: string
+                                        type: array
+                                      owner:
+                                        type: string
+                                      repo:
                                         type: string
                                       tokenRef:
-                                        description: Authentication token reference.
                                         properties:
                                           key:
                                             type: string
@@ -4350,56 +2481,15 @@ spec:
                                         - secretName
                                         type: object
                                     required:
-                                    - organization
-                                    type: object
-                                  gitlab:
-                                    description: SCMProviderGeneratorGitlab defines
-                                      a connection info specific to Gitlab.
-                                    properties:
-                                      allBranches:
-                                        description: Scan all branches instead of
-                                          just the default branch.
-                                        type: boolean
-                                      api:
-                                        description: The Gitlab API URL to talk to.
-                                        type: string
-                                      group:
-                                        description: Gitlab group to scan. Required.  You
-                                          can use either the project id (recommended)
-                                          or the full namespaced path.
-                                        type: string
-                                      includeSubgroups:
-                                        description: Recurse through subgroups (true)
-                                          or scan only the base group (false).  Defaults
-                                          to "false"
-                                        type: boolean
-                                      tokenRef:
-                                        description: Authentication token reference.
-                                        properties:
-                                          key:
-                                            type: string
-                                          secretName:
-                                            type: string
-                                        required:
-                                        - key
-                                        - secretName
-                                        type: object
-                                    required:
-                                    - group
+                                    - owner
+                                    - repo
                                     type: object
                                   requeueAfterSeconds:
-                                    description: Standard parameters.
                                     format: int64
                                     type: integer
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -4419,44 +2509,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -4470,6 +2534,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -4479,9 +2547,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -4494,67 +2559,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -4568,19 +2590,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -4595,106 +2609,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -4709,88 +2670,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -4801,92 +2714,381 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
+                              scmProvider:
+                                properties:
+                                  cloneProtocol:
+                                    type: string
+                                  filters:
+                                    items:
+                                      properties:
+                                        branchMatch:
+                                          type: string
+                                        labelMatch:
+                                          type: string
+                                        pathsExist:
+                                          items:
+                                            type: string
+                                          type: array
+                                        repositoryMatch:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  github:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      organization:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - organization
+                                    type: object
+                                  gitlab:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      group:
+                                        type: string
+                                      includeSubgroups:
+                                        type: boolean
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - group
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
                                                 items:
                                                   type: string
                                                 type: array
@@ -4904,12 +3106,8 @@ spec:
                             type: object
                           type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -4929,40 +3127,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -4976,6 +3152,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -4985,9 +3165,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -5000,58 +3177,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5065,18 +3208,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5091,91 +3227,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -5190,77 +3288,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -5271,82 +3332,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -5363,114 +3382,1878 @@ spec:
                       required:
                       - generators
                       type: object
-                    scmProvider:
-                      description: SCMProviderGenerator defines a generator that scrapes
-                        a SCMaaS API to find candidate repos.
+                    merge:
                       properties:
-                        cloneProtocol:
-                          description: Which protocol to use for the SCM URL. Default
-                            is provider-specific but ssh if possible. Not all providers
-                            necessarily support all protocols.
-                          type: string
-                        filters:
-                          description: Filters for which repos should be considered.
+                        generators:
                           items:
-                            description: SCMProviderGeneratorFilter is a single repository
-                              filter. If multiple filter types are set on a single
-                              struct, they will be AND'd together. All filters must
-                              pass for a repo to be included.
                             properties:
-                              branchMatch:
-                                description: A regex which must match the branch name.
-                                type: string
-                              labelMatch:
-                                description: A regex which must match at least one
-                                  label.
-                                type: string
-                              pathsExist:
-                                description: An array of paths, all of which must
-                                  exist.
-                                items:
-                                  type: string
-                                type: array
-                              repositoryMatch:
-                                description: A regex for repo names.
-                                type: string
+                              clusterDecisionResource:
+                                properties:
+                                  configMapRef:
+                                    type: string
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  name:
+                                    type: string
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                  values:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                required:
+                                - configMapRef
+                                type: object
+                              clusters:
+                                properties:
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                  values:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              git:
+                                properties:
+                                  directories:
+                                    items:
+                                      properties:
+                                        exclude:
+                                          type: boolean
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                  files:
+                                    items:
+                                      properties:
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                  repoURL:
+                                    type: string
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  revision:
+                                    type: string
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                required:
+                                - repoURL
+                                - revision
+                                type: object
+                              list:
+                                properties:
+                                  elements:
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                required:
+                                - elements
+                                type: object
+                              matrix:
+                                x-kubernetes-preserve-unknown-fields: true
+                              merge:
+                                x-kubernetes-preserve-unknown-fields: true
+                              pullRequest:
+                                properties:
+                                  github:
+                                    properties:
+                                      api:
+                                        type: string
+                                      labels:
+                                        items:
+                                          type: string
+                                        type: array
+                                      owner:
+                                        type: string
+                                      repo:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - owner
+                                    - repo
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
+                              scmProvider:
+                                properties:
+                                  cloneProtocol:
+                                    type: string
+                                  filters:
+                                    items:
+                                      properties:
+                                        branchMatch:
+                                          type: string
+                                        labelMatch:
+                                          type: string
+                                        pathsExist:
+                                          items:
+                                            type: string
+                                          type: array
+                                        repositoryMatch:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  github:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      organization:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - organization
+                                    type: object
+                                  gitlab:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      group:
+                                        type: string
+                                      includeSubgroups:
+                                        type: boolean
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - group
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
                             type: object
                           type: array
-                        github:
-                          description: Which provider to use and config for it.
-                          properties:
-                            allBranches:
-                              description: Scan all branches instead of just the default
-                                branch.
-                              type: boolean
-                            api:
-                              description: The GitHub API URL to talk to. If blank,
-                                use https://api.github.com/.
-                              type: string
-                            organization:
-                              description: GitHub org to scan. Required.
-                              type: string
-                            tokenRef:
-                              description: Authentication token reference.
-                              properties:
-                                key:
-                                  type: string
-                                secretName:
-                                  type: string
-                              required:
-                              - key
-                              - secretName
-                              type: object
-                          required:
-                          - organization
-                          type: object
-                        gitlab:
-                          description: SCMProviderGeneratorGitlab defines a connection
-                            info specific to Gitlab.
-                          properties:
-                            allBranches:
-                              description: Scan all branches instead of just the default
-                                branch.
-                              type: boolean
-                            api:
-                              description: The Gitlab API URL to talk to.
-                              type: string
-                            group:
-                              description: Gitlab group to scan. Required.  You can
-                                use either the project id (recommended) or the full
-                                namespaced path.
-                              type: string
-                            includeSubgroups:
-                              description: Recurse through subgroups (true) or scan
-                                only the base group (false).  Defaults to "false"
-                              type: boolean
-                            tokenRef:
-                              description: Authentication token reference.
-                              properties:
-                                key:
-                                  type: string
-                                secretName:
-                                  type: string
-                              required:
-                              - key
-                              - secretName
-                              type: object
-                          required:
-                          - group
-                          type: object
-                        requeueAfterSeconds:
-                          description: Standard parameters.
-                          format: int64
-                          type: integer
+                        mergeKeys:
+                          items:
+                            type: string
+                          type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -5490,40 +5273,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -5537,6 +5298,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -5546,9 +5311,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -5561,58 +5323,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5626,18 +5354,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5652,91 +5373,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -5751,77 +5434,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -5832,82 +5478,690 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      required:
+                      - generators
+                      - mergeKeys
+                      type: object
+                    pullRequest:
+                      properties:
+                        github:
+                          properties:
+                            api:
+                              type: string
+                            labels:
+                              items:
+                                type: string
+                              type: array
+                            owner:
+                              type: string
+                            repo:
+                              type: string
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - owner
+                          - repo
+                          type: object
+                        requeueAfterSeconds:
+                          format: int64
+                          type: integer
+                        template:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              properties:
+                                destination:
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    server:
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  items:
+                                    properties:
+                                      group:
+                                        type: string
+                                      jqPathExpressions:
+                                        items:
+                                          type: string
+                                        type: array
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  type: string
+                                revisionHistoryLimit:
+                                  format: int64
+                                  type: integer
+                                source:
+                                  properties:
+                                    chart:
+                                      type: string
+                                    directory:
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        include:
+                                          type: string
+                                        jsonnet:
+                                          properties:
+                                            extVars:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      properties:
+                                        fileParameters:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              path:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
+                                        parameters:
+                                          items:
+                                            properties:
+                                              forceString:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          type: boolean
+                                        releaseName:
+                                          type: string
+                                        skipCrds:
+                                          type: boolean
+                                        valueFiles:
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      properties:
+                                        environment:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        forceCommonAnnotations:
+                                          type: boolean
+                                        forceCommonLabels:
+                                          type: boolean
+                                        images:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          type: string
+                                        nameSuffix:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    path:
+                                      type: string
+                                    plugin:
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      type: string
+                                    targetRevision:
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  properties:
+                                    automated:
+                                      properties:
+                                        allowEmpty:
+                                          type: boolean
+                                        prune:
+                                          type: boolean
+                                        selfHeal:
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      properties:
+                                        backoff:
+                                          properties:
+                                            duration:
+                                              type: string
+                                            factor:
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              type: string
+                                          type: object
+                                        limit:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      type: object
+                    scmProvider:
+                      properties:
+                        cloneProtocol:
+                          type: string
+                        filters:
+                          items:
+                            properties:
+                              branchMatch:
+                                type: string
+                              labelMatch:
+                                type: string
+                              pathsExist:
+                                items:
+                                  type: string
+                                type: array
+                              repositoryMatch:
+                                type: string
+                            type: object
+                          type: array
+                        github:
+                          properties:
+                            allBranches:
+                              type: boolean
+                            api:
+                              type: string
+                            organization:
+                              type: string
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - organization
+                          type: object
+                        gitlab:
+                          properties:
+                            allBranches:
+                              type: boolean
+                            api:
+                              type: string
+                            group:
+                              type: string
+                            includeSubgroups:
+                              type: boolean
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - group
+                          type: object
+                        requeueAfterSeconds:
+                          format: int64
+                          type: integer
+                        template:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              properties:
+                                destination:
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    server:
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  items:
+                                    properties:
+                                      group:
+                                        type: string
+                                      jqPathExpressions:
+                                        items:
+                                          type: string
+                                        type: array
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  type: string
+                                revisionHistoryLimit:
+                                  format: int64
+                                  type: integer
+                                source:
+                                  properties:
+                                    chart:
+                                      type: string
+                                    directory:
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        include:
+                                          type: string
+                                        jsonnet:
+                                          properties:
+                                            extVars:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      properties:
+                                        fileParameters:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              path:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
+                                        parameters:
+                                          items:
+                                            properties:
+                                              forceString:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          type: boolean
+                                        releaseName:
+                                          type: string
+                                        skipCrds:
+                                          type: boolean
+                                        valueFiles:
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      properties:
+                                        environment:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        forceCommonAnnotations:
+                                          type: boolean
+                                        forceCommonLabels:
+                                          type: boolean
+                                        images:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          type: string
+                                        nameSuffix:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    path:
+                                      type: string
+                                    plugin:
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      type: string
+                                    targetRevision:
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  properties:
+                                    automated:
+                                      properties:
+                                        allowEmpty:
+                                          type: boolean
+                                        prune:
+                                          type: boolean
+                                        selfHeal:
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      properties:
+                                        backoff:
+                                          properties:
+                                            duration:
+                                              type: string
+                                            factor:
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              type: string
+                                          type: object
+                                        limit:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
                                       items:
                                         type: string
                                       type: array
@@ -5925,22 +6179,13 @@ spec:
                   type: object
                 type: array
               syncPolicy:
-                description: ApplicationSetSyncPolicy configures how generated Applications
-                  will relate to their ApplicationSet.
                 properties:
                   preserveResourcesOnDeletion:
-                    description: PreserveResourcesOnDeletion will preserve resources
-                      on deletion. If PreserveResourcesOnDeletion is set to true,
-                      these Applications will not be deleted.
                     type: boolean
                 type: object
               template:
-                description: ApplicationSetTemplate represents argocd ApplicationSpec
                 properties:
                   metadata:
-                    description: ApplicationSetTemplateMeta represents the Argo CD
-                      application fields that may be used for Applications generated
-                      from the ApplicationSet (based on metav1.ObjectMeta)
                     properties:
                       annotations:
                         additionalProperties:
@@ -5960,36 +6205,18 @@ spec:
                         type: string
                     type: object
                   spec:
-                    description: ApplicationSpec represents desired application state.
-                      Contains link to repository with application definition and
-                      additional parameters link definition revision.
                     properties:
                       destination:
-                        description: Destination is a reference to the target Kubernetes
-                          server and namespace
                         properties:
                           name:
-                            description: Name is an alternate way of specifying the
-                              target cluster by its symbolic name
                             type: string
                           namespace:
-                            description: Namespace specifies the target namespace
-                              for the application's resources. The namespace will
-                              only be set for namespace-scoped resources that have
-                              not set a value for .metadata.namespace
                             type: string
                           server:
-                            description: Server specifies the URL of the target cluster
-                              and must be set to the Kubernetes control plane API
                             type: string
                         type: object
                       ignoreDifferences:
-                        description: IgnoreDifferences is a list of resources and
-                          their fields which should be ignored during comparison
                         items:
-                          description: ResourceIgnoreDifferences contains resource
-                            filter and list of json paths which should be ignored
-                            during comparison with live state.
                           properties:
                             group:
                               type: string
@@ -6003,6 +6230,10 @@ spec:
                               type: array
                             kind:
                               type: string
+                            managedFieldsManagers:
+                              items:
+                                type: string
+                              type: array
                             name:
                               type: string
                             namespace:
@@ -6012,8 +6243,6 @@ spec:
                           type: object
                         type: array
                       info:
-                        description: Info contains a list of information (URLs, email
-                          addresses, and plain text) that relates to the application
                         items:
                           properties:
                             name:
@@ -6026,51 +6255,24 @@ spec:
                           type: object
                         type: array
                       project:
-                        description: Project is a reference to the project this application
-                          belongs to. The empty string means that application belongs
-                          to the 'default' project.
                         type: string
                       revisionHistoryLimit:
-                        description: RevisionHistoryLimit limits the number of items
-                          kept in the application's revision history, which is used
-                          for informational purposes as well as for rollbacks to previous
-                          versions. This should only be changed in exceptional circumstances.
-                          Setting to zero will store no history. This will reduce
-                          storage used. Increasing will increase the space used to
-                          store the history, so we do not recommend increasing it.
-                          Default is 10.
                         format: int64
                         type: integer
                       source:
-                        description: Source is a reference to the location of the
-                          application's manifests or chart
                         properties:
                           chart:
-                            description: Chart is a Helm chart name, and must be specified
-                              for applications sourced from a Helm repo.
                             type: string
                           directory:
-                            description: Directory holds path/directory specific options
                             properties:
                               exclude:
-                                description: Exclude contains a glob pattern to match
-                                  paths against that should be explicitly excluded
-                                  from being used during manifest generation
                                 type: string
                               include:
-                                description: Include contains a glob pattern to match
-                                  paths against that should be explicitly included
-                                  during manifest generation
                                 type: string
                               jsonnet:
-                                description: Jsonnet holds options specific to Jsonnet
                                 properties:
                                   extVars:
-                                    description: ExtVars is a list of Jsonnet External
-                                      Variables
                                     items:
-                                      description: JsonnetVar represents a variable
-                                        to be passed to jsonnet during manifest generation
                                       properties:
                                         code:
                                           type: boolean
@@ -6084,16 +6286,11 @@ spec:
                                       type: object
                                     type: array
                                   libs:
-                                    description: Additional library search dirs
                                     items:
                                       type: string
                                     type: array
                                   tlas:
-                                    description: TLAS is a list of Jsonnet Top-level
-                                      Arguments
                                     items:
-                                      description: JsonnetVar represents a variable
-                                        to be passed to jsonnet during manifest generation
                                       properties:
                                         code:
                                           type: boolean
@@ -6108,84 +6305,53 @@ spec:
                                     type: array
                                 type: object
                               recurse:
-                                description: Recurse specifies whether to scan a directory
-                                  recursively for manifests
                                 type: boolean
                             type: object
                           helm:
-                            description: Helm holds helm specific options
                             properties:
                               fileParameters:
-                                description: FileParameters are file parameters to
-                                  the helm template
                                 items:
-                                  description: HelmFileParameter is a file parameter
-                                    that's passed to helm template during manifest
-                                    generation
                                   properties:
                                     name:
-                                      description: Name is the name of the Helm parameter
                                       type: string
                                     path:
-                                      description: Path is the path to the file containing
-                                        the values for the Helm parameter
                                       type: string
                                   type: object
                                 type: array
+                              ignoreMissingValueFiles:
+                                type: boolean
                               parameters:
-                                description: Parameters is a list of Helm parameters
-                                  which are passed to the helm template command upon
-                                  manifest generation
                                 items:
-                                  description: HelmParameter is a parameter that's
-                                    passed to helm template during manifest generation
                                   properties:
                                     forceString:
-                                      description: ForceString determines whether
-                                        to tell Helm to interpret booleans and numbers
-                                        as strings
                                       type: boolean
                                     name:
-                                      description: Name is the name of the Helm parameter
                                       type: string
                                     value:
-                                      description: Value is the value for the Helm
-                                        parameter
                                       type: string
                                   type: object
                                 type: array
+                              passCredentials:
+                                type: boolean
                               releaseName:
-                                description: ReleaseName is the Helm release name
-                                  to use. If omitted it will use the application name
                                 type: string
+                              skipCrds:
+                                type: boolean
                               valueFiles:
-                                description: ValuesFiles is a list of Helm value files
-                                  to use when generating a template
                                 items:
                                   type: string
                                 type: array
                               values:
-                                description: Values specifies Helm values to be passed
-                                  to helm template, typically defined as a block
                                 type: string
                               version:
-                                description: Version is the Helm version to use for
-                                  templating (either "2" or "3")
                                 type: string
                             type: object
                           ksonnet:
-                            description: Ksonnet holds ksonnet specific options
                             properties:
                               environment:
-                                description: Environment is a ksonnet application
-                                  environment name
                                 type: string
                               parameters:
-                                description: Parameters are a list of ksonnet component
-                                  parameter override values
                                 items:
-                                  description: KsonnetParameter is a ksonnet component
-                                    parameter
                                   properties:
                                     component:
                                       type: string
@@ -6200,72 +6366,40 @@ spec:
                                 type: array
                             type: object
                           kustomize:
-                            description: Kustomize holds kustomize specific options
                             properties:
                               commonAnnotations:
                                 additionalProperties:
                                   type: string
-                                description: CommonAnnotations is a list of additional
-                                  annotations to add to rendered manifests
                                 type: object
                               commonLabels:
                                 additionalProperties:
                                   type: string
-                                description: CommonLabels is a list of additional
-                                  labels to add to rendered manifests
                                 type: object
                               forceCommonAnnotations:
-                                description: ForceCommonAnnotations specifies whether
-                                  to force applying common annotations to resources
-                                  for Kustomize apps
                                 type: boolean
                               forceCommonLabels:
-                                description: ForceCommonLabels specifies whether to
-                                  force applying common labels to resources for Kustomize
-                                  apps
                                 type: boolean
                               images:
-                                description: Images is a list of Kustomize image override
-                                  specifications
                                 items:
-                                  description: KustomizeImage represents a Kustomize
-                                    image definition in the format [old_image_name=]<image_name>:<image_tag>
                                   type: string
                                 type: array
                               namePrefix:
-                                description: NamePrefix is a prefix appended to resources
-                                  for Kustomize apps
                                 type: string
                               nameSuffix:
-                                description: NameSuffix is a suffix appended to resources
-                                  for Kustomize apps
                                 type: string
                               version:
-                                description: Version controls which version of Kustomize
-                                  to use for rendering manifests
                                 type: string
                             type: object
                           path:
-                            description: Path is a directory path within the Git repository,
-                              and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
                             properties:
                               env:
-                                description: Env is a list of environment variable
-                                  entries
                                 items:
-                                  description: EnvEntry represents an entry in the
-                                    application's environment
                                   properties:
                                     name:
-                                      description: Name is the name of the variable,
-                                        usually expressed in uppercase
                                       type: string
                                     value:
-                                      description: Value is the value of the variable
                                       type: string
                                   required:
                                   - name
@@ -6276,73 +6410,40 @@ spec:
                                 type: string
                             type: object
                           repoURL:
-                            description: RepoURL is the URL to the repository (Git
-                              or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
                             type: string
                         required:
                         - repoURL
                         type: object
                       syncPolicy:
-                        description: SyncPolicy controls when and how a sync will
-                          be performed
                         properties:
                           automated:
-                            description: Automated will keep an application synced
-                              to the target revision
                             properties:
                               allowEmpty:
-                                description: 'AllowEmpty allows apps have zero live
-                                  resources (default: false)'
                                 type: boolean
                               prune:
-                                description: 'Prune specifies whether to delete resources
-                                  from the cluster that are not found in the sources
-                                  anymore as part of automated sync (default: false)'
                                 type: boolean
                               selfHeal:
-                                description: 'SelfHeal specifes whether to revert
-                                  resources back to their desired state upon modification
-                                  in the cluster (default: false)'
                                 type: boolean
                             type: object
                           retry:
-                            description: Retry controls failed sync retry behavior
                             properties:
                               backoff:
-                                description: Backoff controls how to backoff on subsequent
-                                  retries of failed syncs
                                 properties:
                                   duration:
-                                    description: Duration is the amount to back off.
-                                      Default unit is seconds, but could also be a
-                                      duration (e.g. "2m", "1h")
                                     type: string
                                   factor:
-                                    description: Factor is a factor to multiply the
-                                      base duration after each failed retry
                                     format: int64
                                     type: integer
                                   maxDuration:
-                                    description: MaxDuration is the maximum amount
-                                      of time allowed for the backoff strategy
                                     type: string
                                 type: object
                               limit:
-                                description: Limit is the maximum number of attempts
-                                  for retrying a failed sync. If set to 0, no retries
-                                  will be performed.
                                 format: int64
                                 type: integer
                             type: object
                           syncOptions:
-                            description: Options allow you to specify whole app sync-options
                             items:
                               type: string
                             type: array
@@ -6361,7 +6462,28 @@ spec:
             - template
             type: object
           status:
-            description: ApplicationSetStatus defines the observed state of ApplicationSet
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
             type: object
         required:
         - metadata
@@ -6369,6 +6491,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/olm-catalog/argocd-operator/0.3.0/argocd-operator.v0.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.3.0/argocd-operator.v0.3.0.clusterserviceversion.yaml
@@ -124,7 +124,7 @@ metadata:
           }
         }
       ]
-    capabilities: Deep Inisights
+    capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.

--- a/deploy/olm-catalog/argocd-operator/0.3.0/argoproj.io_applicationsets.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.3.0/argoproj.io_applicationsets.yaml
@@ -20,71 +20,32 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ApplicationSet is a set of Application resources
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: ApplicationSetSpec represents a class of application set
-              state.
             properties:
               generators:
                 items:
-                  description: ApplicationSetGenerator include list item info
                   properties:
                     clusterDecisionResource:
-                      description: DuckType defines a generator to match against clusters
-                        registered with ArgoCD.
                       properties:
                         configMapRef:
-                          description: ConfigMapRef is a ConfigMap with the duck type
-                            definitions needed to retreive the data              this
-                            includes apiVersion(group/version), kind, matchKey and
-                            validation settings Name is the resource name of the kind,
-                            group and version, defined in the ConfigMapRef RequeueAfterSeconds
-                            is how long before the duckType will be rechecked for
-                            a change
                           type: string
                         labelSelector:
-                          description: A label selector is a label query over a set
-                            of resources. The result of matchLabels and matchExpressions
-                            are ANDed. An empty label selector matches all objects.
-                            A null label selector matches no objects.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -96,11 +57,6 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         name:
@@ -109,12 +65,8 @@ spec:
                           format: int64
                           type: integer
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -134,40 +86,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -181,6 +111,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -190,9 +124,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -205,58 +136,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -270,18 +167,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -296,91 +186,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -395,77 +247,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -476,82 +291,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -568,46 +341,22 @@ spec:
                         values:
                           additionalProperties:
                             type: string
-                          description: Values contains key/value pairs which are passed
-                            directly as parameters to the template
                           type: object
                       required:
                       - configMapRef
                       type: object
                     clusters:
-                      description: ClusterGenerator defines a generator to match against
-                        clusters registered with ArgoCD.
                       properties:
                         selector:
-                          description: Selector defines a label selector to match
-                            against all clusters registered with ArgoCD. Clusters
-                            today are stored as Kubernetes Secrets, thus the Secret
-                            labels will be used for matching the selector.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -619,20 +368,11 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -652,40 +392,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -699,6 +417,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -708,9 +430,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -723,58 +442,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -788,18 +473,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -814,91 +492,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -913,77 +553,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -994,82 +597,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -1086,8 +647,6 @@ spec:
                         values:
                           additionalProperties:
                             type: string
-                          description: Values contains key/value pairs which are passed
-                            directly as parameters to the template
                           type: object
                       type: object
                     git:
@@ -1120,12 +679,8 @@ spec:
                         revision:
                           type: string
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1145,40 +700,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -1192,6 +725,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -1201,9 +738,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -1216,58 +750,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1281,18 +781,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1307,91 +800,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -1406,77 +861,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -1487,82 +905,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -1581,19 +957,14 @@ spec:
                       - revision
                       type: object
                     list:
-                      description: ListGenerator include items info
                       properties:
                         elements:
                           items:
                             x-kubernetes-preserve-unknown-fields: true
                           type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1613,40 +984,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -1660,6 +1009,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -1669,9 +1022,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -1684,58 +1034,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1749,18 +1065,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -1775,91 +1084,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -1874,77 +1145,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -1955,82 +1189,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -2048,63 +1240,24 @@ spec:
                       - elements
                       type: object
                     matrix:
-                      description: MatrixGenerator include Other generators
                       properties:
                         generators:
                           items:
-                            description: ApplicationSetBaseGenerator include list
-                              item info CRD dosn't support recursive types so we need
-                              a different type for the matrix generator https://github.com/kubernetes-sigs/controller-tools/issues/477
                             properties:
                               clusterDecisionResource:
-                                description: DuckType defines a generator to match
-                                  against clusters registered with ArgoCD.
                                 properties:
                                   configMapRef:
-                                    description: ConfigMapRef is a ConfigMap with
-                                      the duck type definitions needed to retreive
-                                      the data              this includes apiVersion(group/version),
-                                      kind, matchKey and validation settings Name
-                                      is the resource name of the kind, group and
-                                      version, defined in the ConfigMapRef RequeueAfterSeconds
-                                      is how long before the duckType will be rechecked
-                                      for a change
                                     type: string
                                   labelSelector:
-                                    description: A label selector is a label query
-                                      over a set of resources. The result of matchLabels
-                                      and matchExpressions are ANDed. An empty label
-                                      selector matches all objects. A null label selector
-                                      matches no objects.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2116,12 +1269,6 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   name:
@@ -2130,14 +1277,8 @@ spec:
                                     format: int64
                                     type: integer
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -2157,44 +1298,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -2208,6 +1323,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -2217,9 +1336,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -2232,67 +1348,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2306,19 +1379,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2333,106 +1398,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -2447,88 +1459,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -2539,92 +1503,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -2641,51 +1553,22 @@ spec:
                                   values:
                                     additionalProperties:
                                       type: string
-                                    description: Values contains key/value pairs which
-                                      are passed directly as parameters to the template
                                     type: object
                                 required:
                                 - configMapRef
                                 type: object
                               clusters:
-                                description: ClusterGenerator defines a generator
-                                  to match against clusters registered with ArgoCD.
                                 properties:
                                   selector:
-                                    description: Selector defines a label selector
-                                      to match against all clusters registered with
-                                      ArgoCD. Clusters today are stored as Kubernetes
-                                      Secrets, thus the Secret labels will be used
-                                      for matching the selector.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2697,23 +1580,11 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -2733,44 +1604,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -2784,6 +1629,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -2793,9 +1642,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -2808,67 +1654,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2882,19 +1685,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -2909,106 +1704,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -3023,88 +1765,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -3115,92 +1809,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -3217,8 +1859,6 @@ spec:
                                   values:
                                     additionalProperties:
                                       type: string
-                                    description: Values contains key/value pairs which
-                                      are passed directly as parameters to the template
                                     type: object
                                 type: object
                               git:
@@ -3251,14 +1891,8 @@ spec:
                                   revision:
                                     type: string
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -3278,44 +1912,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -3329,6 +1937,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -3338,9 +1950,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -3353,67 +1962,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3427,19 +1993,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3454,106 +2012,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -3568,88 +2073,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -3660,92 +2117,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -3764,21 +2169,14 @@ spec:
                                 - revision
                                 type: object
                               list:
-                                description: ListGenerator include items info
                                 properties:
                                   elements:
                                     items:
                                       x-kubernetes-preserve-unknown-fields: true
                                     type: array
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -3798,44 +2196,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -3849,6 +2221,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -3858,9 +2234,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -3873,67 +2246,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3947,19 +2277,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -3974,106 +2296,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -4088,88 +2357,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -4180,92 +2401,40 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
                                                 items:
                                                   type: string
                                                 type: array
@@ -4282,62 +2451,25 @@ spec:
                                 required:
                                 - elements
                                 type: object
-                              scmProvider:
-                                description: SCMProviderGenerator defines a generator
-                                  that scrapes a SCMaaS API to find candidate repos.
+                              matrix:
+                                x-kubernetes-preserve-unknown-fields: true
+                              merge:
+                                x-kubernetes-preserve-unknown-fields: true
+                              pullRequest:
                                 properties:
-                                  cloneProtocol:
-                                    description: Which protocol to use for the SCM
-                                      URL. Default is provider-specific but ssh if
-                                      possible. Not all providers necessarily support
-                                      all protocols.
-                                    type: string
-                                  filters:
-                                    description: Filters for which repos should be
-                                      considered.
-                                    items:
-                                      description: SCMProviderGeneratorFilter is a
-                                        single repository filter. If multiple filter
-                                        types are set on a single struct, they will
-                                        be AND'd together. All filters must pass for
-                                        a repo to be included.
-                                      properties:
-                                        branchMatch:
-                                          description: A regex which must match the
-                                            branch name.
-                                          type: string
-                                        labelMatch:
-                                          description: A regex which must match at
-                                            least one label.
-                                          type: string
-                                        pathsExist:
-                                          description: An array of paths, all of which
-                                            must exist.
-                                          items:
-                                            type: string
-                                          type: array
-                                        repositoryMatch:
-                                          description: A regex for repo names.
-                                          type: string
-                                      type: object
-                                    type: array
                                   github:
-                                    description: Which provider to use and config
-                                      for it.
                                     properties:
-                                      allBranches:
-                                        description: Scan all branches instead of
-                                          just the default branch.
-                                        type: boolean
                                       api:
-                                        description: The GitHub API URL to talk to.
-                                          If blank, use https://api.github.com/.
                                         type: string
-                                      organization:
-                                        description: GitHub org to scan. Required.
+                                      labels:
+                                        items:
+                                          type: string
+                                        type: array
+                                      owner:
+                                        type: string
+                                      repo:
                                         type: string
                                       tokenRef:
-                                        description: Authentication token reference.
                                         properties:
                                           key:
                                             type: string
@@ -4348,56 +2480,15 @@ spec:
                                         - secretName
                                         type: object
                                     required:
-                                    - organization
-                                    type: object
-                                  gitlab:
-                                    description: SCMProviderGeneratorGitlab defines
-                                      a connection info specific to Gitlab.
-                                    properties:
-                                      allBranches:
-                                        description: Scan all branches instead of
-                                          just the default branch.
-                                        type: boolean
-                                      api:
-                                        description: The Gitlab API URL to talk to.
-                                        type: string
-                                      group:
-                                        description: Gitlab group to scan. Required.  You
-                                          can use either the project id (recommended)
-                                          or the full namespaced path.
-                                        type: string
-                                      includeSubgroups:
-                                        description: Recurse through subgroups (true)
-                                          or scan only the base group (false).  Defaults
-                                          to "false"
-                                        type: boolean
-                                      tokenRef:
-                                        description: Authentication token reference.
-                                        properties:
-                                          key:
-                                            type: string
-                                          secretName:
-                                            type: string
-                                        required:
-                                        - key
-                                        - secretName
-                                        type: object
-                                    required:
-                                    - group
+                                    - owner
+                                    - repo
                                     type: object
                                   requeueAfterSeconds:
-                                    description: Standard parameters.
                                     format: int64
                                     type: integer
                                   template:
-                                    description: ApplicationSetTemplate represents
-                                      argocd ApplicationSpec
                                     properties:
                                       metadata:
-                                        description: ApplicationSetTemplateMeta represents
-                                          the Argo CD application fields that may
-                                          be used for Applications generated from
-                                          the ApplicationSet (based on metav1.ObjectMeta)
                                         properties:
                                           annotations:
                                             additionalProperties:
@@ -4417,44 +2508,18 @@ spec:
                                             type: string
                                         type: object
                                       spec:
-                                        description: ApplicationSpec represents desired
-                                          application state. Contains link to repository
-                                          with application definition and additional
-                                          parameters link definition revision.
                                         properties:
                                           destination:
-                                            description: Destination is a reference
-                                              to the target Kubernetes server and
-                                              namespace
                                             properties:
                                               name:
-                                                description: Name is an alternate
-                                                  way of specifying the target cluster
-                                                  by its symbolic name
                                                 type: string
                                               namespace:
-                                                description: Namespace specifies the
-                                                  target namespace for the application's
-                                                  resources. The namespace will only
-                                                  be set for namespace-scoped resources
-                                                  that have not set a value for .metadata.namespace
                                                 type: string
                                               server:
-                                                description: Server specifies the
-                                                  URL of the target cluster and must
-                                                  be set to the Kubernetes control
-                                                  plane API
                                                 type: string
                                             type: object
                                           ignoreDifferences:
-                                            description: IgnoreDifferences is a list
-                                              of resources and their fields which
-                                              should be ignored during comparison
                                             items:
-                                              description: ResourceIgnoreDifferences
-                                                contains resource filter and list
-                                                of json paths which should be ignored
-                                                during comparison with live state.
                                               properties:
                                                 group:
                                                   type: string
@@ -4468,6 +2533,10 @@ spec:
                                                   type: array
                                                 kind:
                                                   type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
                                                 name:
                                                   type: string
                                                 namespace:
@@ -4477,9 +2546,6 @@ spec:
                                               type: object
                                             type: array
                                           info:
-                                            description: Info contains a list of information
-                                              (URLs, email addresses, and plain text)
-                                              that relates to the application
                                             items:
                                               properties:
                                                 name:
@@ -4492,67 +2558,24 @@ spec:
                                               type: object
                                             type: array
                                           project:
-                                            description: Project is a reference to
-                                              the project this application belongs
-                                              to. The empty string means that application
-                                              belongs to the 'default' project.
                                             type: string
                                           revisionHistoryLimit:
-                                            description: RevisionHistoryLimit limits
-                                              the number of items kept in the application's
-                                              revision history, which is used for
-                                              informational purposes as well as for
-                                              rollbacks to previous versions. This
-                                              should only be changed in exceptional
-                                              circumstances. Setting to zero will
-                                              store no history. This will reduce storage
-                                              used. Increasing will increase the space
-                                              used to store the history, so we do
-                                              not recommend increasing it. Default
-                                              is 10.
                                             format: int64
                                             type: integer
                                           source:
-                                            description: Source is a reference to
-                                              the location of the application's manifests
-                                              or chart
                                             properties:
                                               chart:
-                                                description: Chart is a Helm chart
-                                                  name, and must be specified for
-                                                  applications sourced from a Helm
-                                                  repo.
                                                 type: string
                                               directory:
-                                                description: Directory holds path/directory
-                                                  specific options
                                                 properties:
                                                   exclude:
-                                                    description: Exclude contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      excluded from being used during
-                                                      manifest generation
                                                     type: string
                                                   include:
-                                                    description: Include contains
-                                                      a glob pattern to match paths
-                                                      against that should be explicitly
-                                                      included during manifest generation
                                                     type: string
                                                   jsonnet:
-                                                    description: Jsonnet holds options
-                                                      specific to Jsonnet
                                                     properties:
                                                       extVars:
-                                                        description: ExtVars is a
-                                                          list of Jsonnet External
-                                                          Variables
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -4566,19 +2589,11 @@ spec:
                                                           type: object
                                                         type: array
                                                       libs:
-                                                        description: Additional library
-                                                          search dirs
                                                         items:
                                                           type: string
                                                         type: array
                                                       tlas:
-                                                        description: TLAS is a list
-                                                          of Jsonnet Top-level Arguments
                                                         items:
-                                                          description: JsonnetVar
-                                                            represents a variable
-                                                            to be passed to jsonnet
-                                                            during manifest generation
                                                           properties:
                                                             code:
                                                               type: boolean
@@ -4593,106 +2608,53 @@ spec:
                                                         type: array
                                                     type: object
                                                   recurse:
-                                                    description: Recurse specifies
-                                                      whether to scan a directory
-                                                      recursively for manifests
                                                     type: boolean
                                                 type: object
                                               helm:
-                                                description: Helm holds helm specific
-                                                  options
                                                 properties:
                                                   fileParameters:
-                                                    description: FileParameters are
-                                                      file parameters to the helm
-                                                      template
                                                     items:
-                                                      description: HelmFileParameter
-                                                        is a file parameter that's
-                                                        passed to helm template during
-                                                        manifest generation
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         path:
-                                                          description: Path is the
-                                                            path to the file containing
-                                                            the values for the Helm
-                                                            parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
                                                   parameters:
-                                                    description: Parameters is a list
-                                                      of Helm parameters which are
-                                                      passed to the helm template
-                                                      command upon manifest generation
                                                     items:
-                                                      description: HelmParameter is
-                                                        a parameter that's passed
-                                                        to helm template during manifest
-                                                        generation
                                                       properties:
                                                         forceString:
-                                                          description: ForceString
-                                                            determines whether to
-                                                            tell Helm to interpret
-                                                            booleans and numbers as
-                                                            strings
                                                           type: boolean
                                                         name:
-                                                          description: Name is the
-                                                            name of the Helm parameter
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value for the Helm parameter
                                                           type: string
                                                       type: object
                                                     type: array
+                                                  passCredentials:
+                                                    type: boolean
                                                   releaseName:
-                                                    description: ReleaseName is the
-                                                      Helm release name to use. If
-                                                      omitted it will use the application
-                                                      name
                                                     type: string
+                                                  skipCrds:
+                                                    type: boolean
                                                   valueFiles:
-                                                    description: ValuesFiles is a
-                                                      list of Helm value files to
-                                                      use when generating a template
                                                     items:
                                                       type: string
                                                     type: array
                                                   values:
-                                                    description: Values specifies
-                                                      Helm values to be passed to
-                                                      helm template, typically defined
-                                                      as a block
                                                     type: string
                                                   version:
-                                                    description: Version is the Helm
-                                                      version to use for templating
-                                                      (either "2" or "3")
                                                     type: string
                                                 type: object
                                               ksonnet:
-                                                description: Ksonnet holds ksonnet
-                                                  specific options
                                                 properties:
                                                   environment:
-                                                    description: Environment is a
-                                                      ksonnet application environment
-                                                      name
                                                     type: string
                                                   parameters:
-                                                    description: Parameters are a
-                                                      list of ksonnet component parameter
-                                                      override values
                                                     items:
-                                                      description: KsonnetParameter
-                                                        is a ksonnet component parameter
                                                       properties:
                                                         component:
                                                           type: string
@@ -4707,88 +2669,40 @@ spec:
                                                     type: array
                                                 type: object
                                               kustomize:
-                                                description: Kustomize holds kustomize
-                                                  specific options
                                                 properties:
                                                   commonAnnotations:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonAnnotations
-                                                      is a list of additional annotations
-                                                      to add to rendered manifests
                                                     type: object
                                                   commonLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: CommonLabels is a
-                                                      list of additional labels to
-                                                      add to rendered manifests
                                                     type: object
                                                   forceCommonAnnotations:
-                                                    description: ForceCommonAnnotations
-                                                      specifies whether to force applying
-                                                      common annotations to resources
-                                                      for Kustomize apps
                                                     type: boolean
                                                   forceCommonLabels:
-                                                    description: ForceCommonLabels
-                                                      specifies whether to force applying
-                                                      common labels to resources for
-                                                      Kustomize apps
                                                     type: boolean
                                                   images:
-                                                    description: Images is a list
-                                                      of Kustomize image override
-                                                      specifications
                                                     items:
-                                                      description: KustomizeImage
-                                                        represents a Kustomize image
-                                                        definition in the format [old_image_name=]<image_name>:<image_tag>
                                                       type: string
                                                     type: array
                                                   namePrefix:
-                                                    description: NamePrefix is a prefix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   nameSuffix:
-                                                    description: NameSuffix is a suffix
-                                                      appended to resources for Kustomize
-                                                      apps
                                                     type: string
                                                   version:
-                                                    description: Version controls
-                                                      which version of Kustomize to
-                                                      use for rendering manifests
                                                     type: string
                                                 type: object
                                               path:
-                                                description: Path is a directory path
-                                                  within the Git repository, and is
-                                                  only valid for applications sourced
-                                                  from Git.
                                                 type: string
                                               plugin:
-                                                description: ConfigManagementPlugin
-                                                  holds config management plugin specific
-                                                  options
                                                 properties:
                                                   env:
-                                                    description: Env is a list of
-                                                      environment variable entries
                                                     items:
-                                                      description: EnvEntry represents
-                                                        an entry in the application's
-                                                        environment
                                                       properties:
                                                         name:
-                                                          description: Name is the
-                                                            name of the variable,
-                                                            usually expressed in uppercase
                                                           type: string
                                                         value:
-                                                          description: Value is the
-                                                            value of the variable
                                                           type: string
                                                       required:
                                                       - name
@@ -4799,92 +2713,381 @@ spec:
                                                     type: string
                                                 type: object
                                               repoURL:
-                                                description: RepoURL is the URL to
-                                                  the repository (Git or Helm) that
-                                                  contains the application manifests
                                                 type: string
                                               targetRevision:
-                                                description: TargetRevision defines
-                                                  the revision of the source to sync
-                                                  the application to. In case of Git,
-                                                  this can be commit, tag, or branch.
-                                                  If omitted, will equal to HEAD.
-                                                  In case of Helm, this is a semver
-                                                  tag for the Chart's version.
                                                 type: string
                                             required:
                                             - repoURL
                                             type: object
                                           syncPolicy:
-                                            description: SyncPolicy controls when
-                                              and how a sync will be performed
                                             properties:
                                               automated:
-                                                description: Automated will keep an
-                                                  application synced to the target
-                                                  revision
                                                 properties:
                                                   allowEmpty:
-                                                    description: 'AllowEmpty allows
-                                                      apps have zero live resources
-                                                      (default: false)'
                                                     type: boolean
                                                   prune:
-                                                    description: 'Prune specifies
-                                                      whether to delete resources
-                                                      from the cluster that are not
-                                                      found in the sources anymore
-                                                      as part of automated sync (default:
-                                                      false)'
                                                     type: boolean
                                                   selfHeal:
-                                                    description: 'SelfHeal specifes
-                                                      whether to revert resources
-                                                      back to their desired state
-                                                      upon modification in the cluster
-                                                      (default: false)'
                                                     type: boolean
                                                 type: object
                                               retry:
-                                                description: Retry controls failed
-                                                  sync retry behavior
                                                 properties:
                                                   backoff:
-                                                    description: Backoff controls
-                                                      how to backoff on subsequent
-                                                      retries of failed syncs
                                                     properties:
                                                       duration:
-                                                        description: Duration is the
-                                                          amount to back off. Default
-                                                          unit is seconds, but could
-                                                          also be a duration (e.g.
-                                                          "2m", "1h")
                                                         type: string
                                                       factor:
-                                                        description: Factor is a factor
-                                                          to multiply the base duration
-                                                          after each failed retry
                                                         format: int64
                                                         type: integer
                                                       maxDuration:
-                                                        description: MaxDuration is
-                                                          the maximum amount of time
-                                                          allowed for the backoff
-                                                          strategy
                                                         type: string
                                                     type: object
                                                   limit:
-                                                    description: Limit is the maximum
-                                                      number of attempts for retrying
-                                                      a failed sync. If set to 0,
-                                                      no retries will be performed.
                                                     format: int64
                                                     type: integer
                                                 type: object
                                               syncOptions:
-                                                description: Options allow you to
-                                                  specify whole app sync-options
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
+                              scmProvider:
+                                properties:
+                                  cloneProtocol:
+                                    type: string
+                                  filters:
+                                    items:
+                                      properties:
+                                        branchMatch:
+                                          type: string
+                                        labelMatch:
+                                          type: string
+                                        pathsExist:
+                                          items:
+                                            type: string
+                                          type: array
+                                        repositoryMatch:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  github:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      organization:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - organization
+                                    type: object
+                                  gitlab:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      group:
+                                        type: string
+                                      includeSubgroups:
+                                        type: boolean
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - group
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
                                                 items:
                                                   type: string
                                                 type: array
@@ -4902,12 +3105,8 @@ spec:
                             type: object
                           type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -4927,40 +3126,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -4974,6 +3151,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -4983,9 +3164,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -4998,58 +3176,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5063,18 +3207,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5089,91 +3226,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -5188,77 +3287,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -5269,82 +3331,40 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
                                       items:
                                         type: string
                                       type: array
@@ -5361,114 +3381,1878 @@ spec:
                       required:
                       - generators
                       type: object
-                    scmProvider:
-                      description: SCMProviderGenerator defines a generator that scrapes
-                        a SCMaaS API to find candidate repos.
+                    merge:
                       properties:
-                        cloneProtocol:
-                          description: Which protocol to use for the SCM URL. Default
-                            is provider-specific but ssh if possible. Not all providers
-                            necessarily support all protocols.
-                          type: string
-                        filters:
-                          description: Filters for which repos should be considered.
+                        generators:
                           items:
-                            description: SCMProviderGeneratorFilter is a single repository
-                              filter. If multiple filter types are set on a single
-                              struct, they will be AND'd together. All filters must
-                              pass for a repo to be included.
                             properties:
-                              branchMatch:
-                                description: A regex which must match the branch name.
-                                type: string
-                              labelMatch:
-                                description: A regex which must match at least one
-                                  label.
-                                type: string
-                              pathsExist:
-                                description: An array of paths, all of which must
-                                  exist.
-                                items:
-                                  type: string
-                                type: array
-                              repositoryMatch:
-                                description: A regex for repo names.
-                                type: string
+                              clusterDecisionResource:
+                                properties:
+                                  configMapRef:
+                                    type: string
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  name:
+                                    type: string
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                  values:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                required:
+                                - configMapRef
+                                type: object
+                              clusters:
+                                properties:
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                  values:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              git:
+                                properties:
+                                  directories:
+                                    items:
+                                      properties:
+                                        exclude:
+                                          type: boolean
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                  files:
+                                    items:
+                                      properties:
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                  repoURL:
+                                    type: string
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  revision:
+                                    type: string
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                required:
+                                - repoURL
+                                - revision
+                                type: object
+                              list:
+                                properties:
+                                  elements:
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                required:
+                                - elements
+                                type: object
+                              matrix:
+                                x-kubernetes-preserve-unknown-fields: true
+                              merge:
+                                x-kubernetes-preserve-unknown-fields: true
+                              pullRequest:
+                                properties:
+                                  github:
+                                    properties:
+                                      api:
+                                        type: string
+                                      labels:
+                                        items:
+                                          type: string
+                                        type: array
+                                      owner:
+                                        type: string
+                                      repo:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - owner
+                                    - repo
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
+                              scmProvider:
+                                properties:
+                                  cloneProtocol:
+                                    type: string
+                                  filters:
+                                    items:
+                                      properties:
+                                        branchMatch:
+                                          type: string
+                                        labelMatch:
+                                          type: string
+                                        pathsExist:
+                                          items:
+                                            type: string
+                                          type: array
+                                        repositoryMatch:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  github:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      organization:
+                                        type: string
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - organization
+                                    type: object
+                                  gitlab:
+                                    properties:
+                                      allBranches:
+                                        type: boolean
+                                      api:
+                                        type: string
+                                      group:
+                                        type: string
+                                      includeSubgroups:
+                                        type: boolean
+                                      tokenRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          secretName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - secretName
+                                        type: object
+                                    required:
+                                    - group
+                                    type: object
+                                  requeueAfterSeconds:
+                                    format: int64
+                                    type: integer
+                                  template:
+                                    properties:
+                                      metadata:
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      spec:
+                                        properties:
+                                          destination:
+                                            properties:
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                              server:
+                                                type: string
+                                            type: object
+                                          ignoreDifferences:
+                                            items:
+                                              properties:
+                                                group:
+                                                  type: string
+                                                jqPathExpressions:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                jsonPointers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                kind:
+                                                  type: string
+                                                managedFieldsManagers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              type: object
+                                            type: array
+                                          info:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          project:
+                                            type: string
+                                          revisionHistoryLimit:
+                                            format: int64
+                                            type: integer
+                                          source:
+                                            properties:
+                                              chart:
+                                                type: string
+                                              directory:
+                                                properties:
+                                                  exclude:
+                                                    type: string
+                                                  include:
+                                                    type: string
+                                                  jsonnet:
+                                                    properties:
+                                                      extVars:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      libs:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      tlas:
+                                                        items:
+                                                          properties:
+                                                            code:
+                                                              type: boolean
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  recurse:
+                                                    type: boolean
+                                                type: object
+                                              helm:
+                                                properties:
+                                                  fileParameters:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        path:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  ignoreMissingValueFiles:
+                                                    type: boolean
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        forceString:
+                                                          type: boolean
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      type: object
+                                                    type: array
+                                                  passCredentials:
+                                                    type: boolean
+                                                  releaseName:
+                                                    type: string
+                                                  skipCrds:
+                                                    type: boolean
+                                                  valueFiles:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  values:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              ksonnet:
+                                                properties:
+                                                  environment:
+                                                    type: string
+                                                  parameters:
+                                                    items:
+                                                      properties:
+                                                        component:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              kustomize:
+                                                properties:
+                                                  commonAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  commonLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  forceCommonAnnotations:
+                                                    type: boolean
+                                                  forceCommonLabels:
+                                                    type: boolean
+                                                  images:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  namePrefix:
+                                                    type: string
+                                                  nameSuffix:
+                                                    type: string
+                                                  version:
+                                                    type: string
+                                                type: object
+                                              path:
+                                                type: string
+                                              plugin:
+                                                properties:
+                                                  env:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              repoURL:
+                                                type: string
+                                              targetRevision:
+                                                type: string
+                                            required:
+                                            - repoURL
+                                            type: object
+                                          syncPolicy:
+                                            properties:
+                                              automated:
+                                                properties:
+                                                  allowEmpty:
+                                                    type: boolean
+                                                  prune:
+                                                    type: boolean
+                                                  selfHeal:
+                                                    type: boolean
+                                                type: object
+                                              retry:
+                                                properties:
+                                                  backoff:
+                                                    properties:
+                                                      duration:
+                                                        type: string
+                                                      factor:
+                                                        format: int64
+                                                        type: integer
+                                                      maxDuration:
+                                                        type: string
+                                                    type: object
+                                                  limit:
+                                                    format: int64
+                                                    type: integer
+                                                type: object
+                                              syncOptions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        required:
+                                        - destination
+                                        - project
+                                        - source
+                                        type: object
+                                    required:
+                                    - metadata
+                                    - spec
+                                    type: object
+                                type: object
                             type: object
                           type: array
-                        github:
-                          description: Which provider to use and config for it.
-                          properties:
-                            allBranches:
-                              description: Scan all branches instead of just the default
-                                branch.
-                              type: boolean
-                            api:
-                              description: The GitHub API URL to talk to. If blank,
-                                use https://api.github.com/.
-                              type: string
-                            organization:
-                              description: GitHub org to scan. Required.
-                              type: string
-                            tokenRef:
-                              description: Authentication token reference.
-                              properties:
-                                key:
-                                  type: string
-                                secretName:
-                                  type: string
-                              required:
-                              - key
-                              - secretName
-                              type: object
-                          required:
-                          - organization
-                          type: object
-                        gitlab:
-                          description: SCMProviderGeneratorGitlab defines a connection
-                            info specific to Gitlab.
-                          properties:
-                            allBranches:
-                              description: Scan all branches instead of just the default
-                                branch.
-                              type: boolean
-                            api:
-                              description: The Gitlab API URL to talk to.
-                              type: string
-                            group:
-                              description: Gitlab group to scan. Required.  You can
-                                use either the project id (recommended) or the full
-                                namespaced path.
-                              type: string
-                            includeSubgroups:
-                              description: Recurse through subgroups (true) or scan
-                                only the base group (false).  Defaults to "false"
-                              type: boolean
-                            tokenRef:
-                              description: Authentication token reference.
-                              properties:
-                                key:
-                                  type: string
-                                secretName:
-                                  type: string
-                              required:
-                              - key
-                              - secretName
-                              type: object
-                          required:
-                          - group
-                          type: object
-                        requeueAfterSeconds:
-                          description: Standard parameters.
-                          format: int64
-                          type: integer
+                        mergeKeys:
+                          items:
+                            type: string
+                          type: array
                         template:
-                          description: ApplicationSetTemplate represents argocd ApplicationSpec
                           properties:
                             metadata:
-                              description: ApplicationSetTemplateMeta represents the
-                                Argo CD application fields that may be used for Applications
-                                generated from the ApplicationSet (based on metav1.ObjectMeta)
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -5488,40 +5272,18 @@ spec:
                                   type: string
                               type: object
                             spec:
-                              description: ApplicationSpec represents desired application
-                                state. Contains link to repository with application
-                                definition and additional parameters link definition
-                                revision.
                               properties:
                                 destination:
-                                  description: Destination is a reference to the target
-                                    Kubernetes server and namespace
                                   properties:
                                     name:
-                                      description: Name is an alternate way of specifying
-                                        the target cluster by its symbolic name
                                       type: string
                                     namespace:
-                                      description: Namespace specifies the target
-                                        namespace for the application's resources.
-                                        The namespace will only be set for namespace-scoped
-                                        resources that have not set a value for .metadata.namespace
                                       type: string
                                     server:
-                                      description: Server specifies the URL of the
-                                        target cluster and must be set to the Kubernetes
-                                        control plane API
                                       type: string
                                   type: object
                                 ignoreDifferences:
-                                  description: IgnoreDifferences is a list of resources
-                                    and their fields which should be ignored during
-                                    comparison
                                   items:
-                                    description: ResourceIgnoreDifferences contains
-                                      resource filter and list of json paths which
-                                      should be ignored during comparison with live
-                                      state.
                                     properties:
                                       group:
                                         type: string
@@ -5535,6 +5297,10 @@ spec:
                                         type: array
                                       kind:
                                         type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
                                       name:
                                         type: string
                                       namespace:
@@ -5544,9 +5310,6 @@ spec:
                                     type: object
                                   type: array
                                 info:
-                                  description: Info contains a list of information
-                                    (URLs, email addresses, and plain text) that relates
-                                    to the application
                                   items:
                                     properties:
                                       name:
@@ -5559,58 +5322,24 @@ spec:
                                     type: object
                                   type: array
                                 project:
-                                  description: Project is a reference to the project
-                                    this application belongs to. The empty string
-                                    means that application belongs to the 'default'
-                                    project.
                                   type: string
                                 revisionHistoryLimit:
-                                  description: RevisionHistoryLimit limits the number
-                                    of items kept in the application's revision history,
-                                    which is used for informational purposes as well
-                                    as for rollbacks to previous versions. This should
-                                    only be changed in exceptional circumstances.
-                                    Setting to zero will store no history. This will
-                                    reduce storage used. Increasing will increase
-                                    the space used to store the history, so we do
-                                    not recommend increasing it. Default is 10.
                                   format: int64
                                   type: integer
                                 source:
-                                  description: Source is a reference to the location
-                                    of the application's manifests or chart
                                   properties:
                                     chart:
-                                      description: Chart is a Helm chart name, and
-                                        must be specified for applications sourced
-                                        from a Helm repo.
                                       type: string
                                     directory:
-                                      description: Directory holds path/directory
-                                        specific options
                                       properties:
                                         exclude:
-                                          description: Exclude contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly excluded from being used during
-                                            manifest generation
                                           type: string
                                         include:
-                                          description: Include contains a glob pattern
-                                            to match paths against that should be
-                                            explicitly included during manifest generation
                                           type: string
                                         jsonnet:
-                                          description: Jsonnet holds options specific
-                                            to Jsonnet
                                           properties:
                                             extVars:
-                                              description: ExtVars is a list of Jsonnet
-                                                External Variables
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5624,18 +5353,11 @@ spec:
                                                 type: object
                                               type: array
                                             libs:
-                                              description: Additional library search
-                                                dirs
                                               items:
                                                 type: string
                                               type: array
                                             tlas:
-                                              description: TLAS is a list of Jsonnet
-                                                Top-level Arguments
                                               items:
-                                                description: JsonnetVar represents
-                                                  a variable to be passed to jsonnet
-                                                  during manifest generation
                                                 properties:
                                                   code:
                                                     type: boolean
@@ -5650,91 +5372,53 @@ spec:
                                               type: array
                                           type: object
                                         recurse:
-                                          description: Recurse specifies whether to
-                                            scan a directory recursively for manifests
                                           type: boolean
                                       type: object
                                     helm:
-                                      description: Helm holds helm specific options
                                       properties:
                                         fileParameters:
-                                          description: FileParameters are file parameters
-                                            to the helm template
                                           items:
-                                            description: HelmFileParameter is a file
-                                              parameter that's passed to helm template
-                                              during manifest generation
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               path:
-                                                description: Path is the path to the
-                                                  file containing the values for the
-                                                  Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
                                         parameters:
-                                          description: Parameters is a list of Helm
-                                            parameters which are passed to the helm
-                                            template command upon manifest generation
                                           items:
-                                            description: HelmParameter is a parameter
-                                              that's passed to helm template during
-                                              manifest generation
                                             properties:
                                               forceString:
-                                                description: ForceString determines
-                                                  whether to tell Helm to interpret
-                                                  booleans and numbers as strings
                                                 type: boolean
                                               name:
-                                                description: Name is the name of the
-                                                  Helm parameter
                                                 type: string
                                               value:
-                                                description: Value is the value for
-                                                  the Helm parameter
                                                 type: string
                                             type: object
                                           type: array
+                                        passCredentials:
+                                          type: boolean
                                         releaseName:
-                                          description: ReleaseName is the Helm release
-                                            name to use. If omitted it will use the
-                                            application name
                                           type: string
+                                        skipCrds:
+                                          type: boolean
                                         valueFiles:
-                                          description: ValuesFiles is a list of Helm
-                                            value files to use when generating a template
                                           items:
                                             type: string
                                           type: array
                                         values:
-                                          description: Values specifies Helm values
-                                            to be passed to helm template, typically
-                                            defined as a block
                                           type: string
                                         version:
-                                          description: Version is the Helm version
-                                            to use for templating (either "2" or "3")
                                           type: string
                                       type: object
                                     ksonnet:
-                                      description: Ksonnet holds ksonnet specific
-                                        options
                                       properties:
                                         environment:
-                                          description: Environment is a ksonnet application
-                                            environment name
                                           type: string
                                         parameters:
-                                          description: Parameters are a list of ksonnet
-                                            component parameter override values
                                           items:
-                                            description: KsonnetParameter is a ksonnet
-                                              component parameter
                                             properties:
                                               component:
                                                 type: string
@@ -5749,77 +5433,40 @@ spec:
                                           type: array
                                       type: object
                                     kustomize:
-                                      description: Kustomize holds kustomize specific
-                                        options
                                       properties:
                                         commonAnnotations:
                                           additionalProperties:
                                             type: string
-                                          description: CommonAnnotations is a list
-                                            of additional annotations to add to rendered
-                                            manifests
                                           type: object
                                         commonLabels:
                                           additionalProperties:
                                             type: string
-                                          description: CommonLabels is a list of additional
-                                            labels to add to rendered manifests
                                           type: object
                                         forceCommonAnnotations:
-                                          description: ForceCommonAnnotations specifies
-                                            whether to force applying common annotations
-                                            to resources for Kustomize apps
                                           type: boolean
                                         forceCommonLabels:
-                                          description: ForceCommonLabels specifies
-                                            whether to force applying common labels
-                                            to resources for Kustomize apps
                                           type: boolean
                                         images:
-                                          description: Images is a list of Kustomize
-                                            image override specifications
                                           items:
-                                            description: KustomizeImage represents
-                                              a Kustomize image definition in the
-                                              format [old_image_name=]<image_name>:<image_tag>
                                             type: string
                                           type: array
                                         namePrefix:
-                                          description: NamePrefix is a prefix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         nameSuffix:
-                                          description: NameSuffix is a suffix appended
-                                            to resources for Kustomize apps
                                           type: string
                                         version:
-                                          description: Version controls which version
-                                            of Kustomize to use for rendering manifests
                                           type: string
                                       type: object
                                     path:
-                                      description: Path is a directory path within
-                                        the Git repository, and is only valid for
-                                        applications sourced from Git.
                                       type: string
                                     plugin:
-                                      description: ConfigManagementPlugin holds config
-                                        management plugin specific options
                                       properties:
                                         env:
-                                          description: Env is a list of environment
-                                            variable entries
                                           items:
-                                            description: EnvEntry represents an entry
-                                              in the application's environment
                                             properties:
                                               name:
-                                                description: Name is the name of the
-                                                  variable, usually expressed in uppercase
                                                 type: string
                                               value:
-                                                description: Value is the value of
-                                                  the variable
                                                 type: string
                                             required:
                                             - name
@@ -5830,82 +5477,690 @@ spec:
                                           type: string
                                       type: object
                                     repoURL:
-                                      description: RepoURL is the URL to the repository
-                                        (Git or Helm) that contains the application
-                                        manifests
                                       type: string
                                     targetRevision:
-                                      description: TargetRevision defines the revision
-                                        of the source to sync the application to.
-                                        In case of Git, this can be commit, tag, or
-                                        branch. If omitted, will equal to HEAD. In
-                                        case of Helm, this is a semver tag for the
-                                        Chart's version.
                                       type: string
                                   required:
                                   - repoURL
                                   type: object
                                 syncPolicy:
-                                  description: SyncPolicy controls when and how a
-                                    sync will be performed
                                   properties:
                                     automated:
-                                      description: Automated will keep an application
-                                        synced to the target revision
                                       properties:
                                         allowEmpty:
-                                          description: 'AllowEmpty allows apps have
-                                            zero live resources (default: false)'
                                           type: boolean
                                         prune:
-                                          description: 'Prune specifies whether to
-                                            delete resources from the cluster that
-                                            are not found in the sources anymore as
-                                            part of automated sync (default: false)'
                                           type: boolean
                                         selfHeal:
-                                          description: 'SelfHeal specifes whether
-                                            to revert resources back to their desired
-                                            state upon modification in the cluster
-                                            (default: false)'
                                           type: boolean
                                       type: object
                                     retry:
-                                      description: Retry controls failed sync retry
-                                        behavior
                                       properties:
                                         backoff:
-                                          description: Backoff controls how to backoff
-                                            on subsequent retries of failed syncs
                                           properties:
                                             duration:
-                                              description: Duration is the amount
-                                                to back off. Default unit is seconds,
-                                                but could also be a duration (e.g.
-                                                "2m", "1h")
                                               type: string
                                             factor:
-                                              description: Factor is a factor to multiply
-                                                the base duration after each failed
-                                                retry
                                               format: int64
                                               type: integer
                                             maxDuration:
-                                              description: MaxDuration is the maximum
-                                                amount of time allowed for the backoff
-                                                strategy
                                               type: string
                                           type: object
                                         limit:
-                                          description: Limit is the maximum number
-                                            of attempts for retrying a failed sync.
-                                            If set to 0, no retries will be performed.
                                           format: int64
                                           type: integer
                                       type: object
                                     syncOptions:
-                                      description: Options allow you to specify whole
-                                        app sync-options
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      required:
+                      - generators
+                      - mergeKeys
+                      type: object
+                    pullRequest:
+                      properties:
+                        github:
+                          properties:
+                            api:
+                              type: string
+                            labels:
+                              items:
+                                type: string
+                              type: array
+                            owner:
+                              type: string
+                            repo:
+                              type: string
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - owner
+                          - repo
+                          type: object
+                        requeueAfterSeconds:
+                          format: int64
+                          type: integer
+                        template:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              properties:
+                                destination:
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    server:
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  items:
+                                    properties:
+                                      group:
+                                        type: string
+                                      jqPathExpressions:
+                                        items:
+                                          type: string
+                                        type: array
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  type: string
+                                revisionHistoryLimit:
+                                  format: int64
+                                  type: integer
+                                source:
+                                  properties:
+                                    chart:
+                                      type: string
+                                    directory:
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        include:
+                                          type: string
+                                        jsonnet:
+                                          properties:
+                                            extVars:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      properties:
+                                        fileParameters:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              path:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
+                                        parameters:
+                                          items:
+                                            properties:
+                                              forceString:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          type: boolean
+                                        releaseName:
+                                          type: string
+                                        skipCrds:
+                                          type: boolean
+                                        valueFiles:
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      properties:
+                                        environment:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        forceCommonAnnotations:
+                                          type: boolean
+                                        forceCommonLabels:
+                                          type: boolean
+                                        images:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          type: string
+                                        nameSuffix:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    path:
+                                      type: string
+                                    plugin:
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      type: string
+                                    targetRevision:
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  properties:
+                                    automated:
+                                      properties:
+                                        allowEmpty:
+                                          type: boolean
+                                        prune:
+                                          type: boolean
+                                        selfHeal:
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      properties:
+                                        backoff:
+                                          properties:
+                                            duration:
+                                              type: string
+                                            factor:
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              type: string
+                                          type: object
+                                        limit:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              required:
+                              - destination
+                              - project
+                              - source
+                              type: object
+                          required:
+                          - metadata
+                          - spec
+                          type: object
+                      type: object
+                    scmProvider:
+                      properties:
+                        cloneProtocol:
+                          type: string
+                        filters:
+                          items:
+                            properties:
+                              branchMatch:
+                                type: string
+                              labelMatch:
+                                type: string
+                              pathsExist:
+                                items:
+                                  type: string
+                                type: array
+                              repositoryMatch:
+                                type: string
+                            type: object
+                          type: array
+                        github:
+                          properties:
+                            allBranches:
+                              type: boolean
+                            api:
+                              type: string
+                            organization:
+                              type: string
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - organization
+                          type: object
+                        gitlab:
+                          properties:
+                            allBranches:
+                              type: boolean
+                            api:
+                              type: string
+                            group:
+                              type: string
+                            includeSubgroups:
+                              type: boolean
+                            tokenRef:
+                              properties:
+                                key:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - key
+                              - secretName
+                              type: object
+                          required:
+                          - group
+                          type: object
+                        requeueAfterSeconds:
+                          format: int64
+                          type: integer
+                        template:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              properties:
+                                destination:
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    server:
+                                      type: string
+                                  type: object
+                                ignoreDifferences:
+                                  items:
+                                    properties:
+                                      group:
+                                        type: string
+                                      jqPathExpressions:
+                                        items:
+                                          type: string
+                                        type: array
+                                      jsonPointers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      kind:
+                                        type: string
+                                      managedFieldsManagers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                    - kind
+                                    type: object
+                                  type: array
+                                info:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                project:
+                                  type: string
+                                revisionHistoryLimit:
+                                  format: int64
+                                  type: integer
+                                source:
+                                  properties:
+                                    chart:
+                                      type: string
+                                    directory:
+                                      properties:
+                                        exclude:
+                                          type: string
+                                        include:
+                                          type: string
+                                        jsonnet:
+                                          properties:
+                                            extVars:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            libs:
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlas:
+                                              items:
+                                                properties:
+                                                  code:
+                                                    type: boolean
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                          type: object
+                                        recurse:
+                                          type: boolean
+                                      type: object
+                                    helm:
+                                      properties:
+                                        fileParameters:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              path:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        ignoreMissingValueFiles:
+                                          type: boolean
+                                        parameters:
+                                          items:
+                                            properties:
+                                              forceString:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        passCredentials:
+                                          type: boolean
+                                        releaseName:
+                                          type: string
+                                        skipCrds:
+                                          type: boolean
+                                        valueFiles:
+                                          items:
+                                            type: string
+                                          type: array
+                                        values:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    ksonnet:
+                                      properties:
+                                        environment:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              component:
+                                                type: string
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                      type: object
+                                    kustomize:
+                                      properties:
+                                        commonAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        commonLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        forceCommonAnnotations:
+                                          type: boolean
+                                        forceCommonLabels:
+                                          type: boolean
+                                        images:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namePrefix:
+                                          type: string
+                                        nameSuffix:
+                                          type: string
+                                        version:
+                                          type: string
+                                      type: object
+                                    path:
+                                      type: string
+                                    plugin:
+                                      properties:
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                      type: object
+                                    repoURL:
+                                      type: string
+                                    targetRevision:
+                                      type: string
+                                  required:
+                                  - repoURL
+                                  type: object
+                                syncPolicy:
+                                  properties:
+                                    automated:
+                                      properties:
+                                        allowEmpty:
+                                          type: boolean
+                                        prune:
+                                          type: boolean
+                                        selfHeal:
+                                          type: boolean
+                                      type: object
+                                    retry:
+                                      properties:
+                                        backoff:
+                                          properties:
+                                            duration:
+                                              type: string
+                                            factor:
+                                              format: int64
+                                              type: integer
+                                            maxDuration:
+                                              type: string
+                                          type: object
+                                        limit:
+                                          format: int64
+                                          type: integer
+                                      type: object
+                                    syncOptions:
                                       items:
                                         type: string
                                       type: array
@@ -5923,22 +6178,13 @@ spec:
                   type: object
                 type: array
               syncPolicy:
-                description: ApplicationSetSyncPolicy configures how generated Applications
-                  will relate to their ApplicationSet.
                 properties:
                   preserveResourcesOnDeletion:
-                    description: PreserveResourcesOnDeletion will preserve resources
-                      on deletion. If PreserveResourcesOnDeletion is set to true,
-                      these Applications will not be deleted.
                     type: boolean
                 type: object
               template:
-                description: ApplicationSetTemplate represents argocd ApplicationSpec
                 properties:
                   metadata:
-                    description: ApplicationSetTemplateMeta represents the Argo CD
-                      application fields that may be used for Applications generated
-                      from the ApplicationSet (based on metav1.ObjectMeta)
                     properties:
                       annotations:
                         additionalProperties:
@@ -5958,36 +6204,18 @@ spec:
                         type: string
                     type: object
                   spec:
-                    description: ApplicationSpec represents desired application state.
-                      Contains link to repository with application definition and
-                      additional parameters link definition revision.
                     properties:
                       destination:
-                        description: Destination is a reference to the target Kubernetes
-                          server and namespace
                         properties:
                           name:
-                            description: Name is an alternate way of specifying the
-                              target cluster by its symbolic name
                             type: string
                           namespace:
-                            description: Namespace specifies the target namespace
-                              for the application's resources. The namespace will
-                              only be set for namespace-scoped resources that have
-                              not set a value for .metadata.namespace
                             type: string
                           server:
-                            description: Server specifies the URL of the target cluster
-                              and must be set to the Kubernetes control plane API
                             type: string
                         type: object
                       ignoreDifferences:
-                        description: IgnoreDifferences is a list of resources and
-                          their fields which should be ignored during comparison
                         items:
-                          description: ResourceIgnoreDifferences contains resource
-                            filter and list of json paths which should be ignored
-                            during comparison with live state.
                           properties:
                             group:
                               type: string
@@ -6001,6 +6229,10 @@ spec:
                               type: array
                             kind:
                               type: string
+                            managedFieldsManagers:
+                              items:
+                                type: string
+                              type: array
                             name:
                               type: string
                             namespace:
@@ -6010,8 +6242,6 @@ spec:
                           type: object
                         type: array
                       info:
-                        description: Info contains a list of information (URLs, email
-                          addresses, and plain text) that relates to the application
                         items:
                           properties:
                             name:
@@ -6024,51 +6254,24 @@ spec:
                           type: object
                         type: array
                       project:
-                        description: Project is a reference to the project this application
-                          belongs to. The empty string means that application belongs
-                          to the 'default' project.
                         type: string
                       revisionHistoryLimit:
-                        description: RevisionHistoryLimit limits the number of items
-                          kept in the application's revision history, which is used
-                          for informational purposes as well as for rollbacks to previous
-                          versions. This should only be changed in exceptional circumstances.
-                          Setting to zero will store no history. This will reduce
-                          storage used. Increasing will increase the space used to
-                          store the history, so we do not recommend increasing it.
-                          Default is 10.
                         format: int64
                         type: integer
                       source:
-                        description: Source is a reference to the location of the
-                          application's manifests or chart
                         properties:
                           chart:
-                            description: Chart is a Helm chart name, and must be specified
-                              for applications sourced from a Helm repo.
                             type: string
                           directory:
-                            description: Directory holds path/directory specific options
                             properties:
                               exclude:
-                                description: Exclude contains a glob pattern to match
-                                  paths against that should be explicitly excluded
-                                  from being used during manifest generation
                                 type: string
                               include:
-                                description: Include contains a glob pattern to match
-                                  paths against that should be explicitly included
-                                  during manifest generation
                                 type: string
                               jsonnet:
-                                description: Jsonnet holds options specific to Jsonnet
                                 properties:
                                   extVars:
-                                    description: ExtVars is a list of Jsonnet External
-                                      Variables
                                     items:
-                                      description: JsonnetVar represents a variable
-                                        to be passed to jsonnet during manifest generation
                                       properties:
                                         code:
                                           type: boolean
@@ -6082,16 +6285,11 @@ spec:
                                       type: object
                                     type: array
                                   libs:
-                                    description: Additional library search dirs
                                     items:
                                       type: string
                                     type: array
                                   tlas:
-                                    description: TLAS is a list of Jsonnet Top-level
-                                      Arguments
                                     items:
-                                      description: JsonnetVar represents a variable
-                                        to be passed to jsonnet during manifest generation
                                       properties:
                                         code:
                                           type: boolean
@@ -6106,84 +6304,53 @@ spec:
                                     type: array
                                 type: object
                               recurse:
-                                description: Recurse specifies whether to scan a directory
-                                  recursively for manifests
                                 type: boolean
                             type: object
                           helm:
-                            description: Helm holds helm specific options
                             properties:
                               fileParameters:
-                                description: FileParameters are file parameters to
-                                  the helm template
                                 items:
-                                  description: HelmFileParameter is a file parameter
-                                    that's passed to helm template during manifest
-                                    generation
                                   properties:
                                     name:
-                                      description: Name is the name of the Helm parameter
                                       type: string
                                     path:
-                                      description: Path is the path to the file containing
-                                        the values for the Helm parameter
                                       type: string
                                   type: object
                                 type: array
+                              ignoreMissingValueFiles:
+                                type: boolean
                               parameters:
-                                description: Parameters is a list of Helm parameters
-                                  which are passed to the helm template command upon
-                                  manifest generation
                                 items:
-                                  description: HelmParameter is a parameter that's
-                                    passed to helm template during manifest generation
                                   properties:
                                     forceString:
-                                      description: ForceString determines whether
-                                        to tell Helm to interpret booleans and numbers
-                                        as strings
                                       type: boolean
                                     name:
-                                      description: Name is the name of the Helm parameter
                                       type: string
                                     value:
-                                      description: Value is the value for the Helm
-                                        parameter
                                       type: string
                                   type: object
                                 type: array
+                              passCredentials:
+                                type: boolean
                               releaseName:
-                                description: ReleaseName is the Helm release name
-                                  to use. If omitted it will use the application name
                                 type: string
+                              skipCrds:
+                                type: boolean
                               valueFiles:
-                                description: ValuesFiles is a list of Helm value files
-                                  to use when generating a template
                                 items:
                                   type: string
                                 type: array
                               values:
-                                description: Values specifies Helm values to be passed
-                                  to helm template, typically defined as a block
                                 type: string
                               version:
-                                description: Version is the Helm version to use for
-                                  templating (either "2" or "3")
                                 type: string
                             type: object
                           ksonnet:
-                            description: Ksonnet holds ksonnet specific options
                             properties:
                               environment:
-                                description: Environment is a ksonnet application
-                                  environment name
                                 type: string
                               parameters:
-                                description: Parameters are a list of ksonnet component
-                                  parameter override values
                                 items:
-                                  description: KsonnetParameter is a ksonnet component
-                                    parameter
                                   properties:
                                     component:
                                       type: string
@@ -6198,72 +6365,40 @@ spec:
                                 type: array
                             type: object
                           kustomize:
-                            description: Kustomize holds kustomize specific options
                             properties:
                               commonAnnotations:
                                 additionalProperties:
                                   type: string
-                                description: CommonAnnotations is a list of additional
-                                  annotations to add to rendered manifests
                                 type: object
                               commonLabels:
                                 additionalProperties:
                                   type: string
-                                description: CommonLabels is a list of additional
-                                  labels to add to rendered manifests
                                 type: object
                               forceCommonAnnotations:
-                                description: ForceCommonAnnotations specifies whether
-                                  to force applying common annotations to resources
-                                  for Kustomize apps
                                 type: boolean
                               forceCommonLabels:
-                                description: ForceCommonLabels specifies whether to
-                                  force applying common labels to resources for Kustomize
-                                  apps
                                 type: boolean
                               images:
-                                description: Images is a list of Kustomize image override
-                                  specifications
                                 items:
-                                  description: KustomizeImage represents a Kustomize
-                                    image definition in the format [old_image_name=]<image_name>:<image_tag>
                                   type: string
                                 type: array
                               namePrefix:
-                                description: NamePrefix is a prefix appended to resources
-                                  for Kustomize apps
                                 type: string
                               nameSuffix:
-                                description: NameSuffix is a suffix appended to resources
-                                  for Kustomize apps
                                 type: string
                               version:
-                                description: Version controls which version of Kustomize
-                                  to use for rendering manifests
                                 type: string
                             type: object
                           path:
-                            description: Path is a directory path within the Git repository,
-                              and is only valid for applications sourced from Git.
                             type: string
                           plugin:
-                            description: ConfigManagementPlugin holds config management
-                              plugin specific options
                             properties:
                               env:
-                                description: Env is a list of environment variable
-                                  entries
                                 items:
-                                  description: EnvEntry represents an entry in the
-                                    application's environment
                                   properties:
                                     name:
-                                      description: Name is the name of the variable,
-                                        usually expressed in uppercase
                                       type: string
                                     value:
-                                      description: Value is the value of the variable
                                       type: string
                                   required:
                                   - name
@@ -6274,73 +6409,40 @@ spec:
                                 type: string
                             type: object
                           repoURL:
-                            description: RepoURL is the URL to the repository (Git
-                              or Helm) that contains the application manifests
                             type: string
                           targetRevision:
-                            description: TargetRevision defines the revision of the
-                              source to sync the application to. In case of Git, this
-                              can be commit, tag, or branch. If omitted, will equal
-                              to HEAD. In case of Helm, this is a semver tag for the
-                              Chart's version.
                             type: string
                         required:
                         - repoURL
                         type: object
                       syncPolicy:
-                        description: SyncPolicy controls when and how a sync will
-                          be performed
                         properties:
                           automated:
-                            description: Automated will keep an application synced
-                              to the target revision
                             properties:
                               allowEmpty:
-                                description: 'AllowEmpty allows apps have zero live
-                                  resources (default: false)'
                                 type: boolean
                               prune:
-                                description: 'Prune specifies whether to delete resources
-                                  from the cluster that are not found in the sources
-                                  anymore as part of automated sync (default: false)'
                                 type: boolean
                               selfHeal:
-                                description: 'SelfHeal specifes whether to revert
-                                  resources back to their desired state upon modification
-                                  in the cluster (default: false)'
                                 type: boolean
                             type: object
                           retry:
-                            description: Retry controls failed sync retry behavior
                             properties:
                               backoff:
-                                description: Backoff controls how to backoff on subsequent
-                                  retries of failed syncs
                                 properties:
                                   duration:
-                                    description: Duration is the amount to back off.
-                                      Default unit is seconds, but could also be a
-                                      duration (e.g. "2m", "1h")
                                     type: string
                                   factor:
-                                    description: Factor is a factor to multiply the
-                                      base duration after each failed retry
                                     format: int64
                                     type: integer
                                   maxDuration:
-                                    description: MaxDuration is the maximum amount
-                                      of time allowed for the backoff strategy
                                     type: string
                                 type: object
                               limit:
-                                description: Limit is the maximum number of attempts
-                                  for retrying a failed sync. If set to 0, no retries
-                                  will be performed.
                                 format: int64
                                 type: integer
                             type: object
                           syncOptions:
-                            description: Options allow you to specify whole app sync-options
                             items:
                               type: string
                             type: array
@@ -6359,7 +6461,28 @@ spec:
             - template
             type: object
           status:
-            description: ApplicationSetStatus defines the observed state of ApplicationSet
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
             type: object
         required:
         - metadata
@@ -6367,6 +6490,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind chore

**What does this PR do / why we need it**:
upgrades appsets to v0.4.1

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
upgrades appsets to v0.4.1

**How to test changes / Special notes to the reviewer**:
1. Run the operator locally using `make install run`
2. Deploy the below Argo CD CR.
```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: autoscale
spec:
  applicationSet: {}
  server:
    ingress:
      enabled: true
```
3. Wait for a minute for operator to reconcile the Argo CD resource and create its workloads.
4. Use the below command to verify the ApplicationSet version.
`kubectl describe deployment example-argocd-applciationset-controller `