### PR TITLE
fix: mount secret to service account for dex if its not there

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -384,7 +384,7 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoprojv1a1.ArgoCD) (*str
 		sa.Secrets = append(sa.Secrets, *tokenSecret)
 		err = r.Client.Update(context.TODO(), sa)
 		if err != nil {
-			return nil, errors.New("Failed to Add ServiceAccount token for OAuth client secret")
+			return nil, errors.New("failed to add ServiceAccount token for OAuth client secret")
 		}
 	}
 

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -377,11 +377,15 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoprojv1a1.ArgoCD) (*str
 		if err != nil {
 			return nil, errors.New("unable to locate and create ServiceAccount token for OAuth client secret")
 		}
-		tokenSecret := &corev1.ObjectReference{
+		tokenSecret = &corev1.ObjectReference{
 			Name:      secret.Name,
 			Namespace: cr.Namespace,
 		}
 		sa.Secrets = append(sa.Secrets, *tokenSecret)
+		err = r.Client.Update(context.TODO(), sa)
+		if err != nil {
+			return nil, errors.New("Failed to Add ServiceAccount token for OAuth client secret")
+		}
 	}
 
 	// Fetch the secret to obtain the token

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -29,6 +29,7 @@ import (
 	"text/template"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"gopkg.in/yaml.v2"
 
@@ -376,6 +377,10 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoprojv1a1.ArgoCD) (*str
 		err := r.Client.Create(context.TODO(), secret)
 		if err != nil {
 			return nil, errors.New("unable to locate and create ServiceAccount token for OAuth client secret")
+		}
+		err = controllerutil.SetControllerReference(cr, secret, r.Scheme)
+		if err != nil {
+			return nil, err
 		}
 		tokenSecret = &corev1.ObjectReference{
 			Name:      secret.Name,

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -364,6 +364,7 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoprojv1a1.ArgoCD) (*str
 	}
 
 	if tokenSecret == nil {
+		// This change of creating secret for dex service account,is due to change of reduction of secret-based service account tokens in k8s v1.24 so from k8s v1.24 no default secret for service account is created, but for dex to work we need to provide token of secret used by dex service account as a oauth token, this change helps to achieve it, in long run we should see do dex really requires a secret or it manages to create one using TokenRequest API or may be change how dex is used or configured by operator
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "argocd-dex-server-token-",

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
@@ -679,4 +680,17 @@ func generateEncodedPEM(t *testing.T, host string) []byte {
 
 	encoded := argoutil.EncodeCertificatePEM(cert)
 	return encoded
+}
+
+//sTestReconcileArgoCD_reconcileDexOAuthClientSecret This test make sures that if dex is enabled a service account is created with token stored in a secret which is used for oauth
+func TestReconcileArgoCD_reconcileDexOAuthClientSecret(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+	a.Spec.Dex.OpenShiftOAuth = true
+	r := makeTestReconciler(t, a)
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
+	assert.NoError(t, err)
+	_, err = r.getDexOAuthClientSecret(a)
+	assert.NoError(t, err)
 }

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -693,4 +693,13 @@ func TestReconcileArgoCD_reconcileDexOAuthClientSecret(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = r.getDexOAuthClientSecret(a)
 	assert.NoError(t, err)
+	sa := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, a)
+	assert.NoError(t, argoutil.FetchObject(r.Client, a.Namespace, sa.Name, sa))
+	tokenExists := false
+	for _, saSecret := range sa.Secrets {
+		if strings.Contains(saSecret.Name, "dex-server-token") {
+			tokenExists = true
+		}
+	}
+	assert.True(t, tokenExists, "Dex is enabled but unable to create oauth client secret")
 }

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -682,7 +682,7 @@ func generateEncodedPEM(t *testing.T, host string) []byte {
 	return encoded
 }
 
-//sTestReconcileArgoCD_reconcileDexOAuthClientSecret This test make sures that if dex is enabled a service account is created with token stored in a secret which is used for oauth
+// TestReconcileArgoCD_reconcileDexOAuthClientSecret This test make sures that if dex is enabled a service account is created with token stored in a secret which is used for oauth
 func TestReconcileArgoCD_reconcileDexOAuthClientSecret(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()


### PR DESCRIPTION
Signed-off-by: rishabh625 <rishabhmishra625@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug

> /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

since k8s v1.24 secret is not auto mounted to SA , dex creation fails as oauth client used for dex is service account. This PR creates a token and adds the token to service account

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes  [326](https://github.com/redhat-developer/gitops-operator/issues/326)

**How to test changes / Special notes to the reviewer**:
Run this on ocp v4.11 and on lower version to check backward compatibility
