### PR TITLE
feat: Support Ingress Class Annotation in Argo CD CRD

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -249,6 +249,9 @@ type ArgoCDIngressSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
 
+	// IngressClassName for the Ingress resource.
+	IngressClassName *string `json:"ingressClassName,omitempty"`
+
 	// Path used for the Ingress resource.
 	Path string `json:"path,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -406,6 +406,11 @@ func (in *ArgoCDIngressSpec) DeepCopyInto(out *ArgoCDIngressSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.IngressClassName != nil {
+		in, out := &in.IngressClassName, &out.IngressClassName
+		*out = new(string)
+		**out = **in
+	}
 	if in.TLS != nil {
 		in, out := &in.TLS, &out.TLS
 		*out = make([]networkingv1.IngressTLS, len(*in))

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -378,6 +378,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string
@@ -714,6 +717,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string
@@ -5234,6 +5240,9 @@ spec:
                           enabled:
                             description: Enabled will toggle the creation of the Ingress.
                             type: boolean
+                          ingressClassName:
+                            description: IngressClassName for the Ingress resource.
+                            type: string
                           path:
                             description: Path used for the Ingress resource.
                             type: string
@@ -5289,6 +5298,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -380,6 +380,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string
@@ -716,6 +719,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string
@@ -5236,6 +5242,9 @@ spec:
                           enabled:
                             description: Enabled will toggle the creation of the Ingress.
                             type: boolean
+                          ingressClassName:
+                            description: IngressClassName for the Ingress resource.
+                            type: string
                           path:
                             description: Path used for the Ingress resource.
                             type: string
@@ -5291,6 +5300,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string

--- a/controllers/argocd/ingress.go
+++ b/controllers/argocd/ingress.go
@@ -30,7 +30,7 @@ import (
 // getDefaultIngressAnnotations will return the default Ingress Annotations for the given ArgoCD.
 func getDefaultIngressAnnotations() map[string]string {
 	annotations := make(map[string]string)
-	annotations[common.ArgoCDKeyIngressClass] = "nginx"
+	// annotations[common.ArgoCDKeyIngressClass] = "nginx"
 	return annotations
 }
 
@@ -118,6 +118,8 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoprojv1a1.ArgoCD) er
 
 	ingress.ObjectMeta.Annotations = atns
 
+	ingress.Spec.IngressClassName = cr.Spec.Server.Ingress.IngressClassName
+
 	pathType := networkingv1.PathTypeImplementationSpecific
 	// Add rules
 	ingress.Spec.Rules = []networkingv1.IngressRule{
@@ -190,6 +192,8 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoprojv1a1.ArgoCD
 	}
 
 	ingress.ObjectMeta.Annotations = atns
+
+	ingress.Spec.IngressClassName = cr.Spec.Server.GRPC.Ingress.IngressClassName
 
 	pathType := networkingv1.PathTypeImplementationSpecific
 	// Add rules
@@ -265,6 +269,8 @@ func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoprojv1a1.ArgoCD) error
 
 	ingress.ObjectMeta.Annotations = atns
 
+	ingress.Spec.IngressClassName = cr.Spec.Grafana.Ingress.IngressClassName
+
 	pathType := networkingv1.PathTypeImplementationSpecific
 	// Add rules
 	ingress.Spec.Rules = []networkingv1.IngressRule{
@@ -339,6 +345,8 @@ func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoprojv1a1.ArgoCD) er
 	}
 
 	ingress.ObjectMeta.Annotations = atns
+
+	ingress.Spec.IngressClassName = cr.Spec.Prometheus.Ingress.IngressClassName
 
 	pathType := networkingv1.PathTypeImplementationSpecific
 	// Add rules

--- a/controllers/argocd/ingress.go
+++ b/controllers/argocd/ingress.go
@@ -27,13 +27,6 @@ import (
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
-// getDefaultIngressAnnotations will return the default Ingress Annotations for the given ArgoCD.
-func getDefaultIngressAnnotations() map[string]string {
-	annotations := make(map[string]string)
-	// annotations[common.ArgoCDKeyIngressClass] = "nginx"
-	return annotations
-}
-
 // getArgoServerPath will return the Ingress Path for the Argo CD component.
 func getPathOrDefault(path string) string {
 	result := common.ArgoCDDefaultIngressPath
@@ -106,8 +99,8 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoprojv1a1.ArgoCD) er
 		return nil // Ingress not enabled, move along...
 	}
 
-	// Add annotations
-	atns := getDefaultIngressAnnotations()
+	// Add default annotations
+	atns := make(map[string]string)
 	atns[common.ArgoCDKeyIngressSSLRedirect] = "true"
 	atns[common.ArgoCDKeyIngressBackendProtocol] = "HTTP"
 
@@ -182,8 +175,8 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoprojv1a1.ArgoCD
 		return nil // Ingress not enabled, move along...
 	}
 
-	// Add annotations
-	atns := getDefaultIngressAnnotations()
+	// Add default annotations
+	atns := make(map[string]string)
 	atns[common.ArgoCDKeyIngressBackendProtocol] = "GRPC"
 
 	// Override default annotations if specified
@@ -257,8 +250,8 @@ func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoprojv1a1.ArgoCD) error
 		return nil // Grafana itself or Ingress not enabled, move along...
 	}
 
-	// Add annotations
-	atns := getDefaultIngressAnnotations()
+	// Add default annotations
+	atns := make(map[string]string)
 	atns[common.ArgoCDKeyIngressSSLRedirect] = "true"
 	atns[common.ArgoCDKeyIngressBackendProtocol] = "HTTP"
 
@@ -334,8 +327,8 @@ func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoprojv1a1.ArgoCD) er
 		return nil // Prometheus itself or Ingress not enabled, move along...
 	}
 
-	// Add annotations
-	atns := getDefaultIngressAnnotations()
+	// Add default annotations
+	atns := make(map[string]string)
 	atns[common.ArgoCDKeyIngressSSLRedirect] = "true"
 	atns[common.ArgoCDKeyIngressBackendProtocol] = "HTTP"
 

--- a/controllers/argocd/ingress_test.go
+++ b/controllers/argocd/ingress_test.go
@@ -1,0 +1,184 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/stretchr/testify/assert"
+
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+)
+
+func TestReconcileArgoCD_reconcile_ServerIngress_ingressClassName(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	nginx := "nginx"
+
+	tests := []struct {
+		name             string
+		ingressClassName *string
+	}{
+		{
+			name:             "undefined ingress class name",
+			ingressClassName: nil,
+		},
+		{
+			name:             "ingress class name specified",
+			ingressClassName: &nginx,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+				a.Spec.Server.Ingress.Enabled = true
+				a.Spec.Server.Ingress.IngressClassName = test.ingressClassName
+			})
+			r := makeTestReconciler(t, a)
+
+			err := r.reconcileArgoServerIngress(a)
+			assert.NoError(t, err)
+
+			ingress := &networkingv1.Ingress{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      "argocd-server",
+				Namespace: testNamespace,
+			}, ingress)
+			assert.NoError(t, err)
+			assert.Equal(t, test.ingressClassName, ingress.Spec.IngressClassName)
+		})
+	}
+}
+
+func TestReconcileArgoCD_reconcile_ServerGRPCIngress_ingressClassName(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	nginx := "nginx"
+
+	tests := []struct {
+		name             string
+		ingressClassName *string
+	}{
+		{
+			name:             "undefined ingress class name",
+			ingressClassName: nil,
+		},
+		{
+			name:             "ingress class name specified",
+			ingressClassName: &nginx,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+				a.Spec.Server.GRPC.Ingress.Enabled = true
+				a.Spec.Server.GRPC.Ingress.IngressClassName = test.ingressClassName
+			})
+			r := makeTestReconciler(t, a)
+
+			err := r.reconcileArgoServerGRPCIngress(a)
+			assert.NoError(t, err)
+
+			ingress := &networkingv1.Ingress{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      "argocd-grpc",
+				Namespace: testNamespace,
+			}, ingress)
+			assert.NoError(t, err)
+			assert.Equal(t, test.ingressClassName, ingress.Spec.IngressClassName)
+		})
+	}
+}
+
+func TestReconcileArgoCD_reconcile_GrafanaIngress_ingressClassName(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	nginx := "nginx"
+
+	tests := []struct {
+		name             string
+		ingressClassName *string
+	}{
+		{
+			name:             "undefined ingress class name",
+			ingressClassName: nil,
+		},
+		{
+			name:             "ingress class name specified",
+			ingressClassName: &nginx,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+				a.Spec.Grafana.Enabled = true
+				a.Spec.Grafana.Ingress.Enabled = true
+				a.Spec.Grafana.Ingress.IngressClassName = test.ingressClassName
+			})
+			r := makeTestReconciler(t, a)
+
+			err := r.reconcileGrafanaIngress(a)
+			assert.NoError(t, err)
+
+			ingress := &networkingv1.Ingress{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      "argocd-grafana",
+				Namespace: testNamespace,
+			}, ingress)
+			assert.NoError(t, err)
+			assert.Equal(t, test.ingressClassName, ingress.Spec.IngressClassName)
+		})
+	}
+}
+
+func TestReconcileArgoCD_reconcile_PrometheusIngress_ingressClassName(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	nginx := "nginx"
+
+	tests := []struct {
+		name             string
+		ingressClassName *string
+	}{
+		{
+			name:             "undefined ingress class name",
+			ingressClassName: nil,
+		},
+		{
+			name:             "ingress class name specified",
+			ingressClassName: &nginx,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+				a.Spec.Prometheus.Enabled = true
+				a.Spec.Prometheus.Ingress.Enabled = true
+				a.Spec.Prometheus.Ingress.IngressClassName = test.ingressClassName
+			})
+			r := makeTestReconciler(t, a)
+
+			err := r.reconcilePrometheusIngress(a)
+			assert.NoError(t, err)
+
+			ingress := &networkingv1.Ingress{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      "argocd-prometheus",
+				Namespace: testNamespace,
+			}, ingress)
+			assert.NoError(t, err)
+			assert.Equal(t, test.ingressClassName, ingress.Spec.IngressClassName)
+		})
+	}
+}

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -555,8 +555,8 @@ func newKeycloakIngress(cr *argoprojv1a1.ArgoCD) *networkingv1.Ingress {
 
 	pathType := networkingv1.PathTypeImplementationSpecific
 
-	// annotations
-	atns := getDefaultIngressAnnotations()
+	// Add default annotations
+	atns := make(map[string]string)
 	atns[common.ArgoCDKeyIngressSSLRedirect] = "true"
 	atns[common.ArgoCDKeyIngressBackendProtocol] = "HTTP"
 

--- a/deploy/olm-catalog/argocd-operator/0.4.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.4.0/argoproj.io_argocds.yaml
@@ -378,6 +378,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string
@@ -714,6 +717,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string
@@ -5234,6 +5240,9 @@ spec:
                           enabled:
                             description: Enabled will toggle the creation of the Ingress.
                             type: boolean
+                          ingressClassName:
+                            description: IngressClassName for the Ingress resource.
+                            type: string
                           path:
                             description: Path used for the Ingress resource.
                             type: string
@@ -5289,6 +5298,9 @@ spec:
                       enabled:
                         description: Enabled will toggle the creation of the Ingress.
                         type: boolean
+                      ingressClassName:
+                        description: IngressClassName for the Ingress resource.
+                        type: string
                       path:
                         description: Path used for the Ingress resource.
                         type: string

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -305,6 +305,7 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to use for the Ingress resource.
 Enabled | `false` | Toggle creation of an Ingress resource.
+IngressClassName | [Empty] | IngressClass to use for the Ingress resource.
 Path | `/` | Path to use for Ingress resources.
 TLS | [Empty] | TLS configuration for the Ingress.
 
@@ -712,6 +713,7 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to use for the Ingress resource.
 Enabled | `false` | Toggle creation of an Ingress resource.
+IngressClassName | [Empty] | IngressClass to use for the Ingress resource.
 Path | `/` | Path to use for Ingress resources.
 TLS | [Empty] | TLS configuration for the Ingress.
 
@@ -1068,6 +1070,7 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to use for the Ingress resource.
 Enabled | `false` | Toggle creation of an Ingress resource.
+IngressClassName | [Empty] | IngressClass to use for the Ingress resource.
 Path | `/` | Path to use for Ingress resources.
 TLS | [Empty] | TLS configuration for the Ingress.
 
@@ -1079,6 +1082,7 @@ Name | Default | Description
 --- | --- | ---
 Annotations | [Empty] | The map of annotations to use for the Ingress resource.
 Enabled | `false` | Toggle creation of an Ingress resource.
+IngressClassName | [Empty] | IngressClass to use for the Ingress resource.
 Path | `/` | Path to use for Ingress resources.
 TLS | [Empty] | TLS configuration for the Ingress.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement


**What does this PR do / why we need it**:
This PR adds IngressClass support to Ingress resources.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #626

**How to test changes / Special notes to the reviewer**:

Relevant tests can be run by the following command:

```shell
go test -v -run 'TestReconcileArgoCD_reconcile_.*Ingress_ingressClassName' ./controllers/argocd/
```

Change can be tested by setting up a dev environment and applying the following manifest:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: ingress
spec:
  server:
    grpc:
      ingress:
        enabled: true
    ingress:
      enabled: true
      ingressClassName: nginx
    insecure: true
```

**Note:** As discussed in #626, this PR contains a breaking change: `kubernetes.io/ingress.class` annotation is no longer added and nginx is no longer the default ingress controller (Kubernetes will fall back to the default ingress class)

Default nginx annotations (SSL redirect, backend) are still added though.