### PR TITLE
Fix security context on operator manifests

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -93,7 +93,7 @@ type ArgoCDApplicationControllerSpec struct {
 	ParallelismLimit int32 `json:"parallelismLimit,omitempty"`
 
 	// AppSync is used to control the sync frequency, by default the ArgoCD
-	// controller polls Git every 3m by default.
+	// controller polls Git every 3m.
 	//
 	// Set this to a duration, e.g. 10m or 600s to control the synchronisation
 	// frequency.

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -1066,6 +1066,11 @@ spec:
                 resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: argocd-operator-controller-manager

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -106,8 +106,8 @@ spec:
                 properties:
                   appSync:
                     description: "AppSync is used to control the sync frequency, by
-                      default the ArgoCD controller polls Git every 3m by default.
-                      \n Set this to a duration, e.g. 10m or 600s to control the synchronisation
+                      default the ArgoCD controller polls Git every 3m. \n Set this
+                      to a duration, e.g. 10m or 600s to control the synchronisation
                       frequency."
                     type: string
                   env:

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -108,8 +108,8 @@ spec:
                 properties:
                   appSync:
                     description: "AppSync is used to control the sync frequency, by
-                      default the ArgoCD controller polls Git every 3m by default.
-                      \n Set this to a duration, e.g. 10m or 600s to control the synchronisation
+                      default the ArgoCD controller polls Git every 3m. \n Set this
+                      to a duration, e.g. 10m or 600s to control the synchronisation
                       frequency."
                     type: string
                   env:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,3 +24,10 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true 
+          runAsNonRoot: true

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -14,6 +14,13 @@ spec:
         - name: manager-config
           mountPath: /controller_manager_config.yaml
           subPath: controller_manager_config.yaml
+        securityContext:
+           capabilities:
+             drop:
+             - ALL
+           allowPrivilegeEscalation: false
+           readOnlyRootFilesystem: true 
+           runAsNonRoot: true
       volumes:
       - name: manager-config
         configMap:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,12 @@ spec:
         image: controller:latest
         name: manager
         securityContext:
+          capabilities:
+             drop:
+             - ALL
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true 
+          runAsNonRoot: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -614,7 +614,7 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoprojv1a1.ArgoCD, useT
 			return r.Client.Delete(context.TODO(), deploy)
 		}
 		changed := false
-		actualImage := deploy.Spec.Template.Spec.Containers[0].Image
+		actualImage := existing.Spec.Template.Spec.Containers[0].Image
 		desiredImage := getRedisContainerImage(cr)
 		if actualImage != desiredImage {
 			existing.Spec.Template.Spec.Containers[0].Image = desiredImage

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1283,6 +1283,29 @@ func TestReconcileArgoCD_reconcileRedisDeployment(t *testing.T) {
 	assert.Equal(t, int32(3), *d.Spec.Replicas)
 }
 
+func TestReconcileArgoCD_reconcileRedisDeployment_testImageUpgrade(t *testing.T) {
+	// tests reconciler hook for redis deployment
+	cr := makeTestArgoCD()
+	r := makeTestReconciler(t, cr)
+
+	defer resetHooks()()
+	Register(testDeploymentHook)
+
+	// Verify redis deployment
+	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
+	existing := &appsv1.Deployment{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, existing))
+
+	// Verify Image upgrade
+	os.Setenv("ARGOCD_REDIS_IMAGE", "docker.io/redis/redis:latest")
+	defer os.Unsetenv("ARGOCD_REDIS_IMAGE")
+	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
+
+	newRedis := &appsv1.Deployment{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, newRedis))
+	assert.Equal(t, newRedis.Spec.Template.Spec.Containers[0].Image, "docker.io/redis/redis:latest")
+}
+
 func TestReconcileArgoCD_reconcileRedisDeployment_with_error(t *testing.T) {
 	// tests reconciler hook for redis deployment
 	cr := makeTestArgoCD()

--- a/controllers/argocd/notifications_util.go
+++ b/controllers/argocd/notifications_util.go
@@ -535,7 +535,7 @@ teams:
   - app-sync-status-unknown
   when: app.status.sync.status == 'Unknown'`
 
-	notificationsConfig["trigger.on-sync-succeeded"] = `-description: Application syncing has succeeded
+	notificationsConfig["trigger.on-sync-succeeded"] = `- description: Application syncing has succeeded
   send:
   - app-sync-succeeded
   when: app.status.operationState.phase in ['Succeeded']`

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -95,9 +95,18 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 	}
 
 	for _, namespace := range r.ManagedNamespaces.Items {
-		// only create dexServer and redisHa rolebindings for the namespace where the argocd instance is deployed
-		if cr.ObjectMeta.Namespace != namespace.Name && (name == common.ArgoCDDexServerComponent || name == common.ArgoCDRedisHAComponent) {
-			break
+		list := &argoprojv1a1.ArgoCDList{}
+		listOption := &client.ListOptions{Namespace: namespace.Name}
+		err := r.Client.List(context.TODO(), list, listOption)
+		if err != nil {
+			return err
+		}
+		// only skip creation of dex and redisHa rolebindings for namespaces that no argocd instance is deployed in
+		if len(list.Items) < 1 {
+			// only create dexServer and redisHa rolebindings for the namespace where the argocd instance is deployed
+			if cr.ObjectMeta.Namespace != namespace.Name && (name == common.ArgoCDDexServerComponent || name == common.ArgoCDRedisHAComponent) {
+				continue
+			}
 		}
 		// get expected name
 		roleBinding := newRoleBindingWithname(name, cr)
@@ -105,7 +114,7 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 
 		// fetch existing rolebinding by name
 		existingRoleBinding := &v1.RoleBinding{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, existingRoleBinding)
+		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, existingRoleBinding)
 		roleBindingExists := true
 		if err != nil {
 			if !errors.IsNotFound(err) {

--- a/deploy/olm-catalog/argocd-operator/0.4.0/argocd-operator.v0.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.4.0/argocd-operator.v0.4.0.clusterserviceversion.yaml
@@ -1066,6 +1066,11 @@ spec:
                 resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: argocd-operator-controller-manager

--- a/deploy/olm-catalog/argocd-operator/0.4.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.4.0/argoproj.io_argocds.yaml
@@ -106,8 +106,8 @@ spec:
                 properties:
                   appSync:
                     description: "AppSync is used to control the sync frequency, by
-                      default the ArgoCD controller polls Git every 3m by default.
-                      \n Set this to a duration, e.g. 10m or 600s to control the synchronisation
+                      default the ArgoCD controller polls Git every 3m. \n Set this
+                      to a duration, e.g. 10m or 600s to control the synchronisation
                       frequency."
                     type: string
                   env:

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-assert.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-assert.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-argocd-argocd-application-controller
+  namespace: central-argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-argocd-argocd-server
+  namespace: central-argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-argocd-argocd-application-controller
+  namespace: central-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-argocd-argocd-application-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-argocd-argocd-server
+  namespace: central-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-argocd-argocd-server

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-basic.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-basic.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: central-argocd
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd-1
+  labels:
+      argocd.argoproj.io/managed-by: central-argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  namespace: central-argocd
+  labels:
+    example: basic
+spec: {}

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-basic.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/01-basic.yaml
@@ -17,4 +17,8 @@ metadata:
   namespace: central-argocd
   labels:
     example: basic
-spec: {}
+spec:
+  sso:
+    provider: dex
+    dex:
+      config: test-config

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-argocd-instance.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-argocd-instance.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: child-argocd
+  namespace: argocd-1
+spec: {}

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-argocd-instance.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-argocd-instance.yaml
@@ -3,4 +3,8 @@ kind: ArgoCD
 metadata:
   name: child-argocd
   namespace: argocd-1
-spec: {}
+spec:
+  sso:
+    provider: dex
+    dex:
+      config: test-config

--- a/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-assert.yaml
+++ b/tests/k8s/1-019_validate_rolebindings_with_managed_by/02-assert.yaml
@@ -1,0 +1,95 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-argocd-argocd-application-controller
+  namespace: central-argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-argocd-argocd-server
+  namespace: central-argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: child-argocd-argocd-application-controller
+  namespace: argocd-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: child-argocd-argocd-server
+  namespace: argocd-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: child-argocd-argocd-dex-server
+  namespace: argocd-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: child-argocd-argocd-redis-ha
+  namespace: argocd-1
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-argocd-argocd-application-controller
+  namespace: central-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-argocd-argocd-application-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-argocd-argocd-server
+  namespace: central-argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: example-argocd-argocd-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: child-argocd-argocd-application-controller
+  namespace: argocd-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: child-argocd-argocd-application-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: child-argocd-argocd-server
+  namespace: argocd-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: child-argocd-argocd-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: child-argocd-argocd-dex-server
+  namespace: argocd-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: child-argocd-argocd-dex-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: child-argocd-argocd-redis-ha
+  namespace: argocd-1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: child-argocd-argocd-redis-ha


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
