### PR TITLE
fix: Keycloak/RHSSO login yields in certificate signed by unknown authority 

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -272,6 +272,9 @@ type ArgoCDKeycloakSpec struct {
 	// Resources defines the Compute Resources required by the container for Keycloak.
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// Custom root CA certificate for communicating with the Keycloak OIDC provider
+	RootCA string `json:"rootCA,omitempty"`
+
 	// Version is the Keycloak container image tag.
 	Version string `json:"version,omitempty"`
 

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -5767,6 +5767,10 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
+                      rootCA:
+                        description: Custom root CA certificate for communicating
+                          with the Keycloak OIDC provider
+                        type: string
                       verifyTLS:
                         description: VerifyTLS set to false disables strict TLS validation.
                         type: boolean

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -5769,6 +5769,10 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
+                      rootCA:
+                        description: Custom root CA certificate for communicating
+                          with the Keycloak OIDC provider
+                        type: string
                       verifyTLS:
                         description: VerifyTLS set to false disables strict TLS validation.
                         type: boolean

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -107,6 +107,7 @@ type oidcConfig struct {
 	ClientID       string   `json:"clientID"`
 	ClientSecret   string   `json:"clientSecret"`
 	RequestedScope []string `json:"requestedScopes"`
+	RootCA         string   `json:"rootCA,omitempty"`
 }
 
 // KeycloakIdentityProviderMapper defines IdentityProvider Mappers
@@ -1100,6 +1101,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoprojv1a1.ArgoCD, kRo
 		ClientID:       keycloakClient,
 		ClientSecret:   "$oidc.keycloak.clientSecret",
 		RequestedScope: []string{"openid", "profile", "email", "groups"},
+		RootCA:         cr.Spec.SSO.Keycloak.RootCA,
 	})
 
 	if err != nil {

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -85,7 +85,8 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 		}
 	}
 
-	if cr.Spec.SSO != nil && (cr.Spec.SSO.Image != "" || cr.Spec.SSO.Version != "" || cr.Spec.SSO.VerifyTLS != nil || cr.Spec.SSO.Resources != nil) {
+	if cr.Spec.SSO != nil && (cr.Spec.SSO.Image != "" || cr.Spec.SSO.Version != "" ||
+		cr.Spec.SSO.VerifyTLS != nil || cr.Spec.SSO.Resources != nil) {
 
 		// Emit event warning users about deprecation notice for `.spec.SSO` field users
 		err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.SSO.Image`, `.spec.SSO.Version`, `.spec.SSO.Resources` and `.spec.SSO.VerifyTLS` are deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Keycloak configuration can be managed through `.spec.sso.keycloak`", "DeprecationNotice", cr.ObjectMeta)
@@ -164,7 +165,8 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 		if cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeKeycloak {
 			// Relevant SSO settings at play are `DISABLE_DEX`, `.spec.dex`, `.spec.sso` fields, `.spec.sso.keycloak`, `.spec.sso.dex`
 
-			if (cr.Spec.SSO.Keycloak != nil) && (cr.Spec.SSO.Image != "" || cr.Spec.SSO.Version != "" || cr.Spec.SSO.Resources != nil || cr.Spec.SSO.VerifyTLS != cr.Spec.SSO.Keycloak.VerifyTLS) {
+			if (cr.Spec.SSO.Keycloak != nil) && (cr.Spec.SSO.Image != "" || cr.Spec.SSO.Version != "" ||
+				cr.Spec.SSO.Resources != nil || cr.Spec.SSO.VerifyTLS != nil) {
 				// Keycloak specs expressed both in old `.spec.sso` fields as well as in `.spec.sso.keycloak` simultaneously and they don't match
 				// ==> conflict
 				errMsg = "cannot specify keycloak fields in .spec.sso when keycloak is configured through .spec.sso.keycloak"

--- a/deploy/olm-catalog/argocd-operator/0.5.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.5.0/argoproj.io_argocds.yaml
@@ -5767,6 +5767,10 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
+                      rootCA:
+                        description: Custom root CA certificate for communicating
+                          with the Keycloak OIDC provider
+                        type: string
                       verifyTLS:
                         description: VerifyTLS set to false disables strict TLS validation.
                         type: boolean

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -644,6 +644,7 @@ Name | Default | Description
 --- | --- | ---
 Image | OpenShift - `registry.redhat.io/rh-sso-7/sso75-openshift-rhel8` <br/> Kuberentes - `quay.io/keycloak/keycloak` | The container image for keycloak. This overrides the `ARGOCD_KEYCLOAK_IMAGE` environment variable.
 Resources | `Requests`: CPU=500m, Mem=512Mi, `Limits`: CPU=1000m, Mem=1024Mi | The container compute resources.
+RootCA | "" | root CA certificate for communicating with the OIDC provider
 VerifyTLS | true | Whether to enforce strict TLS checking when communicating with Keycloak service.
 Version | OpenShift - `sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3` (7.5.1) <br/> Kubernetes - `sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9` (15.0.2) | The tag to use with the keycloak container image.
 

--- a/docs/usage/keycloak/kubernetes.md
+++ b/docs/usage/keycloak/kubernetes.md
@@ -45,6 +45,35 @@ spec:
     insecure: true
 ```
 
+If your keycloak is setup with a certificate which is not signed by one of the well known certificate authorities you can provide a custom certificate which will be used in verifying the Keycloak's TLS certificate when communicating with it.
+Add the rootCA to your Argo CD custom resource `.spec.keycloak.rootCA` field. The operator reconciles to this change and updates the `oidc.config` in `argocd-cm` configmap with the PEM encoded root certificate.
+
+!!! note
+    Argo CD server pod should be restarted after updating the `.spec.keycloak.rootCA`.
+
+Please refer to the below example:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  sso:
+    provider: keycloak
+    keycloak:
+     rootCA: |
+       ---- BEGIN CERTIFICATE ----
+       This is a dummy certificate
+       Please place this section with appropriate rootCA
+       ---- END CERTIFICATE ----
+  server:
+    ingress:
+      enabled: true
+```
+
 !!! warning
     `.spec.sso.Image`, `.spec.sso.Version`, `.spec.sso.Resources` and `.spec.sso.verifyTLS` are deprecated and support will be removed in Argo CD operator v0.6.0. Please use equivalent fields under `.spec.sso.keycloak` to configure your keycloak instance.
 

--- a/docs/usage/keycloak/openshift.md
+++ b/docs/usage/keycloak/openshift.md
@@ -19,6 +19,35 @@ spec:
      enabled: true
 ```
 
+If your keycloak is setup with a certificate which is not signed by one of the well known certificate authorities you can provide a custom certificate which will be used in verifying the Keycloak's TLS certificate when communicating with it.
+Add the rootCA to your Argo CD custom resource `.spec.keycloak.rootCA` field. The operator reconciles to this change and updates the `oidc.config` in `argocd-cm` configmap with the PEM encoded root certificate.
+
+!!! note
+    Argo CD server pod should be restarted after updating the `.spec.keycloak.rootCA`.
+
+Please refer to the below example:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  sso:
+    provider: keycloak
+    keycloak:
+     rootCA: |
+       ---- BEGIN CERTIFICATE ----
+       This is a dummy certificate
+       Please place this section with appropriate rootCA
+       ---- END CERTIFICATE ----
+  server:
+    route:
+      enabled: true
+```
+
 ## Create
 
 Create a new Argo CD Instance in the `argocd` namespace using the provided example.

--- a/examples/argocd-keycloak-k8s.yaml
+++ b/examples/argocd-keycloak-k8s.yaml
@@ -7,7 +7,8 @@ metadata:
 spec:
   sso:
     provider: keycloak
-    verifyTLS: false
+    keycloak:
+     verifyTLS: false
   server:
     ingress:
       enabled: true

--- a/examples/argocd-route.yaml
+++ b/examples/argocd-route.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     example: route
 spec:
+  sso:
+   provider: keycloak
+   keycloak:
+     verifyTLS: false
   grafana:
     enabled: true
     route:

--- a/examples/argocd-route.yaml
+++ b/examples/argocd-route.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     example: route
 spec:
-  sso:
-   provider: keycloak
-   keycloak:
-     verifyTLS: false
   grafana:
     enabled: true
     route:

--- a/tests/ocp/1-001_validate_rhsso/01-argocd-rhsso.yaml
+++ b/tests/ocp/1-001_validate_rhsso/01-argocd-rhsso.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   sso: 
     provider: keycloak
-    verifyTLS: false # required when running operator locally
+    keycloak:
+      verifyTLS: false # required when running operator locally
+      rootCA: "---BEGIN---END---"
   server:
     route: 
       enabled: true

--- a/tests/ocp/1-001_validate_rhsso/03-verify-oidc.yaml
+++ b/tests/ocp/1-001_validate_rhsso/03-verify-oidc.yaml
@@ -4,8 +4,8 @@ commands:
 # verify OIDC config
 # verify issuer
 - script: |
-    issuer=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n argocd-e2e-rhsso | grep issuer | awk -F' ' '{print $2}')
-    keycloakRoute=$(kubectl get route keycloak -n argocd-e2e-rhsso -o jsonpath='{.spec.host}')
+    issuer=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n $NAMESPACE | grep issuer | awk -F' ' '{print $2}')
+    keycloakRoute=$(kubectl get route keycloak -n $NAMESPACE -o jsonpath='{.spec.host}')
     if [[ "${issuer}" == "https://${keycloakRoute}/auth/realms/argocd" ]]; then 
       echo "issuer matched"
     else 
@@ -13,15 +13,16 @@ commands:
       echo "${issuer} not equals ${keycloakRoute}/auth/realms/argocd"
       exit 1
     fi  
-# verify oidc config name and clientid
+# verify oidc config name, clientid
 - script: | 
-    clientid=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n argocd-e2e-rhsso | grep clientid | awk -F' ' '{print $2}')
-    name=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n argocd-e2e-rhsso | grep name | awk -F' ' '{print $2}')
-    
-    if [[ "${clientid}" == "argocd" && "${name}" == "Keycloak" ]]; then 
-      echo "oidc name and clientid matched"
+    clientid=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n $NAMESPACE | grep clientid | awk -F' ' '{print $2}')
+    name=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n $NAMESPACE | grep name | awk -F' ' '{print $2}')
+    rootCA=$(kubectl get configmap argocd-cm -o jsonpath='{.data.oidc\.config}' -n $NAMESPACE | grep rootca | awk -F' ' '{print $2}')
+
+    if [[ "${clientid}" == "argocd" && "${name}" == "Keycloak" && "${rootCA}" == "'---BEGIN---END---'"  ]]; then 
+      echo "oidc name, clientid and rootCA matched"
     else 
-      echo "oidc name and clientid mismatched"
-      echo "${clientid} and ${name}"
+      echo "oidc name, clientid or rootCA mismatched"
+      echo "${clientid}, ${name} and ${rootCA}"
       exit 1
     fi

--- a/tests/ocp/1-001_validate_rhsso/04-verifyRealmCreation.yaml
+++ b/tests/ocp/1-001_validate_rhsso/04-verifyRealmCreation.yaml
@@ -7,10 +7,10 @@ kind: TestStep
 commands:
 - script: |
     # Set the needed parameter for the authorization
-    KEYCLOAK_URL=$(oc get route keycloak -n argocd-e2e-rhsso -o jsonpath='{.spec.host}')
+    KEYCLOAK_URL=$(oc get route keycloak -n $NAMESPACE -o jsonpath='{.spec.host}')
     tenant=argocd
-    USER=$(oc get secret keycloak-secret -n argocd-e2e-rhsso -o jsonpath='{.data.SSO_USERNAME}' | base64 --decode)
-    PASSWORD=$(oc get secret keycloak-secret -n argocd-e2e-rhsso -o jsonpath='{.data.SSO_PASSWORD}' | base64 --decode)
+    USER=$(oc get secret keycloak-secret -n $NAMESPACE -o jsonpath='{.data.SSO_USERNAME}' | base64 --decode)
+    PASSWORD=$(oc get secret keycloak-secret -n $NAMESPACE -o jsonpath='{.data.SSO_PASSWORD}' | base64 --decode)
     GRANT_TYPE=password
     CLIENT_ID=admin-cli
     

--- a/tests/ocp/1-001_validate_rhsso/99-delete.yaml
+++ b/tests/ocp/1-001_validate_rhsso/99-delete.yaml
@@ -1,5 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: oc delete argocd example-argocd-keycloak -n argocd-e2e-rhsso
-  - command: oc delete ns argocd-e2e-rhsso
+  - command: oc delete argocd example-argocd-keycloak -n $NAMESPACE


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Single Sign On with GitOps Operator can fail with the error message "x509: certificate signed by unknown authority" under the following circumstances:

You are using RHSSO (KeyCloak) as SSO provider and You are using a self-signed certificate for your route endpoints, or you are using a private CA to issue certificates.

This behavior is a result of a [security fix](https://github.com/argoproj/argo-cd/security/advisories/GHSA-7943-82jg-wmw5) in Argo CD, which enforces a strict validation of TLS certificates on the configued OIDC endpoints.

**Workaround & Mitigation**
There are multiple workarounds available:
For Argo CD Operator 0.4.0, you can disable TLS validation for the OIDC (Keycloak/RHSSO) endpoint in the ArgoCD spec:
```
spec:
  extraConfig:
    oidc.tls.insecure.skip.verify: "true"
```

For Argo CD Operator 0.3.0 or less, you need to patch the `argocd-cm` ConfigMap in your instance's namespace as follows
```
oc patch configmap argocd-cm --patch='{"data": {"oidc.tls.insecure.skip.verify": "true"}}'
```

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes #761 
Closes #761 

**How to test changes / Special notes to the reviewer**:
1. Run the operator locally using `make install run`
2. Run the e2e test using `kubectl kuttl test ./tests/ocp --config ./tests/kuttl-tests.yaml --test 1-001_validate_rhsso`

(or)

3. You can also test this manually by
4. Create the Argo CD Instance using Keycloak as SSO provider.
```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: route
spec:
  sso:
    provider: keycloak
    keycloak:
       verifyTLS: false
       rootTLS: "--- Some Dummy Root CA ---"
  server:
    route:
      enabled: true
```
5. Give the operator 3-4 minutes to reconcile.
6. Verify that `rootCA` is added to the oidc.config in `argocd-cm` ConfigMap.
7. Modify the `rootCA` and verify that the operator reconciles the changes.