### PR TITLE
fix: operator overrides the OIDC configuration for Keycloak

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -398,7 +398,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 				return err
 			}
 		} else {
-			if cr.Spec.SSO.Provider == "keycloak" {
+			if cr.Spec.SSO.Provider == argoprojv1a1.SSOProviderTypeKeycloak {
 				cm.Data[common.ArgoCDKeyOIDCConfig] = existingCM.Data[common.ArgoCDKeyOIDCConfig]
 			}
 		}

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -390,9 +390,16 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 
 	existingCM := &corev1.ConfigMap{}
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, existingCM) {
+		// This logic should be refactored as part of SSO Unification.
+		// https://github.com/argoproj-labs/argocd-operator/pull/646
+		// In future, Both Keycloak and Dex can be configured using `.spec.SSO`.
 		if cr.Spec.SSO == nil {
 			if err := r.reconcileDexConfiguration(existingCM, cr); err != nil {
 				return err
+			}
+		} else {
+			if cr.Spec.SSO.Provider == "keycloak" {
+				cm.Data[common.ArgoCDKeyOIDCConfig] = existingCM.Data[common.ArgoCDKeyOIDCConfig]
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
As part of the [PR](https://github.com/argoproj-labs/argocd-operator/pull/642), I have refactored the Argo CD config map reconciliation logic and made it simpler. @rishabh while integrating the changes into DownStream(openshift-gitops) noticed that OIDC configuration is not getting updated when `.spec.SSO.provider` is set to Keycloak.

I could have caught this by testing the PR on OpenShift platform. There is an existing test to validate the changes.
`1-001_validate_rhsso`

This PR will fix the issue.

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Run the operator locally.
2. Run the below `1-001_validate_rhsso` test by using the command.
`kubectl kuttl test ./tests/ocp --config ./tests/kuttl-tests.yaml --test 1-001_validate_rhsso`