### PR TITLE
chore: remove invalid unit test

### DIFF
--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -627,34 +627,6 @@ func TestSetManagedNamespaces(t *testing.T) {
 	}
 }
 
-func TestGetRedisConf(t *testing.T) {
-	s1 := getRedisConf(true)
-	//assert.Equal(t, "", s1)
-
-	s1 = getRedisConf(false)
-	//assert.Equal(t, "", s1)
-
-	s1 = getRedisSentinelConf(true)
-	//assert.Equal(t, "", s1)
-
-	s1 = getRedisSentinelConf(false)
-	//assert.Equal(t, "", s1)
-
-	a := makeTestArgoCD()
-
-	s1 = getRedisInitScript(a, true)
-	//assert.Equal(t, "", s1)
-
-	s1 = getRedisLivenessScript(false)
-	//assert.Equal(t, "", s1)
-
-	s1 = getRedisReadinessScript(true)
-	//assert.Equal(t, "", s1)
-
-	s1 = getSentinelLivenessScript(true)
-	assert.Equal(t, "", s1)
-}
-
 func TestGenerateRandomString(t *testing.T) {
 
 	// verify the creation of unique strings


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

As part of PR: https://github.com/argoproj-labs/argocd-operator/pull/647 I inadvertently committed an invalid unit test.  This PR is to remove that test.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

Run `REDIS_CONFIG_PATH="$PWD/build/redis" make test`.  The tests should complete without errors.
