### PR TITLE
fix: pass cluster version to haproxy reconciler hook

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -835,7 +835,11 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoprojv1a1.ArgoC
 
 	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, "argocd-redis-ha")
 
-	if err := applyReconcilerHook(cr, deploy, ""); err != nil {
+	version, err := getClusterVersion(r.Client)
+	if err != nil {
+		log.Error(err, "error getting cluster version")
+	}
+	if err := applyReconcilerHook(cr, deploy, version); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
kind enhancement

**What does this PR do / why we need it**:

Passes the cluster version to the reconcilerHook when reconciling the Redis haproxy deployment.  This is to allow the behaviour of the hook to be based on the OpenShift version that the operator is running on.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
