### PR TITLE
chore: Fix readthedocs builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs==1.2.3
 mkdocs-material==7.1.7
 pygments==2.7.4
+jinja2===3.0.3


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

Fix builds of readthedocs by pinning jinja2 version.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Builds are failing with the below error on Readthedocs.
```
Traceback (most recent call last):
  File "/home/docs/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/docs/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/mkdocs/__main__.py", line 221, in <module>
    cli()
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/mkdocs/__main__.py", line 187, in build_command
    build.build(config.load_config(**kwargs), dirty=not clean)
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/mkdocs/config/base.py", line 216, in load_config
    from mkdocs.config.defaults import get_schema
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/mkdocs/config/defaults.py", line 1, in <module>
    from mkdocs.config import config_options
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/mkdocs/config/config_options.py", line 8, in <module>
    from mkdocs import utils, theme, plugins
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/mkdocs/theme.py", line 6, in <module>
    from mkdocs.utils import filters
  File "/home/docs/checkouts/readthedocs.org/user_builds/argocd-operator/envs/latest/lib/python3.7/site-packages/mkdocs/utils/filters.py", line 13, in <module>
    @jinja2.contextfilter
AttributeError: module 'jinja2' has no attribute 'contextfilter'
```

**How to test changes / Special notes to the reviewer**:
