### PR TITLE
bug: fix continuous reconciliation of resources

### DIFF
--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -63,7 +63,7 @@ func (r *ReconcileArgoCD) reconcileRoles(cr *argoprojv1a1.ArgoCD) error {
 	clusterParams := getPolicyRuleClusterRoleList()
 
 	for _, clusterParam := range clusterParams {
-		if _, err := r.reconcileRole(clusterParam.name, clusterParam.policyRule, cr); err != nil {
+		if _, err := r.reconcileClusterRole(clusterParam.name, clusterParam.policyRule, cr); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
The reconciliation process has entered a continuous loop with #605 . This PR fixes the function call that was used for reconciling cluster roles.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
* Start the operator using `make install run`
* Create an argocd instance using below command
```
cat <<EOF | kubectl apply -f -                                                                    
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: argocd
spec: {}
EOF
```
* check if all pods are running and READY status is 1/1
```
$ kubectl get pods
NAME                                  READY   STATUS    RESTARTS      AGE
argocd-application-controller-0       1/1     Running   0             11m
argocd-dex-server-7fb595cb96-kvg84    1/1     Running   4 (29s ago)   8m59s
argocd-redis-67f8cd6789-x5sg7         1/1     Running   0             11m
argocd-repo-server-6f6dd84754-xnt7w   1/1     Running   0             8m59s
argocd-server-9cd99895d-z6wb8         1/1     Running   0             11m
```
* Operator should have stopped reconciling resources in a loop