### PR TITLE
[v0.2.x] fix: terminating namespaces blocks new managed Argo CD namespaces for…

### DIFF
--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -96,6 +96,11 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 
 	// create policy rules for each namespace
 	for _, namespace := range r.ManagedNamespaces.Items {
+		// Skip terminating namespaces.
+		if namespace.DeletionTimestamp != nil {
+			continue
+		}
+
 		customRole := getCustomRoleName(name)
 		role := newRole(name, policyRules, cr)
 		if err := applyReconcilerHook(cr, role, ""); err != nil {

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -177,4 +179,70 @@ func TestReconcileArgoCD_reconcileRole_custom_role(t *testing.T) {
 	if err == nil || !errors.IsNotFound(err) {
 		t.Fatal(err)
 	}
+}
+
+// This test validates the behavior of the operator reconciliation when a managed namespace is not properly terminated
+// or remains terminating may be because of some resources in the namespace not getting deleted.
+func TestReconcileRoles_ManagedTerminatingNamespace(t *testing.T) {
+
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+
+	// Create a managed namespace
+	assert.NoError(t, createNamespace(r, "managedNS", a.Namespace))
+
+	workloadIdentifier := "x"
+	expectedRules := policyRuleForApplicationController()
+	_, err := r.reconcileRole(workloadIdentifier, expectedRules, a)
+	assert.NoError(t, err)
+
+	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
+	reconciledRole := &v1.Role{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.Equal(t, expectedRules, reconciledRole.Rules)
+
+	// Check if roles are created for the new namespace as well
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS"}, reconciledRole))
+	assert.Equal(t, expectedRules, reconciledRole.Rules)
+
+	// Create a configmap with an invalid finalizer in the "managedNS".
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dummy",
+			Namespace: "managedNS",
+			Finalizers: []string{
+				"nonexistent.finalizer/dummy",
+			},
+		},
+	}
+	assert.NoError(t, r.Client.Create(
+		context.TODO(), configMap))
+
+	// Delete the newNamespaceTest ns.
+	// Verify that operator should not reconcile back to create the roles in terminating ns.
+	newNS := &corev1.Namespace{}
+	r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "managedNS", Name: "managedNS"}, newNS)
+	r.Client.Delete(context.TODO(), newNS)
+
+	// Verify that the namespace exists and is in terminating state.
+	r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "managedNS", Name: "managedNS"}, newNS)
+	assert.NotEqual(t, newNS.DeletionTimestamp, nil)
+
+	_, err = r.reconcileRole(workloadIdentifier, expectedRules, a)
+	assert.NoError(t, err)
+
+	// Verify that the roles are deleted
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, reconciledRole)
+	assert.EqualError(t, err, "roles.rbac.authorization.k8s.io \"argocd-x\" not found")
+
+	// Create another managed namespace
+	assert.NoError(t, createNamespace(r, "managedNS2", a.Namespace))
+
+	// Check if roles are created for the new namespace as well
+	_, err = r.reconcileRole(workloadIdentifier, expectedRules, a)
+	assert.NoError(t, err)
+
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, reconciledRole))
+	assert.Equal(t, expectedRules, reconciledRole.Rules)
 }

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -104,6 +104,11 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 	}
 
 	for _, namespace := range r.ManagedNamespaces.Items {
+		// Skip terminating namespaces.
+		if namespace.DeletionTimestamp != nil {
+			continue
+		}
+
 		// get expected name
 		roleBinding := newRoleBindingWithname(name, cr)
 		roleBinding.Namespace = namespace.Name

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -98,6 +98,62 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding(t *testing.T) {
 	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding))
 }
 
+// This test validates the behavior of the operator reconciliation when a managed namespace is not properly terminated
+// or remains terminating may be because of some resources in the namespace not getting deleted.
+func TestReconcileRoleBinding_for_Managed_Teminating_Namespace(t *testing.T) {
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+	assert.NoError(t, createNamespace(r, "managedNS", a.Namespace))
+
+	// Verify role bindings are created for the new namespace with managed-by label
+	roleBinding := &rbacv1.RoleBinding{}
+	workloadIdentifier := common.ArgoCDApplicationControllerComponent
+	expectedRules := policyRuleForApplicationController()
+	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
+	assert.NoError(t, r.reconcileRoleBinding(workloadIdentifier, expectedRules, a))
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS"}, roleBinding))
+
+	// Create a configmap with an invalid finalizer in the "managedNS".
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dummy",
+			Namespace: "managedNS",
+			Finalizers: []string{
+				"nonexistent.finalizer/dummy",
+			},
+		},
+	}
+	assert.NoError(t, r.Client.Create(
+		context.TODO(), configMap))
+
+	// Delete the newNamespaceTest ns.
+	// Verify that operator should not reconcile back to create the roleBindings in terminating ns.
+	newNS := &corev1.Namespace{}
+	r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "managedNS", Name: "managedNS"}, newNS)
+	r.Client.Delete(context.TODO(), newNS)
+
+	// Verify that the namespace exists and is in terminating state.
+	r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "managedNS", Name: "managedNS"}, newNS)
+	assert.NotEqual(t, newNS.DeletionTimestamp, nil)
+
+	err := r.reconcileRoleBinding(workloadIdentifier, expectedRules, a)
+	assert.NoError(t, err)
+
+	// Verify that the role bindings are deleted
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, roleBinding)
+	assert.EqualError(t, err, "rolebindings.rbac.authorization.k8s.io \"argocd-argocd-application-controller\" not found")
+
+	// Create another managed namespace
+	assert.NoError(t, createNamespace(r, "managedNS2", a.Namespace))
+
+	// Check if roleBindings are created for the new namespace as well
+	err = r.reconcileRoleBinding(workloadIdentifier, expectedRules, a)
+	assert.NoError(t, err)
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, roleBinding))
+}
+
 func TestReconcileArgoCD_reconcileRoleBinding_custom_role(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Fixes #755 
Closes #755 

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
Fixes #755 

**How to test changes / Special notes to the reviewer**:
Steps to reproduce:
**Prerequisite**:
Run the operator locally using `make install run`

1) Install namespace-scoped Argo CD:
kubectl create ns gitops-service-argocd
kubectl apply -f https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/gitops/staging/argo-cd.yaml
kubectl apply -f https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/gitops/staging/allow-argocd-to-manage.yaml

2) Create a Namespace managed by Argo CD.
```
apiVersion: v1
kind: Namespace
metadata:
  name: jane
  labels:
    argocd.argoproj.io/managed-by: gitops-service-argocd
```

3) Create 'ConfigMap' with a finalizer, in Namespace.
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-config-map-2
  namespace: jane  
  finalizers:
  - some.random/finalizer 
data: {}
```
4) Delete the 'Namespace', putting it into 'Terminating' state. The Namespace will never finish deleting, due to the finalizer on the 'ConfigMap'.

kubectl delete namespace jane

5) Finally, attempt to create a new managed 'Namespace'
```
apiVersion: v1
kind: Namespace
metadata:
  name: john
  labels:
    argocd.argoproj.io/managed-by: gitops-service-argocd
```
The 'john' Namespace never becomes managed by Argo CD: the Argo CD RoleBinding SHOULD be created (that gives Argo CD access to the 'john' namespace) is never created.

Likewise, if you attempt to deploy into the 'john' Namespace using an Argo CD Application, the Application status field will show an error like:
'Namespace "e2e-test-bktg" for (...) "build-suite-test-component-git-source-sbfh" is not managed'
(because the  operator has not created the RoleBinding that allows Argo CD to target this namespace)