### PR TITLE
fix: argocd login won't crash when .data is repopulated in argocd-secret

### DIFF
--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
@@ -204,6 +205,45 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 		}
 
 	})
+
+}
+
+func Test_ReconcileArgoCD_ReconcileExistingArgoSecret(t *testing.T) {
+	argocd := &v1alpha1.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd",
+			Namespace: "argocd-operator",
+		},
+	}
+
+	clusterSecret := argoutil.NewSecretWithSuffix(argocd, "cluster")
+	clusterSecret.Data = map[string][]byte{common.ArgoCDKeyAdminPassword: []byte("something")}
+	tlsSecret := argoutil.NewSecretWithSuffix(argocd, "tls")
+	r := makeTestReconciler(t, argocd)
+	r.Client.Create(context.TODO(), clusterSecret)
+	r.Client.Create(context.TODO(), tlsSecret)
+	err := r.reconcileArgoSecret(argocd)
+
+	assert.NoError(t, err)
+
+	testSecret := &corev1.Secret{}
+	secretErr := r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
+	assert.NoError(t, secretErr)
+
+	// if you remove the secret.Data it should come back, including the secretKey
+	testSecret.Data = nil
+	r.Client.Update(context.TODO(), testSecret)
+
+	_ = r.reconcileExistingArgoSecret(testSecret, clusterSecret, tlsSecret)
+	_ = r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
+
+	if testSecret.Data == nil {
+		t.Errorf("Expected data for data.server but got nothing")
+	}
+
+	if testSecret.Data[common.ArgoCDKeyServerSecretKey] == nil {
+		t.Errorf("Expected data for data.server.secretKey but got nothing")
+	}
 
 }
 


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:

This PR makes the following changes.
1) If argocd-secret does not exist (has been deleted) , the reconciler recreates the secret and regenerates a new server session key.
2) When the admin password changes, the reconciler adds the new password hash to the argocd_secret.

When .data field has been deleted from argocd-secret and get regenerated, this fixes a bug where argocd login no longer works afterwards. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-2006

**How to test changes / Special notes to the reviewer**:

Verifying the error behavior: 
- checkout to recent version of master branch `git checkout master`
- Run `make docker-build`, `make docker-push` and login to a cluster and then run `make deploy`
- Add the Argo CD instance: 
```
cat <<EOF | kubectl apply -f -                                                                    
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: argocd
spec: {}
EOF 
```
- go to OpenShift console and under Administrator View, set namespace as `default` and navigate to Secrets > `argocd-secret`. View the yaml for this secret and delete the entire `.data` section, then save. You should be able to see that the data section gets repopulated but is missing the `server.secretkey` field. Logging into argocd will throw an error stating that this secretKey is missing and login fails. (workaround is restarting the argocd-server pod)

Testing the fix: 
- checkout to this PR
- Go to Makefile and change the version # (just to something else) and change image base tag to `IMAGE_TAG_BASE ?= quay.io/{your quay or docker username}/argocd-operator`
- Run `make docker-build`, `make docker-push` and `make deploy` again
- go back to the OpenShift console and still under Administrator View, set namespace as `default` and go again to Secrets > `argocd-secret`
- add the argocd instance again, and try deleting the secret again the same way as before. This time when you delete it and hit save, you should see that the entire secret regenerates, including the `server.secretkey`.
- to test that login now works, get the route of the argocd instance (no route is created automatically, but you can run `oc edit argocd` and then change `route: enabled: true` in the spec. Now once you run `oc get routes` you should get the route.
- get the admin password from the OpenShift UI under Secrets > `argocd-cluster` (in default namespace). Copy the data for admin.password at the bottom of the page.
- Now login to argocd with `argocd login [route you had from earlier]` and supply the username as `admin` and password as the password from the step above. This should succeed now. 
