### PR TITLE
feat: Add support for ExtraConfig in Argo CD CRD

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -544,6 +544,14 @@ type ArgoCDSpec struct {
 	// DisableAdmin will disable the admin user.
 	DisableAdmin bool `json:"disableAdmin,omitempty"`
 
+	// ExtraConfig can be used to add fields to Argo CD configmap that are not supported by Argo CD CRD.
+	//
+	// Note: ExtraConfig takes precedence over Argo CD CRD.
+	// For example, A user sets `argocd.Spec.DisableAdmin` = true and also
+	// `a.Spec.ExtraConfig["admin.enabled"]` = true. In this case, operator updates
+	// Argo CD Configmap as follows -> argocd-cm.Data["admin.enabled"] = true.
+	ExtraConfig map[string]string `json:"extraConfig,omitempty"`
+
 	// GATrackingID is the google analytics tracking ID to use.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Tracking ID'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	GATrackingID string `json:"gaTrackingID,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -790,6 +790,13 @@ func (in *ArgoCDSpec) DeepCopyInto(out *ArgoCDSpec) {
 	}
 	in.Controller.DeepCopyInto(&out.Controller)
 	in.Dex.DeepCopyInto(&out.Dex)
+	if in.ExtraConfig != nil {
+		in, out := &in.ExtraConfig, &out.ExtraConfig
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Grafana.DeepCopyInto(&out.Grafana)
 	in.HA.DeepCopyInto(&out.HA)
 	if in.Import != nil {

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -345,6 +345,16 @@ spec:
               disableAdmin:
                 description: DisableAdmin will disable the admin user.
                 type: boolean
+              extraConfig:
+                additionalProperties:
+                  type: string
+                description: "ExtraConfig can be used to add fields to Argo CD configmap
+                  that are not supported by Argo CD CRD. \n Note: ExtraConfig takes
+                  precedence over Argo CD CRD. For example, A user sets `argocd.Spec.DisableAdmin`
+                  = true and also `a.Spec.ExtraConfig[\"admin.enabled\"]` = true.
+                  In this case, operator updates Argo CD Configmap as follows -> argocd-cm.Data[\"admin.enabled\"]
+                  = true."
+                type: object
               gaAnonymizeUsers:
                 description: GAAnonymizeUsers toggles user IDs being hashed before
                   sending to google analytics.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -347,6 +347,16 @@ spec:
               disableAdmin:
                 description: DisableAdmin will disable the admin user.
                 type: boolean
+              extraConfig:
+                additionalProperties:
+                  type: string
+                description: "ExtraConfig can be used to add fields to Argo CD configmap
+                  that are not supported by Argo CD CRD. \n Note: ExtraConfig takes
+                  precedence over Argo CD CRD. For example, A user sets `argocd.Spec.DisableAdmin`
+                  = true and also `a.Spec.ExtraConfig[\"admin.enabled\"]` = true.
+                  In this case, operator updates Argo CD Configmap as follows -> argocd-cm.Data[\"admin.enabled\"]
+                  = true."
+                type: object
               gaAnonymizeUsers:
                 description: GAAnonymizeUsers toggles user IDs being hashed before
                   sending to google analytics.

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -319,18 +320,8 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoprojv1a1.ArgoCD) error {
 // reconcileConfiguration will ensure that the main ConfigMap for ArgoCD is present.
 func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
-		if cr.Spec.SSO == nil {
-			if err := r.reconcileDexConfiguration(cm, cr); err != nil {
-				return err
-			}
-		}
-		return r.reconcileExistingArgoConfigMap(cm, cr)
-	}
 
-	if cm.Data == nil {
-		cm.Data = make(map[string]string)
-	}
+	cm.Data = make(map[string]string)
 
 	cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = getApplicationInstanceLabelKey(cr)
 	cm.Data[common.ArgoCDKeyConfigManagementPlugins] = getConfigManagementPlugins(cr)
@@ -383,10 +374,32 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 		}
 	}
 
+	if len(cr.Spec.ExtraConfig) > 0 {
+		for k, v := range cr.Spec.ExtraConfig {
+			cm.Data[k] = v
+		}
+	}
+
 	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
 		return err
 	}
+
+	existingCM := &corev1.ConfigMap{}
+	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, existingCM) {
+		if cr.Spec.SSO == nil {
+			if err := r.reconcileDexConfiguration(cm, cr); err != nil {
+				return err
+			}
+		}
+
+		if !reflect.DeepEqual(cm.Data, existingCM.Data) {
+			existingCM.Data = cm.Data
+			return r.Client.Update(context.TODO(), existingCM)
+		}
+		return nil // Do nothing as there is no change in the configmap.
+	}
 	return r.Client.Create(context.TODO(), cm)
+
 }
 
 // reconcileDexConfiguration will ensure that Dex is configured properly.
@@ -419,137 +432,6 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 		return r.Client.Update(context.TODO(), deploy)
 	}
 	return nil
-}
-
-func (r *ReconcileArgoCD) reconcileExistingArgoConfigMap(cm *corev1.ConfigMap, cr *argoprojv1a1.ArgoCD) error {
-	changed := false
-
-	if cm.Data == nil {
-		cm.Data = make(map[string]string)
-	}
-
-	if cm.Data[common.ArgoCDKeyAdminEnabled] == fmt.Sprintf("%t", cr.Spec.DisableAdmin) {
-		cm.Data[common.ArgoCDKeyAdminEnabled] = fmt.Sprintf("%t", !cr.Spec.DisableAdmin)
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] != cr.Spec.ApplicationInstanceLabelKey {
-		cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = cr.Spec.ApplicationInstanceLabelKey
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyConfigManagementPlugins] != cr.Spec.ConfigManagementPlugins {
-		cm.Data[common.ArgoCDKeyConfigManagementPlugins] = cr.Spec.ConfigManagementPlugins
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyGATrackingID] != cr.Spec.GATrackingID {
-		cm.Data[common.ArgoCDKeyGATrackingID] = cr.Spec.GATrackingID
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyGAAnonymizeUsers] != fmt.Sprint(cr.Spec.GAAnonymizeUsers) {
-		cm.Data[common.ArgoCDKeyGAAnonymizeUsers] = fmt.Sprint(cr.Spec.GAAnonymizeUsers)
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyHelpChatURL] != cr.Spec.HelpChatURL {
-		cm.Data[common.ArgoCDKeyHelpChatURL] = cr.Spec.HelpChatURL
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyHelpChatText] != cr.Spec.HelpChatText {
-		cm.Data[common.ArgoCDKeyHelpChatText] = cr.Spec.HelpChatText
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyKustomizeBuildOptions] != cr.Spec.KustomizeBuildOptions {
-		cm.Data[common.ArgoCDKeyKustomizeBuildOptions] = cr.Spec.KustomizeBuildOptions
-		changed = true
-	}
-
-	if len(cr.Spec.KustomizeVersions) > 0 {
-		for _, kv := range cr.Spec.KustomizeVersions {
-			if cm.Data["kustomize.version"+kv.Version] != kv.Path {
-				cm.Data["kustomize.version."+kv.Version] = kv.Path
-				changed = true
-			}
-		}
-	}
-
-	if cr.Spec.SSO == nil {
-		if cm.Data[common.ArgoCDKeyOIDCConfig] != cr.Spec.OIDCConfig {
-			cm.Data[common.ArgoCDKeyOIDCConfig] = cr.Spec.OIDCConfig
-			changed = true
-		}
-	}
-
-	if cm.Data[common.ArgoCDKeyResourceCustomizations] != cr.Spec.ResourceCustomizations {
-		cm.Data[common.ArgoCDKeyResourceCustomizations] = cr.Spec.ResourceCustomizations
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyResourceExclusions] != cr.Spec.ResourceExclusions {
-		cm.Data[common.ArgoCDKeyResourceExclusions] = cr.Spec.ResourceExclusions
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyResourceInclusions] != cr.Spec.ResourceInclusions {
-		cm.Data[common.ArgoCDKeyResourceInclusions] = cr.Spec.ResourceInclusions
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyResourceTrackingMethod] != cr.Spec.ResourceTrackingMethod {
-		cm.Data[common.ArgoCDKeyResourceTrackingMethod] = getResourceTrackingMethod(cr)
-		changed = true
-	}
-
-	uri := r.getArgoServerURI(cr)
-	if cm.Data[common.ArgoCDKeyServerURL] != uri {
-		cm.Data[common.ArgoCDKeyServerURL] = uri
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyStatusBadgeEnabled] != fmt.Sprint(cr.Spec.StatusBadgeEnabled) {
-		cm.Data[common.ArgoCDKeyStatusBadgeEnabled] = fmt.Sprint(cr.Spec.StatusBadgeEnabled)
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] != fmt.Sprint(cr.Spec.UsersAnonymousEnabled) {
-		cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] = fmt.Sprint(cr.Spec.UsersAnonymousEnabled)
-		changed = true
-	}
-
-	if cm.Data[common.ArgoCDKeyRepositoryCredentials] != cr.Spec.RepositoryCredentials {
-		cm.Data[common.ArgoCDKeyRepositoryCredentials] = cr.Spec.RepositoryCredentials
-		changed = true
-	}
-
-	if cr.Spec.Banner != nil {
-		if cm.Data[common.ArgoCDKeyBannerContent] != fmt.Sprint(cr.Spec.Banner.Content) {
-			cm.Data[common.ArgoCDKeyBannerContent] = fmt.Sprint(cr.Spec.Banner.Content)
-			changed = true
-		}
-		if cm.Data[common.ArgoCDKeyBannerURL] != fmt.Sprint(cr.Spec.Banner.URL) {
-			cm.Data[common.ArgoCDKeyBannerURL] = fmt.Sprint(cr.Spec.Banner.URL)
-			changed = true
-		}
-	} else {
-		if _, ok := cm.Data[common.ArgoCDKeyBannerContent]; ok {
-			delete(cm.Data, common.ArgoCDKeyBannerContent)
-			changed = true
-		}
-		if _, ok := cm.Data[common.ArgoCDKeyBannerURL]; ok {
-			delete(cm.Data, common.ArgoCDKeyBannerURL)
-			changed = true
-		}
-	}
-
-	if changed {
-		return r.Client.Update(context.TODO(), cm) // TODO: Reload Argo CD server after ConfigMap change (which properties)?
-	}
-
-	return nil // Nothing changed, no update needed...
 }
 
 // reconcileGrafanaConfiguration will ensure that the Grafana configuration ConfigMap is present.

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -75,7 +75,11 @@ func getConfigManagementPlugins(cr *argoprojv1a1.ArgoCD) string {
 func getDexConfig(cr *argoprojv1a1.ArgoCD) string {
 	config := common.ArgoCDDefaultDexConfig
 	if len(cr.Spec.Dex.Config) > 0 {
-		config = cr.Spec.Dex.Config
+		if cr.Spec.ExtraConfig["dex.config"] != "" {
+			config = cr.Spec.ExtraConfig["dex.config"]
+		} else {
+			config = cr.Spec.Dex.Config
+		}
 	}
 	return config
 }
@@ -387,7 +391,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 	existingCM := &corev1.ConfigMap{}
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, existingCM) {
 		if cr.Spec.SSO == nil {
-			if err := r.reconcileDexConfiguration(cm, cr); err != nil {
+			if err := r.reconcileDexConfiguration(existingCM, cr); err != nil {
 				return err
 			}
 		}

--- a/deploy/olm-catalog/argocd-operator/0.4.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.4.0/argoproj.io_argocds.yaml
@@ -345,6 +345,16 @@ spec:
               disableAdmin:
                 description: DisableAdmin will disable the admin user.
                 type: boolean
+              extraConfig:
+                additionalProperties:
+                  type: string
+                description: "ExtraConfig can be used to add fields to Argo CD configmap
+                  that are not supported by Argo CD CRD. \n Note: ExtraConfig takes
+                  precedence over Argo CD CRD. For example, A user sets `argocd.Spec.DisableAdmin`
+                  = true and also `a.Spec.ExtraConfig[\"admin.enabled\"]` = true.
+                  In this case, operator updates Argo CD Configmap as follows -> argocd-cm.Data[\"admin.enabled\"]
+                  = true."
+                type: object
               gaAnonymizeUsers:
                 description: GAAnonymizeUsers toggles user IDs being hashed before
                   sending to google analytics.

--- a/docs/usage/extra-config.md
+++ b/docs/usage/extra-config.md
@@ -1,0 +1,30 @@
+# Configure Argo CD ConfigMap for features not supported by Argo CD CRD
+
+## Motivation
+
+As the Argo CD upstream project evolves, new features are continuously added and new Argo CD config map configurations are constantly introduced. It is very difficult to keep Argocd Operator up to date with Argo CD’s new configurations. Argocd Operator is lagging behind to support new Argo CD features in months or more.
+
+But, oftentimes to support a new feature, it is as simple as reconciling a configmap entry.  However, the code to make this a first class configuration by making it as a field in Argocd CR requires many changes. It takes quite a bit of development effort to reconcile just one new configmap entry. Also, since we made a new field in Argo CD CR, User will have to read the Argocd Operator’s manual in order to figure out the name of the field even though the user may already know the configmap entry key.
+
+## Using ExtraConfig
+
+Users can add dynamic entries to Argo CD configmap using `ExtraConfig` in Argocd CR. It is completely optional and has no default value.
+
+When `ExtraConfig` is set, the entries specified are reconciled to the live Argo CD configmap. Users can specify arbitrary configmap entries with this `ExtraConfig`. This allows users to specify a new configuration even though the configuration is not supported by Argo CD CRD.
+
+**Note**: `ExtraConfig` takes precedence over Argo CD CRD.
+
+## Example
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  extraConfig: 
+    "ping": "pong" // The same entry is reflected in Argo CD Configmap.
+  server:
+    ingress:
+      enabled: true
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Usage: 
     - Basics: usage/basics.md
     - Export: usage/export.md
+    - ExtraConfig: usage/extra-config.md
     - High Availability: usage/ha.md
     - Ingress: usage/ingress.md
     - Insights: usage/insights.md

--- a/tests/k8s/1-018_validate_extra_config/01-argocd-with-extraconfig.yaml
+++ b/tests/k8s/1-018_validate_extra_config/01-argocd-with-extraconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  extraConfig:
+    "admin.enabled": "true" # enable admin user through extraConfig

--- a/tests/k8s/1-018_validate_extra_config/01-assert.yaml
+++ b/tests/k8s/1-018_validate_extra_config/01-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  admin.enabled: "true"

--- a/tests/k8s/1-018_validate_extra_config/02-argocd-with-firstclass-and-extraconfig copy.yaml
+++ b/tests/k8s/1-018_validate_extra_config/02-argocd-with-firstclass-and-extraconfig copy.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  disableAdmin: true
+  extraConfig:
+    "admin.enabled": "true" # override admin user through extraConfig

--- a/tests/k8s/1-018_validate_extra_config/02-assert.yaml
+++ b/tests/k8s/1-018_validate_extra_config/02-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  admin.enabled: "true"

--- a/tests/k8s/1-018_validate_extra_config/03-assert.yaml
+++ b/tests/k8s/1-018_validate_extra_config/03-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  admin.enabled: "true" # operator should reject any manual updates to the configmap.

--- a/tests/k8s/1-018_validate_extra_config/03-update-configmap.yaml
+++ b/tests/k8s/1-018_validate_extra_config/03-update-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  admin.enabled: "false"

--- a/tests/k8s/1-018_validate_extra_config/04-assert.yaml
+++ b/tests/k8s/1-018_validate_extra_config/04-assert.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  admin.enabled: "true"
+  dex.config: |
+    connectors:
+      - type: github
+        id: github
+        name: github-using-first-class
+        config:
+          clientID: first-class
+          clientSecret: $dex.github.clientSecret
+          orgs:
+          - name: first-class

--- a/tests/k8s/1-018_validate_extra_config/04-create-dex-without-extraconfig.yaml
+++ b/tests/k8s/1-018_validate_extra_config/04-create-dex-without-extraconfig.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  disableAdmin: true
+  dex:
+   config: |
+    connectors:
+      - type: github
+        id: github
+        name: github-using-first-class
+        config:
+          clientID: first-class
+          clientSecret: $dex.github.clientSecret
+          orgs:
+          - name: first-class
+

--- a/tests/k8s/1-018_validate_extra_config/05-assert.yaml
+++ b/tests/k8s/1-018_validate_extra_config/05-assert.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  admin.enabled: "true"
+  dex.config: |
+    connectors:
+      - type: github
+        id: github
+        name: github-using-extra-config
+        config:
+          clientID: extra-config
+          clientSecret: $dex.github.clientSecret
+          orgs:
+          - name: extra-config

--- a/tests/k8s/1-018_validate_extra_config/05-override-dex-using-extraconfig.yaml
+++ b/tests/k8s/1-018_validate_extra_config/05-override-dex-using-extraconfig.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  disableAdmin: true
+  dex:
+   config: |
+    connectors:
+      - type: github
+        id: github
+        name: github-using-first-class
+        config:
+          clientID: first-class
+          clientSecret: $dex.github.clientSecret
+          orgs:
+          - name: first-class
+  extraConfig:
+    "admin.enabled": "true"
+    "dex.config": |
+      connectors:
+        - type: github
+          id: github
+          name: github-using-extra-config
+          config:
+            clientID: extra-config
+            clientSecret: $dex.github.clientSecret
+            orgs:
+            - name: extra-config


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
Problem Statements
As the Argo CD upstream project evolves, new features are continuously added and new config-cm configurations are constantly introduced. Argocd Operator is virtually impossible to keep up with Argo CD’s new configurations. Argocd Operator is lagging behind to support new Argo CD features in months or more
Oftentimes to support a new feature, it is as simple as reconciling a config-cm entry. For example,https://github.com/argoproj-labs/argocd-operator/pull/598 introduced a map entry application.resourceTrackingMethod. However, the code to make this a first class configuration as a field Argocd CR required to touch 10+ files. It takes quite  a bit of engineering effort to reconcile just one new config-cm entry. Since we make a new field in Arogcd CR, the user will have to read the Argocd Operator’s manual in order to figure out the name of the field even though the user may already know the config-cm entry key.

Proposed Solution
Going forward, we enable users to add extra config-cm map entries in Argocd CR. We call this the extraConfig field in Argocd CR  The value of the extraConfig is key-value pairs  It is completely optional and has no default value. Therefore, when extraConfig is not set, the behavior is exactly the same as how it is today. When extraConfig  is set, the entries specified are reconciled to the live config-cm configmap without validations. Users can specify arbitrary configmap entries with the extraConfig .  Hence, users can use the extraConfig field to specify a new configuration even though the configuration is introduced after the argocd operator is released.  A nice thing is that it does not require any code changes in argocd operator to support a new configuration (well, in config-cm anyways).

Here is an example of an Argocd CR enabled with extraConfig.  In this example, supporting ,[https://github.com/argoproj-labs/argocd-operator/pull/59](https://github.com/argoproj-labs/argocd-operator/pull/598) could have been replaced with the specifying application.resourceTrackingMethod  in extraConfig.

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes #641 

**How to test changes / Special notes to the reviewer**:
1. Run the operator locally using `make install run`
2. Create an Argo CD Instance
3. Verify that Argo CD Configmap(argocd-cm) is created.
4. Verify the below scenarios (refer the UnitTest - `TestReconcileArgoCD_reconcileArgoConfigMap_withExtraConfig`)
     - Verify that updates to the configmap are rejected(reconciled back to default) by the operator.
     - Verify that operator updates argocd-cm according to ExtraConfig.
     - Verify that ExtraConfig overrides FirstClass entries.
     - Verify that deletion of a field from ExtraConfig does not delete any existing configuration
        created by FirstClass citizens.
5. e2e test for the PR.
   `kubectl kuttl test ./tests/k8s --config ./tests/kuttl-tests.yaml --test 1-018_validate_extra_config`