### PR TITLE
Fix: reconcile repo server on mountSAToken and mountSAToken Name change setting

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1119,6 +1119,7 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD, useTL
 			existing.Spec.Template.Spec.InitContainers = deploy.Spec.Template.Spec.InitContainers
 			changed = true
 		}
+
 		if !reflect.DeepEqual(deploy.Spec.Replicas, existing.Spec.Replicas) {
 			existing.Spec.Replicas = deploy.Spec.Replicas
 			changed = true

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1123,6 +1123,17 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD, useTL
 			existing.Spec.Replicas = deploy.Spec.Replicas
 			changed = true
 		}
+
+		if deploy.Spec.Template.Spec.AutomountServiceAccountToken != existing.Spec.Template.Spec.AutomountServiceAccountToken {
+			existing.Spec.Template.Spec.AutomountServiceAccountToken = deploy.Spec.Template.Spec.AutomountServiceAccountToken
+			changed = true
+		}
+
+		if deploy.Spec.Template.Spec.ServiceAccountName != existing.Spec.Template.Spec.ServiceAccountName {
+			existing.Spec.Template.Spec.ServiceAccountName = deploy.Spec.Template.Spec.ServiceAccountName
+			changed = true
+		}
+
 		if changed {
 			return r.Client.Update(context.TODO(), existing)
 		}

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -19,6 +19,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -1627,4 +1628,55 @@ func serverDefaultVolumeMounts() []corev1.VolumeMount {
 		},
 	}
 	return mounts
+}
+
+func TestReconcileArgoCD_reconcile_RepoServerChanges(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	tests := []struct {
+		name           string
+		mountSAToken   bool
+		serviceAccount string
+	}{
+		{
+			name:           "default Deployment",
+			mountSAToken:   false,
+			serviceAccount: "default",
+		},
+		{
+			name:           "change Service Account and mountSAToken",
+			mountSAToken:   false,
+			serviceAccount: "argocd-argocd-server",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+				a.Spec.Repo.MountSAToken = test.mountSAToken
+				a.Spec.Repo.ServiceAccount = test.serviceAccount
+			})
+			r := makeTestReconciler(t, a)
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      test.serviceAccount,
+					Namespace: a.Namespace,
+					Labels:    argoutil.LabelsForCluster(a),
+				},
+			}
+			r.Client.Create(context.TODO(), sa)
+			err := r.reconcileRepoDeployment(a, false)
+			assert.NoError(t, err)
+
+			deployment := &appsv1.Deployment{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      "argocd-repo-server",
+				Namespace: testNamespace,
+			}, deployment)
+			assert.NoError(t, err)
+			assert.Equal(t, test.mountSAToken, deployment.Spec.Template.Spec.AutomountServiceAccountToken)
+			assert.Equal(t, test.serviceAccount, deployment.Spec.Template.Spec.ServiceAccountName)
+		})
+	}
 }

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1645,7 +1645,7 @@ func TestReconcileArgoCD_reconcile_RepoServerChanges(t *testing.T) {
 		},
 		{
 			name:           "change Service Account and mountSAToken",
-			mountSAToken:   false,
+			mountSAToken:   true,
 			serviceAccount: "argocd-argocd-server",
 		},
 	}
@@ -1675,7 +1675,7 @@ func TestReconcileArgoCD_reconcile_RepoServerChanges(t *testing.T) {
 				Namespace: testNamespace,
 			}, deployment)
 			assert.NoError(t, err)
-			assert.Equal(t, test.mountSAToken, deployment.Spec.Template.Spec.AutomountServiceAccountToken)
+			assert.Equal(t, &test.mountSAToken, deployment.Spec.Template.Spec.AutomountServiceAccountToken)
 			assert.Equal(t, test.serviceAccount, deployment.Spec.Template.Spec.ServiceAccountName)
 		})
 	}

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1027,30 +1027,30 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 
 	// Add new predicate to delete Notifications Resources. The predicate watches the Argo CD CR for changes to the `.spec.Notifications.Enabled`
 	// field. When a change is detected that results in notifications being disabled, we trigger deletion of notifications resources
-	repoDeployment := predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			newCR, ok := e.ObjectNew.(*argoprojv1a1.ArgoCD)
-			if !ok {
-				return false
-			}
-			oldCR, ok := e.ObjectOld.(*argoprojv1a1.ArgoCD)
-			if !ok {
-				return false
-			}
-			if (oldCR.Spec.Repo.ServiceAccount != newCR.Spec.Repo.ServiceAccount) || (!oldCR.Spec.Repo.MountSAToken && newCR.Spec.Repo.MountSAToken) {
-				useTLSForRedis := r.redisShouldUseTLS(newCR)
-				err := r.reconcileRepoDeployment(newCR, useTLSForRedis)
-				if err != nil {
-					log.Error(err, fmt.Sprintf("Failed to delete notifications controller resources for ArgoCD %s in namespace %s",
-						newCR.Name, newCR.Namespace))
-				}
-			}
-			return true
-		},
-	}
+	// repoDeployment := predicate.Funcs{
+	// 	UpdateFunc: func(e event.UpdateEvent) bool {
+	// 		newCR, ok := e.ObjectNew.(*argoprojv1a1.ArgoCD)
+	// 		if !ok {
+	// 			return false
+	// 		}
+	// 		oldCR, ok := e.ObjectOld.(*argoprojv1a1.ArgoCD)
+	// 		if !ok {
+	// 			return false
+	// 		}
+	// 		if (oldCR.Spec.Repo.ServiceAccount != newCR.Spec.Repo.ServiceAccount) || (!oldCR.Spec.Repo.MountSAToken && newCR.Spec.Repo.MountSAToken) {
+	// 			useTLSForRedis := r.redisShouldUseTLS(newCR)
+	// 			err := r.reconcileRepoDeployment(newCR, useTLSForRedis)
+	// 			if err != nil {
+	// 				log.Error(err, fmt.Sprintf("Failed to delete notifications controller resources for ArgoCD %s in namespace %s",
+	// 					newCR.Name, newCR.Namespace))
+	// 			}
+	// 		}
+	// 		return true
+	// 	},
+	// }
 
 	// Watch for changes to primary resource ArgoCD
-	bldr.For(&argoprojv1a1.ArgoCD{}, builder.WithPredicates(deleteSSOPred, deleteNotificationsPred, repoDeployment))
+	bldr.For(&argoprojv1a1.ArgoCD{}, builder.WithPredicates(deleteSSOPred, deleteNotificationsPred))
 
 	// Watch for changes to ConfigMap sub-resources owned by ArgoCD instances.
 	bldr.Owns(&corev1.ConfigMap{})

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1025,30 +1025,6 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 		},
 	}
 
-	// Add new predicate to delete Notifications Resources. The predicate watches the Argo CD CR for changes to the `.spec.Notifications.Enabled`
-	// field. When a change is detected that results in notifications being disabled, we trigger deletion of notifications resources
-	// repoDeployment := predicate.Funcs{
-	// 	UpdateFunc: func(e event.UpdateEvent) bool {
-	// 		newCR, ok := e.ObjectNew.(*argoprojv1a1.ArgoCD)
-	// 		if !ok {
-	// 			return false
-	// 		}
-	// 		oldCR, ok := e.ObjectOld.(*argoprojv1a1.ArgoCD)
-	// 		if !ok {
-	// 			return false
-	// 		}
-	// 		if (oldCR.Spec.Repo.ServiceAccount != newCR.Spec.Repo.ServiceAccount) || (!oldCR.Spec.Repo.MountSAToken && newCR.Spec.Repo.MountSAToken) {
-	// 			useTLSForRedis := r.redisShouldUseTLS(newCR)
-	// 			err := r.reconcileRepoDeployment(newCR, useTLSForRedis)
-	// 			if err != nil {
-	// 				log.Error(err, fmt.Sprintf("Failed to delete notifications controller resources for ArgoCD %s in namespace %s",
-	// 					newCR.Name, newCR.Namespace))
-	// 			}
-	// 		}
-	// 		return true
-	// 	},
-	// }
-
 	// Watch for changes to primary resource ArgoCD
 	bldr.For(&argoprojv1a1.ArgoCD{}, builder.WithPredicates(deleteSSOPred, deleteNotificationsPred))
 

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1025,8 +1025,32 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 		},
 	}
 
+	// Add new predicate to delete Notifications Resources. The predicate watches the Argo CD CR for changes to the `.spec.Notifications.Enabled`
+	// field. When a change is detected that results in notifications being disabled, we trigger deletion of notifications resources
+	repoDeployment := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newCR, ok := e.ObjectNew.(*argoprojv1a1.ArgoCD)
+			if !ok {
+				return false
+			}
+			oldCR, ok := e.ObjectOld.(*argoprojv1a1.ArgoCD)
+			if !ok {
+				return false
+			}
+			if (oldCR.Spec.Repo.ServiceAccount != newCR.Spec.Repo.ServiceAccount) || (!oldCR.Spec.Repo.MountSAToken && newCR.Spec.Repo.MountSAToken) {
+				useTLSForRedis := r.redisShouldUseTLS(newCR)
+				err := r.reconcileRepoDeployment(newCR, useTLSForRedis)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("Failed to delete notifications controller resources for ArgoCD %s in namespace %s",
+						newCR.Name, newCR.Namespace))
+				}
+			}
+			return true
+		},
+	}
+
 	// Watch for changes to primary resource ArgoCD
-	bldr.For(&argoprojv1a1.ArgoCD{}, builder.WithPredicates(deleteSSOPred, deleteNotificationsPred))
+	bldr.For(&argoprojv1a1.ArgoCD{}, builder.WithPredicates(deleteSSOPred, deleteNotificationsPred, repoDeployment))
 
 	// Watch for changes to ConfigMap sub-resources owned by ArgoCD instances.
 	bldr.Owns(&corev1.ConfigMap{})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This PR aims to identify all the fields of RepoServer and ensures as CR changes for repo server fields new deployment is triggered with updated values

As a part of PR have seen all fields  of spec.Repo
logLevel, logFormat, image, version are reconciled as a part of init containers 
reconcilation on change for env, volumes, volumeMounts, initContainers is already present
sidecarContainers are reconciled as a part of comtainers

left with two fields  mountSAToken, serviceaccount reconiclation logic is in this PR

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1) Make default deployment of ArgoCD via operator
2) Create a service Account similar to default service account of a namespace
3) Add that Service Account into ArgoCD CR .spec.repo.serviceAccount

Check pod using this new ServiceAccount
