### PR TITLE
fix: imagePullPolicy in dex deployment

### DIFF
--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -229,10 +229,9 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoprojv1a1.ArgoCD) error 
 			"/shared/argocd-dex",
 			"rundex",
 		},
-		Image:           getDexContainerImage(cr),
-		ImagePullPolicy: corev1.PullAlways,
-		Name:            "dex",
-		Env:             proxyEnvVars(),
+		Image: getDexContainerImage(cr),
+		Name:  "dex",
+		Env:   proxyEnvVars(),
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -421,7 +421,6 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "static-files", MountPath: "/shared"}},
-				ImagePullPolicy: corev1.PullAlways,
 			},
 		},
 		ServiceAccountName: "argocd-argocd-dex-server",
@@ -512,7 +511,6 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "static-files", MountPath: "/shared"}},
-				ImagePullPolicy: corev1.PullAlways,
 			},
 		},
 		ServiceAccountName: "argocd-argocd-dex-server",


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:

Fixes https://github.com/redhat-developer/gitops-operator/issues/132
Removing the `ImagePullPolicy` in dex deployment
The default policy of `IfNotPresent` property will be used in the deployment.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
