### PR TITLE
fix: upgrade Argo CD to handle CVE-2022-29165

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,5 +1,5 @@
-# Argo CD v2.4.0-rc1
-FROM quay.io/argoproj/argocd@sha256:92ea7377a66fa3e79dd1d7c804307a8b8829049fcf30df3884be764945d8ce7e
+# Argo CD v2.4.0-rc2
+FROM quay.io/argoproj/argocd@sha256:e8f78f3217012b52c482f5d38c162391cdc5dbfb5a1402667454bde8126700bf
 
 USER root
 

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -55,7 +55,7 @@ const (
 	ArgoCDDefaultArgoImage = "quay.io/argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:92ea7377a66fa3e79dd1d7c804307a8b8829049fcf30df3884be764945d8ce7e" // v2.4.0-rc1
+	ArgoCDDefaultArgoVersion = "sha256:e8f78f3217012b52c482f5d38c162391cdc5dbfb5a1402667454bde8126700bf" // v2.4.0-rc2
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -44,7 +44,7 @@ Name | Default | Description
 [**StatusBadgeEnabled**](#status-badge-enabled) | `true` | Enable application status badge feature.
 [**TLS**](#tls-options) | [Object] | TLS configuration options.
 [**UsersAnonymousEnabled**](#users-anonymous-enabled) | `true` | Enable anonymous user access.
-[**Version**](#version) | v2.3.3 (SHA) | The tag to use with the container image for all Argo CD components.
+[**Version**](#version) | v2.4.0 (SHA) | The tag to use with the container image for all Argo CD components.
 [**Banner**](#banner) | [Object] | Add a UI banner message.
 
 ## Application Instance Label Key

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-operator
 go 1.18
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.3.3
+	github.com/argoproj/argo-cd/v2 v2.3.4
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.2
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.m
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj/argo-cd/v2 v2.3.3 h1:SE1Cb8MDqP5T2iUtyL9bwpKYIvpGkVUsgzKCAqZZ5Vc=
-github.com/argoproj/argo-cd/v2 v2.3.3/go.mod h1:EuPH0/rLe/FdHGwQ/EVucspMnF3v4qd7da6N6CG+oJA=
+github.com/argoproj/argo-cd/v2 v2.3.4 h1:mj+snMMf9LoHWMH3rLCkBWSRETv1Sq8lxuuyLxH+76A=
+github.com/argoproj/argo-cd/v2 v2.3.4/go.mod h1:EuPH0/rLe/FdHGwQ/EVucspMnF3v4qd7da6N6CG+oJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Fixes **CVE-2022-29165**

```
A critical vulnerability has been discovered in Argo CD which would allow unauthenticated users to impersonate as any Argo CD user or role, including the admin user, by sending a specifically crafted JSON Web Token (JWT) along with the request. In order for this vulnerability to be exploited, [anonymous access](https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/#anonymous-access) to the Argo CD instance must have been enabled.

In a default Argo CD installation, anonymous access is disabled. To find out if anonymous access is enabled in your instance, please see the Workarounds section of this advisory below.

The vulnerability can be exploited to impersonate as any user or role, including the built-in admin account regardless of whether that account is enabled or disabled. Also, the attacker does not need an account on the Argo CD instance in order to exploit this.

If anonymous access to the instance is enabled, an attacker can:

    Escalate their privileges, effectively allowing them to gain the same privileges on the cluster as the Argo CD instance, which is cluster admin in a default installation. This will allow the attacker to create, manipulate and delete any resource on the cluster.

    Exfiltrate data by deploying malicious workloads with elevated privileges, thus bypassing any redaction of sensitive data otherwise enforced by the Argo CD API

We strongly recommend that all users of Argo CD update to a version containing this patch as soon as possible, regardless of whether or not anonymous access is enabled in your instance.
```

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
**CVE-2022-29165**

**How to test changes / Special notes to the reviewer**:
Upgrade to Argo CD dependency version to v2.3.4