### PR TITLE
update deprecated cronjob reference

### DIFF
--- a/controllers/argocdexport/reconcile.go
+++ b/controllers/argocdexport/reconcile.go
@@ -16,7 +16,6 @@ package argocdexport
 
 import (
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1b1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
@@ -46,7 +45,7 @@ func setResourceWatches(bld *builder.Builder) *builder.Builder {
 	bld.For(&argoproj.ArgoCDExport{})
 
 	// Watch for changes to CronJob sub-resources owned by ArgoCDExport instances.
-	bld.Owns(&batchv1b1.CronJob{})
+	bld.Owns(&batchv1.CronJob{})
 
 	// Watch for changes to Job sub-resources owned by ArgoCD instances.
 	bld.Owns(&batchv1.Job{})


### PR DESCRIPTION
Signed-off-by: ishitasequeira <ishiseq29@gmail.com>

**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
CronJob has been deprecated in v1.21+, and unavailable in v1.25+.
References of CronJob were updated to use "batch/v1" in PR #477 but couple of places were missed out.
Updating missed places to use "batch/v1" for CronJob.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
https://issues.redhat.com/browse/GITOPS-1940

**How to test changes / Special notes to the reviewer**:
- make install run
- make test
All tests should pass successfully.
