### PR TITLE
feat: Secure communication with redis

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -328,8 +328,8 @@ type ArgoCDRedisSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis","urn:alm:descriptor:com.tectonic.ui:text"}
 	Version string `json:"version,omitempty"`
 
-	// VerifyTLS defines whether redis server API should be accessed using strict TLS validation
-	VerifyTLS bool `json:"verifytls,omitempty"`
+	// DisableTLSVerification defines whether redis server API should be accessed using strict TLS validation
+	DisableTLSVerification bool `json:"disableTLSVerification,omitempty"`
 
 	// AutoTLS specifies the method to use for automatic TLS configuration for the redis server
 	// The value specified here can currently be:

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -327,6 +327,14 @@ type ArgoCDRedisSpec struct {
 	// Version is the Redis container image tag.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis","urn:alm:descriptor:com.tectonic.ui:text"}
 	Version string `json:"version,omitempty"`
+
+	// VerifyTLS defines whether redis server API should be accessed using strict TLS validation
+	VerifyTLS bool `json:"verifytls,omitempty"`
+
+	// AutoTLS specifies the method to use for automatic TLS configuration for the redis server
+	// The value specified here can currently be:
+	// - openshift - Use the OpenShift service CA to request TLS config
+	AutoTLS string `json:"autotls,omitempty"`
 }
 
 // ArgoCDRepoSpec defines the desired state for the Argo CD repo server component.
@@ -717,6 +725,9 @@ type ArgoCDStatus struct {
 
 	// RepoTLSChecksum contains the SHA256 checksum of the latest known state of tls.crt and tls.key in the argocd-repo-server-tls secret.
 	RepoTLSChecksum string `json:"repoTLSChecksum,omitempty"`
+
+	// RedisTLSChecksum contains the SHA256 checksum of the latest known state of tls.crt and tls.key in the argocd-operator-redis-tls secret.
+	RedisTLSChecksum string `json:"redisTLSChecksum,omitempty"`
 
 	// Host is the hostname of the Ingress.
 	Host string `json:"host,omitempty"`

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -783,6 +783,12 @@ func (r *ArgoCDRepoSpec) WantsAutoTLS() bool {
 	return r.AutoTLS == "openshift"
 }
 
+// WantsAutoTLS returns true if the redis server configuration has set
+// the autoTLS toggle to a supported provider.
+func (r *ArgoCDRedisSpec) WantsAutoTLS() bool {
+	return r.AutoTLS == "openshift"
+}
+
 // ApplicationInstanceLabelKey returns either the custom application instance
 // label key if set, or the default value.
 func (a *ArgoCD) ApplicationInstanceLabelKey() string {

--- a/build/redis/haproxy.cfg.tpl
+++ b/build/redis/haproxy.cfg.tpl
@@ -1,3 +1,8 @@
+{{- if eq .UseTLS "true"}}
+global
+    ca-base /app/config/redis/tls
+{{- end}}
+
 defaults REDIS
     mode tcp
     timeout connect 4s
@@ -14,44 +19,74 @@ listen health_check_http_url
 backend check_if_redis_is_master_0
     mode tcp
     option tcp-check
+{{- if eq .UseTLS "false"}}
     tcp-check connect
+{{- else}}
+    tcp-check connect ssl
+{{- end}}
     tcp-check send PING\r\n
     tcp-check expect string +PONG
     tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
     tcp-check expect string REPLACE_ANNOUNCE0
     tcp-check send QUIT\r\n
     tcp-check expect string +OK
+{{- if eq .UseTLS "false"}}
     server R0 {{.ServiceName}}-announce-0:26379 check inter 3s
     server R1 {{.ServiceName}}-announce-1:26379 check inter 3s
     server R2 {{.ServiceName}}-announce-2:26379 check inter 3s
+{{- else}}
+    server R0 {{.ServiceName}}-announce-0:26379 verify required ca-file tls.crt check inter 3s
+    server R1 {{.ServiceName}}-announce-1:26379 verify required ca-file tls.crt check inter 3s
+    server R2 {{.ServiceName}}-announce-2:26379 verify required ca-file tls.crt check inter 3s
+{{- end}}
 # Check Sentinel and whether they are nominated master
 backend check_if_redis_is_master_1
     mode tcp
     option tcp-check
+{{- if eq .UseTLS "false"}}
     tcp-check connect
+{{- else}}
+    tcp-check connect ssl
+{{- end}}
     tcp-check send PING\r\n
     tcp-check expect string +PONG
     tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
     tcp-check expect string REPLACE_ANNOUNCE1
     tcp-check send QUIT\r\n
     tcp-check expect string +OK
+{{- if eq .UseTLS "false"}}
     server R0 {{.ServiceName}}-announce-0:26379 check inter 3s
     server R1 {{.ServiceName}}-announce-1:26379 check inter 3s
     server R2 {{.ServiceName}}-announce-2:26379 check inter 3s
+{{- else}}
+    server R0 {{.ServiceName}}-announce-0:26379 verify required ca-file tls.crt check inter 3s
+    server R1 {{.ServiceName}}-announce-1:26379 verify required ca-file tls.crt check inter 3s
+    server R2 {{.ServiceName}}-announce-2:26379 verify required ca-file tls.crt check inter 3s
+{{- end}}
 # Check Sentinel and whether they are nominated master
 backend check_if_redis_is_master_2
     mode tcp
     option tcp-check
+{{- if eq .UseTLS "false"}}
     tcp-check connect
+{{- else}}
+    tcp-check connect ssl
+{{- end}}
     tcp-check send PING\r\n
     tcp-check expect string +PONG
     tcp-check send SENTINEL\ get-master-addr-by-name\ argocd\r\n
     tcp-check expect string REPLACE_ANNOUNCE2
     tcp-check send QUIT\r\n
     tcp-check expect string +OK
+{{- if eq .UseTLS "false"}}
     server R0 {{.ServiceName}}-announce-0:26379 check inter 3s
     server R1 {{.ServiceName}}-announce-1:26379 check inter 3s
     server R2 {{.ServiceName}}-announce-2:26379 check inter 3s
+{{- else}}
+    server R0 {{.ServiceName}}-announce-0:26379 verify required ca-file tls.crt check inter 3s
+    server R1 {{.ServiceName}}-announce-1:26379 verify required ca-file tls.crt check inter 3s
+    server R2 {{.ServiceName}}-announce-2:26379 verify required ca-file tls.crt check inter 3s
+{{- end}}
 
 # decide redis backend to use
 #master
@@ -62,16 +97,29 @@ frontend ft_redis_master
 backend bk_redis_master
     mode tcp
     option tcp-check
+{{- if eq .UseTLS "false"}}
     tcp-check connect
+{{- else}}
+    tcp-check connect ssl
+{{- end}}
     tcp-check send PING\r\n
     tcp-check expect string +PONG
     tcp-check send info\ replication\r\n
     tcp-check expect string role:master
     tcp-check send QUIT\r\n
     tcp-check expect string +OK
+{{- if eq .UseTLS "false"}}
     use-server R0 if { srv_is_up(R0) } { nbsrv(check_if_redis_is_master_0) ge 2 }
     server R0 {{.ServiceName}}-announce-0:6379 check inter 3s fall 1 rise 1
     use-server R1 if { srv_is_up(R1) } { nbsrv(check_if_redis_is_master_1) ge 2 }
     server R1 {{.ServiceName}}-announce-1:6379 check inter 3s fall 1 rise 1
     use-server R2 if { srv_is_up(R2) } { nbsrv(check_if_redis_is_master_2) ge 2 }
     server R2 {{.ServiceName}}-announce-2:6379 check inter 3s fall 1 rise 1
+{{- else}}
+    use-server R0 if { srv_is_up(R0) } { nbsrv(check_if_redis_is_master_0) ge 2 }
+    server R0 {{.ServiceName}}-announce-0:6379 verify required ca-file tls.crt check inter 3s fall 1 rise 1
+    use-server R1 if { srv_is_up(R1) } { nbsrv(check_if_redis_is_master_1) ge 2 }
+    server R1 {{.ServiceName}}-announce-1:6379 verify required ca-file tls.crt check inter 3s fall 1 rise 1
+    use-server R2 if { srv_is_up(R2) } { nbsrv(check_if_redis_is_master_2) ge 2 }
+    server R2 {{.ServiceName}}-announce-2:6379 verify required ca-file tls.crt check inter 3s fall 1 rise 1
+{{- end}}

--- a/build/redis/redis.conf.tpl
+++ b/build/redis/redis.conf.tpl
@@ -1,5 +1,15 @@
 dir "/data"
+{{- if eq .UseTLS "false"}}
 port 6379
+{{- else}}
+port 0
+tls-port 6379
+tls-cert-file /app/config/redis/tls/tls.crt
+tls-ca-cert-file /app/config/redis/tls/tls.crt
+tls-key-file /app/config/redis/tls/tls.key
+tls-replication yes
+tls-auth-clients no
+{{- end}}
 bind 0.0.0.0
 maxmemory 0
 maxmemory-policy volatile-lru

--- a/build/redis/redis_liveness.sh.tpl
+++ b/build/redis/redis_liveness.sh.tpl
@@ -2,6 +2,10 @@ response=$(
   redis-cli \
     -h localhost \
     -p 6379 \
+{{- if eq .UseTLS "true"}}
+    --tls \
+    --cacert /app/config/redis/tls/tls.crt \
+{{- end}}
     ping
 )
 if [ "$response" != "PONG" ] && [ "${response:0:7}" != "LOADING" ] ; then

--- a/build/redis/redis_readiness.sh.tpl
+++ b/build/redis/redis_readiness.sh.tpl
@@ -2,6 +2,10 @@ response=$(
   redis-cli \
     -h localhost \
     -p 6379 \
+{{- if eq .UseTLS "true"}}
+    --tls \
+    --cacert /app/config/redis/tls/tls.crt \
+{{- end}}
     ping
 )
 if [ "$response" != "PONG" ] ; then

--- a/build/redis/sentinel.conf.tpl
+++ b/build/redis/sentinel.conf.tpl
@@ -1,5 +1,15 @@
 dir "/data"
+{{- if eq .UseTLS "false"}}
 port 26379
+{{- else}}
+port 0
+tls-port 26379
+tls-cert-file /app/config/redis/tls/tls.crt
+tls-ca-cert-file /app/config/redis/tls/tls.crt
+tls-key-file /app/config/redis/tls/tls.key
+tls-replication yes
+tls-auth-clients no
+{{- end}}
 bind 0.0.0.0
     sentinel down-after-milliseconds argocd 10000
     sentinel failover-timeout argocd 180000

--- a/build/redis/sentinel_liveness.sh.tpl
+++ b/build/redis/sentinel_liveness.sh.tpl
@@ -2,6 +2,10 @@ response=$(
   redis-cli \
     -h localhost \
     -p 26379 \
+{{- if eq .UseTLS "true"}}
+    --tls \
+    --cacert /app/config/redis/tls/tls.crt \
+{{- end}}
     ping
 )
 if [ "$response" != "PONG" ]; then

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -862,6 +862,10 @@ spec:
                       can currently be: - openshift - Use the OpenShift service CA
                       to request TLS config'
                     type: string
+                  disableTLSVerification:
+                    description: DisableTLSVerification defines whether redis server
+                      API should be accessed using strict TLS validation
+                    type: boolean
                   image:
                     description: Image is the Redis container image.
                     type: string
@@ -892,10 +896,6 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  verifytls:
-                    description: VerifyTLS defines whether redis server API should
-                      be accessed using strict TLS validation
-                    type: boolean
                   version:
                     description: Version is the Redis container image tag.
                     type: string
@@ -5725,6 +5725,11 @@ spec:
                   of the  Argo CD Redis component Pods had a failure. Unknown: For
                   some reason the state of the Argo CD Redis component could not be
                   obtained.'
+                type: string
+              redisTLSChecksum:
+                description: RedisTLSChecksum contains the SHA256 checksum of the
+                  latest known state of tls.crt and tls.key in the argocd-operator-redis-tls
+                  secret.
                 type: string
               repo:
                 description: 'Repo is a simple, high-level summary of where the Argo

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -856,6 +856,12 @@ spec:
               redis:
                 description: Redis defines the Redis server options for ArgoCD.
                 properties:
+                  autotls:
+                    description: 'AutoTLS specifies the method to use for automatic
+                      TLS configuration for the redis server The value specified here
+                      can currently be: - openshift - Use the OpenShift service CA
+                      to request TLS config'
+                    type: string
                   image:
                     description: Image is the Redis container image.
                     type: string
@@ -886,6 +892,10 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  verifytls:
+                    description: VerifyTLS defines whether redis server API should
+                      be accessed using strict TLS validation
+                    type: boolean
                   version:
                     description: Version is the Redis container image tag.
                     type: string

--- a/common/values.go
+++ b/common/values.go
@@ -77,6 +77,9 @@ const (
 	// ArgoCDTLSCertsConfigMapName is the upstream hard-coded TLS certificate data ConfigMap name.
 	ArgoCDTLSCertsConfigMapName = "argocd-tls-certs-cm"
 
+	// ArgoCDRedisServerTLSSecretName is the name of the TLS secret for the redis-server
+	ArgoCDRedisServerTLSSecretName = "argocd-operator-redis-tls"
+
 	// ArgoCDRepoServerTLSSecretName is the name of the TLS secret for the repo-server
 	ArgoCDRepoServerTLSSecretName = "argocd-repo-server-tls"
 

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -864,6 +864,10 @@ spec:
                       can currently be: - openshift - Use the OpenShift service CA
                       to request TLS config'
                     type: string
+                  disableTLSVerification:
+                    description: DisableTLSVerification defines whether redis server
+                      API should be accessed using strict TLS validation
+                    type: boolean
                   image:
                     description: Image is the Redis container image.
                     type: string
@@ -894,10 +898,6 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  verifytls:
-                    description: VerifyTLS defines whether redis server API should
-                      be accessed using strict TLS validation
-                    type: boolean
                   version:
                     description: Version is the Redis container image tag.
                     type: string

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -858,6 +858,12 @@ spec:
               redis:
                 description: Redis defines the Redis server options for ArgoCD.
                 properties:
+                  autotls:
+                    description: 'AutoTLS specifies the method to use for automatic
+                      TLS configuration for the redis server The value specified here
+                      can currently be: - openshift - Use the OpenShift service CA
+                      to request TLS config'
+                    type: string
                   image:
                     description: Image is the Redis container image.
                     type: string
@@ -888,6 +894,10 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  verifytls:
+                    description: VerifyTLS defines whether redis server API should
+                      be accessed using strict TLS validation
+                    type: boolean
                   version:
                     description: Version is the Redis container image tag.
                     type: string
@@ -5717,6 +5727,11 @@ spec:
                   of the  Argo CD Redis component Pods had a failure. Unknown: For
                   some reason the state of the Argo CD Redis component could not be
                   obtained.'
+                type: string
+              redisTLSChecksum:
+                description: RedisTLSChecksum contains the SHA256 checksum of the
+                  latest known state of tls.crt and tls.key in the argocd-operator-redis-tls
+                  secret.
                 type: string
               repo:
                 description: 'Repo is a simple, high-level summary of where the Argo

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -38,8 +38,8 @@ import (
 func applicationSetDefaultVolumeMounts() []corev1.VolumeMount {
 	repoMounts := repoServerDefaultVolumeMounts()
 	ignoredMounts := map[string]bool{
-		"plugins":                true,
-		"argocd-repo-server-tls": true,
+		"plugins":                             true,
+		"argocd-repo-server-tls":              true,
 		common.ArgoCDRedisServerTLSSecretName: true,
 	}
 	mounts := make([]corev1.VolumeMount, len(repoMounts)-len(ignoredMounts), len(repoMounts)-len(ignoredMounts))
@@ -56,16 +56,10 @@ func applicationSetDefaultVolumeMounts() []corev1.VolumeMount {
 func applicationSetDefaultVolumes() []corev1.Volume {
 	repoVolumes := repoServerDefaultVolumes()
 	ignoredVolumes := map[string]bool{
-<<<<<<< HEAD
-		"var-files":              true,
-		"plugins":                true,
-		"argocd-repo-server-tls": true,
-=======
 		"var-files":                           true,
 		"plugins":                             true,
-		"tmp":                                 true,
+		"argocd-repo-server-tls":              true,
 		common.ArgoCDRedisServerTLSSecretName: true,
->>>>>>> 40e37db (feat: secure communication with redis)
 	}
 	volumes := make([]corev1.Volume, len(repoVolumes)-len(ignoredVolumes), len(repoVolumes)-len(ignoredVolumes))
 	j := 0

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -40,6 +40,7 @@ func applicationSetDefaultVolumeMounts() []corev1.VolumeMount {
 	ignoredMounts := map[string]bool{
 		"plugins":                true,
 		"argocd-repo-server-tls": true,
+		common.ArgoCDRedisServerTLSSecretName: true,
 	}
 	mounts := make([]corev1.VolumeMount, len(repoMounts)-len(ignoredMounts), len(repoMounts)-len(ignoredMounts))
 	j := 0
@@ -55,9 +56,16 @@ func applicationSetDefaultVolumeMounts() []corev1.VolumeMount {
 func applicationSetDefaultVolumes() []corev1.Volume {
 	repoVolumes := repoServerDefaultVolumes()
 	ignoredVolumes := map[string]bool{
+<<<<<<< HEAD
 		"var-files":              true,
 		"plugins":                true,
 		"argocd-repo-server-tls": true,
+=======
+		"var-files":                           true,
+		"plugins":                             true,
+		"tmp":                                 true,
+		common.ArgoCDRedisServerTLSSecretName: true,
+>>>>>>> 40e37db (feat: secure communication with redis)
 	}
 	volumes := make([]corev1.Volume, len(repoVolumes)-len(ignoredVolumes), len(repoVolumes)-len(ignoredVolumes))
 	j := 0

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -260,12 +260,12 @@ func newConfigMapWithSuffix(suffix string, cr *argoprojv1a1.ArgoCD) *corev1.Conf
 }
 
 // reconcileConfigMaps will ensure that all ArgoCD ConfigMaps are present.
-func (r *ReconcileArgoCD) reconcileConfigMaps(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileConfigMaps(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
 	if err := r.reconcileArgoConfigMap(cr); err != nil {
 		return err
 	}
 
-	if err := r.reconcileRedisConfiguration(cr); err != nil {
+	if err := r.reconcileRedisConfiguration(cr, useTLSForRedis); err != nil {
 		return err
 	}
 
@@ -672,18 +672,18 @@ func (r *ReconcileArgoCD) reconcileRBACConfigMap(cm *corev1.ConfigMap, cr *argop
 }
 
 // reconcileRedisConfiguration will ensure that all of the Redis ConfigMaps are present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileRedisConfiguration(cr *argoprojv1a1.ArgoCD) error {
-	if err := r.reconcileRedisHAConfigMap(cr); err != nil {
+func (r *ReconcileArgoCD) reconcileRedisConfiguration(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+	if err := r.reconcileRedisHAConfigMap(cr, useTLSForRedis); err != nil {
 		return err
 	}
-	if err := r.reconcileRedisHAHealthConfigMap(cr); err != nil {
+	if err := r.reconcileRedisHAHealthConfigMap(cr, useTLSForRedis); err != nil {
 		return err
 	}
 	return nil
 }
 
 // reconcileRedisHAConfigMap will ensure that the Redis HA Health ConfigMap is present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
 	cm := newConfigMapWithName(common.ArgoCDRedisHAHealthConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		if !cr.Spec.HA.Enabled {
@@ -698,9 +698,9 @@ func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoC
 	}
 
 	cm.Data = map[string]string{
-		"redis_liveness.sh":    getRedisLivenessScript(),
-		"redis_readiness.sh":   getRedisReadinessScript(),
-		"sentinel_liveness.sh": getSentinelLivenessScript(),
+		"redis_liveness.sh":    getRedisLivenessScript(useTLSForRedis),
+		"redis_readiness.sh":   getRedisReadinessScript(useTLSForRedis),
+		"sentinel_liveness.sh": getSentinelLivenessScript(useTLSForRedis),
 	}
 
 	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
@@ -710,7 +710,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoC
 }
 
 // reconcileRedisHAConfigMap will ensure that the Redis HA ConfigMap is present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileRedisHAConfigMap(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRedisHAConfigMap(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
 	cm := newConfigMapWithName(common.ArgoCDRedisHAConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		if !cr.Spec.HA.Enabled {
@@ -725,17 +725,37 @@ func (r *ReconcileArgoCD) reconcileRedisHAConfigMap(cr *argoprojv1a1.ArgoCD) err
 	}
 
 	cm.Data = map[string]string{
-		"haproxy.cfg":     getRedisHAProxyConfig(cr),
+		"haproxy.cfg":     getRedisHAProxyConfig(cr, useTLSForRedis),
 		"haproxy_init.sh": getRedisHAProxyScript(cr),
-		"init.sh":         getRedisInitScript(cr),
-		"redis.conf":      getRedisConf(),
-		"sentinel.conf":   getRedisSentinelConf(),
+		"init.sh":         getRedisInitScript(cr, useTLSForRedis),
+		"redis.conf":      getRedisConf(useTLSForRedis),
+		"sentinel.conf":   getRedisSentinelConf(useTLSForRedis),
 	}
 
 	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
 		return err
 	}
 	return r.Client.Create(context.TODO(), cm)
+}
+
+func (r *ReconcileArgoCD) recreateRedisHAConfigMap(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+	cm := newConfigMapWithName(common.ArgoCDRedisHAConfigMapName, cr)
+	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
+		if err := r.Client.Delete(context.TODO(), cm); err != nil {
+			return err
+		}
+	}
+	return r.reconcileRedisHAConfigMap(cr, useTLSForRedis)
+}
+
+func (r *ReconcileArgoCD) recreateRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+	cm := newConfigMapWithName(common.ArgoCDRedisHAHealthConfigMapName, cr)
+	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
+		if err := r.Client.Delete(context.TODO(), cm); err != nil {
+			return err
+		}
+	}
+	return r.reconcileRedisHAHealthConfigMap(cr, useTLSForRedis)
 }
 
 // reconcileSSHKnownHosts will ensure that the ArgoCD SSH Known Hosts ConfigMap is present.

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -3,13 +3,13 @@ package argocd
 import (
 	"context"
 	"fmt"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -35,6 +35,8 @@ func (r *ReconcileArgoCD) clusterResourceMapper(o client.Object) []reconcile.Req
 	return result
 }
 
+// isSecretOfInterest returns true if the name of the given secret matches one of the
+// well-known tls secrets used to secure communication amongst the Argo CD components.
 func isSecretOfInterest(o client.Object) bool {
 	if strings.HasSuffix(o.GetName(), "-repo-server-tls") {
 		return true
@@ -45,6 +47,9 @@ func isSecretOfInterest(o client.Object) bool {
 	return false
 }
 
+// isOwnerOfInterest returns true if the given owner is one of the Argo CD services that
+// may have been made the owner of the tls secret created by the OpenShift service CA, used
+// to secure communication amongst the Argo CD components.
 func isOwnerOfInterest(owner v1.OwnerReference) bool {
 	if owner.Kind != "Service" {
 		return false

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -289,6 +289,9 @@ func getArgoRepoCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) []string {
 	if useTLSForRedis {
 		cmd = append(cmd, "--redis-use-tls")
 		cmd = append(cmd, "--redis-ca-certificate", "/app/config/reposerver/tls/redis/tls.crt")
+		if isRedisTLSVerificationDisabled(cr) {
+			cmd = append(cmd, "--redis-insecure-skip-tls-verify")
+		}
 	}
 
 	cmd = append(cmd, "--loglevel")
@@ -323,11 +326,6 @@ func getArgoServerCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) []string
 		cmd = append(cmd, "--repo-server-strict-tls")
 	}
 
-	if useTLSForRedis {
-		cmd = append(cmd, "--redis-use-tls")
-		cmd = append(cmd, "--redis-ca-certificate", "/app/config/server/tls/redis/tls.crt")
-	}
-
 	cmd = append(cmd, "--staticassets")
 	cmd = append(cmd, "/shared/app")
 
@@ -339,6 +337,14 @@ func getArgoServerCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) []string
 
 	cmd = append(cmd, "--redis")
 	cmd = append(cmd, getRedisServerAddress(cr))
+
+	if useTLSForRedis {
+		cmd = append(cmd, "--redis-use-tls")
+		cmd = append(cmd, "--redis-ca-certificate", "/app/config/server/tls/redis/tls.crt")
+		if isRedisTLSVerificationDisabled(cr) {
+			cmd = append(cmd, "--redis-insecure-skip-tls-verify")
+		}
+	}
 
 	cmd = append(cmd, "--loglevel")
 	cmd = append(cmd, getLogLevel(cr.Spec.Server.LogLevel))

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -237,9 +237,10 @@ func getArgoRepoCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) []string {
 
 	if useTLSForRedis {
 		cmd = append(cmd, "--redis-use-tls")
-		cmd = append(cmd, "--redis-ca-certificate", "/app/config/reposerver/tls/redis/tls.crt")
 		if isRedisTLSVerificationDisabled(cr) {
 			cmd = append(cmd, "--redis-insecure-skip-tls-verify")
+		} else {
+			cmd = append(cmd, "--redis-ca-certificate", "/app/config/reposerver/tls/redis/tls.crt")
 		}
 	}
 
@@ -289,9 +290,10 @@ func getArgoServerCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) []string
 
 	if useTLSForRedis {
 		cmd = append(cmd, "--redis-use-tls")
-		cmd = append(cmd, "--redis-ca-certificate", "/app/config/server/tls/redis/tls.crt")
 		if isRedisTLSVerificationDisabled(cr) {
 			cmd = append(cmd, "--redis-insecure-skip-tls-verify")
+		} else {
+			cmd = append(cmd, "--redis-ca-certificate", "/app/config/server/tls/redis/tls.crt")
 		}
 	}
 

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1193,7 +1193,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 	}
 
 	deployment := &appsv1.Deployment{}
-	assert.NoError(t, r.reconcileServerDeployment(a))
+	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
 	assert.NoError(t, r.Client.Get(
 		context.TODO(),
@@ -1215,7 +1215,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 		"test",
 	}
 
-	assert.NoError(t, r.reconcileServerDeployment(a))
+	assert.NoError(t, r.reconcileServerDeployment(a, false))
 	assert.NoError(t, r.Client.Get(
 		context.TODO(),
 		types.NamespacedName{
@@ -1233,7 +1233,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 		"foo.scv.cluster.local:6379",
 	}
 
-	assert.NoError(t, r.reconcileServerDeployment(a))
+	assert.NoError(t, r.reconcileServerDeployment(a, false))
 	assert.NoError(t, r.Client.Get(
 		context.TODO(),
 		types.NamespacedName{
@@ -1247,7 +1247,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 	// Remove all the command arguments that were added.
 	a.Spec.Server.ExtraCommandArgs = []string{}
 
-	assert.NoError(t, r.reconcileServerDeployment(a))
+	assert.NoError(t, r.reconcileServerDeployment(a, false))
 	assert.NoError(t, r.Client.Get(
 		context.TODO(),
 		types.NamespacedName{

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -65,7 +66,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_replicas(t *testing.T) {
 			})
 			r := makeTestReconciler(t, a)
 
-			err := r.reconcileRepoDeployment(a)
+			err := r.reconcileRepoDeployment(a, false)
 			assert.NoError(t, err)
 
 			deployment := &appsv1.Deployment{}
@@ -116,7 +117,7 @@ func TestReconcileArgoCD_reconcile_ServerDeployment_replicas(t *testing.T) {
 			})
 			r := makeTestReconciler(t, a)
 
-			err := r.reconcileServerDeployment(a)
+			err := r.reconcileServerDeployment(a, false)
 			assert.NoError(t, err)
 
 			deployment := &appsv1.Deployment{}
@@ -157,7 +158,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_loglevel(t *testing.T) {
 
 		r := makeTestReconciler(t, lglv)
 
-		err := r.reconcileRepoDeployment(lglv)
+		err := r.reconcileRepoDeployment(lglv, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -191,7 +192,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_volumes(t *testing.T) {
 		a := makeTestArgoCD()
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileRepoDeployment(a)
+		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -216,7 +217,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_volumes(t *testing.T) {
 		})
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileRepoDeployment(a)
+		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -246,7 +247,7 @@ func TestReconcileArgoCD_reconcile_ServerDeployment_env(t *testing.T) {
 		a.Spec.Repo.ExecTimeout = &timeout
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileServerDeployment(a)
+		err := r.reconcileServerDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -280,7 +281,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		a.Spec.Repo.ExecTimeout = &timeout
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileRepoDeployment(a)
+		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -302,7 +303,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		a.Spec.Repo.ExecTimeout = &timeout
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileRepoDeployment(a)
+		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -328,7 +329,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		}
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileRepoDeployment(a)
+		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -345,7 +346,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		a := makeTestArgoCD()
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileRepoDeployment(a)
+		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -365,7 +366,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 		a := makeTestArgoCD()
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileRepoDeployment(a)
+		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 
 		deployment := &appsv1.Deployment{}
@@ -389,7 +390,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 		})
 		r := makeTestReconciler(t, a)
 
-		err := r.reconcileRepoDeployment(a)
+		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 
 		deployment := &appsv1.Deployment{}
@@ -413,7 +414,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_initContainers(t *testing.T) {
 	})
 	r := makeTestReconciler(t, a)
 
-	err := r.reconcileRepoDeployment(a)
+	err := r.reconcileRepoDeployment(a, false)
 	assert.NoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -449,7 +450,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_missingInitContainers(t *testin
 	}
 	r := makeTestReconciler(t, a, d)
 
-	err := r.reconcileRepoDeployment(a)
+	err := r.reconcileRepoDeployment(a, false)
 	assert.NoError(t, err)
 	deployment := &appsv1.Deployment{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -490,7 +491,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_unexpectedInitContainer(t *test
 	}
 	r := makeTestReconciler(t, a, d)
 
-	err := r.reconcileRepoDeployment(a)
+	err := r.reconcileRepoDeployment(a, false)
 	assert.NoError(t, err)
 	deployment := &appsv1.Deployment{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -507,7 +508,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_command(t *testing.T) {
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
 
-	err := r.reconcileRepoDeployment(a)
+	err := r.reconcileRepoDeployment(a, false)
 	assert.NoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -518,7 +519,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_command(t *testing.T) {
 	assert.NoError(t, err)
 
 	deployment.Spec.Template.Spec.Containers[0].Command[6] = "debug"
-	err = r.reconcileRepoDeployment(a)
+	err = r.reconcileRepoDeployment(a, false)
 
 	assert.Equal(t, "debug", deployment.Spec.Template.Spec.Containers[0].Command[6])
 }
@@ -606,7 +607,7 @@ func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
 	})
 	r := makeTestReconciler(t, a)
 
-	err := r.reconcileDeployments(a)
+	err := r.reconcileDeployments(a, false)
 	assert.NoError(t, err)
 
 	for _, v := range deploymentNames {
@@ -626,7 +627,7 @@ func TestReconcileArgoCD_reconcileDeployments_proxy_update_existing(t *testing.T
 		a.Spec.Grafana.Enabled = true
 	})
 	r := makeTestReconciler(t, a)
-	err := r.reconcileDeployments(a)
+	err := r.reconcileDeployments(a, false)
 	assert.NoError(t, err)
 	for _, v := range deploymentNames {
 		refuteDeploymentHasProxyVars(t, r.Client, v)
@@ -638,7 +639,7 @@ func TestReconcileArgoCD_reconcileDeployments_proxy_update_existing(t *testing.T
 
 	logf.SetLogger(ZapLogger(true))
 
-	err = r.reconcileDeployments(a)
+	err = r.reconcileDeployments(a, false)
 	assert.NoError(t, err)
 
 	for _, v := range deploymentNames {
@@ -659,7 +660,7 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy(t *testing.T) {
 	})
 	r := makeTestReconciler(t, a)
 
-	err := r.reconcileDeployments(a)
+	err := r.reconcileDeployments(a, false)
 	assert.NoError(t, err)
 
 	assertDeploymentHasProxyVars(t, r.Client, "argocd-redis-ha-haproxy")
@@ -731,7 +732,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_updatesVolumeMounts(t *testing.
 	}
 	r := makeTestReconciler(t, a, d)
 
-	err := r.reconcileRepoDeployment(a)
+	err := r.reconcileRepoDeployment(a, false)
 	assert.NoError(t, err)
 
 	deployment := &appsv1.Deployment{}
@@ -741,8 +742,8 @@ func TestReconcileArgoCD_reconcileRepoDeployment_updatesVolumeMounts(t *testing.
 	}, deployment)
 	assert.NoError(t, err)
 
-	assert.Len(t, deployment.Spec.Template.Spec.Volumes, 8)
-	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, 7)
+	assert.Len(t, deployment.Spec.Template.Spec.Volumes, 9)
+	assert.Len(t, deployment.Spec.Template.Spec.Containers[0].VolumeMounts, 8)
 }
 
 func Test_proxyEnvVars(t *testing.T) {
@@ -790,7 +791,7 @@ func TestReconcileArgoCD_reconcileDeployment_nodePlacement(t *testing.T) {
 		}
 	}))
 	r := makeTestReconciler(t, a)
-	err := r.reconcileRepoDeployment(a) //can use other deployments as well
+	err := r.reconcileRepoDeployment(a, false) //can use other deployments as well
 	assert.NoError(t, err)
 	deployment := &appsv1.Deployment{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{
@@ -1008,11 +1009,38 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 	assert.Equal(t, want, deployment.Spec.Template.Spec)
 }
 
+func TestReconcileArgocd_reconcileRepoServerRedisTLS(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+	assert.NoError(t, r.reconcileRepoDeployment(a, true))
+
+	deployment := &appsv1.Deployment{}
+	assert.NoError(t, r.Client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      "argocd-repo-server",
+			Namespace: a.Namespace,
+		},
+		deployment))
+
+	wantCmd := []string{
+		"uid_entrypoint.sh",
+		"argocd-repo-server",
+		"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
+		"--redis-use-tls",
+		"--redis-ca-certificate", "/app/config/reposerver/tls/redis/tls.crt",
+		"--loglevel", "info",
+		"--logformat", "text",
+	}
+	assert.Equal(t, wantCmd, deployment.Spec.Template.Spec.Containers[0].Command)
+}
+
 func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
-	assert.NoError(t, r.reconcileServerDeployment(a))
+	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.Client.Get(
@@ -1075,6 +1103,35 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 	}
 
 	assert.Equal(t, want, deployment.Spec.Template.Spec)
+
+	assert.NoError(t, r.reconcileServerDeployment(a, true))
+	deployment = &appsv1.Deployment{}
+	assert.NoError(t, r.Client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      "argocd-server",
+			Namespace: a.Namespace,
+		},
+		deployment))
+	wantCmd := []string{
+		"argocd-server",
+		"--redis-use-tls",
+		"--redis-ca-certificate",
+		"/app/config/server/tls/redis/tls.crt",
+		"--staticassets",
+		"/shared/app",
+		"--dex-server",
+		"http://argocd-dex-server.argocd.svc.cluster.local:5556",
+		"--repo-server",
+		"argocd-repo-server.argocd.svc.cluster.local:8081",
+		"--redis",
+		"argocd-redis.argocd.svc.cluster.local:6379",
+		"--loglevel",
+		"info",
+		"--logformat",
+		"text",
+	}
+	assert.Equal(t, wantCmd, deployment.Spec.Template.Spec.Containers[0].Command)
 }
 
 func TestArgoCDServerDeploymentCommand(t *testing.T) {
@@ -1187,7 +1244,7 @@ func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 	})
 	r := makeTestReconciler(t, a)
 
-	assert.NoError(t, r.reconcileServerDeployment(a))
+	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.Client.Get(
@@ -1258,12 +1315,12 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
 
-	assert.NoError(t, r.reconcileServerDeployment(a))
+	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
 	a = makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
 		a.Spec.Server.Insecure = true
 	})
-	assert.NoError(t, r.reconcileServerDeployment(a))
+	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.Client.Get(
@@ -1329,6 +1386,48 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 	assert.Equal(t, want, deployment.Spec.Template.Spec)
 }
 
+func TestReconcileArgoCD_reconcileRedisDeploymentWithoutTLS(t *testing.T) {
+	cr := makeTestArgoCD()
+	r := makeTestReconciler(t, cr)
+
+	want := []string{
+		"--save",
+		"",
+		"--appendonly", "no",
+	}
+
+	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
+	d := &appsv1.Deployment{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
+	got := d.Spec.Template.Spec.Containers[0].Args
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Reconciliation unsucessful: got: %v, want: %v", got, want)
+	}
+}
+
+func TestReconcileArgoCD_reconcileRedisDeploymentWithTLS(t *testing.T) {
+	cr := makeTestArgoCD()
+	r := makeTestReconciler(t, cr)
+
+	want := []string{
+		"--save", "",
+		"--appendonly", "no",
+		"--tls-port", "6379",
+		"--port", "0",
+		"--tls-cert-file", "/app/config/redis/tls/tls.crt",
+		"--tls-key-file", "/app/config/redis/tls/tls.key",
+		"--tls-auth-clients", "no",
+	}
+
+	assert.NoError(t, r.reconcileRedisDeployment(cr, true))
+	d := &appsv1.Deployment{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
+	got := d.Spec.Template.Spec.Containers[0].Args
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Reconciliation unsucessful: got: %v, want: %v", got, want)
+	}
+}
+
 func TestReconcileArgoCD_reconcileRedisDeployment(t *testing.T) {
 	// tests reconciler hook for redis deployment
 	cr := makeTestArgoCD()
@@ -1337,7 +1436,7 @@ func TestReconcileArgoCD_reconcileRedisDeployment(t *testing.T) {
 	defer resetHooks()()
 	Register(testDeploymentHook)
 
-	assert.NoError(t, r.reconcileRedisDeployment(cr))
+	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
 	d := &appsv1.Deployment{}
 	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
 	assert.Equal(t, int32(3), *d.Spec.Replicas)
@@ -1351,7 +1450,7 @@ func TestReconcileArgoCD_reconcileRedisDeployment_with_error(t *testing.T) {
 	defer resetHooks()()
 	Register(testErrorHook)
 
-	assert.Error(t, r.reconcileRedisDeployment(cr), "this is a test error")
+	assert.Error(t, r.reconcileRedisDeployment(cr, false), "this is a test error")
 }
 
 func restoreEnv(t *testing.T) {
@@ -1564,6 +1663,15 @@ func repoServerDefaultVolumes() []corev1.Volume {
 			},
 		},
 		{
+			Name: common.ArgoCDRedisServerTLSSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.ArgoCDRedisServerTLSSecretName,
+					Optional:   boolPtr(true),
+				},
+			},
+		},
+		{
 			Name: "var-files",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
@@ -1588,6 +1696,7 @@ func repoServerDefaultVolumeMounts() []corev1.VolumeMount {
 		{Name: "gpg-keyring", MountPath: "/app/config/gpg/keys"},
 		{Name: "tmp", MountPath: "/tmp"},
 		{Name: "argocd-repo-server-tls", MountPath: "/app/config/reposerver/tls"},
+		{Name: common.ArgoCDRedisServerTLSSecretName, MountPath: "/app/config/reposerver/tls/redis"},
 		{Name: "plugins", MountPath: "/home/argocd/cmp-server/plugins"},
 	}
 	return mounts
@@ -1604,7 +1713,8 @@ func serverDefaultVolumes() []corev1.Volume {
 					},
 				},
 			},
-		}, {
+		},
+		{
 			Name: "tls-certs",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1613,11 +1723,21 @@ func serverDefaultVolumes() []corev1.Volume {
 					},
 				},
 			},
-		}, {
+		},
+		{
 			Name: "argocd-repo-server-tls",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: common.ArgoCDRepoServerTLSSecretName,
+					Optional:   boolPtr(true),
+				},
+			},
+		},
+		{
+			Name: common.ArgoCDRedisServerTLSSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.ArgoCDRedisServerTLSSecretName,
 					Optional:   boolPtr(true),
 				},
 			},
@@ -1637,6 +1757,9 @@ func serverDefaultVolumeMounts() []corev1.VolumeMount {
 		}, {
 			Name:      "argocd-repo-server-tls",
 			MountPath: "/app/config/server/tls",
+		}, {
+			Name:      common.ArgoCDRedisServerTLSSecretName,
+			MountPath: "/app/config/server/tls/redis",
 		},
 	}
 	return mounts

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1059,7 +1059,6 @@ func TestReconcileArgocd_reconcileRepoServerRedisTLS(t *testing.T) {
 			"argocd-repo-server",
 			"--redis", "argocd-redis.argocd.svc.cluster.local:6379",
 			"--redis-use-tls",
-			"--redis-ca-certificate", "/app/config/reposerver/tls/redis/tls.crt",
 			"--redis-insecure-skip-tls-verify",
 			"--loglevel", "info",
 			"--logformat", "text",

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -132,7 +132,7 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
 		}
 		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRollout, ok := serverDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		repoRollout, ok := repoDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
 		if !ok {
 			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
 		}
@@ -158,14 +158,14 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 			t.Errorf("Did not expect rollout of argocd-server, but it did happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
 		}
 		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRolloutNew, ok := serverDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		repoRolloutNew, ok := repoDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
 		if !ok || repoRollout != repoRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-repo-server, but it did happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-repo-server, but it did happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
 		}
 		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
 		ctrlRolloutNew, ok := ctrlSts.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
 		if !ok || ctrlRollout != ctrlRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-application-server, but it did happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-application-server, but it did happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
 		}
 
 		// Update certificate in the secret must trigger new rollout
@@ -187,14 +187,14 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 			t.Errorf("Error in SHA256 sum of secret, want=%s got=%s", shasum, argocd.Status.RepoTLSChecksum)
 		}
 
-		// This time, label should not have changed
+		// This time, label should have changed
 		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
 		deplRolloutNew, ok = serverDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
 		if !ok || deplRollout == deplRolloutNew {
 			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
 		}
 		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRolloutNew, ok = serverDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		repoRolloutNew, ok = repoDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
 		if !ok || repoRollout == repoRolloutNew {
 			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
 		}
@@ -206,6 +206,177 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 
 	})
 
+}
+
+func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
+	argocd := &v1alpha1.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd",
+			Namespace: "argocd-operator",
+			UID:       "abcd",
+		},
+	}
+	crt := []byte("foo")
+	key := []byte("bar")
+	t.Run("Reconcile TLS secret", func(t *testing.T) {
+		service := &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-redis",
+				Namespace: "argocd-operator",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "argoproj.io/v1alpha1",
+						Kind:       "ArgoCD",
+						Name:       "argocd",
+						UID:        argocd.GetUID(),
+					},
+				},
+				UID: "service-123",
+			},
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-operator-redis-tls",
+				Namespace: "argocd-operator",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Kind:       "Service",
+						Name:       "argocd-redis",
+						UID:        service.GetUID(),
+					},
+				},
+			},
+			Type: corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				corev1.TLSCertKey:       crt,
+				corev1.TLSPrivateKeyKey: key,
+			},
+		}
+		var sumOver []byte
+		sumOver = append(sumOver, crt...)
+		sumOver = append(sumOver, key...)
+		shasum := fmt.Sprintf("%x", sha256.Sum256(sumOver))
+		serverDepl := newDeploymentWithSuffix("server", "server", argocd)
+		repoDepl := newDeploymentWithSuffix("repo-server", "repo-server", argocd)
+		redisDepl := newDeploymentWithSuffix("redis", "redis", argocd)
+		ctrlSts := newStatefulSetWithSuffix("application-controller", "application-controller", argocd)
+		objs := []runtime.Object{
+			argocd,
+			secret,
+			service,
+			serverDepl,
+			repoDepl,
+			redisDepl,
+			ctrlSts,
+		}
+
+		r := makeReconciler(t, argocd, objs...)
+
+		err := r.reconcileRedisTLSSecret(argocd)
+		if err != nil {
+			t.Errorf("Error should be nil, but is %v", err)
+		}
+		if shasum != argocd.Status.RedisTLSChecksum {
+			t.Errorf("Error in SHA256 sum of secret, want=%s got=%s", shasum, argocd.Status.RedisTLSChecksum)
+		}
+
+		certChangedLabel := "redis.tls.cert.changed"
+
+		// Workloads should have been requested to re-rollout on a change
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		deplRollout, ok := serverDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok {
+			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		repoRollout, ok := repoDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok {
+			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
+		redisRollout, ok := redisDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok {
+			t.Errorf("Expected rollout of argocd-redis, but it didn't happen: %v", redisDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		ctrlRollout, ok := ctrlSts.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok {
+			t.Errorf("Expected rollout of argocd-application-server, but it didn't happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+		}
+
+		// Second run - no change
+		err = r.reconcileRedisTLSSecret(argocd)
+		if err != nil {
+			t.Errorf("Error should be nil, but is %v", err)
+		}
+		if shasum != argocd.Status.RedisTLSChecksum {
+			t.Errorf("Error in SHA256 sum of secret, want=%s got=%s", shasum, argocd.Status.RepoTLSChecksum)
+		}
+
+		// This time, label should not have changed
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		deplRolloutNew, ok := serverDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok || deplRollout != deplRolloutNew {
+			t.Errorf("Did not expect rollout of argocd-server, but it did happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		repoRolloutNew, ok := repoDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok || repoRollout != repoRolloutNew {
+			t.Errorf("Did not expect rollout of argocd-repo-server, but it did happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
+		redisRolloutNew, ok := redisDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok || redisRollout != redisRolloutNew {
+			t.Errorf("Did not expect rollout of argocd-redis, but it did happen: %v", redisDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		ctrlRolloutNew, ok := ctrlSts.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok || ctrlRollout != ctrlRolloutNew {
+			t.Errorf("Did not expect rollout of argocd-application-server, but it did happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+		}
+
+		// Update certificate in the secret must trigger new rollout
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server-tls", Namespace: "argocd-operator"}, secret)
+		secret.Data["tls.crt"] = []byte("bar")
+		r.Client.Update(context.TODO(), secret)
+
+		sumOver = []byte{}
+		sumOver = append(sumOver, []byte("bar")...)
+		sumOver = append(sumOver, key...)
+		shasum = fmt.Sprintf("%x", sha256.Sum256(sumOver))
+
+		// Second run - no change
+		err = r.reconcileRedisTLSSecret(argocd)
+		if err != nil {
+			t.Errorf("Error should be nil, but is %v", err)
+		}
+		if shasum != argocd.Status.RedisTLSChecksum {
+			t.Errorf("Error in SHA256 sum of secret, want=%s got=%s", shasum, argocd.Status.RedisTLSChecksum)
+		}
+
+		// This time, label should have changed
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		deplRolloutNew, ok = serverDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok || deplRollout == deplRolloutNew {
+			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		repoRolloutNew, ok = repoDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok || repoRollout == repoRolloutNew {
+			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
+		redisRolloutNew, ok = repoDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok || redisRollout == redisRolloutNew {
+			t.Errorf("Expected rollout of argocd-redis, but it didn't happen: %v", redisDepl.Spec.Template.ObjectMeta.Labels)
+		}
+		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		ctrlRolloutNew, ok = ctrlSts.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		if !ok || ctrlRollout == ctrlRolloutNew {
+			t.Errorf("Expected rollout of argocd-application-controller, but it didn't happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+		}
+	})
 }
 
 func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -273,7 +273,7 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 
 		r := makeReconciler(t, argocd, objs...)
 
-		err := r.reconcileRedisTLSSecret(argocd)
+		err := r.reconcileRedisTLSSecret(argocd, true)
 		if err != nil {
 			t.Errorf("Error should be nil, but is %v", err)
 		}
@@ -306,7 +306,7 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 		}
 
 		// Second run - no change
-		err = r.reconcileRedisTLSSecret(argocd)
+		err = r.reconcileRedisTLSSecret(argocd, true)
 		if err != nil {
 			t.Errorf("Error should be nil, but is %v", err)
 		}
@@ -347,7 +347,7 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 		shasum = fmt.Sprintf("%x", sha256.Sum256(sumOver))
 
 		// Second run - no change
-		err = r.reconcileRedisTLSSecret(argocd)
+		err = r.reconcileRedisTLSSecret(argocd, true)
 		if err != nil {
 			t.Errorf("Error should be nil, but is %v", err)
 		}

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -211,6 +211,10 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 					MountPath: "/health",
 					Name:      "health",
 				},
+				{
+					Name:      common.ArgoCDRedisServerTLSSecretName,
+					MountPath: "/app/config/redis/tls",
+				},
 			},
 		},
 		{
@@ -269,6 +273,10 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 					MountPath: "/health",
 					Name:      "health",
 				},
+				{
+					Name:      common.ArgoCDRedisServerTLSSecretName,
+					MountPath: "/app/config/redis/tls",
+				},
 			},
 		},
 	}
@@ -307,6 +315,10 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 			{
 				MountPath: "/data",
 				Name:      "data",
+			},
+			{
+				Name:      common.ArgoCDRedisServerTLSSecretName,
+				MountPath: "/app/config/redis/tls",
 			},
 		},
 	}}
@@ -353,6 +365,15 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 			Name: "data",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: common.ArgoCDRedisServerTLSSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.ArgoCDRedisServerTLSSecretName,
+					Optional:   boolPtr(true),
+				},
 			},
 		},
 	}

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -113,6 +113,9 @@ func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis
 	if useTLSForRedis {
 		cmd = append(cmd, "--redis-use-tls")
 		cmd = append(cmd, "--redis-ca-certificate", "/app/config/controller/tls/redis/tls.crt")
+		if isRedisTLSVerificationDisabled(cr) {
+			cmd = append(cmd, "--redis-insecure-skip-tls-verify")
+		}
 	}
 
 	cmd = append(cmd, "--repo-server", getRepoServerAddress(cr))
@@ -202,6 +205,10 @@ func getArgoServerInsecure(cr *argoprojv1a1.ArgoCD) bool {
 
 func isRepoServerTLSVerificationRequested(cr *argoprojv1a1.ArgoCD) bool {
 	return cr.Spec.Repo.VerifyTLS
+}
+
+func isRedisTLSVerificationDisabled(cr *argoprojv1a1.ArgoCD) bool {
+	return cr.Spec.Redis.DisableTLSVerification
 }
 
 // getArgoServerGRPCHost will return the GRPC host for the given ArgoCD.

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -113,9 +113,10 @@ func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis
 
 	if useTLSForRedis {
 		cmd = append(cmd, "--redis-use-tls")
-		cmd = append(cmd, "--redis-ca-certificate", "/app/config/controller/tls/redis/tls.crt")
 		if isRedisTLSVerificationDisabled(cr) {
 			cmd = append(cmd, "--redis-insecure-skip-tls-verify")
+		} else {
+			cmd = append(cmd, "--redis-ca-certificate", "/app/config/controller/tls/redis/tls.crt")
 		}
 	}
 

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -46,6 +46,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -461,9 +462,12 @@ func getRedisConfigPath() string {
 
 // getRedisInitScript will load the redis configuration from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisConf() string {
+func getRedisConf(useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/redis.conf.tpl", getRedisConfigPath())
-	conf, err := loadTemplateFile(path, map[string]string{})
+	params := map[string]string{
+		"UseTLS": strconv.FormatBool(useTLSForRedis),
+	}
+	conf, err := loadTemplateFile(path, params)
 	if err != nil {
 		log.Error(err, "unable to load redis configuration")
 		return ""
@@ -538,10 +542,11 @@ func getRedisHAProxyContainerImage(cr *argoprojv1a1.ArgoCD) string {
 
 // getRedisInitScript will load the redis init script from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisInitScript(cr *argoprojv1a1.ArgoCD) string {
+func getRedisInitScript(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/init.sh.tpl", getRedisConfigPath())
 	vars := map[string]string{
 		"ServiceName": nameWithSuffix("redis-ha", cr),
+		"UseTLS":      strconv.FormatBool(useTLSForRedis),
 	}
 
 	script, err := loadTemplateFile(path, vars)
@@ -554,10 +559,11 @@ func getRedisInitScript(cr *argoprojv1a1.ArgoCD) string {
 
 // getRedisHAProxySConfig will load the Redis HA Proxy configuration from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisHAProxyConfig(cr *argoprojv1a1.ArgoCD) string {
+func getRedisHAProxyConfig(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/haproxy.cfg.tpl", getRedisConfigPath())
 	vars := map[string]string{
 		"ServiceName": nameWithSuffix("redis-ha", cr),
+		"UseTLS":      strconv.FormatBool(useTLSForRedis),
 	}
 
 	script, err := loadTemplateFile(path, vars)
@@ -610,9 +616,12 @@ func getRedisHAProxyResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequiremen
 
 // getRedisSentinelConf will load the redis sentinel configuration from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisSentinelConf() string {
+func getRedisSentinelConf(useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/sentinel.conf.tpl", getRedisConfigPath())
-	conf, err := loadTemplateFile(path, map[string]string{})
+	params := map[string]string{
+		"UseTLS": strconv.FormatBool(useTLSForRedis),
+	}
+	conf, err := loadTemplateFile(path, params)
 	if err != nil {
 		log.Error(err, "unable to load redis sentinel configuration")
 		return ""
@@ -622,9 +631,12 @@ func getRedisSentinelConf() string {
 
 // getRedisLivenessScript will load the redis liveness script from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisLivenessScript() string {
+func getRedisLivenessScript(useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/redis_liveness.sh.tpl", getRedisConfigPath())
-	conf, err := loadTemplateFile(path, map[string]string{})
+	params := map[string]string{
+		"UseTLS": strconv.FormatBool(useTLSForRedis),
+	}
+	conf, err := loadTemplateFile(path, params)
 	if err != nil {
 		log.Error(err, "unable to load redis liveness script")
 		return ""
@@ -634,9 +646,12 @@ func getRedisLivenessScript() string {
 
 // getRedisReadinessScript will load the redis readiness script from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisReadinessScript() string {
+func getRedisReadinessScript(useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/redis_readiness.sh.tpl", getRedisConfigPath())
-	conf, err := loadTemplateFile(path, map[string]string{})
+	params := map[string]string{
+		"UseTLS": strconv.FormatBool(useTLSForRedis),
+	}
+	conf, err := loadTemplateFile(path, params)
 	if err != nil {
 		log.Error(err, "unable to load redis readiness script")
 		return ""
@@ -646,9 +661,12 @@ func getRedisReadinessScript() string {
 
 // getSentinelLivenessScript will load the redis liveness script from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getSentinelLivenessScript() string {
+func getSentinelLivenessScript(useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/sentinel_liveness.sh.tpl", getRedisConfigPath())
-	conf, err := loadTemplateFile(path, map[string]string{})
+	params := map[string]string{
+		"UseTLS": strconv.FormatBool(useTLSForRedis),
+	}
+	conf, err := loadTemplateFile(path, params)
 	if err != nil {
 		log.Error(err, "unable to load sentinel liveness script")
 		return ""
@@ -725,6 +743,55 @@ func (r *ReconcileArgoCD) reconcileCertificateAuthority(cr *argoprojv1a1.ArgoCD)
 	return nil
 }
 
+func (r *ReconcileArgoCD) redisShouldUseTLS(cr *argoprojv1a1.ArgoCD) bool {
+	var tlsSecretObj corev1.Secret
+	tlsSecretName := types.NamespacedName{Namespace: cr.Namespace, Name: common.ArgoCDRedisServerTLSSecretName}
+	err := r.Client.Get(context.TODO(), tlsSecretName, &tlsSecretObj)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "error looking up redis tls secret")
+		}
+		return false
+	}
+
+	secretOwnerRefs := tlsSecretObj.GetOwnerReferences()
+	if len(secretOwnerRefs) > 0 {
+		// OpenShift service CA makes the owner reference for the TLS secret to the
+		// service, which in turn is owned by the controller. This method performs
+		// a lookup of the controller through the intermediate owning service.
+		for _, secretOwner := range secretOwnerRefs {
+			if isOwnerOfInterest(secretOwner) {
+				key := client.ObjectKey{Name: secretOwner.Name, Namespace: tlsSecretObj.GetNamespace()}
+				svc := &corev1.Service{}
+
+				// Get the owning object of the secret
+				err := r.Client.Get(context.TODO(), key, svc)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("could not get owner of secret %s", tlsSecretObj.GetName()))
+					return false
+				}
+
+				// If there's an object of kind ArgoCD in the owner's list,
+				// this will be our reconciled object.
+				serviceOwnerRefs := svc.GetOwnerReferences()
+				for _, serviceOwner := range serviceOwnerRefs {
+					if serviceOwner.Kind == "ArgoCD" {
+						return true
+					}
+				}
+			}
+		}
+	} else {
+		// For secrets without owner (i.e. manually created), we apply some
+		// heuristics. This may not be as accurate (e.g. if the user made a
+		// typo in the resource's name), but should be good enough for now.
+		if _, ok := tlsSecretObj.Annotations[common.AnnotationName]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // reconcileResources will reconcile common ArgoCD resources.
 func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
 	log.Info("reconciling status")
@@ -757,8 +824,10 @@ func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
 		return err
 	}
 
+	useTLSForRedis := r.redisShouldUseTLS(cr)
+
 	log.Info("reconciling config maps")
-	if err := r.reconcileConfigMaps(cr); err != nil {
+	if err := r.reconcileConfigMaps(cr, useTLSForRedis); err != nil {
 		return err
 	}
 
@@ -766,8 +835,6 @@ func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
 	if err := r.reconcileServices(cr); err != nil {
 		return err
 	}
-
-	useTLSForRedis := r.redisShouldUseTLS(cr)
 
 	log.Info("reconciling deployments")
 	if err := r.reconcileDeployments(cr, useTLSForRedis); err != nil {
@@ -826,7 +893,7 @@ func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
 		return err
 	}
 
-	if err := r.reconcileRedisTLSSecret(cr); err != nil {
+	if err := r.reconcileRedisTLSSecret(cr, useTLSForRedis); err != nil {
 		return err
 	}
 

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -627,6 +627,34 @@ func TestSetManagedNamespaces(t *testing.T) {
 	}
 }
 
+func TestGetRedisConf(t *testing.T) {
+	s1 := getRedisConf(true)
+	//assert.Equal(t, "", s1)
+
+	s1 = getRedisConf(false)
+	//assert.Equal(t, "", s1)
+
+	s1 = getRedisSentinelConf(true)
+	//assert.Equal(t, "", s1)
+
+	s1 = getRedisSentinelConf(false)
+	//assert.Equal(t, "", s1)
+
+	a := makeTestArgoCD()
+
+	s1 = getRedisInitScript(a, true)
+	//assert.Equal(t, "", s1)
+
+	s1 = getRedisLivenessScript(false)
+	//assert.Equal(t, "", s1)
+
+	s1 = getRedisReadinessScript(true)
+	//assert.Equal(t, "", s1)
+
+	s1 = getSentinelLivenessScript(true)
+	assert.Equal(t, "", s1)
+}
+
 func TestGenerateRandomString(t *testing.T) {
 
 	// verify the creation of unique strings

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -427,7 +427,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 
 	for _, tt := range cmdTests {
 		cr := makeTestArgoCD(tt.opts...)
-		cmd := getArgoApplicationControllerCommand(cr)
+		cmd := getArgoApplicationControllerCommand(cr, false)
 
 		if !reflect.DeepEqual(cmd, tt.want) {
 			t.Fatalf("got %#v, want %#v", cmd, tt.want)

--- a/deploy/olm-catalog/argocd-operator/0.4.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.4.0/argoproj.io_argocds.yaml
@@ -856,6 +856,16 @@ spec:
               redis:
                 description: Redis defines the Redis server options for ArgoCD.
                 properties:
+                  autotls:
+                    description: 'AutoTLS specifies the method to use for automatic
+                      TLS configuration for the redis server The value specified here
+                      can currently be: - openshift - Use the OpenShift service CA
+                      to request TLS config'
+                    type: string
+                  disableTLSVerification:
+                    description: DisableTLSVerification defines whether redis server
+                      API should be accessed using strict TLS validation
+                    type: boolean
                   image:
                     description: Image is the Redis container image.
                     type: string
@@ -5715,6 +5725,11 @@ spec:
                   of the  Argo CD Redis component Pods had a failure. Unknown: For
                   some reason the state of the Argo CD Redis component could not be
                   obtained.'
+                type: string
+              redisTLSChecksum:
+                description: RedisTLSChecksum contains the SHA256 checksum of the
+                  latest known state of tls.crt and tls.key in the argocd-operator-redis-tls
+                  secret.
                 type: string
               repo:
                 description: 'Repo is a simple, high-level summary of where the Argo

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -784,6 +784,8 @@ The following properties are available for configuring the Redis component.
 
 Name | Default | Description
 --- | --- | ---
+AutoTLS | "" | Provider to use for creating the redis server's TLS certificate (one of: `openshift`). Currently only available for OpenShift.
+DisableTLSVerification | false | defines whether the redis server should be accessed using strict TLS validation
 Image | `redis` | The container image for Redis. This overrides the `ARGOCD_REDIS_IMAGE` environment variable.
 Resources | [Empty] | The container compute resources.
 Version | 5.0.3 (SHA) | The tag to use with the Redis container image.
@@ -804,6 +806,8 @@ spec:
     image: redis
     resources: {}
     version: "5.0.3"
+    disableTLSVerification: false
+    autotls: ""
 ```
 
 ## Repo Options

--- a/tests/k8s/1-007_validate_volume_mounts/01-assert.yaml
+++ b/tests/k8s/1-007_validate_volume_mounts/01-assert.yaml
@@ -24,6 +24,8 @@ spec:
           name: tls-certs
         - mountPath: /app/config/server/tls
           name: argocd-repo-server-tls
+        - mountPath: /app/config/server/tls/redis
+          name: argocd-operator-redis-tls
       volumes:
       - configMap:
           defaultMode: 420
@@ -38,6 +40,11 @@ spec:
           defaultMode: 420
           optional: true
           secretName: argocd-repo-server-tls
+      - name: argocd-operator-redis-tls
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: argocd-operator-redis-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -60,6 +67,8 @@ spec:
           name: tmp
         - mountPath: /app/config/reposerver/tls
           name: argocd-repo-server-tls
+        - mountPath: /app/config/reposerver/tls/redis
+          name: argocd-operator-redis-tls
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
       volumes:
@@ -84,6 +93,11 @@ spec:
           defaultMode: 420
           optional: true
           secretName: argocd-repo-server-tls
+      - name: argocd-operator-redis-tls
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: argocd-operator-redis-tls
       - emptyDir: {}
         name: var-files
       - emptyDir: {}
@@ -100,10 +114,16 @@ spec:
       - volumeMounts: 
         - mountPath: /app/config/controller/tls
           name: argocd-repo-server-tls
+        - mountPath: /app/config/controller/tls/redis
+          name: argocd-operator-redis-tls
       volumes:
       - name: argocd-repo-server-tls
         secret:
           defaultMode: 420
           optional: true
           secretName: argocd-repo-server-tls
-    
+      - name: argocd-operator-redis-tls
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: argocd-operator-redis-tls


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:

This PR adds support to watch for changes to the `argocd-operator-redis-tls` secret, which should contain the TLS configuration (cert/key combination) that the argocd components should use to communicate with the redis server. If a change is detected, the appropriate workloads will be restarted.  Note that this secret is something defined by the operator and not by Argo CD itself.

The PR adds two new settings
-  `.spec.redis.disableTLSVerification: <bool>`: if set to `true`, the application controller, the repo server and the api server will not validate the TLS certificate used by the redis server (by setting the `--redis-insecure-skip-tls-verify` flag when starting these components).
- `.spec.redis.autotls: <string>`: Can be set to a provider which does automatic provisioning of the `argocd-operator-redis-tls` secret. Currently, the only provider supported is openshift 

If the `argocd-operator-redis-tls` secret was created using the AutoTLS setting, no further configuration will be necessary. If the secret was manually added to the namespace, it will require an annotation argocds.argoproj.io/name: <instance_name> to be successfully mapped back to the managing ArgoCD instance.

OpenShift Container Platform provides a cluster-internal CA to issue service certificates, as described [here](https://docs.openshift.com/container-platform/4.10/security/certificates/service-serving-certificate.html). If .spec.redis.autotls: openshift is specified, the controller will add the appropriate annotation to the redis servers Service in the instance's namespace, which indicates that a TLS certificate for this service should be issued by the service CA.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

### To test the enablement of TLS for Redis when autotls is disabled

- Create an Argo CD CR with default values
```yaml
apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd
```
- Wait until reconciliation is complete and workloads became available
- Create a self-signed certificate for the redis server. The cert will be stored in `/tmp/redis.crt`, and the key will be stored in `/tmp/redis.key`.  Set the environment variable `NAMESPACE` to the namespace where argocd is running.
```bash
openssl req -new -x509 -sha256 \
  -subj "/C=XX/ST=XX/O=Testing/CN=redis" \
  -reqexts SAN -extensions SAN \
  -config <(printf "\n[SAN]\nsubjectAltName=DNS:argocd-redis.$NAMESPACE.svc.cluster.local\n[req]\ndistinguished_name=req") \
  -keyout /tmp/redis.key \
  -out /tmp/redis.crt \
  -newkey rsa:4096 \
  -nodes \
  -sha256 \
  -days 10
```
- Create the `argocd-operator-redis-tls` secret
```bash
kubectl create secret tls argocd-operator-redis-tls --key=/tmp/redis.key --cert=/tmp/redis.crt
```
- Check that the pods for the `argocd-server`, `argocd-repo-server`, `argocd-redis` and `argocd-application-controller` were **not** restarted yet
- Annotate the secret to indicate it belongs to the `argocd` operand
```bash
kubectl annotate secret argocd-operator-redis-tls argocds.argoproj.io/name=argocd
```
- Check that the operator reconciled and the `argocd-server`, `argocd-repo-server`, `argocd-redis` and `argocd-application-controller` have been restarted.

- Check that the redis server has been started with the correct arguments.  Run
```bash
kubectl get deployments.apps argocd-redis -o jsonpath='{.spec.template.spec.containers[0].args}'
```
- The arguments should include
  - "--tls-port","6379"
  - "--port","0"
  - "--tls-cert-file","/app/config/redis/tls/tls.crt"
  - "--tls-key-file","/app/config/redis/tls/tls.key"
  - "--tls-auth-clients","no"

- Check that the repo server has been started with the correct arguments. Run
```bash
kubectl get deployments.apps argocd-repo-server -o jsonpath='{.spec.template.spec.containers[0].command}'
```
- The arguments should include
  - "--redis-use-tls"
  - "--redis-ca-certificate","/app/config/reposerver/tls/redis/tls.crt"

- Check that the api server has been started with the correct arguments. Run
```bash
kubectl get deployments.apps argocd-server -o jsonpath='{.spec.template.spec.containers[0].command}' 
```
- The arguments should include
  - "--redis-use-tls"
  - "--redis-ca-certificate","/app/config/server/tls/redis/tls.crt"

- Check that the application controller has been started with the correct arguments. Run
```bash
kubectl get statefulsets.apps argocd-application-controller -o jsonpath='{.spec.template.spec.containers[0].command}'
```
- The arguments should include
  - "--redis-use-tls"
  - "--redis-ca-certificate","/app/config/controller/tls/redis/tls.crt"

### To test the enablement of TLS for Redis when HA is enabled and autotls is disabled

**Note that this requires running on a cluster with at least three worker nodes.**

- Create an Argo CD CR with which enables HA
```yaml
apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd
spec:
  ha:
    enabled: true
```
- Wait until reconciliation is complete and workloads became available.  This may take many minutes
- Create a self-signed certificate for the redis server. Note that this cert is different from the one for non-HA mode. The cert will be stored in `/tmp/redis-ha.crt`, and the key will be stored in `/tmp/redis-ha.key`.  Set the environment variable `NAMESPACE` to the namespace where argocd is running.
```bash
openssl req -new -x509 -sha256 \
  -subj "/C=XX/ST=XX/O=Testing/CN=redis" \
  -reqexts SAN -extensions SAN \
  -config <(printf "\n[SAN]\nsubjectAltName=DNS:argocd-redis-ha-haproxy.$NAMESPACE.svc.cluster.local\n[req]\ndistinguished_name=req") \
  -keyout /tmp/redis-ha.key \
  -out /tmp/redis-ha.crt \
  -newkey rsa:4096 \
  -nodes \
  -sha256 \
  -days 10
```
- Create the `argocd-operator-redis-tls` secret
```bash
kubectl create secret tls argocd-operator-redis-tls --key=/tmp/redis-ha.key --cert=/tmp/redis-ha.crt
```
- Check that the pods for the `argocd-server`, `argocd-repo-server`, `argocd-redis-ha-server-0`, `argocd-redis-ha-server-1`, `argocd-redis-ha-server-2`, `argocd-redis-ha-haproxy` and `argocd-application-controller` were **not** restarted yet
- Annotate the secret to indicate it belongs to the `argocd` operand
```bash
kubectl annotate secret argocd-operator-redis-tls argocds.argoproj.io/name=argocd
```
- Check that the operator reconciled and the `argocd-server`, `argocd-repo-server`, `argocd-redis-ha-server-0`, `argocd-redis-ha-server-1`, `argocd-redis-ha-server-2`, `argocd-redis-ha-haproxy` and `argocd-application-controller` pods have restarted. It may take many minutes for the pods to restart.

- Check that the configuration for the redis servers is correct. Run
```bash
kubectl exec -ti argocd-redis-ha-server-0 -c redis -- sh
```
- Examine the `redis.conf` file.  Run `less conf/redis.conf`
- The file should include the following lines
```
port 0
tls-port 6379
tls-cert-file /app/config/redis/tls/tls.crt
tls-ca-cert-file /app/config/redis/tls/tls.crt
tls-key-file /app/config/redis/tls/tls.key
tls-replication yes
tls-auth-clients no
```
- Examine the `sentinel.conf` file.  Run `less conf/sentinel.conf`
- The file should include the following lines
```
port 0
tls-port 26379
tls-cert-file "/app/config/redis/tls/tls.crt"
tls-ca-cert-file "/app/config/redis/tls/tls.crt"
tls-key-file "/app/config/redis/tls/tls.key"
tls-replication yes
tls-auth-clients no
```
- Check that the repo server has been started with the correct arguments. Run
```bash
kubectl get deployments.apps argocd-repo-server -o jsonpath='{.spec.template.spec.containers[0].command}'
```
- The arguments should include
  - "--redis-use-tls"
  - "--redis-ca-certificate","/app/config/reposerver/tls/redis/tls.crt"

- Check that the api server has been started with the correct arguments. Run
```bash
kubectl get deployments.apps argocd-server -o jsonpath='{.spec.template.spec.containers[0].command}' 
```
- The arguments should include
  - "--redis-use-tls"
  - "--redis-ca-certificate","/app/config/server/tls/redis/tls.crt"

- Check that the application controller has been started with the correct arguments. Run
```bash
kubectl get statefulsets.apps argocd-application-controller -o jsonpath='{.spec.template.spec.containers[0].command}'
```
- The arguments should include
  - "--redis-use-tls"
  - "--redis-ca-certificate","/app/config/controller/tls/redis/tls.crt"

### To test the enablement of TLS for Redis when autotls is enabled (only works on OpenShift)

- Create an Argo CD CR with default values
```yaml
apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd
```
- Wait until reconciliation is complete and workloads became available
- Patch the ArgoCD CR to set `.spec.redis.autotls` to `openshift`
```bash
kubectl patch argocds.argoproj.io argocd --type=merge -p '{"spec":{"redis":{"autotls":"openshift"}}}'
```
- Check that a secret called `argocd-operator-redis-tls` was created by the CA's controller.
```bash
kubectl get secrets argocd-operator-redis-tls
```
- The secret should be of type `kubernetes.io/tls` and should have a size of `2`
- Check that the operator reconciled and the `argocd-server`, `argocd-repo-server`, `argocd-redis` and `argocd-application-controller` have been restarted.
- For each of the `argocd-server`, `argocd-repo-server`, `argocd-redis` and `argocd-application-controller` pods, do a `kubectl exec -it <podname> -- sh` and look for the following files to exist there:
  - argocd-server: /app/config/server/tls/redis/tls.crt
  - argocd-repo-server: /app/config/reposerver/tls/redis/tls.crt
  - argocd-redis-server: /app/config/redis/tls/tls.crt
  - argocd-application-controller: /app/config/controller/tls/redis/tls.crt

### To test the enablement of TLS for Redis when HA is enabled and autotls is enabled (only works on OpenShift)

**Note that this requires running on a cluster with at least three worker nodes.**

- Create an Argo CD CR with which enables HA
```yaml
apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd
spec:
  ha:
    enabled: true
```
- Wait until reconciliation is complete and workloads became available.  This may take many minutes
- Patch the ArgoCD CR to set `.spec.redis.autotls` to `openshift`
```bash
kubectl patch argocds.argoproj.io argocd --type=merge -p '{"spec":{"redis":{"autotls":"openshift"}}}'
```
- Check that a secret called `argocd-operator-redis-tls` was created by the CA's controller.
```bash
kubectl get secrets argocd-operator-redis-tls
```
- The secret should be of type `kubernetes.io/tls` and should have a size of `2`
- Check that the operator reconciled and the `argocd-server`, `argocd-repo-server`, `argocd-redis-ha-server-0`, `argocd-redis-ha-server-1`, `argocd-redis-ha-server-2`, `argocd-redis-ha-haproxy` and `argocd-application-controller` pods have restarted. It may take many minutes for the pods to restart.