### PR TITLE
chore: fix flaky e2e test

### DIFF
--- a/tests/k8s/1-005_validate-custom-argocd-namespace/02-assert.yaml
+++ b/tests/k8s/1-005_validate-custom-argocd-namespace/02-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

/kind failing-test

**What does this PR do / why we need it**:

After updating to use argocd 2.4-rc2, the `1-005_validate-custom-argocd-namespace` e2e test started failing most of the time, with an occasional successful run.

The problem seems to be that when the test creates the application CR, the repo server is not yet ready, and so argocd backs off and waits to retry the sync.  For some reason it seems to be backing off for longer than before.

The current timeout for the test is 300 seconds.  After running the test case multiple times with a timeout of 600 seconds, I see that most of the time the test is taking around 400 seconds to complete successfully, with the occasional run completing in under 300 seconds.

This PR increases the timeout for the `1-005_validate-custom-argocd-namespace` test to 600 seconds

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

Run the e2e test multiple times and ensure it is always successful
```bash
kubectl kuttl test ./tests/k8s --config ./tests/kuttl-tests.yaml --test 1-005_validate-custom-argocd-namespace
```