### PR TITLE
fix: operator resources should have unique labels.

### DIFF
--- a/bundle/manifests/argocd-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/argocd-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    control-plane: controller-manager
+    control-plane: argocd-operator
   name: argocd-operator-controller-manager-metrics-service
 spec:
   ports:
@@ -11,6 +11,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: argocd-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -1019,12 +1019,12 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              control-plane: argocd-operator
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: controller-manager
+                control-plane: argocd-operator
             spec:
               containers:
               - args:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: argocd-operator
   name: system
 ---
 apiVersion: apps/v1
@@ -11,16 +11,16 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: argocd-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: argocd-operator
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: argocd-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: argocd-operator
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: argocd-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: argocd-operator
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: argocd-operator

--- a/deploy/olm-catalog/argocd-operator/0.5.0/argocd-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.5.0/argocd-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    control-plane: controller-manager
+    control-plane: argocd-operator
   name: argocd-operator-controller-manager-metrics-service
 spec:
   ports:
@@ -11,6 +11,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: argocd-operator
 status:
   loadBalancer: {}

--- a/deploy/olm-catalog/argocd-operator/0.5.0/argocd-operator.v0.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.5.0/argocd-operator.v0.5.0.clusterserviceversion.yaml
@@ -1019,12 +1019,12 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              control-plane: argocd-operator
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: controller-manager
+                control-plane: argocd-operator
             spec:
               containers:
               - args:


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Fixes #750 

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
Fixes #750 
Closes #750 

**How to test changes / Special notes to the reviewer**:
1. Build the operator using the steps mentioned [here](https://argocd-operator.readthedocs.io/en/latest/contribute/development/#bundle).
2. Publish the operator to your OpenShift Cluster.
3. Install the Operator from operatorhub console.
4. Wait for the operator to create resources.
5. Check the operator pod label is now updated to `control-plane: argocd-operator`.
