### PR TITLE
fix: delete broken pods of statefulSets

### DIFF
--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -496,7 +496,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 		podSpec.Volumes = getArgoImportVolumes(export)
 	}
 
-	invalidImagePod := containsInvalidImage(ss, cr, r)
+	invalidImagePod := containsInvalidImage(cr, r)
 	if invalidImagePod {
 		if err := r.Client.Delete(context.TODO(), ss); err != nil {
 			return err
@@ -602,7 +602,7 @@ func updateNodePlacementStateful(existing *appsv1.StatefulSet, ss *appsv1.Statef
 
 // Returns true if a StatefulSet has pods in ErrImagePull or ImagePullBackoff state.
 // These pods cannot be restarted automatially due to known kubernetes issue https://github.com/kubernetes/kubernetes/issues/67250
-func containsInvalidImage(ss *appsv1.StatefulSet, cr *argoprojv1a1.ArgoCD, r *ReconcileArgoCD) bool {
+func containsInvalidImage(cr *argoprojv1a1.ArgoCD, r *ReconcileArgoCD) bool {
 
 	brokenPod := false
 

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -551,13 +551,11 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 		}
 		return nil // StatefulSet found with nothing to do, move along...
 	}
-	// pod := &corev1.PodList{}
-	// fmt.Println("PODSSS ", r.Client.List(context.TODO(), pod))
+
 	// Delete existing deployment for Application Controller, if any ..
 	deploy := newDeploymentWithSuffix("application-controller", "application-controller", cr)
 	if argoutil.IsObjectFound(r.Client, deploy.Namespace, deploy.Name, deploy) {
 		if err := r.Client.Delete(context.TODO(), deploy); err != nil {
-
 			return err
 		}
 	}
@@ -612,7 +610,7 @@ func containsInvalidImage(ss *appsv1.StatefulSet, cr *argoprojv1a1.ArgoCD, r *Re
 	listOption := client.MatchingLabels{common.ArgoCDKeyName: fmt.Sprintf("%s-%s", cr.Name, "application-controller")}
 
 	if err := r.Client.List(context.TODO(), podList, listOption); err != nil {
-		fmt.Println(err, "Failed to list Pods")
+		log.Error(err, "Failed to list Pods")
 	}
 	if len(podList.Items) > 0 {
 		if len(podList.Items[0].Status.ContainerStatuses) > 0 {

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -7,6 +7,7 @@ import (
 
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 
@@ -363,4 +364,42 @@ func Test_UpdateNodePlacementStateful(t *testing.T) {
 	if actualChange == expectedChange {
 		t.Fatalf("updateNodePlacement failed, value of changed: %t", actualChange)
 	}
+}
+
+func Test_ContainsValidImage(t *testing.T) {
+
+	a := makeTestArgoCD()
+
+	ss := newStatefulSetWithSuffix("application-controller", "application-controller", a)
+	ssName := fmt.Sprintf("%s-%s", a.Name, "application-controller")
+	ss.Spec = appsv1.StatefulSetSpec{
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				common.ArgoCDKeyName: ssName,
+			},
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					common.ArgoCDKeyName: ssName,
+				},
+			},
+		},
+	}
+	po := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				common.ArgoCDKeyName: ssName,
+			},
+		},
+	}
+	objs := []runtime.Object{
+		po,
+		a,
+	}
+	r := makeTestReconciler(t, objs...)
+	if containsInvalidImage(ss, a, r) {
+		t.Fatalf("containsInvalidImage failed, got true, expected false")
+	}
+
 }

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -364,3 +364,10 @@ func Test_UpdateNodePlacementStateful(t *testing.T) {
 		t.Fatalf("updateNodePlacement failed, value of changed: %t", actualChange)
 	}
 }
+func Test_ContainsBrokenPod(t *testing.T) {
+	a := makeTestArgoCD()
+	ss := &appsv1.StatefulSet{}
+	if containsBrokenPod(ss, a) {
+		t.Fatalf("containsBrokenPod should return false but returned true")
+	}
+}

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -364,10 +364,3 @@ func Test_UpdateNodePlacementStateful(t *testing.T) {
 		t.Fatalf("updateNodePlacement failed, value of changed: %t", actualChange)
 	}
 }
-func Test_ContainsBrokenPod(t *testing.T) {
-	a := makeTestArgoCD()
-	ss := &appsv1.StatefulSet{}
-	if containsBrokenPod(ss, a) {
-		t.Fatalf("containsBrokenPod should return false but returned true")
-	}
-}

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -369,27 +369,10 @@ func Test_UpdateNodePlacementStateful(t *testing.T) {
 func Test_ContainsValidImage(t *testing.T) {
 
 	a := makeTestArgoCD()
-
-	ss := newStatefulSetWithSuffix("application-controller", "application-controller", a)
-	ssName := fmt.Sprintf("%s-%s", a.Name, "application-controller")
-	ss.Spec = appsv1.StatefulSetSpec{
-		Selector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				common.ArgoCDKeyName: ssName,
-			},
-		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					common.ArgoCDKeyName: ssName,
-				},
-			},
-		},
-	}
 	po := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				common.ArgoCDKeyName: ssName,
+				common.ArgoCDKeyName: fmt.Sprintf("%s-%s", a.Name, "application-controller"),
 			},
 		},
 	}
@@ -398,7 +381,7 @@ func Test_ContainsValidImage(t *testing.T) {
 		a,
 	}
 	r := makeTestReconciler(t, objs...)
-	if containsInvalidImage(ss, a, r) {
+	if containsInvalidImage(a, r) {
 		t.Fatalf("containsInvalidImage failed, got true, expected false")
 	}
 


### PR DESCRIPTION
Signed-off-by: saumeya <saumeyakatyal@gmail.com>

**What type of PR is this?**
/kind bug



**What does this PR do / why we need it**:
There is a known issue in Kubernetes (https://github.com/kubernetes/kubernetes/issues/67250) where, if the pods created by StatefulSets fail then they don't get restarted on their own unless manually deleted. This PR adds the deletion in the operator itself, so that it can fetch such a broken pod and restart it.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Run the operator using `make intall` and `make run`
2. In the Application Controller StatefulSet, update the image to any broken url, this will recreate the bug and the `application-controller` pod will show `ImagePullBackOff` or `ErrImagePull`
3. Verify that in a few seconds the pod will be recreated as the StatefulSet reconciler update the image to the correct path