### PR TITLE
chore: Redirect e2e test logs to both stdout and log file

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -100,6 +100,7 @@ jobs:
           REDIS_CONFIG_PATH="build/redis" GRAFANA_CONFIG_PATH="grafana" go run ./main.go 2>&1 | tee /tmp/e2e-operator-run.log &
       - name: Run tests
         run: |
+          set -o pipefail
           bash hack/test.sh 2>&1 | tee /tmp/e2e-test.log
       - name: Upload operator logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -100,7 +100,7 @@ jobs:
           REDIS_CONFIG_PATH="build/redis" GRAFANA_CONFIG_PATH="grafana" go run ./main.go 2>&1 | tee /tmp/e2e-operator-run.log &
       - name: Run tests
         run: |
-          bash hack/test.sh 2>&1 > /tmp/e2e-test.log
+          bash hack/test.sh 2>&1 | tee /tmp/e2e-test.log
       - name: Upload operator logs
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
**What type of PR is this?**

 /kind chore

**What does this PR do / why we need it**:

Currently, the output of e2e tests is only redirected to a log file. With this change, the logs will also be displayed on the console
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
