### PR TITLE
fix: enable security context in pods

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -30,11 +30,20 @@ const (
 	// ArgoCDServerComponent is the name of the Dex server control plane component
 	ArgoCDServerComponent = "argocd-server"
 
-	// ArgoCDRedisHAComponent is the name of the Redis control plane component
+	// ArgoCDRedisComponent is the name of the Redis control plane component
+	ArgoCDRedisComponent = "argocd-redis"
+
+	// ArgoCDRedisHAComponent is the name of the Redis HA control plane component
 	ArgoCDRedisHAComponent = "argocd-redis-ha"
 
 	// ArgoCDDexServerComponent is the name of the Dex server control plane component
 	ArgoCDDexServerComponent = "argocd-dex-server"
+
+	// ArgoCDNotificationsControllerComponent is the name of the Notifications controller control plane component
+	ArgoCDNotificationsControllerComponent = "argocd-notifications-controller"
+
+	// ArgoCDOperatorGrafanaComponent is the name of the Grafana control plane component
+	ArgoCDOperatorGrafanaComponent = "argocd-grafana"
 
 	// ArgoCDDefaultAdminPasswordLength is the length of the generated default admin password.
 	ArgoCDDefaultAdminPasswordLength = 32

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -88,6 +88,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - prometheuses

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -53,6 +53,7 @@ var log = logr.Log.WithName("controller_argocd")
 //+kubebuilder:rbac:groups=argoproj.io,resources=argocds;argocds/finalizers;argocds/status,verbs=*
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=*
 //+kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=*
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=*
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses;servicemonitors,verbs=*
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=*

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -355,6 +355,9 @@ func (r *ReconcileArgoCD) reconcileDeployments(cr *argoprojv1a1.ArgoCD) error {
 // reconcileDexDeployment will ensure the Deployment resource is present for the ArgoCD Dex component.
 func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error {
 	deploy := newDeploymentWithSuffix("dex-server", "dex-server", cr)
+
+	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
+
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{{
 		Command: []string{
 			"/shared/argocd-dex",
@@ -374,6 +377,15 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 			},
 		},
 		Resources: getDexResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
 		VolumeMounts: []corev1.VolumeMount{{
 			Name:      "static-files",
 			MountPath: "/shared",
@@ -392,6 +404,15 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 		ImagePullPolicy: corev1.PullAlways,
 		Name:            "copyutil",
 		Resources:       getDexResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
 		VolumeMounts: []corev1.VolumeMount{{
 			Name:      "static-files",
 			MountPath: "/shared",
@@ -472,6 +493,7 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoprojv1a1.ArgoCD) error {
 	deploy := newDeploymentWithSuffix("grafana", "grafana", cr)
 	deploy.Spec.Replicas = getGrafanaReplicas(cr)
+	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{{
 		Image:           getGrafanaContainerImage(cr),
 		ImagePullPolicy: corev1.PullAlways,
@@ -483,6 +505,16 @@ func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoprojv1a1.ArgoCD) er
 		},
 		Env:       proxyEnvVars(),
 		Resources: getGrafanaResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+			RunAsUser:    int64Ptr(472),
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "grafana-config",
@@ -500,6 +532,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoprojv1a1.ArgoCD) er
 		},
 	}}
 
+	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, "argocd-grafana")
 	deploy.Spec.Template.Spec.Volumes = []corev1.Volume{
 		{
 			Name: "grafana-config",
@@ -591,6 +624,9 @@ func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoprojv1a1.ArgoCD) er
 // reconcileRedisDeployment will ensure the Deployment resource is present for the ArgoCD Redis component.
 func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoprojv1a1.ArgoCD) error {
 	deploy := newDeploymentWithSuffix("redis", "redis", cr)
+
+	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
+
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{{
 		Args: []string{
 			"--save",
@@ -608,7 +644,36 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoprojv1a1.ArgoCD) erro
 		},
 		Resources: getRedisResources(cr),
 		Env:       proxyEnvVars(),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+			RunAsUser:    int64Ptr(999),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      common.ArgoCDRedisServerTLSSecretName,
+				MountPath: "/app/config/redis/tls",
+			},
+		},
 	}}
+
+	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, "argocd-redis")
+	deploy.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: common.ArgoCDRedisServerTLSSecretName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.ArgoCDRedisServerTLSSecretName,
+					Optional:   boolPtr(true),
+				},
+			},
+		},
+	}
 
 	if err := applyReconcilerHook(cr, deploy, ""); err != nil {
 		return err
@@ -735,6 +800,15 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoprojv1a1.ArgoC
 			},
 		},
 		Resources: getRedisHAProxyResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "data",
@@ -759,6 +833,14 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoprojv1a1.ArgoC
 		Name:            "config-init",
 		Env:             proxyEnvVars(),
 		Resources:       getRedisHAProxyResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "config-volume",
@@ -797,6 +879,13 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoprojv1a1.ArgoC
 		},
 	}
 
+	deploy.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot: boolPtr(true),
+		RunAsUser:    int64Ptr(1000),
+		FSGroup:      int64Ptr(1000),
+	}
+	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
+
 	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, "argocd-redis-ha")
 
 	if err := applyReconcilerHook(cr, deploy, ""); err != nil {
@@ -831,7 +920,35 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 		repoEnv = argoutil.EnvMerge(repoEnv, []corev1.EnvVar{{Name: "ARGOCD_EXEC_TIMEOUT", Value: fmt.Sprintf("%d", *cr.Spec.Repo.ExecTimeout)}}, true)
 	}
 
-	deploy.Spec.Template.Spec.InitContainers = getArgoRepoInitContainers(cr)
+	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
+
+	deploy.Spec.Template.Spec.InitContainers = []corev1.Container{{
+		Name:            "copyutil",
+		Image:           getArgoContainerImage(cr),
+		Command:         getArgoCmpServerInitCommand(),
+		ImagePullPolicy: corev1.PullAlways,
+		Resources:       getArgoRepoResources(cr),
+		Env:             proxyEnvVars(),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "var-files",
+				MountPath: "/var/run/argocd",
+			},
+		},
+	}}
+
+	if cr.Spec.Repo.InitContainers != nil {
+		deploy.Spec.Template.Spec.InitContainers = append(deploy.Spec.Template.Spec.InitContainers, cr.Spec.Repo.InitContainers...)
+	}
 
 	repoServerVolumeMounts := []corev1.VolumeMount{
 		{
@@ -893,7 +1010,16 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD) error
 			InitialDelaySeconds: 5,
 			PeriodSeconds:       10,
 		},
-		Resources:    getArgoRepoResources(cr),
+		Resources: getArgoRepoResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
 		VolumeMounts: repoServerVolumeMounts,
 	}}
 
@@ -1018,6 +1144,7 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoprojv1a1.ArgoCD) err
 	deploy := newDeploymentWithSuffix("server", "server", cr)
 	serverEnv := cr.Spec.Server.Env
 	serverEnv = argoutil.EnvMerge(serverEnv, proxyEnvVars(), false)
+	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{{
 		Command:         getArgoServerCommand(cr),
 		Image:           getArgoContainerImage(cr),
@@ -1052,6 +1179,15 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoprojv1a1.ArgoCD) err
 			PeriodSeconds:       30,
 		},
 		Resources: getArgoServerResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "ssh-known-hosts",

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -782,6 +782,15 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 					"/usr/local/bin/argocd",
 					"/shared/argocd-dex",
 				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: boolPtr(true),
+				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "static-files",
@@ -808,6 +817,15 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 						Name:          "grpc",
 						ContainerPort: 5557,
 					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: boolPtr(true),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "static-files", MountPath: "/shared"}},
@@ -860,6 +878,15 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 					"/usr/local/bin/argocd",
 					"/shared/argocd-dex",
 				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: boolPtr(true),
+				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "static-files",
@@ -886,6 +913,15 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 						Name:          "grpc",
 						ContainerPort: 5557,
 					},
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: boolPtr(true),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "static-files", MountPath: "/shared"}},
@@ -955,6 +991,15 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 					},
 					InitialDelaySeconds: 3,
 					PeriodSeconds:       30,
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: boolPtr(true),
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),
 			},
@@ -1028,6 +1073,15 @@ func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 					},
 					InitialDelaySeconds: 3,
 					PeriodSeconds:       30,
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: boolPtr(true),
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),
 			},
@@ -1104,6 +1158,15 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 					},
 					InitialDelaySeconds: 3,
 					PeriodSeconds:       30,
+				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: boolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: boolPtr(true),
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),
 			},

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -1,0 +1,533 @@
+package argocd
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
+)
+
+func (r *ReconcileArgoCD) reconcileNotificationsController(cr *argoprojv1a1.ArgoCD) error {
+
+	log.Info("reconciling notifications serviceaccount")
+	sa, err := r.reconcileNotificationsServiceAccount(cr)
+	if err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications role")
+	role, err := r.reconcileNotificationsRole(cr)
+	if err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications role binding")
+	if err := r.reconcileNotificationsRoleBinding(cr, role, sa); err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications configmap")
+	if err := r.reconcileNotificationsConfigMap(cr); err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications secret")
+	if err := r.reconcileNotificationsSecret(cr); err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications deployment")
+	if err := r.reconcileNotificationsDeployment(cr, sa); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// The code to create/delete notifications resources is written within the reconciliation logic itself. However, these functions must be called
+// in the right order depending on whether resources are getting created or deleted. During creation we must create the role and sa first.
+// RoleBinding and deployment are dependent on these resouces. During deletion the order is reversed.
+// Deployment and RoleBinding must be deleted before the role and sa. deleteNotificationsResources will only be called during
+// delete events, so we don't need to worry about duplicate, recurring reconciliation calls
+func (r *ReconcileArgoCD) deleteNotificationsResources(cr *argoprojv1a1.ArgoCD) error {
+
+	sa := &corev1.ServiceAccount{}
+	role := &rbacv1.Role{}
+
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDNotificationsControllerComponent), sa); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDNotificationsControllerComponent), role); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	log.Info("reconciling notifications deployment")
+	if err := r.reconcileNotificationsDeployment(cr, sa); err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications secret")
+	if err := r.reconcileNotificationsSecret(cr); err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications configmap")
+	if err := r.reconcileNotificationsConfigMap(cr); err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications role binding")
+	if err := r.reconcileNotificationsRoleBinding(cr, role, sa); err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications role")
+	_, err := r.reconcileNotificationsRole(cr)
+	if err != nil {
+		return err
+	}
+
+	log.Info("reconciling notifications serviceaccount")
+	_, err = r.reconcileNotificationsServiceAccount(cr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoprojv1a1.ArgoCD) (*corev1.ServiceAccount, error) {
+
+	sa := newServiceAccountWithName(common.ArgoCDNotificationsControllerComponent, cr)
+
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, sa.Name, sa); err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get the serviceAccount associated with %s : %s", sa.Name, err)
+		}
+
+		// SA doesn't exist and shouldn't, nothing to do here
+		if !cr.Spec.Notifications.Enabled {
+			return nil, nil
+		}
+
+		// SA doesn't exist but should, so it should be created
+		if err := controllerutil.SetControllerReference(cr, sa, r.Scheme); err != nil {
+			return nil, err
+		}
+
+		log.Info(fmt.Sprintf("Creating serviceaccount %s", sa.Name))
+		err := r.Client.Create(context.TODO(), sa)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// SA exists but shouldn't, so it should be deleted
+	if !cr.Spec.Notifications.Enabled {
+		log.Info(fmt.Sprintf("Deleting serviceaccount %s as notifications is disabled", sa.Name))
+		return nil, r.Client.Delete(context.TODO(), sa)
+	}
+
+	return sa, nil
+}
+
+func (r *ReconcileArgoCD) reconcileNotificationsRole(cr *argoprojv1a1.ArgoCD) (*rbacv1.Role, error) {
+
+	policyRules := policyRuleForNotificationsController()
+	desiredRole := newRole(common.ArgoCDNotificationsControllerComponent, policyRules, cr)
+
+	existingRole := &rbacv1.Role{}
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, desiredRole.Name, existingRole); err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get the role associated with %s : %s", desiredRole.Name, err)
+		}
+
+		// role does not exist and shouldn't, nothing to do here
+		if !cr.Spec.Notifications.Enabled {
+			return nil, nil
+		}
+
+		// role does not exist but should, so it should be created
+		if err := controllerutil.SetControllerReference(cr, desiredRole, r.Scheme); err != nil {
+			return nil, err
+		}
+
+		log.Info(fmt.Sprintf("Creating role %s", desiredRole.Name))
+		err := r.Client.Create(context.TODO(), desiredRole)
+		if err != nil {
+			return nil, err
+		}
+		return desiredRole, nil
+	}
+
+	// role exists but shouldn't, so it should be deleted
+	if !cr.Spec.Notifications.Enabled {
+		log.Info(fmt.Sprintf("Deleting role %s as notifications is disabled", existingRole.Name))
+		return nil, r.Client.Delete(context.TODO(), existingRole)
+	}
+
+	// role exists and should. Reconcile role if changed
+	if !reflect.DeepEqual(existingRole.Rules, desiredRole.Rules) {
+		existingRole.Rules = desiredRole.Rules
+		if err := controllerutil.SetControllerReference(cr, existingRole, r.Scheme); err != nil {
+			return nil, err
+		}
+		return existingRole, r.Client.Update(context.TODO(), existingRole)
+	}
+
+	return desiredRole, nil
+}
+
+func (r *ReconcileArgoCD) reconcileNotificationsRoleBinding(cr *argoprojv1a1.ArgoCD, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
+
+	desiredRoleBinding := newRoleBindingWithname(common.ArgoCDNotificationsControllerComponent, cr)
+	desiredRoleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+
+	desiredRoleBinding.Subjects = []rbacv1.Subject{
+		{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+	}
+
+	// fetch existing rolebinding by name
+	existingRoleBinding := &rbacv1.RoleBinding{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: desiredRoleBinding.Name, Namespace: cr.Namespace}, existingRoleBinding); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get the rolebinding associated with %s : %s", desiredRoleBinding.Name, err)
+		}
+
+		// roleBinding does not exist and shouldn't, nothing to do here
+		if !cr.Spec.Notifications.Enabled {
+			return nil
+		}
+
+		// roleBinding does not exist but should, so it should be created
+		if err := controllerutil.SetControllerReference(cr, desiredRoleBinding, r.Scheme); err != nil {
+			return err
+		}
+
+		log.Info(fmt.Sprintf("Creating roleBinding %s", desiredRoleBinding.Name))
+		return r.Client.Create(context.TODO(), desiredRoleBinding)
+	}
+
+	// roleBinding exists but shouldn't, so it should be deleted
+	if !cr.Spec.Notifications.Enabled {
+		log.Info(fmt.Sprintf("Deleting roleBinding %s as notifications is disabled", existingRoleBinding.Name))
+		return r.Client.Delete(context.TODO(), existingRoleBinding)
+	}
+
+	// roleBinding exists and should. Reconcile roleBinding if changed
+	if !reflect.DeepEqual(existingRoleBinding.RoleRef, desiredRoleBinding.RoleRef) {
+		// if the RoleRef changes, delete the existing role binding and create a new one
+		if err := r.Client.Delete(context.TODO(), existingRoleBinding); err != nil {
+			return err
+		}
+	} else if !reflect.DeepEqual(existingRoleBinding.Subjects, desiredRoleBinding.Subjects) {
+		existingRoleBinding.Subjects = desiredRoleBinding.Subjects
+		if err := controllerutil.SetControllerReference(cr, existingRoleBinding, r.Scheme); err != nil {
+			return err
+		}
+		return r.Client.Update(context.TODO(), existingRoleBinding)
+	}
+
+	return nil
+}
+
+func (r *ReconcileArgoCD) reconcileNotificationsDeployment(cr *argoprojv1a1.ArgoCD, sa *corev1.ServiceAccount) error {
+
+	desiredDeployment := newDeploymentWithSuffix("notifications-controller", "controller", cr)
+
+	desiredDeployment.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
+	}
+
+	if replicas := getArgoCDNotificationsControllerReplicas(cr); replicas != nil {
+		desiredDeployment.Spec.Replicas = replicas
+	}
+
+	podSpec := &desiredDeployment.Spec.Template.Spec
+	podSpec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot: boolPtr(true),
+	}
+	AddSeccompProfileForOpenShift(r.Client, podSpec)
+	podSpec.ServiceAccountName = sa.ObjectMeta.Name
+	podSpec.Volumes = []corev1.Volume{
+		{
+			Name: "tls-certs",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: common.ArgoCDTLSCertsConfigMapName,
+					},
+				},
+			},
+		},
+		{
+			Name: "argocd-repo-server-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: common.ArgoCDRepoServerTLSSecretName,
+					Optional:   boolPtr(true),
+				},
+			},
+		},
+	}
+
+	podSpec.Containers = []corev1.Container{{
+		Command:         getNotificationsCommand(),
+		Image:           getArgoContainerImage(cr),
+		ImagePullPolicy: corev1.PullAlways,
+		Name:            common.ArgoCDNotificationsControllerComponent,
+		Resources:       getNotificationsResources(cr),
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.IntOrString{
+						IntVal: int32(9001),
+					},
+				},
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "tls-certs",
+				MountPath: "/app/config/tls",
+			},
+			{
+				Name:      "argocd-repo-server-tls",
+				MountPath: "/app/config/reposerver/tls",
+			},
+		},
+		WorkingDir: "/app",
+	}}
+
+	// fetch existing deployment by name
+	deploymentChanged := false
+	existingDeployment := &appsv1.Deployment{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: desiredDeployment.Name, Namespace: cr.Namespace}, existingDeployment); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get the deployment associated with %s : %s", existingDeployment.Name, err)
+		}
+
+		// deployment does not exist and shouldn't, nothing to do here
+		if !cr.Spec.Notifications.Enabled {
+			return nil
+		}
+
+		// deployment does not exist but should, so it should be created
+		if err := controllerutil.SetControllerReference(cr, desiredDeployment, r.Scheme); err != nil {
+			return err
+		}
+
+		log.Info(fmt.Sprintf("Creating deployment %s", desiredDeployment.Name))
+		return r.Client.Create(context.TODO(), desiredDeployment)
+	}
+
+	// deployment exists but shouldn't, so it should be deleted
+	if !cr.Spec.Notifications.Enabled {
+		log.Info(fmt.Sprintf("Deleting deployment %s as notifications is disabled", existingDeployment.Name))
+		return r.Client.Delete(context.TODO(), existingDeployment)
+	}
+
+	// deployment exists and should. Reconcile deployment if changed
+	updateNodePlacement(existingDeployment, desiredDeployment, &deploymentChanged)
+
+	if existingDeployment.Spec.Template.Spec.Containers[0].Image != desiredDeployment.Spec.Template.Spec.Containers[0].Image {
+		existingDeployment.Spec.Template.Spec.Containers[0].Image = desiredDeployment.Spec.Template.Spec.Containers[0].Image
+		existingDeployment.Spec.Template.ObjectMeta.Labels["image.upgraded"] = time.Now().UTC().Format("01022006-150406-MST")
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].Command, desiredDeployment.Spec.Template.Spec.Containers[0].Command) {
+		existingDeployment.Spec.Template.Spec.Containers[0].Command = desiredDeployment.Spec.Template.Spec.Containers[0].Command
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Volumes, desiredDeployment.Spec.Template.Spec.Volumes) {
+		existingDeployment.Spec.Template.Spec.Volumes = desiredDeployment.Spec.Template.Spec.Volumes
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Spec.Replicas, desiredDeployment.Spec.Replicas) {
+		existingDeployment.Spec.Replicas = desiredDeployment.Spec.Replicas
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts) {
+		existingDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = desiredDeployment.Spec.Template.Spec.Containers[0].VolumeMounts
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].Resources, desiredDeployment.Spec.Template.Spec.Containers[0].Resources) {
+		existingDeployment.Spec.Template.Spec.Containers[0].Resources = desiredDeployment.Spec.Template.Spec.Containers[0].Resources
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.ServiceAccountName, desiredDeployment.Spec.Template.Spec.ServiceAccountName) {
+		existingDeployment.Spec.Template.Spec.ServiceAccountName = desiredDeployment.Spec.Template.Spec.ServiceAccountName
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Labels, desiredDeployment.Labels) {
+		existingDeployment.Labels = desiredDeployment.Labels
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Spec.Template.Labels, desiredDeployment.Spec.Template.Labels) {
+		existingDeployment.Spec.Template.Labels = desiredDeployment.Spec.Template.Labels
+		deploymentChanged = true
+	}
+
+	if !reflect.DeepEqual(existingDeployment.Spec.Selector, desiredDeployment.Spec.Selector) {
+		existingDeployment.Spec.Selector = desiredDeployment.Spec.Selector
+		deploymentChanged = true
+	}
+
+	if deploymentChanged {
+		return r.Client.Update(context.TODO(), existingDeployment)
+	}
+
+	return nil
+
+}
+
+// reconcileNotificationsConfigMap only creates/deletes the argocd-notifications-cm based on whether notifications is enabled/disabled in the CR
+// It does not reconcile/overwrite any fields or information in the configmap itself
+func (r *ReconcileArgoCD) reconcileNotificationsConfigMap(cr *argoprojv1a1.ArgoCD) error {
+
+	desiredConfigMap := newConfigMapWithName("argocd-notifications-cm", cr)
+	desiredConfigMap.Data = getDefaultNotificationsConfig()
+
+	cmExists := true
+	existingConfigMap := &corev1.ConfigMap{}
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, desiredConfigMap.Name, existingConfigMap); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get the configmap associated with %s : %s", desiredConfigMap.Name, err)
+		}
+		cmExists = false
+	}
+
+	if cmExists {
+		// CM exists but shouldn't, so it should be deleted
+		if !cr.Spec.Notifications.Enabled {
+			log.Info(fmt.Sprintf("Deleting configmap %s as notifications is disabled", existingConfigMap.Name))
+			return r.Client.Delete(context.TODO(), existingConfigMap)
+		}
+
+		// CM exists and should, nothing to do here
+		return nil
+	}
+
+	// CM doesn't exist and shouldn't, nothing to do here
+	if !cr.Spec.Notifications.Enabled {
+		return nil
+	}
+
+	// CM doesn't exist but should, so it should be created
+	if err := controllerutil.SetControllerReference(cr, desiredConfigMap, r.Scheme); err != nil {
+		return err
+	}
+
+	log.Info(fmt.Sprintf("Creating configmap %s", desiredConfigMap.Name))
+	err := r.Client.Create(context.TODO(), desiredConfigMap)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// reconcileNotificationsSecret only creates/deletes the argocd-notifications-secret based on whether notifications is enabled/disabled in the CR
+// It does not reconcile/overwrite any fields or information in the secret itself
+func (r *ReconcileArgoCD) reconcileNotificationsSecret(cr *argoprojv1a1.ArgoCD) error {
+
+	desiredSecret := argoutil.NewSecretWithName(cr, "argocd-notifications-secret")
+
+	secretExists := true
+	existingSecret := &corev1.Secret{}
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, desiredSecret.Name, existingSecret); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get the secret associated with %s : %s", desiredSecret.Name, err)
+		}
+		secretExists = false
+	}
+
+	if secretExists {
+		// secret exists but shouldn't, so it should be deleted
+		if !cr.Spec.Notifications.Enabled {
+			log.Info(fmt.Sprintf("Deleting secret %s as notifications is disabled", existingSecret.Name))
+			return r.Client.Delete(context.TODO(), existingSecret)
+		}
+
+		// secret exists and should, nothing to do here
+		return nil
+	}
+
+	// secret doesn't exist and shouldn't, nothing to do here
+	if !cr.Spec.Notifications.Enabled {
+		return nil
+	}
+
+	// secret doesn't exist but should, so it should be created
+	if err := controllerutil.SetControllerReference(cr, desiredSecret, r.Scheme); err != nil {
+		return err
+	}
+
+	log.Info(fmt.Sprintf("Creating secret %s", desiredSecret.Name))
+	err := r.Client.Create(context.TODO(), desiredSecret)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getNotificationsCommand() []string {
+
+	cmd := make([]string, 0)
+	cmd = append(cmd, "argocd-notifications")
+
+	return cmd
+}
+
+// getNotificationsResources will return the ResourceRequirements for the Notifications container.
+func getNotificationsResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{}
+
+	// Allow override of resource requirements from CR
+	if cr.Spec.Notifications.Resources != nil {
+		resources = *cr.Spec.Notifications.Resources
+	}
+
+	return resources
+}

--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -1,0 +1,283 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
+)
+
+func TestReconcileNotifications_CreateRoles(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a.Spec.Notifications.Enabled = true
+	})
+
+	r := makeTestReconciler(t, a)
+
+	_, err := r.reconcileNotificationsRole(a)
+	assert.NoError(t, err)
+
+	testRole := &rbacv1.Role{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+		Namespace: a.Namespace,
+	}, testRole))
+
+	desiredPolicyRules := policyRuleForNotificationsController()
+
+	assert.Equal(t, desiredPolicyRules, testRole.Rules)
+
+	a.Spec.Notifications.Enabled = false
+	_, err = r.reconcileNotificationsRole(a)
+	assert.NoError(t, err)
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+		Namespace: a.Namespace,
+	}, testRole)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileNotifications_CreateServiceAccount(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a.Spec.Notifications.Enabled = true
+	})
+
+	r := makeTestReconciler(t, a)
+
+	desiredSa, err := r.reconcileNotificationsServiceAccount(a)
+	assert.NoError(t, err)
+
+	testSa := &corev1.ServiceAccount{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+		Namespace: a.Namespace,
+	}, testSa))
+
+	assert.Equal(t, testSa.Name, desiredSa.Name)
+
+	a.Spec.Notifications.Enabled = false
+	_, err = r.reconcileNotificationsServiceAccount(a)
+	assert.NoError(t, err)
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+		Namespace: a.Namespace,
+	}, testSa)
+	assert.True(t, errors.IsNotFound(err))
+
+}
+
+func TestReconcileNotifications_CreateRoleBinding(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a.Spec.Notifications.Enabled = true
+	})
+	r := makeTestReconciler(t, a)
+
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "role-name"}}
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa-name"}}
+
+	err := r.reconcileNotificationsRoleBinding(a, role, sa)
+	assert.NoError(t, err)
+
+	roleBinding := &rbacv1.RoleBinding{}
+	assert.NoError(t, r.Client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+			Namespace: a.Namespace,
+		},
+		roleBinding))
+
+	assert.Equal(t, roleBinding.RoleRef.Name, role.Name)
+	assert.Equal(t, roleBinding.Subjects[0].Name, sa.Name)
+
+	a.Spec.Notifications.Enabled = false
+	err = r.reconcileNotificationsRoleBinding(a, role, sa)
+	assert.NoError(t, err)
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+		Namespace: a.Namespace,
+	}, roleBinding)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileNotifications_CreateDeployments(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a.Spec.Notifications.Enabled = true
+	})
+
+	r := makeTestReconciler(t, a)
+
+	sa := corev1.ServiceAccount{}
+
+	assert.NoError(t, r.reconcileNotificationsDeployment(a, &sa))
+
+	deployment := &appsv1.Deployment{}
+	assert.NoError(t, r.Client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      a.Name + "-notifications-controller",
+			Namespace: a.Namespace,
+		},
+		deployment))
+
+	// Ensure the created Deployment has the expected properties
+	assert.Equal(t, deployment.Spec.Template.Spec.ServiceAccountName, sa.ObjectMeta.Name)
+
+	want := []corev1.Container{{
+		Command:         []string{"argocd-notifications"},
+		Image:           argoutil.CombineImageTag(common.ArgoCDDefaultArgoImage, common.ArgoCDDefaultArgoVersion),
+		ImagePullPolicy: corev1.PullAlways,
+		Name:            "argocd-notifications-controller",
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "tls-certs",
+				MountPath: "/app/config/tls",
+			},
+			{
+				Name:      "argocd-repo-server-tls",
+				MountPath: "/app/config/reposerver/tls",
+			},
+		},
+		Resources:  corev1.ResourceRequirements{},
+		WorkingDir: "/app",
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.IntOrString{
+						IntVal: int32(9001),
+					},
+				},
+			},
+		},
+	}}
+
+	if diff := cmp.Diff(want, deployment.Spec.Template.Spec.Containers); diff != "" {
+		t.Fatalf("failed to reconcile notifications-controller deployment containers:\n%s", diff)
+	}
+
+	volumes := []corev1.Volume{
+		{
+			Name: "tls-certs",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "argocd-tls-certs-cm",
+					},
+				},
+			},
+		},
+		{
+			Name: "argocd-repo-server-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "argocd-repo-server-tls",
+					Optional:   boolPtr(true),
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(volumes, deployment.Spec.Template.Spec.Volumes); diff != "" {
+		t.Fatalf("failed to reconcile notifications-controller deployment volumes:\n%s", diff)
+	}
+
+	expectedSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			common.ArgoCDKeyName: deployment.Name,
+		},
+	}
+
+	if diff := cmp.Diff(expectedSelector, deployment.Spec.Selector); diff != "" {
+		t.Fatalf("failed to reconcile notifications-controller label selector:\n%s", diff)
+	}
+
+	a.Spec.Notifications.Enabled = false
+	err := r.reconcileNotificationsDeployment(a, &sa)
+	assert.NoError(t, err)
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+		Namespace: a.Namespace,
+	}, deployment)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileNotifications_CreateSecret(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a.Spec.Notifications.Enabled = true
+	})
+
+	r := makeTestReconciler(t, a)
+
+	err := r.reconcileNotificationsSecret(a)
+	assert.NoError(t, err)
+
+	testSecret := &corev1.Secret{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-notifications-secret",
+		Namespace: a.Namespace,
+	}, testSecret))
+
+	a.Spec.Notifications.Enabled = false
+	err = r.reconcileNotificationsSecret(a)
+	assert.NoError(t, err)
+	secret := &corev1.Secret{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-notifications-secret", Namespace: a.Namespace}, secret)
+	assertNotFound(t, err)
+}
+
+func TestReconcileNotifications_CreateConfigMap(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a.Spec.Notifications.Enabled = true
+	})
+
+	r := makeTestReconciler(t, a)
+
+	err := r.reconcileNotificationsConfigMap(a)
+	assert.NoError(t, err)
+
+	testCm := &corev1.ConfigMap{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-notifications-cm",
+		Namespace: a.Namespace,
+	}, testCm))
+
+	assert.True(t, len(testCm.Data) > 0)
+
+	a.Spec.Notifications.Enabled = false
+	err = r.reconcileNotificationsConfigMap(a)
+	assert.NoError(t, err)
+	testCm = &corev1.ConfigMap{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-notifications-cm", Namespace: a.Namespace}, testCm)
+	assertNotFound(t, err)
+}

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -56,10 +56,8 @@ func newClusterRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD)
 }
 
 // reconcileRoles will ensure that all ArgoCD Service Accounts are configured.
-func (r *ReconcileArgoCD) reconcileRoles(cr *argoprojv1a1.ArgoCD) (role *v1.Role, err error) {
-	if _, err := r.reconcileRole(applicationController, policyRuleForApplicationController(), cr); err != nil {
-		return role, err
-	}
+func (r *ReconcileArgoCD) reconcileRoles(cr *argoprojv1a1.ArgoCD) error {
+	params := getPolicyRuleList(r.Client)
 
 	if _, err := r.reconcileRole(dexServer, policyRuleForDexServer(), cr); err != nil {
 		return role, err

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -37,7 +37,11 @@ func TestReconcileArgoCD_reconcileRole(t *testing.T) {
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// update reconciledRole policy rules to RedisHa policy rules
+<<<<<<< HEAD
 	reconciledRole.Rules = policyRuleForRedisHa(a)
+=======
+	reconciledRole.Rules = policyRuleForRedisHa(r.Client)
+>>>>>>> 5240e6a (chore: enable pod security admission (#675))
 	assert.NoError(t, r.Client.Update(context.TODO(), reconciledRole))
 
 	// Check if the RedisHa policy rules are overwritten to Application Controller
@@ -66,8 +70,8 @@ func TestReconcileArgoCD_reconcileRole_for_new_namespace(t *testing.T) {
 	assert.Equal(t, expectedRoleNamespace, dexRoles[0].ObjectMeta.Namespace)
 	
 	// check no redisHa role is created for the new namespace with managed-by label
-	workloadIdentifier = redisHa
-	expectedRedisHaRules := policyRuleForRedisHa(a)
+	workloadIdentifier = common.ArgoCDRedisHAComponent
+	expectedRedisHaRules := policyRuleForRedisHa(r.Client)
 	redisHaRoles, err := r.reconcileRole(workloadIdentifier, expectedRedisHaRules, a)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedNumberOfRoles, len(redisHaRoles))
@@ -127,7 +131,11 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	assert.Equal(t, expectedRules, reconciledClusterRole.Rules)
 
 	// update reconciledRole policy rules to RedisHa policy rules
+<<<<<<< HEAD
 	reconciledClusterRole.Rules = policyRuleForRedisHa(a)
+=======
+	reconciledClusterRole.Rules = policyRuleForRedisHa(r.Client)
+>>>>>>> 5240e6a (chore: enable pod security admission (#675))
 	assert.NoError(t, r.Client.Update(context.TODO(), reconciledClusterRole))
 
 	// Check if the RedisHa policy rules are overwritten to Application Controller

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -75,8 +75,12 @@ func (r *ReconcileArgoCD) reconcileRoleBindings(cr *argoprojv1a1.ArgoCD) error {
 		return fmt.Errorf("error reconciling roleBinding for %q: %w", dexServer, err)
 	}
 
-	if err := r.reconcileRoleBinding(redisHa, policyRuleForRedisHa(cr), cr); err != nil {
-		return fmt.Errorf("error reconciling roleBinding for %q: %w", redisHa, err)
+	params := getPolicyRuleList(r.Client)
+
+	for _, param := range params {
+		if err := r.reconcileRoleBinding(param.name, param.policyRule, cr); err != nil {
+			return fmt.Errorf("error reconciling roleBinding for %q: %w", param.name, err)
+		}
 	}
 
 	if err := r.reconcileRoleBinding(server, policyRuleForServer(), cr); err != nil {

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -62,8 +62,8 @@ func TestReconcileArgoCD_reconcileRoleBinding_for_new_namespace(t *testing.T) {
 	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "newTestNamespace"}, roleBinding))
 
 	// check no redisHa rolebinding is created for the new namespace with managed-by label
-	workloadIdentifier = redisHa
-	expectedRedisHaRules := policyRuleForRedisHa(a)
+	workloadIdentifier = common.ArgoCDRedisHAComponent
+	expectedRedisHaRules := policyRuleForRedisHa(r.Client)
 	assert.NoError(t, r.reconcileRoleBinding(workloadIdentifier, expectedRedisHaRules, a))
 	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "newTestNamespace"}, roleBinding))
 }

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
 	argov1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
@@ -205,6 +206,7 @@ func makeReconciler(t *testing.T, acd *argov1alpha1.ArgoCD, objs ...runtime.Obje
 	s := scheme.Scheme
 	s.AddKnownTypes(argov1alpha1.GroupVersion, acd)
 	routev1.Install(s)
+	configv1.Install(s)
 	cl := fake.NewFakeClient(objs...)
 	return &ReconcileArgoCD{
 		Client: cl,

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -60,6 +60,7 @@ func newServiceAccountWithName(name string, cr *argoprojv1a1.ArgoCD) *corev1.Ser
 
 // reconcileServiceAccounts will ensure that all ArgoCD Service Accounts are configured.
 func (r *ReconcileArgoCD) reconcileServiceAccounts(cr *argoprojv1a1.ArgoCD) error {
+	params := getPolicyRuleList(r.Client)
 
 	if err := r.reconcileServiceAccountPermissions(common.ArgoCDServerComponent, policyRuleForServer(), cr); err != nil {
 		return err

--- a/controllers/argocd/service_account_test.go
+++ b/controllers/argocd/service_account_test.go
@@ -51,7 +51,7 @@ func TestReconcileArgoCD_reconcileServiceAccountPermissions(t *testing.T) {
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// undesirable changes
-	reconciledRole.Rules = policyRuleForRedisHa(a)
+	reconciledRole.Rules = policyRuleForRedisHa(r.Client)
 	assert.NoError(t, r.Client.Update(context.TODO(), reconciledRole))
 
 	// fetch it

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -185,6 +185,15 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 				Name:          "redis",
 			}},
 			Resources: getRedisResources(cr),
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: boolPtr(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{
+						"ALL",
+					},
+				},
+				RunAsNonRoot: boolPtr(true),
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					MountPath: "/data",
@@ -215,6 +224,15 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 				Name:          "sentinel",
 			}},
 			Resources: getRedisResources(cr),
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: boolPtr(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{
+						"ALL",
+					},
+				},
+				RunAsNonRoot: boolPtr(true),
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					MountPath: "/data",
@@ -249,6 +267,15 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Name:            "config-init",
 		Resources:       getRedisResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				MountPath: "/readonly-config",
@@ -271,6 +298,7 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 		RunAsNonRoot: &runAsNonRoot,
 		RunAsUser:    &runAsUser,
 	}
+	AddSeccompProfileForOpenShift(r.Client, &ss.Spec.Template.Spec)
 
 	ss.Spec.Template.Spec.ServiceAccountName = nameWithSuffix("argocd-redis-ha", cr)
 
@@ -366,6 +394,15 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 			PeriodSeconds:       10,
 		},
 		Resources: getArgoApplicationControllerResources(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "argocd-repo-server-tls",
@@ -373,6 +410,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 			},
 		},
 	}}
+	AddSeccompProfileForOpenShift(r.Client, podSpec)
 	podSpec.ServiceAccountName = nameWithSuffix("argocd-application-controller", cr)
 	podSpec.Volumes = []corev1.Volume{
 		{
@@ -425,7 +463,16 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 			Image:           getArgoImportContainerImage(export),
 			ImagePullPolicy: corev1.PullAlways,
 			Name:            "argocd-import",
-			VolumeMounts:    getArgoImportVolumeMounts(export),
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: boolPtr(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{
+						"ALL",
+					},
+				},
+				RunAsNonRoot: boolPtr(true),
+			},
+			VolumeMounts: getArgoImportVolumeMounts(),
 		}}
 
 		podSpec.Volumes = getArgoImportVolumes(export)

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -40,9 +40,11 @@ import (
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	oappsv1 "github.com/openshift/api/apps/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/sethvargo/go-password/password"
+	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -60,6 +62,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
+
+var (
+	versionAPIFound = false
+)
+
+// IsVersionAPIAvailable returns true if the version api is present
+func IsVersionAPIAvailable() bool {
+	return versionAPIFound
+}
+
+// verifyVersionAPI will verify that the template API is present.
+func verifyVersionAPI() error {
+	found, err := argoutil.VerifyAPI(configv1.GroupName, configv1.GroupVersion.Version)
+	if err != nil {
+		return err
+	}
+	versionAPIFound = found
+	return nil
+}
 
 // DexConnector represents an authentication connector for Dex.
 type DexConnector struct {
@@ -697,6 +718,10 @@ func InspectCluster() error {
 	if err := verifyTemplateAPI(); err != nil {
 		return err
 	}
+
+	if err := verifyVersionAPI(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1062,6 +1087,10 @@ func boolPtr(val bool) *bool {
 	return &val
 }
 
+func int64Ptr(val int64) *int64 {
+	return &val
+}
+
 // triggerRollout will trigger a rollout of a Kubernetes resource specified as
 // obj. It currently supports Deployment and StatefulSet resources.
 func (r *ReconcileArgoCD) triggerRollout(obj interface{}, key string) error {
@@ -1369,6 +1398,43 @@ func getOpenShiftAPIURL() string {
 	}
 
 	return out
+}
+
+func AddSeccompProfileForOpenShift(client client.Client, podspec *corev1.PodSpec) {
+	if !IsVersionAPIAvailable() {
+		return
+	}
+	version, err := getClusterVersion(client)
+	if err != nil {
+		log.Error(err, "couldn't get OpenShift version")
+	}
+	if version == "" || semver.Compare(fmt.Sprintf("v%s", version), "v4.10.999") > 0 {
+		if podspec.SecurityContext == nil {
+			podspec.SecurityContext = &corev1.PodSecurityContext{}
+		}
+		if podspec.SecurityContext.SeccompProfile == nil {
+			podspec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{}
+		}
+		if len(podspec.SecurityContext.SeccompProfile.Type) == 0 {
+			podspec.SecurityContext.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
+		}
+	}
+}
+
+// getClusterVersion returns the OpenShift Cluster version in which the operator is installed
+func getClusterVersion(client client.Client) (string, error) {
+	if !IsVersionAPIAvailable() {
+		return "", nil
+	}
+	clusterVersion := &configv1.ClusterVersion{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: "version"}, clusterVersion)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return clusterVersion.Status.Desired.Version, nil
 }
 
 // generateRandomBytes returns a securely generated random bytes.

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -28,6 +28,7 @@ import (
 
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argocd"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
@@ -164,8 +165,12 @@ func newCronJob(cr *argoprojv1a1.ArgoCDExport) *batchv1.CronJob {
 	}
 }
 
-func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string) corev1.PodSpec {
+func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string, client client.Client) corev1.PodSpec {
 	pod := corev1.PodSpec{}
+
+	boolPtr := func(value bool) *bool {
+		return &value
+	}
 
 	pod.Containers = []corev1.Container{{
 		Command:         getArgoExportCommand(cr),
@@ -173,7 +178,16 @@ func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string) corev1.P
 		Image:           getArgoExportContainerImage(cr),
 		ImagePullPolicy: corev1.PullAlways,
 		Name:            "argocd-export",
-		VolumeMounts:    getArgoExportVolumeMounts(cr),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{
+					"ALL",
+				},
+			},
+			RunAsNonRoot: boolPtr(true),
+		},
+		VolumeMounts: getArgoExportVolumeMounts(),
 	}}
 
 	pod.RestartPolicy = corev1.RestartPolicyOnFailure
@@ -191,18 +205,19 @@ func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string) corev1.P
 		RunAsGroup: &id,
 		FSGroup:    &id,
 	}
+	argocd.AddSeccompProfileForOpenShift(client, &pod)
 
 	return pod
 }
 
-func newPodTemplateSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string) corev1.PodTemplateSpec {
+func newPodTemplateSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string, client client.Client) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: cr.Namespace,
 			Labels:    common.DefaultLabels(cr.Name),
 		},
-		Spec: newExportPodSpec(cr, argocdName),
+		Spec: newExportPodSpec(cr, argocdName, client),
 	}
 }
 
@@ -231,7 +246,7 @@ func (r *ReconcileArgoCDExport) reconcileCronJob(cr *argoprojv1a1.ArgoCDExport) 
 		return err
 	}
 	job := newJob(cr)
-	job.Spec.Template = newPodTemplateSpec(cr, argocdName)
+	job.Spec.Template = newPodTemplateSpec(cr, argocdName, r.Client)
 
 	cj.Spec.JobTemplate.Spec = job.Spec
 
@@ -264,7 +279,7 @@ func (r *ReconcileArgoCDExport) reconcileJob(cr *argoprojv1a1.ArgoCDExport) erro
 	if err != nil {
 		return err
 	}
-	job.Spec.Template = newPodTemplateSpec(cr, argocdName)
+	job.Spec.Template = newPodTemplateSpec(cr, argocdName, r.Client)
 
 	if err := controllerutil.SetControllerReference(cr, job, r.Scheme); err != nil {
 		return err

--- a/deploy/olm-catalog/argocd-operator/0.4.0/argocd-operator.v0.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.4.0/argocd-operator.v0.4.0.clusterserviceversion.yaml
@@ -132,7 +132,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/argoproj-labs/argocd-operator
     support: Argo CD
-  name: argocd-operator.v0.3.0
+  name: argocd-operator.v0.4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -580,6 +580,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
+      - description: ResourceTrackingMethod defines how Argo CD should track resources
+          that it manages
+        displayName: Resource Tracking Method'
+        path: resourceTrackingMethod
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Enabled will toggle autoscaling support for the Argo CD Server
           component.
         displayName: Autoscale Enabled'
@@ -692,6 +699,19 @@ spec:
           For some reason the state of the Argo CD Dex component could not be obtained.'
         displayName: Dex
         path: dex
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'NotificationsController is a simple, high-level summary of where
+          the Argo CD notifications controller component is in its lifecycle. There
+          are five possible NotificationsController values: Pending: The Argo CD notifications
+          controller component has been accepted by the Kubernetes system, but one
+          or more of the required resources have not been created. Running: All of
+          the required Pods for the Argo CD notifications controller component are
+          in a Ready state. Failed: At least one of the  Argo CD notifications controller
+          component Pods had a failure. Unknown: For some reason the state of the
+          Argo CD notifications controller component could not be obtained.'
+        displayName: NotificationsController
+        path: notificationsController
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Phase is a simple, high-level summary of where the ArgoCD is
@@ -994,7 +1014,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/argoprojlabs/argocd-operator@sha256:f6fc8c310ff6c86d9e0b5acbc16de7dc14d0f5dd813094e380d636482bccb090
+                image: quay.io/argoprojlabs/argocd-operator:v0.4.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1075,5 +1095,5 @@ spec:
   maturity: alpha
   provider:
     name: Argo CD Community
-  replaces: argocd-operator.v0.2.1
-  version: 0.3.0
+  replaces: argocd-operator.v0.3.0
+  version: 0.4.0

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/mod v0.5.1-0.20210830214625-1b1db11ec8f4
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -1466,6 +1466,10 @@ golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+<<<<<<< HEAD
+=======
+golang.org/x/mod v0.5.1-0.20210830214625-1b1db11ec8f4 h1:7Qds88gNaRx0Dz/1wOwXlR7asekh1B1u26wEwN6FcEI=
+>>>>>>> 5240e6a (chore: enable pod security admission (#675))
 golang.org/x/mod v0.5.1-0.20210830214625-1b1db11ec8f4/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "github.com/openshift/api/apps/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
@@ -147,6 +148,14 @@ func main() {
 	// Setup Scheme for OpenShift Routes if available.
 	if argocd.IsRouteAPIAvailable() {
 		if err := routev1.Install(mgr.GetScheme()); err != nil {
+			setupLog.Error(err, "")
+			os.Exit(1)
+		}
+	}
+
+	// Set up the scheme for openshift config if available
+	if argocd.IsVersionAPIAvailable() {
+		if err := configv1.Install(mgr.GetScheme()); err != nil {
 			setupLog.Error(err, "")
 			os.Exit(1)
 		}


### PR DESCRIPTION
GITOPS-2034
 
* chore: enable pod security admission

Signed-off-by: John Pitman <jpitman@redhat.com>

* make changes for HA mode

Signed-off-by: John Pitman <jpitman@redhat.com>

* update export pod

Signed-off-by: John Pitman <jpitman@redhat.com>

* update notifications deployment

Signed-off-by: John Pitman <jpitman@redhat.com>

* remove unused function

Signed-off-by: John Pitman <jpitman@redhat.com>

* fix version test

Signed-off-by: John Pitman <jpitman@redhat.com>

* only add seccompprofile runtimedefault for openshift 4.11

Signed-off-by: John Pitman <jpitman@redhat.com>

* update rbac

Signed-off-by: John Pitman <jpitman@redhat.com>

* add runAsUser for grafana and redis

Signed-off-by: John Pitman <jpitman@redhat.com>

* update erroneous comment

Signed-off-by: John Pitman <jpitman@redhat.com>

* delete invalid code

Signed-off-by: John Pitman <jpitman@redhat.com>

* fix linter errors

Signed-off-by: John Pitman <jpitman@redhat.com>

* fix another linter error

Signed-off-by: John Pitman <jpitman@redhat.com>

* add missing seccomprofile for app set

Signed-off-by: John Pitman <jpitman@redhat.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
