### PR TITLE
minor change to AppSync description

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -93,7 +93,7 @@ type ArgoCDApplicationControllerSpec struct {
 	ParallelismLimit int32 `json:"parallelismLimit,omitempty"`
 
 	// AppSync is used to control the sync frequency, by default the ArgoCD
-	// controller polls Git every 3m by default.
+	// controller polls Git every 3m.
 	//
 	// Set this to a duration, e.g. 10m or 600s to control the synchronisation
 	// frequency.


### PR DESCRIPTION
Removes duplicate "by default" in the description of the "AppSync" parameter

**What type of PR is this?**

/kind documentation



**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [X] Documentation has been updated.
