### PR TITLE
Fix docs to say host instead of URL

### DIFF
--- a/docs/reference/api.html.md
+++ b/docs/reference/api.html.md
@@ -2216,13 +2216,13 @@ Unknown: For some reason the state of the Argo CD server component could not be 
 </tr>
 <tr>
 <td>
-<code>url</code></br>
+<code>host</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>URL is the url for the hostname to use for Ingress/Route resources</p>
+<p>Host is the url for the hostname to use for Ingress/Route resources</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
Docs incorrectly use URL instead of host, this will fix it. 

**Which issue(s) this PR fixes**:
Fixes #601 

**How to test changes / Special notes to the reviewer**:
N/A