### PR TITLE
fix: minor spacing issue in trigger configuration (#687)

### DIFF
--- a/controllers/argocd/notifications_util.go
+++ b/controllers/argocd/notifications_util.go
@@ -535,7 +535,7 @@ teams:
   - app-sync-status-unknown
   when: app.status.sync.status == 'Unknown'`
 
-	notificationsConfig["trigger.on-sync-succeeded"] = `-description: Application syncing has succeeded
+	notificationsConfig["trigger.on-sync-succeeded"] = `- description: Application syncing has succeeded
   send:
   - app-sync-succeeded
   when: app.status.operationState.phase in ['Succeeded']`


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

 /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
Spacing issue in the on-sync-succeeded trigger configuration in argocd-notifications-cm throws an invalid JSON request, which blocks notifications from being sent out on successful app sync. This PR fixes that
cherry picks notification trigger config fix into release-0.4 branch
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
