### PR TITLE
feat: added env variable to remove managed-by label on argocd instance deletion

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -93,8 +93,10 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 				return reconcile.Result{}, fmt.Errorf("failed to delete ClusterResources: %w", err)
 			}
 
-			if err := r.removeManagedByLabelFromNamespaces(argocd.Namespace); err != nil {
-				return reconcile.Result{}, fmt.Errorf("failed to remove label from namespace[%v], error: %w", argocd.Namespace, err)
+			if removeManagedByLabelOnArgoCDDeletion() {
+				if err := r.removeManagedByLabelFromNamespaces(argocd.Namespace); err != nil {
+					return reconcile.Result{}, fmt.Errorf("failed to remove label from namespace[%v], error: %w", argocd.Namespace, err)
+				}
 			}
 
 			if err := r.removeDeletionFinalizer(argocd); err != nil {

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -93,7 +93,7 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 				return reconcile.Result{}, fmt.Errorf("failed to delete ClusterResources: %w", err)
 			}
 
-			if removeManagedByLabelOnArgoCDDeletion() {
+			if isRemoveManagedByLabelOnArgoCDDeletion() {
 				if err := r.removeManagedByLabelFromNamespaces(argocd.Namespace); err != nil {
 					return reconcile.Result{}, fmt.Errorf("failed to remove label from namespace[%v], error: %w", argocd.Namespace, err)
 				}

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1293,7 +1293,7 @@ func isDexDisabled() bool {
 	return false
 }
 
-func removeManagedByLabelOnArgoCDDeletion() bool {
+func isRemoveManagedByLabelOnArgoCDDeletion() bool {
 	if v := os.Getenv("REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION"); v != "" {
 		return strings.ToLower(v) == "true"
 	}

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1293,6 +1293,13 @@ func isDexDisabled() bool {
 	return false
 }
 
+func removeManagedByLabelOnArgoCDDeletion() bool {
+	if v := os.Getenv("REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION"); v != "" {
+		return strings.ToLower(v) == "true"
+	}
+	return false
+}
+
 // to update nodeSelector and tolerations in reconciler
 func updateNodePlacement(existing *appsv1.Deployment, deploy *appsv1.Deployment, changed *bool) {
 	if !reflect.DeepEqual(existing.Spec.Template.Spec.NodeSelector, deploy.Spec.Template.Spec.NodeSelector) {

--- a/docs/usage/custom_roles.md
+++ b/docs/usage/custom_roles.md
@@ -38,3 +38,19 @@ spec:
           - name: SERVER_CLUSTER_ROLE
             value: custom-server-role
 ```
+
+
+When an target Argo CD instance gets deleted, namespaces with the `argocd.argoproj.io/managed-by` label of that Argo CD instance's namespace will keep the label. Users can remove the `argocd.argoproj.io/managed-by` label value on Argo CD deletion by setting the environment variable `REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION` to `true` in the Subscription.
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: argocd-operator
+  namespace: argocd
+spec:
+  config:
+    env:
+    - name: REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION
+      value: "true"
+```

--- a/docs/usage/custom_roles.md
+++ b/docs/usage/custom_roles.md
@@ -40,7 +40,7 @@ spec:
 ```
 
 
-When an target Argo CD instance gets deleted, namespaces with the `argocd.argoproj.io/managed-by` label of that Argo CD instance's namespace will keep the label. Users can remove the `argocd.argoproj.io/managed-by` label value on Argo CD deletion by setting the environment variable `REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION` to `true` in the Subscription.
+When an Argo CD instance is deleted, namespaces managed by that instance (via the `argocd.argoproj.io/managed-by` label ) will retain the label by default. Users can change this behavior by setting the environment variable `REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION` to `true` in the Subscription.
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
This PR introduces a new environment variable "REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION", and changes the default behave on namespace with "managed-by" label when the target Argo CD instance gets removed by the gitops-operator. By default, when the Argo CD instance with the target namespace gets deleted, the namespace keeps "managed-by" label value. Only when "REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION" is set to "true" in the Subscription config, it will remove the "managed-by" label on Argo CD deletion.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-1826

**How to test changes / Special notes to the reviewer**:
> Without "REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION" set to "true" in argocd-operator Subscription
1. Install argocd-operator with namespace A and create an Argo CD instance
2. Create a new namespace B and set "argocd.argoproj.io/managed-by: <namespace A>" label
3. Delete the Argo CD instance with namespace A
4. Check the new namespace B and see if it still has the "managed-by" label which sets to namespace A

> With "REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION" set to "true" in argocd-operator Subscription
1. Same as 1 from above process
2. Edit Subscription of argocd-operator as below
```
...
spec:
...
  config:
    env:
      - name: REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION
        value: 'true'
...
```
3. Same as 2 -3 from above process
4. Check the new namespace B and see the "managed-by" label no longer exists