### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -16,7 +16,6 @@ package argocd
 
 import (
 	"context"
-	"os"
 	"sort"
 	"testing"
 
@@ -170,8 +169,7 @@ func TestReconcileApplicationSetProxyConfiguration(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
 	// Proxy Env vars
-	setProxyEnvVars()
-	defer unSetProxyEnvVars()
+	setProxyEnvVars(t)
 
 	a := makeTestArgoCD()
 	a.Spec.ApplicationSet = &v1alpha1.ArgoCDApplicationSet{}
@@ -354,8 +352,7 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			for testEnvName, testEnvValue := range test.envVars {
-				os.Setenv(testEnvName, testEnvValue)
-				t.Cleanup(func() { os.Unsetenv(testEnvName) })
+				t.Setenv(testEnvName, testEnvValue)
 			}
 
 			a := makeTestArgoCD()
@@ -484,14 +481,8 @@ func appsetAssertExpectedLabels(t *testing.T, meta *metav1.ObjectMeta) {
 	assert.Equal(t, meta.Labels["app.kubernetes.io/component"], "controller")
 }
 
-func setProxyEnvVars() {
-	os.Setenv("HTTPS_PROXY", "https://example.com")
-	os.Setenv("HTTP_PROXY", "http://example.com")
-	os.Setenv("NO_PROXY", ".cluster.local")
-}
-
-func unSetProxyEnvVars() {
-	os.Unsetenv("HTTPS_PROXY")
-	os.Unsetenv("HTTP_PROXY")
-	os.Unsetenv("NO_PROXY")
+func setProxyEnvVars(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "https://example.com")
+	t.Setenv("HTTP_PROXY", "http://example.com")
+	t.Setenv("NO_PROXY", ".cluster.local")
 }

--- a/controllers/argocd/argocd_controller_test.go
+++ b/controllers/argocd/argocd_controller_test.go
@@ -17,7 +17,6 @@ package argocd
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -104,7 +103,6 @@ func TestReconcileArgoCD_Reconcile(t *testing.T) {
 }
 
 func TestReconcileArgoCD_Reconcile_RemoveManagedByLabelOnArgocdDeletion(t *testing.T) {
-	restoreEnv(t)
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
@@ -136,7 +134,7 @@ func TestReconcileArgoCD_Reconcile_RemoveManagedByLabelOnArgocdDeletion(t *testi
 			assert.NoError(t, err)
 
 			if test.isRemoveManagedByLabelOnArgoCDDeletionSet {
-				os.Setenv("REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION", "true")
+				t.Setenv("REMOVE_MANAGED_BY_LABEL_ON_ARGOCD_DELETION", "true")
 			}
 
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -2,7 +2,6 @@ package argocd
 
 import (
 	"context"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -529,9 +528,9 @@ func TestReconcileArgoCD_reconcileRepoDeployment_command(t *testing.T) {
 // environment propagated.
 func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
 
-	os.Setenv("HTTP_PROXY", testHTTPProxy)
-	os.Setenv("HTTPS_PROXY", testHTTPSProxy)
-	os.Setenv("no_proxy", testNoProxy)
+	t.Setenv("HTTP_PROXY", testHTTPProxy)
+	t.Setenv("HTTPS_PROXY", testHTTPSProxy)
+	t.Setenv("no_proxy", testNoProxy)
 
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
@@ -558,13 +557,6 @@ func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
 // If the deployments already exist, they should be updated to reflect the new
 // environment variables.
 func TestReconcileArgoCD_reconcileDeployments_proxy_update_existing(t *testing.T) {
-	keys := []string{
-		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
-		"http_proxy", "https_proxy", "no_proxy",
-		"DISABLE_DEX"}
-	for _, k := range keys {
-		os.Unsetenv(k)
-	}
 	logf.SetLogger(ZapLogger(true))
 
 	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
@@ -584,9 +576,9 @@ func TestReconcileArgoCD_reconcileDeployments_proxy_update_existing(t *testing.T
 		refuteDeploymentHasProxyVars(t, r.Client, v)
 	}
 
-	os.Setenv("HTTP_PROXY", testHTTPProxy)
-	os.Setenv("HTTPS_PROXY", testHTTPSProxy)
-	os.Setenv("no_proxy", testNoProxy)
+	t.Setenv("HTTP_PROXY", testHTTPProxy)
+	t.Setenv("HTTPS_PROXY", testHTTPSProxy)
+	t.Setenv("no_proxy", testNoProxy)
 
 	logf.SetLogger(ZapLogger(true))
 
@@ -602,10 +594,9 @@ func TestReconcileArgoCD_reconcileDeployments_proxy_update_existing(t *testing.T
 
 // TODO: This should be subsumed into testing of the HA setup.
 func TestReconcileArgoCD_reconcileDeployments_HA_proxy(t *testing.T) {
-	restoreEnv(t)
-	os.Setenv("HTTP_PROXY", testHTTPProxy)
-	os.Setenv("HTTPS_PROXY", testHTTPSProxy)
-	os.Setenv("no_proxy", testNoProxy)
+	t.Setenv("HTTP_PROXY", testHTTPProxy)
+	t.Setenv("HTTPS_PROXY", testHTTPSProxy)
+	t.Setenv("no_proxy", testNoProxy)
 
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
@@ -620,10 +611,9 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy(t *testing.T) {
 }
 
 func TestReconcileArgoCD_reconcileDeployments_HA_proxy_with_resources(t *testing.T) {
-	restoreEnv(t)
-	os.Setenv("HTTP_PROXY", testHTTPProxy)
-	os.Setenv("HTTPS_PROXY", testHTTPSProxy)
-	os.Setenv("no_proxy", testNoProxy)
+	t.Setenv("HTTP_PROXY", testHTTPProxy)
+	t.Setenv("HTTPS_PROXY", testHTTPSProxy)
+	t.Setenv("no_proxy", testNoProxy)
 
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCDWithResources(func(a *argoprojv1alpha1.ArgoCD) {
@@ -700,10 +690,9 @@ func TestReconcileArgoCD_reconcileRepoDeployment_updatesVolumeMounts(t *testing.
 }
 
 func Test_proxyEnvVars(t *testing.T) {
-	restoreEnv(t)
-	os.Setenv("HTTP_PROXY", testHTTPProxy)
-	os.Setenv("HTTPS_PROXY", testHTTPSProxy)
-	os.Setenv("no_proxy", testNoProxy)
+	t.Setenv("HTTP_PROXY", testHTTPProxy)
+	t.Setenv("HTTPS_PROXY", testHTTPSProxy)
+	t.Setenv("no_proxy", testNoProxy)
 	envTests := []struct {
 		vars []corev1.EnvVar
 		want []corev1.EnvVar
@@ -844,13 +833,6 @@ func TestReconcileArgocd_reconcileRepoServerRedisTLS(t *testing.T) {
 }
 
 func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
-	keys := []string{
-		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
-		"http_proxy", "https_proxy", "no_proxy",
-		"DISABLE_DEX"}
-	for _, k := range keys {
-		os.Unsetenv(k)
-	}
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 	r := makeTestReconciler(t, a)
@@ -1297,8 +1279,7 @@ func TestReconcileArgoCD_reconcileRedisDeployment_testImageUpgrade(t *testing.T)
 	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, existing))
 
 	// Verify Image upgrade
-	os.Setenv("ARGOCD_REDIS_IMAGE", "docker.io/redis/redis:latest")
-	defer os.Unsetenv("ARGOCD_REDIS_IMAGE")
+	t.Setenv("ARGOCD_REDIS_IMAGE", "docker.io/redis/redis:latest")
 	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
 
 	newRedis := &appsv1.Deployment{}
@@ -1315,22 +1296,6 @@ func TestReconcileArgoCD_reconcileRedisDeployment_with_error(t *testing.T) {
 	Register(testErrorHook)
 
 	assert.Error(t, r.reconcileRedisDeployment(cr, false), "this is a test error")
-}
-
-func restoreEnv(t *testing.T) {
-	keys := []string{
-		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
-		"http_proxy", "https_proxy", "no_proxy",
-		"DISABLE_DEX"}
-	env := map[string]string{}
-	for _, v := range keys {
-		env[v] = os.Getenv(v)
-	}
-	t.Cleanup(func() {
-		for k, v := range env {
-			os.Setenv(k, v)
-		}
-	})
 }
 
 func operationProcessors(n int32) argoCDOpt {

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -24,57 +24,45 @@ func Test_isDexDisabled(t *testing.T) {
 	tests := []struct {
 		name                string
 		envVar              string
-		envVarFunc          func(string)
+		envVarFunc          func(*testing.T, string)
 		wantIsDisableDexSet bool
 		wantIsDexDisabled   bool
-		restoreEnvFunc      func()
 	}{
 		{
 			name:                "DISABLE_DEX not set",
 			envVar:              "",
 			envVarFunc:          nil,
 			wantIsDisableDexSet: false,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 		},
 		{
 			name:   "DISABLE_DEX set to false",
 			envVar: "false",
-			envVarFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			envVarFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			wantIsDexDisabled:   false,
 			wantIsDisableDexSet: true,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 		},
 		{
 			name:   "DISABLE_DEX set to true",
 			envVar: "true",
-			envVarFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			envVarFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			wantIsDexDisabled:   true,
 			wantIsDisableDexSet: true,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.restoreEnvFunc()
 			if test.envVarFunc != nil {
-				test.envVarFunc(test.envVar)
+				test.envVarFunc(t, test.envVar)
 			}
 
 			gotIsDexDisabled := isDexDisabled()
 			assert.Equal(t, test.wantIsDexDisabled, gotIsDexDisabled)
 			assert.Equal(t, test.wantIsDisableDexSet, isDisableDexSet)
-			test.restoreEnvFunc()
 		})
 	}
 }
@@ -83,18 +71,14 @@ func TestReconcileArgoCD_reconcileDexDeployment_with_dex_disabled(t *testing.T) 
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
-		name           string
-		setEnvFunc     func(string)
-		restoreEnvFunc func()
-		argoCD         *argoprojv1alpha1.ArgoCD
+		name       string
+		setEnvFunc func(*testing.T, string)
+		argoCD     *argoprojv1alpha1.ArgoCD
 	}{
 		{
 			name: "dex disabled using DISABLE_DEX",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
@@ -105,9 +89,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_with_dex_disabled(t *testing.T) 
 		{
 			name:       "dex disabled by not specifying .spec.sso.provider=dex",
 			setEnvFunc: nil,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = nil
 			}),
@@ -115,9 +96,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_with_dex_disabled(t *testing.T) 
 		{
 			name:       "dex disabled by specifying different provider",
 			setEnvFunc: nil,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: v1alpha1.SSOProviderTypeKeycloak,
@@ -128,10 +106,9 @@ func TestReconcileArgoCD_reconcileDexDeployment_with_dex_disabled(t *testing.T) 
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.restoreEnvFunc()
 			r := makeTestReconciler(t, test.argoCD)
 			if test.setEnvFunc != nil {
-				test.setEnvFunc("true")
+				test.setEnvFunc(t, "true")
 			}
 
 			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
@@ -139,7 +116,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_with_dex_disabled(t *testing.T) 
 			deployment := &appsv1.Deployment{}
 			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, deployment)
 			assert.True(t, apierrors.IsNotFound(err))
-			test.restoreEnvFunc()
 		})
 	}
 }
@@ -150,23 +126,19 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 
 	tests := []struct {
 		name                  string
-		setEnvFunc            func(string)
+		setEnvFunc            func(*testing.T, string)
 		updateCrFunc          func(cr *argoprojv1alpha1.ArgoCD)
-		restoreEnvFunc        func()
-		updateEnvFunc         func(string)
+		updateEnvFunc         func(*testing.T, string)
 		argoCD                *argoprojv1alpha1.ArgoCD
 		wantDeploymentDeleted bool
 	}{
 		{
 			name: "dex disabled using DISABLE_DEX",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
-			updateEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			updateEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
@@ -186,9 +158,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = nil
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -207,9 +176,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 					Provider: v1alpha1.SSOProviderTypeKeycloak,
 				}
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -222,14 +188,11 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 		},
 		{
 			name: "dex disabled but deployment not deleted because of existing dex configuration",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: nil,
-			updateEnvFunc: func(envVar string) {
-				os.Unsetenv("DISABLE_DEX")
-			},
-			restoreEnvFunc: func() {
+			updateEnvFunc: func(t *testing.T, envVar string) {
 				os.Unsetenv("DISABLE_DEX")
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
@@ -243,10 +206,9 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.restoreEnvFunc()
 			r := makeTestReconciler(t, test.argoCD)
 			if test.setEnvFunc != nil {
-				test.setEnvFunc("false")
+				test.setEnvFunc(t, "false")
 			}
 
 			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
@@ -257,7 +219,7 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
-				test.updateEnvFunc("true")
+				test.updateEnvFunc(t, "true")
 			}
 			if test.updateCrFunc != nil {
 				test.updateCrFunc(test.argoCD)
@@ -272,7 +234,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 			} else {
 				assert.NoError(t, err)
 			}
-			test.restoreEnvFunc()
 		})
 	}
 }
@@ -281,19 +242,14 @@ func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
-		name           string
-		setEnvFunc     func(string)
-		restoreEnvFunc func()
-		updateEnvFunc  func(string)
-		argoCD         *argoprojv1alpha1.ArgoCD
+		name       string
+		setEnvFunc func(*testing.T, string)
+		argoCD     *argoprojv1alpha1.ArgoCD
 	}{
 		{
 			name: "dex with resources - DISABLE_DEX",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
@@ -314,9 +270,6 @@ func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
 		{
 			name:       "dex with resources - .spec.sso.provider=dex",
 			setEnvFunc: nil,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -339,10 +292,9 @@ func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.restoreEnvFunc()
 			r := makeTestReconciler(t, test.argoCD)
 			if test.setEnvFunc != nil {
-				test.setEnvFunc("false")
+				test.setEnvFunc(t, "false")
 			}
 
 			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
@@ -368,7 +320,6 @@ func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
 			}
 			assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Resources, testResources)
 			assert.Equal(t, deployment.Spec.Template.Spec.InitContainers[0].Resources, testResources)
-			test.restoreEnvFunc()
 		})
 	}
 }
@@ -568,17 +519,16 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		setEnvFunc     func(string)
-		updateCrFunc   func(cr *argoprojv1alpha1.ArgoCD)
-		restoreEnvFunc func()
-		argoCD         *argoprojv1alpha1.ArgoCD
-		wantPodSpec    corev1.PodSpec
+		name         string
+		setEnvFunc   func(*testing.T, string)
+		updateCrFunc func(cr *argoprojv1alpha1.ArgoCD)
+		argoCD       *argoprojv1alpha1.ArgoCD
+		wantPodSpec  corev1.PodSpec
 	}{
 		{
 			name: "update dex deployment - .spec.dex + DISABLE_DEX",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Image = "justatest"
@@ -587,9 +537,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 					Image:   "testdex",
 					Version: "v0.0.1",
 				}
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
 			},
 			argoCD: makeTestArgoCD(func(ac *argoprojv1alpha1.ArgoCD) {
 				ac.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
@@ -612,9 +559,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 					},
 				}
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -629,10 +573,9 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.restoreEnvFunc()
 			r := makeTestReconciler(t, test.argoCD)
 			if test.setEnvFunc != nil {
-				test.setEnvFunc("false")
+				test.setEnvFunc(t, "false")
 			}
 
 			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
@@ -654,8 +597,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 				deployment))
 
 			assert.Equal(t, test.wantPodSpec, deployment.Spec.Template.Spec)
-			test.restoreEnvFunc()
-
 		})
 	}
 }
@@ -666,28 +607,24 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 
 	tests := []struct {
 		name               string
-		setEnvFunc         func(string)
+		setEnvFunc         func(*testing.T, string)
 		updateCrFunc       func(cr *argoprojv1alpha1.ArgoCD)
-		updateEnvFunc      func(string)
-		restoreEnvFunc     func()
+		updateEnvFunc      func(*testing.T, string)
 		argoCD             *argoprojv1alpha1.ArgoCD
 		wantServiceDeleted bool
 	}{
 		{
 			name: "dex disabled using DISABLE_DEX",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
 					OpenShiftOAuth: true,
 				}
 			},
-			updateEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			updateEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
@@ -701,9 +638,6 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 			setEnvFunc: nil,
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = nil
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
@@ -723,9 +657,6 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 					Provider: v1alpha1.SSOProviderTypeKeycloak,
 				}
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -738,19 +669,16 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 		},
 		{
 			name: "dex disabled but deployment not deleted because of existing dex configuration",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: nil,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
 					OpenShiftOAuth: true,
 				}
 			}),
-			updateEnvFunc: func(env string) {
+			updateEnvFunc: func(t *testing.T, env string) {
 				os.Unsetenv("DISABLE_DEX")
 			},
 			wantServiceDeleted: false,
@@ -759,10 +687,9 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.restoreEnvFunc()
 			r := makeTestReconciler(t, test.argoCD)
 			if test.setEnvFunc != nil {
-				test.setEnvFunc("false")
+				test.setEnvFunc(t, "false")
 			}
 
 			assert.NoError(t, r.reconcileDexService(test.argoCD))
@@ -773,7 +700,7 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
-				test.updateEnvFunc("true")
+				test.updateEnvFunc(t, "true")
 			}
 			if test.updateCrFunc != nil {
 				test.updateCrFunc(test.argoCD)
@@ -788,8 +715,6 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 			} else {
 				assert.NoError(t, err)
 			}
-
-			test.restoreEnvFunc()
 		})
 	}
 }
@@ -800,28 +725,24 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 
 	tests := []struct {
 		name                      string
-		setEnvFunc                func(string)
+		setEnvFunc                func(*testing.T, string)
 		updateCrFunc              func(cr *argoprojv1alpha1.ArgoCD)
-		restoreEnvFunc            func()
-		updateEnvFunc             func(string)
+		updateEnvFunc             func(*testing.T, string)
 		argoCD                    *argoprojv1alpha1.ArgoCD
 		wantServiceAccountDeleted bool
 	}{
 		{
 			name: "dex disabled using DISABLE_DEX",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
 					OpenShiftOAuth: false,
 				}
 			},
-			updateEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			updateEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
@@ -835,9 +756,6 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 			setEnvFunc: nil,
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = nil
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
@@ -857,9 +775,6 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 					Provider: v1alpha1.SSOProviderTypeKeycloak,
 				}
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -872,14 +787,11 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 		},
 		{
 			name: "dex disabled but sa not deleted because of existing dex configuration",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: nil,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
-			updateEnvFunc: func(string) {
+			updateEnvFunc: func(*testing.T, string) {
 				os.Unsetenv("DISABLE_DEX")
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
@@ -893,10 +805,9 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.restoreEnvFunc()
 			r := makeTestReconciler(t, test.argoCD)
 			if test.setEnvFunc != nil {
-				test.setEnvFunc("false")
+				test.setEnvFunc(t, "false")
 			}
 
 			sa, err := r.reconcileServiceAccount(common.ArgoCDDexServerComponent, test.argoCD)
@@ -907,7 +818,7 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
-				test.updateEnvFunc("true")
+				test.updateEnvFunc(t, "true")
 			}
 			if test.updateCrFunc != nil {
 				test.updateCrFunc(test.argoCD)
@@ -923,40 +834,34 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 			} else {
 				assert.NoError(t, err)
 			}
-			test.restoreEnvFunc()
 		})
 	}
 }
 
 // When Dex is enabled dex role should be created, when disabled the Dex role should be removed
 func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
-	restoreEnv(t)
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
 		name            string
-		setEnvFunc      func(string)
+		setEnvFunc      func(*testing.T, string)
 		updateCrFunc    func(cr *argoprojv1alpha1.ArgoCD)
-		restoreEnvFunc  func()
-		updateEnvFunc   func(string)
+		updateEnvFunc   func(*testing.T, string)
 		argoCD          *argoprojv1alpha1.ArgoCD
 		wantRoleDeleted bool
 	}{
 		{
 			name: "dex disabled using DISABLE_DEX",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
 					OpenShiftOAuth: false,
 				}
 			},
-			updateEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			updateEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
@@ -970,9 +875,6 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 			setEnvFunc: nil,
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = nil
-			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
@@ -992,9 +894,6 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 					Provider: v1alpha1.SSOProviderTypeKeycloak,
 				}
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -1007,14 +906,11 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 		},
 		{
 			name: "dex disabled but sa not deleted because of existing dex configuration",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: nil,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
-			updateEnvFunc: func(string) {
+			updateEnvFunc: func(*testing.T, string) {
 				os.Unsetenv("DISABLE_DEX")
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
@@ -1028,8 +924,6 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
-			test.restoreEnvFunc()
 			r := makeTestReconciler(t, test.argoCD)
 			assert.NoError(t, createNamespace(r, test.argoCD.Namespace, ""))
 
@@ -1037,7 +931,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 			role := newRole(common.ArgoCDDexServerComponent, rules, test.argoCD)
 
 			if test.setEnvFunc != nil {
-				test.setEnvFunc("false")
+				test.setEnvFunc(t, "false")
 			}
 
 			_, err := r.reconcileRole(common.ArgoCDDexServerComponent, rules, test.argoCD)
@@ -1048,7 +942,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
-				test.updateEnvFunc("true")
+				test.updateEnvFunc(t, "true")
 			}
 			if test.updateCrFunc != nil {
 				test.updateCrFunc(test.argoCD)
@@ -1064,7 +958,6 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			test.restoreEnvFunc()
 		})
 	}
 }
@@ -1075,23 +968,19 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 
 	tests := []struct {
 		name                   string
-		setEnvFunc             func(string)
+		setEnvFunc             func(*testing.T, string)
 		updateCrFunc           func(cr *argoprojv1alpha1.ArgoCD)
-		restoreEnvFunc         func()
-		updateEnvFunc          func(string)
+		updateEnvFunc          func(*testing.T, string)
 		argoCD                 *argoprojv1alpha1.ArgoCD
 		wantRoleBindingDeleted bool
 	}{
 		{
 			name: "dex disabled using DISABLE_DEX",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
-			updateEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			updateEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.Dex = &v1alpha1.ArgoCDDexSpec{
@@ -1111,9 +1000,6 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = nil
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -1132,9 +1018,6 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 					Provider: v1alpha1.SSOProviderTypeKeycloak,
 				}
 			},
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoprojv1alpha1.SSOProviderTypeDex,
@@ -1147,14 +1030,11 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 		},
 		{
 			name: "dex disabled but sa not deleted because of existing dex configuration",
-			setEnvFunc: func(envVar string) {
-				os.Setenv("DISABLE_DEX", envVar)
+			setEnvFunc: func(t *testing.T, envVar string) {
+				t.Setenv("DISABLE_DEX", envVar)
 			},
 			updateCrFunc: nil,
-			restoreEnvFunc: func() {
-				os.Unsetenv("DISABLE_DEX")
-			},
-			updateEnvFunc: func(string) {
+			updateEnvFunc: func(*testing.T, string) {
 				os.Unsetenv("DISABLE_DEX")
 			},
 			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
@@ -1168,8 +1048,6 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
-			test.restoreEnvFunc()
 			r := makeTestReconciler(t, test.argoCD)
 			assert.NoError(t, createNamespace(r, test.argoCD.Namespace, ""))
 
@@ -1177,7 +1055,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 			roleBinding := newRoleBindingWithname(common.ArgoCDDexServerComponent, test.argoCD)
 
 			if test.setEnvFunc != nil {
-				test.setEnvFunc("false")
+				test.setEnvFunc(t, "false")
 			}
 
 			assert.NoError(t, r.reconcileRoleBinding(common.ArgoCDDexServerComponent, rules, test.argoCD))
@@ -1188,7 +1066,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
-				test.updateEnvFunc("true")
+				test.updateEnvFunc(t, "true")
 			}
 			if test.updateCrFunc != nil {
 				test.updateCrFunc(test.argoCD)
@@ -1204,8 +1082,6 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			test.restoreEnvFunc()
-
 		})
 	}
 }

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -17,7 +17,6 @@ package argocd
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -76,19 +75,17 @@ func TestKeycloakContainerImage(t *testing.T) {
 	defer removeTemplateAPI()
 	tests := []struct {
 		name               string
-		setEnvVarFunc      func(string)
+		setEnvVarFunc      func(*testing.T, string)
 		envVar             string
-		restoreEnvFunc     func(t *testing.T)
 		argoCD             *argoprojv1alpha1.ArgoCD
 		updateCrFunc       func(cr *argoprojv1alpha1.ArgoCD)
 		templateAPIFound   bool
 		wantContainerImage string
 	}{
 		{
-			name:           "no .spec.sso, no ArgoCDKeycloakImageEnvName env var set",
-			setEnvVarFunc:  nil,
-			envVar:         "",
-			restoreEnvFunc: restoreEnv,
+			name:          "no .spec.sso, no ArgoCDKeycloakImageEnvName env var set",
+			setEnvVarFunc: nil,
+			envVar:        "",
 			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoappv1.SSOProviderTypeKeycloak,
@@ -99,10 +96,9 @@ func TestKeycloakContainerImage(t *testing.T) {
 			wantContainerImage: "quay.io/keycloak/keycloak@sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9",
 		},
 		{
-			name:           "no .spec.sso, no ArgoCDKeycloakImageEnvName env var set - for OCP",
-			setEnvVarFunc:  nil,
-			envVar:         "",
-			restoreEnvFunc: restoreEnv,
+			name:          "no .spec.sso, no ArgoCDKeycloakImageEnvName env var set - for OCP",
+			setEnvVarFunc: nil,
+			envVar:        "",
 			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoappv1.SSOProviderTypeKeycloak,
@@ -114,11 +110,10 @@ func TestKeycloakContainerImage(t *testing.T) {
 		},
 		{
 			name: "ArgoCDKeycloakImageEnvName env var set",
-			setEnvVarFunc: func(s string) {
-				os.Setenv(common.ArgoCDKeycloakImageEnvName, s)
+			setEnvVarFunc: func(t *testing.T, s string) {
+				t.Setenv(common.ArgoCDKeycloakImageEnvName, s)
 			},
-			envVar:         "envImage:latest",
-			restoreEnvFunc: restoreEnv,
+			envVar: "envImage:latest",
 			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoappv1.SSOProviderTypeKeycloak,
@@ -130,11 +125,10 @@ func TestKeycloakContainerImage(t *testing.T) {
 		},
 		{
 			name: "both cr.spec.sso.Image and ArgoCDKeycloakImageEnvName are set.",
-			setEnvVarFunc: func(s string) {
-				os.Setenv(common.ArgoCDKeycloakImageEnvName, s)
+			setEnvVarFunc: func(t *testing.T, s string) {
+				t.Setenv(common.ArgoCDKeycloakImageEnvName, s)
 			},
-			envVar:         "envImage:latest",
-			restoreEnvFunc: restoreEnv,
+			envVar: "envImage:latest",
 			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoappv1.SSOProviderTypeKeycloak,
@@ -152,11 +146,10 @@ func TestKeycloakContainerImage(t *testing.T) {
 		},
 		{
 			name: "both cr.spec.sso.keycloak.Image and ArgoCDKeycloakImageEnvName are set",
-			setEnvVarFunc: func(s string) {
-				os.Setenv(common.ArgoCDKeycloakImageEnvName, s)
+			setEnvVarFunc: func(t *testing.T, s string) {
+				t.Setenv(common.ArgoCDKeycloakImageEnvName, s)
 			},
-			envVar:         "envImage:latest",
-			restoreEnvFunc: restoreEnv,
+			envVar: "envImage:latest",
 			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
 				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
 					Provider: argoappv1.SSOProviderTypeKeycloak,
@@ -178,11 +171,10 @@ func TestKeycloakContainerImage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.restoreEnvFunc(t)
 			templateAPIFound = test.templateAPIFound
 
 			if test.setEnvVarFunc != nil {
-				test.setEnvVarFunc(test.envVar)
+				test.setEnvVarFunc(t, test.envVar)
 			}
 			if test.updateCrFunc != nil {
 				test.updateCrFunc(test.argoCD)
@@ -261,7 +253,7 @@ func TestNewKeycloakTemplate_testDeploymentConfig(t *testing.T) {
 
 func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
 	// For OpenShift Container Platform.
-	os.Setenv(common.ArgoCDKeycloakImageEnvName, "")
+	t.Setenv(common.ArgoCDKeycloakImageEnvName, "")
 	templateAPIFound = true
 	defer removeTemplateAPI()
 

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -90,7 +90,7 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, &v1.ClusterRole{}))
 	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, &v1.ClusterRole{}).Error(), "not found")
 
-	os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
+	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
 	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
@@ -159,8 +159,7 @@ func TestReconcileArgoCD_reconcileRole_custom_role(t *testing.T) {
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// set the custom role as env variable
-	assert.NoError(t, os.Setenv(common.ArgoCDControllerClusterRoleEnvName, "custom-role"))
-	defer os.Unsetenv(common.ArgoCDControllerClusterRoleEnvName)
+	t.Setenv(common.ArgoCDControllerClusterRoleEnvName, "custom-role")
 
 	_, err = r.reconcileRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -3,7 +3,6 @@ package argocd
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -129,15 +128,13 @@ func TestReconcileArgoCD_reconcileRoleBinding_custom_role(t *testing.T) {
 		assert.Equal(t, roleBinding.RoleRef, expectedRoleRef)
 	}
 
-	assert.NoError(t, os.Setenv(common.ArgoCDControllerClusterRoleEnvName, "custom-controller-role"))
-	defer os.Unsetenv(common.ArgoCDControllerClusterRoleEnvName)
+	t.Setenv(common.ArgoCDControllerClusterRoleEnvName, "custom-controller-role")
 	assert.NoError(t, r.reconcileRoleBinding(common.ArgoCDApplicationControllerComponent, p, a))
 
 	expectedName = fmt.Sprintf("%s-%s", a.Name, "argocd-application-controller")
 	checkForUpdatedRoleRef(t, "custom-controller-role", expectedName)
 
-	assert.NoError(t, os.Setenv(common.ArgoCDServerClusterRoleEnvName, "custom-server-role"))
-	defer os.Unsetenv(common.ArgoCDServerClusterRoleEnvName)
+	t.Setenv(common.ArgoCDServerClusterRoleEnvName, "custom-server-role")
 	assert.NoError(t, r.reconcileRoleBinding("argocd-server", p, a))
 
 	expectedName = fmt.Sprintf("%s-%s", a.Name, "argocd-server")

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -411,8 +410,7 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
 	assert.Equal(t, string(testSecret.Data["namespaces"]), want)
 
-	os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
-	defer os.Unsetenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES")
+	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
 
 	assert.NoError(t, r.reconcileClusterPermissionsSecret(a))
 	//assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret), "not found")

--- a/controllers/argocd/service_account_test.go
+++ b/controllers/argocd/service_account_test.go
@@ -95,7 +95,7 @@ func TestReconcileArgoCD_reconcileServiceAccountClusterPermissions(t *testing.T)
 	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRoleName}, reconcileClusterRole))
 	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRoleName}, reconcileClusterRole).Error(), "not found")
 
-	os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
+	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
 
 	// objective is to verify if the right SA associations have happened.
 	assert.NoError(t, r.reconcileServiceAccountClusterPermissions(workloadIdentifier, testRules(), a))

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -3,7 +3,6 @@ package argocd
 import (
 	"context"
 	b64 "encoding/base64"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -59,11 +58,7 @@ var imageTests = []struct {
 		imageFunc: getDexContainerImage,
 		want:      dexTestImage,
 		pre: func(t *testing.T) {
-			old := os.Getenv(common.ArgoCDDexImageEnvName)
-			t.Cleanup(func() {
-				os.Setenv(common.ArgoCDDexImageEnvName, old)
-			})
-			os.Setenv(common.ArgoCDDexImageEnvName, dexTestImage)
+			t.Setenv(common.ArgoCDDexImageEnvName, dexTestImage)
 		},
 	},
 	{
@@ -84,11 +79,7 @@ var imageTests = []struct {
 		imageFunc: getArgoContainerImage,
 		want:      argoTestImage,
 		pre: func(t *testing.T) {
-			old := os.Getenv(common.ArgoCDImageEnvName)
-			t.Cleanup(func() {
-				os.Setenv(common.ArgoCDImageEnvName, old)
-			})
-			os.Setenv(common.ArgoCDImageEnvName, argoTestImage)
+			t.Setenv(common.ArgoCDImageEnvName, argoTestImage)
 		},
 	},
 	{
@@ -110,11 +101,7 @@ var imageTests = []struct {
 		imageFunc: getGrafanaContainerImage,
 		want:      grafanaTestImage,
 		pre: func(t *testing.T) {
-			old := os.Getenv(common.ArgoCDGrafanaImageEnvName)
-			t.Cleanup(func() {
-				os.Setenv(common.ArgoCDGrafanaImageEnvName, old)
-			})
-			os.Setenv(common.ArgoCDGrafanaImageEnvName, grafanaTestImage)
+			t.Setenv(common.ArgoCDGrafanaImageEnvName, grafanaTestImage)
 		},
 	},
 	{
@@ -136,11 +123,7 @@ var imageTests = []struct {
 		imageFunc: getRedisContainerImage,
 		want:      redisTestImage,
 		pre: func(t *testing.T) {
-			old := os.Getenv(common.ArgoCDRedisImageEnvName)
-			t.Cleanup(func() {
-				os.Setenv(common.ArgoCDRedisImageEnvName, old)
-			})
-			os.Setenv(common.ArgoCDRedisImageEnvName, redisTestImage)
+			t.Setenv(common.ArgoCDRedisImageEnvName, redisTestImage)
 		},
 	},
 	{
@@ -164,11 +147,7 @@ var imageTests = []struct {
 		imageFunc: getRedisHAContainerImage,
 		want:      redisHATestImage,
 		pre: func(t *testing.T) {
-			old := os.Getenv(common.ArgoCDRedisHAImageEnvName)
-			t.Cleanup(func() {
-				os.Setenv(common.ArgoCDRedisHAImageEnvName, old)
-			})
-			os.Setenv(common.ArgoCDRedisHAImageEnvName, redisHATestImage)
+			t.Setenv(common.ArgoCDRedisHAImageEnvName, redisHATestImage)
 		},
 	},
 	{
@@ -192,11 +171,7 @@ var imageTests = []struct {
 		imageFunc: getRedisHAProxyContainerImage,
 		want:      redisHAProxyTestImage,
 		pre: func(t *testing.T) {
-			old := os.Getenv(common.ArgoCDRedisHAProxyImageEnvName)
-			t.Cleanup(func() {
-				os.Setenv(common.ArgoCDRedisHAProxyImageEnvName, old)
-			})
-			os.Setenv(common.ArgoCDRedisHAProxyImageEnvName, redisHAProxyTestImage)
+			t.Setenv(common.ArgoCDRedisHAProxyImageEnvName, redisHAProxyTestImage)
 		},
 	},
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind code-refactoring

**What does this PR do / why we need it**:

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

The changes are covered by the CI job.
