### PR TITLE
fix: Operator does not create necessary RoleBindings in all cases

### DIFF
--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -85,10 +85,10 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 			return nil, err
 		}
 		// only skip creation of dex and redisHa roles for namespaces that no argocd instance is deployed in
-		if len(list.Items) > 0 {
+		if len(list.Items) < 1 {
 			// only create dexServer and redisHa roles for the namespace where the argocd instance is deployed
 			if cr.ObjectMeta.Namespace != namespace.Name && (name == common.ArgoCDDexServerComponent || name == common.ArgoCDRedisHAComponent) {
-				break
+				continue
 			}
 		}
 		customRole := getCustomRoleName(name)

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -78,9 +78,18 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 
 	// create policy rules for each namespace
 	for _, namespace := range r.ManagedNamespaces.Items {
-		// only create dexServer and redisHa roles for the namespace where the argocd instance is deployed
-		if cr.ObjectMeta.Namespace != namespace.Name && (name == common.ArgoCDDexServerComponent || name == common.ArgoCDRedisHAComponent) {
-			break
+		list := &argoprojv1a1.ArgoCDList{}
+		listOption := &client.ListOptions{Namespace: namespace.Name}
+		err := r.Client.List(context.TODO(), list, listOption)
+		if err != nil {
+			return nil, err
+		}
+		// only skip creation of dex and redisHa roles for namespaces that no argocd instance is deployed in
+		if len(list.Items) > 0 {
+			// only create dexServer and redisHa roles for the namespace where the argocd instance is deployed
+			if cr.ObjectMeta.Namespace != namespace.Name && (name == common.ArgoCDDexServerComponent || name == common.ArgoCDRedisHAComponent) {
+				break
+			}
 		}
 		customRole := getCustomRoleName(name)
 		role := newRole(name, policyRules, cr)
@@ -89,7 +98,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 		}
 		role.Namespace = namespace.Name
 		existingRole := v1.Role{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, &existingRole)
+		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, &existingRole)
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to reconcile the role for the service account associated with %s : %s", name, err)

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -102,10 +102,10 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 			return err
 		}
 		// only skip creation of dex and redisHa rolebindings for namespaces that no argocd instance is deployed in
-		if len(list.Items) > 0 {
+		if len(list.Items) < 1 {
 			// only create dexServer and redisHa rolebindings for the namespace where the argocd instance is deployed
 			if cr.ObjectMeta.Namespace != namespace.Name && (name == common.ArgoCDDexServerComponent || name == common.ArgoCDRedisHAComponent) {
-				break
+				continue
 			}
 		}
 		// get expected name

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-assert.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-assert.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-argocd-argocd-application-controller
+  namespace: central-argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-argocd-argocd-server
+  namespace: central-argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-argocd-argocd-application-controller
+  namespace: central-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-argocd-argocd-application-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-argocd-argocd-server
+  namespace: central-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-argocd-argocd-server

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-basic.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-basic.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: central-argocd
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd-1
+  labels:
+      argocd.argoproj.io/managed-by: central-argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  namespace: central-argocd
+  labels:
+    example: basic
+spec: {}

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-argocd-instance.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-argocd-instance.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: child-argocd
+  namespace: argocd-1
+spec: {}

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-assert.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-assert.yaml
@@ -1,0 +1,95 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-argocd-argocd-application-controller
+  namespace: central-argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-argocd-argocd-server
+  namespace: central-argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: child-argocd-argocd-application-controller
+  namespace: argocd-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: child-argocd-argocd-server
+  namespace: argocd-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: child-argocd-argocd-dex-server
+  namespace: argocd-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: child-argocd-argocd-redis-ha
+  namespace: argocd-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-argocd-argocd-application-controller
+  namespace: central-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-argocd-argocd-application-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-argocd-argocd-server
+  namespace: central-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-argocd-argocd-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: child-argocd-argocd-application-controller
+  namespace: argocd-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: child-argocd-argocd-application-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: child-argocd-argocd-server
+  namespace: argocd-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: child-argocd-argocd-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: child-argocd-argocd-dex-server
+  namespace: argocd-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: child-argocd-argocd-dex-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: child-argocd-argocd-redis-ha
+  namespace: argocd-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: child-argocd-argocd-redis-ha


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Fixes [GITOPS-1963](https://issues.redhat.com/browse/GITOPS-1963) issue.

**Have you updated the necessary documentation?**
* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes #GITOPS-1963 Operator does not create necessary RoleBindings in all cases

**How to test changes / Special notes to the reviewer**:
a. $ oc create namespace central-argocd
b. $ oc create namespace argocd-1
c. $ oc label ns argocd-1 [argocd.argoproj.io/managed-by=central-argocd](http://argocd.argoproj.io/managed-by=central-argocd)
d. $ oc project central-argocd
e. $ oc apply -f argocd-basic.yaml
f. $ oc get roles -n central-argocd 
Now observe that all 4 roles/rolebindings including dex and redis service are created for central-argocd ns