### PR TITLE
Added probes to Dex container

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -103,6 +103,9 @@ const (
 	// ArgoCDDefaultDexHTTPPort is the default HTTP listen port for Dex.
 	ArgoCDDefaultDexHTTPPort = 5556
 
+	// ArgoCDDefaultDexMetricsPort is the default Metrics listen port for Dex.
+	ArgoCDDefaultDexMetricsPort = 5558
+
 	// ArgoCDDefaultDexServiceAccountName is the default Service Account name for the Dex server.
 	ArgoCDDefaultDexServiceAccountName = "argocd-dex-server"
 

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -374,6 +374,16 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 		ImagePullPolicy: corev1.PullAlways,
 		Name:            "dex",
 		Env:             proxyEnvVars(),
+		LivenessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz/live",
+					Port: intstr.FromInt(common.ArgoCDDefaultDexMetricsPort),
+				},
+			},
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       30,
+		},
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: common.ArgoCDDefaultDexHTTPPort,
@@ -381,6 +391,9 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 			}, {
 				ContainerPort: common.ArgoCDDefaultDexGRPCPort,
 				Name:          "grpc",
+			}, {
+				ContainerPort: common.ArgoCDDefaultDexMetricsPort,
+				Name:          "metrics",
 			},
 		},
 		Resources: getDexResources(cr),

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -882,6 +882,16 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 					"/shared/argocd-dex",
 					"rundex",
 				},
+				LivenessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz/live",
+							Port: intstr.FromInt(5558),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       30,
+				},
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http",
@@ -890,6 +900,10 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 					{
 						Name:          "grpc",
 						ContainerPort: 5557,
+					},
+					{
+						Name:          "metrics",
+						ContainerPort: 5558,
 					},
 				},
 				VolumeMounts: []corev1.VolumeMount{
@@ -960,6 +974,16 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 					"/shared/argocd-dex",
 					"rundex",
 				},
+				LivenessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz/live",
+							Port: intstr.FromInt(5558),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       30,
+				},
 				Ports: []corev1.ContainerPort{
 					{
 						Name:          "http",
@@ -968,6 +992,10 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 					{
 						Name:          "grpc",
 						ContainerPort: 5557,
+					},
+					{
+						Name:          "metrics",
+						ContainerPort: 5558,
 					},
 				},
 				VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
Enables probes on dex container which ensures instance is running properly.

It has been observed in some circumstances that dex becomes unhealthy and requires manual deletion of the pod to bring it back into working order