### PR TITLE
fix: remove liveness probe from application controller statefulset

### DIFF
--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -453,17 +453,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 		Image:           getArgoContainerImage(cr),
 		ImagePullPolicy: corev1.PullAlways,
 		Name:            "argocd-application-controller",
-		LivenessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/healthz",
-					Port: intstr.FromInt(8082),
-				},
-			},
-			InitialDelaySeconds: 5,
-			PeriodSeconds:       10,
-		},
-		Env: controllerEnv,
+		Env:             controllerEnv,
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: 8082,


### PR DESCRIPTION
Signed-off-by: saumeya <saumeyakatyal@gmail.com>

**What type of PR is this?**
/kind bug


**What does this PR do / why we need it**:

According to the upstream PR - https://github.com/argoproj/argo-cd/pull/9557. This PR updates the statefulset in the operator 

This will be backported to previous versions after merge

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.


**How to test changes / Special notes to the reviewer**:
```make install run```