### PR TITLE
chore: update dex version to v2.30.3

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -110,7 +110,7 @@ const (
 	ArgoCDDefaultDexServiceAccountName = "argocd-dex-server"
 
 	// ArgoCDDefaultDexVersion is the Dex container image tag to use when not specified.
-	ArgoCDDefaultDexVersion = "sha256:6b3cc1c385fbc7542244614e4432f2546c619b7850d44d2379c598309a06bed8" // v2.30.0
+	ArgoCDDefaultDexVersion = "sha256:d5f887574312f606c61e7e188cfb11ddb33ff3bf4bd9f06e6b1458efca75f604" // v2.30.3
 
 	// ArgoCDDefaultExportJobImage is the export job container image to use when not specified.
 	ArgoCDDefaultExportJobImage = "quay.io/argoprojlabs/argocd-operator-util"


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind chore

**What does this PR do / why we need it**:
Fixes [CVE-2021-36159](https://alpinelinux.org/posts/Alpine-3.14.1-released.html) and [CVE-2021-3711](https://www.alpinelinux.org/posts/Alpine-3.14.2-released.html)

**Which issue(s) this PR fixes**:
Fixes [CVE-2021-36159](https://alpinelinux.org/posts/Alpine-3.14.1-released.html) and [CVE-2021-3711](https://www.alpinelinux.org/posts/Alpine-3.14.2-released.html)

**How to test changes / Special notes to the reviewer**:
Install and run the operator using `make install run`
Create an Argo CD instance using 
```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: ingress
spec:
  server:
    ingress:
      enabled: true
    insecure: true
```
Wait for the operator to reconcile and create pods.
Login to the dex pod using `kubectl exec -it <dex-pod> manager /bin/sh`
Enter the command `dex version` to get the dex version.

The version should be:
```
Dex Version: v2.30.3-dirty
Go Version: go1.16.6
Go OS/ARCH: linux amd64
```