### PR TITLE
fix: issue with redis image upgrade

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -599,7 +599,7 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoprojv1a1.ArgoCD) erro
 			return r.Client.Delete(context.TODO(), deploy)
 		}
 		changed := false
-		actualImage := deploy.Spec.Template.Spec.Containers[0].Image
+		actualImage := existing.Spec.Template.Spec.Containers[0].Image
 		desiredImage := getRedisContainerImage(cr)
 		if actualImage != desiredImage {
 			existing.Spec.Template.Spec.Containers[0].Image = desiredImage


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

> /kind bug

**What does this PR do / why we need it**:
Redis Image upgrade is not work as expected. There is an issue with the current implementation that does not allow the operator to upgrade the redis image.

This PR will fix the above issue.

**Have you updated the necessary documentation?**
NA

**How to test changes / Special notes to the reviewer**:
1. Run the below UnitTest
`/usr/local/go/bin/go test -timeout 30s -run ^TestReconcileArgoCD_reconcileRedisDeployment_testImageUpgrade$ github.com/argoproj-labs/argocd-operator/controllers/argocd`

or

2. Run the operator locally using `make install run`
    - Create an Argo CD instance.
    - Stop the operator
    - Rerun the operator using the below command
       `ARGOCD_REDIS_IMAGE=docker.io/redis/redis` make run
    - Verify the redis deployment is recreated with new Image.
