### PR TITLE
[v0.3.x] fix: Keycloak/RHSSO login yields in certificate signed by unknown authority

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -494,6 +494,8 @@ type ArgoCDSSOSpec struct {
 	VerifyTLS *bool `json:"verifyTLS,omitempty"`
 	// Version is the SSO container image tag.
 	Version string `json:"version,omitempty"`
+	// Custom root CA certificate for communicating with the Keycloak OIDC provider
+	RootCA string `json:"rootCA,omitempty"`
 }
 
 // KustomizeVersionSpec is used to specify information about a kustomize version to be used within ArgoCD.

--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,5 +1,5 @@
 # Argo CD v2.3.3
-FROM quay.io/argoproj/argocd@sha256:dd738f234fcdb0aac8631a0fd1aafbbcd86f936480b06e8377b033ef7a764f71
+FROM quay.io/argoproj/argocd@sha256:428f55f0c1edd30f9bb10031da4a66a2a2acbe141cc1aeeeea6940a67dd9dd16
 
 USER root
 

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -994,7 +994,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/argoprojlabs/argocd-operator@sha256:f6fc8c310ff6c86d9e0b5acbc16de7dc14d0f5dd813094e380d636482bccb090
+                image: quay.io/argoprojlabs/argocd-operator:v0.3.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -4287,6 +4287,10 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  rootCA:
+                    description: Custom root CA certificate for communicating with
+                      the Keycloak OIDC provider
+                    type: string
                   verifyTLS:
                     description: VerifyTLS set to false disables strict TLS validation.
                     type: boolean

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -64,7 +64,7 @@ const (
 	ArgoCDDefaultArgoImage = "quay.io/argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:dd738f234fcdb0aac8631a0fd1aafbbcd86f936480b06e8377b033ef7a764f71" // v2.3.3
+	ArgoCDDefaultArgoVersion = "sha256:428f55f0c1edd30f9bb10031da4a66a2a2acbe141cc1aeeeea6940a67dd9dd16" // v2.3.7
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -4289,6 +4289,10 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  rootCA:
+                    description: Custom root CA certificate for communicating with
+                      the Keycloak OIDC provider
+                    type: string
                   verifyTLS:
                     description: VerifyTLS set to false disables strict TLS validation.
                     type: boolean

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,6 +11,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:f6fc8c310ff6c86d9e0b5acbc16de7dc14d0f5dd813094e380d636482bccb090
-  name: controller
+- name: controller
   newName: quay.io/argoprojlabs/argocd-operator
+  newTag: v0.3.0

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -107,6 +107,7 @@ type oidcConfig struct {
 	ClientID       string   `json:"clientID"`
 	ClientSecret   string   `json:"clientSecret"`
 	RequestedScope []string `json:"requestedScopes"`
+	RootCA         string   `json:"rootCA,omitempty"`
 }
 
 // KeycloakIdentityProviderMapper defines IdentityProvider Mappers
@@ -292,7 +293,7 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 			{ContainerPort: 8888, Name: "ping", Protocol: "TCP"},
 		},
 		ReadinessProbe: &corev1.Probe{
-			FailureThreshold: 10,
+			FailureThreshold: 20,
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
@@ -1078,6 +1079,10 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoprojv1a1.ArgoCD, kRo
 	}
 
 	// Update ArgoCD instance for OIDC Config with Keycloakrealm URL
+	rootCA := ""
+	if cr.Spec.SSO.RootCA != "" {
+		rootCA = cr.Spec.SSO.RootCA
+	}
 	o, err := yaml.Marshal(oidcConfig{
 		Name: "Keycloak",
 		Issuer: fmt.Sprintf("%s/auth/realms/%s",
@@ -1085,6 +1090,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoprojv1a1.ArgoCD, kRo
 		ClientID:       keycloakClient,
 		ClientSecret:   "$oidc.keycloak.clientSecret",
 		RequestedScope: []string{"openid", "profile", "email", "groups"},
+		RootCA:         rootCA,
 	})
 
 	if err != nil {
@@ -1341,9 +1347,8 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoprojv1a1.ArgoCD)
 		}
 	}
 
-	// If Keycloak deployment exists and a realm is already created for ArgoCD, Do not create a new one.
-	if existingDC.Status.AvailableReplicas == expectedReplicas &&
-		existingDC.Annotations["argocd.argoproj.io/realm-created"] == "false" {
+	// Proceed with the keycloak configuration only once the keycloak pod is up and running.
+	if existingDC.Status.AvailableReplicas == expectedReplicas {
 
 		cfg, err := r.prepareKeycloakConfig(cr)
 		if err != nil {
@@ -1353,48 +1358,54 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoprojv1a1.ArgoCD)
 		// keycloakRouteURL is used to update the OIDC configuration for ArgoCD.
 		keycloakRouteURL := cfg.KeycloakURL
 
-		// Create a keycloak realm and publish.
-		response, err := createRealm(cfg)
-		if err != nil {
-			log.Error(err, fmt.Sprintf("Failed posting keycloak realm configuration for ArgoCD %s in namespace %s",
-				cr.Name, cr.Namespace))
-			return err
-		}
+		// If Keycloak deployment exists and a realm is already created for ArgoCD, Do not create a new one.
+		if existingDC.Annotations["argocd.argoproj.io/realm-created"] == "false" {
 
-		if response == successResponse {
-			log.Info(fmt.Sprintf("Successfully created keycloak realm for ArgoCD %s in namespace %s",
-				cr.Name, cr.Namespace))
-
-			// TODO: Remove the deleteOAuthClient invocation once the issue is resolved.
-			// OAuthClient configuration does not get deleted from previous instances occasionally.
-			// It is safe to delete before updating the OIDC config.
-			// https://github.com/openshift/client-go/issues/209
-			err = deleteOAuthClient(cr)
+			// Create a keycloak realm and publish.
+			response, err := createRealm(cfg)
 			if err != nil {
-				return err
-			}
-
-			// Update Realm creation. This will avoid posting of realm configuration on further reconciliations.
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingDC.Name, Namespace: existingDC.Namespace}, existingDC)
-			if err != nil {
-				return err
-			}
-
-			existingDC.Annotations["argocd.argoproj.io/realm-created"] = "true"
-			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				return r.Client.Update(context.TODO(), existingDC)
-			})
-
-			if err != nil {
-				return err
-			}
-
-			err = r.updateArgoCDConfiguration(cr, keycloakRouteURL)
-			if err != nil {
-				log.Error(err, fmt.Sprintf("Failed to update OIDC Configuration for ArgoCD %s in namespace %s",
+				log.Error(err, fmt.Sprintf("Failed posting keycloak realm configuration for ArgoCD %s in namespace %s",
 					cr.Name, cr.Namespace))
 				return err
 			}
+
+			if response == successResponse {
+				log.Info(fmt.Sprintf("Successfully created keycloak realm for ArgoCD %s in namespace %s",
+					cr.Name, cr.Namespace))
+
+				// TODO: Remove the deleteOAuthClient invocation once the issue is resolved.
+				// OAuthClient configuration does not get deleted from previous instances occasionally.
+				// It is safe to delete before updating the OIDC config.
+				// https://github.com/openshift/client-go/issues/209
+				err = deleteOAuthClient(cr)
+				if err != nil {
+					return err
+				}
+
+				// Update Realm creation. This will avoid posting of realm configuration on further reconciliations.
+				err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingDC.Name, Namespace: existingDC.Namespace}, existingDC)
+				if err != nil {
+					return err
+				}
+
+				existingDC.Annotations["argocd.argoproj.io/realm-created"] = "true"
+				err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					return r.Client.Update(context.TODO(), existingDC)
+				})
+
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// Updates OIDC Configuration in the argocd-cm when Keycloak is initially configured
+		// or when user requests to update the OIDC configuration through `.spec.sso.keycloak.rootCA`.
+		err = r.updateArgoCDConfiguration(cr, keycloakRouteURL)
+		if err != nil {
+			log.Error(err, fmt.Sprintf("Failed to update OIDC Configuration for ArgoCD %s in namespace %s",
+				cr.Name, cr.Namespace))
+			return err
 		}
 	}
 

--- a/deploy/olm-catalog/argocd-operator/0.3.0/argocd-operator.v0.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.3.0/argocd-operator.v0.3.0.clusterserviceversion.yaml
@@ -885,6 +885,14 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - monitoring.coreos.com
           resources:
           - prometheuses
@@ -986,7 +994,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/argoprojlabs/argocd-operator@sha256:f6fc8c310ff6c86d9e0b5acbc16de7dc14d0f5dd813094e380d636482bccb090
+                image: quay.io/argoprojlabs/argocd-operator:v0.3.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/deploy/olm-catalog/argocd-operator/0.3.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.3.0/argoproj.io_argocds.yaml
@@ -4287,6 +4287,10 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  rootCA:
+                    description: Custom root CA certificate for communicating with
+                      the Keycloak OIDC provider
+                    type: string
                   verifyTLS:
                     description: VerifyTLS set to false disables strict TLS validation.
                     type: boolean

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1107,6 +1107,7 @@ Name | Default | Description
 Image | OpenShift - `registry.redhat.io/rh-sso-7/sso75-openshift-rhel8` <br/> Kuberentes - `quay.io/keycloak/keycloak` | The container image for keycloak. This overrides the `ARGOCD_KEYCLOAK_IMAGE` environment variable.
 Provider | [Empty] | The name of the provider used to configure Single sign-on. For now the only supported option is keycloak.
 Resources | `Requests`: CPU=500m, Mem=512Mi, `Limits`: CPU=1000m, Mem=1024Mi | The container compute resources.
+RootCA | "" | root CA certificate for communicating with the OIDC provider
 VerifyTLS | true | Whether to enforce strict TLS checking when communicating with Keycloak service.
 Version | OpenShift - `sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3` (7.5.1) <br/> Kubernetes - `sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9` (15.0.2) | The tag to use with the keycloak container image.
 

--- a/docs/usage/keycloak/kubernetes.md
+++ b/docs/usage/keycloak/kubernetes.md
@@ -45,6 +45,34 @@ spec:
     insecure: true
 ```
 
+If your keycloak is setup with a certificate which is not signed by one of the well known certificate authorities you can provide a custom certificate which will be used in verifying the Keycloak's TLS certificate when communicating with it.
+Add the rootCA to your Argo CD custom resource `.spec.sso.rootCA` field. The operator reconciles to this change and updates the `oidc.config` in `argocd-cm` configmap with the PEM encoded root certificate.
+
+!!! note
+    Argo CD server pod should be restarted after updating the `.spec.sso.rootCA`.
+
+Please refer to the below example:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  sso:
+    provider: keycloak
+    rootCA: |
+      ---- BEGIN CERTIFICATE ----
+      This is a dummy certificate
+      Please place this section with appropriate rootCA
+      ---- END CERTIFICATE ----
+  server:
+    ingress:
+      enabled: true
+```
+
 **NOTE**: If you test the operator locally using `make run`, please add `verifyTLS: false` to the `.spec.sso` field.
 
 ## Create

--- a/docs/usage/keycloak/openshift.md
+++ b/docs/usage/keycloak/openshift.md
@@ -19,6 +19,34 @@ spec:
      enabled: true
 ```
 
+If your keycloak is setup with a certificate which is not signed by one of the well known certificate authorities you can provide a custom certificate which will be used in verifying the Keycloak's TLS certificate when communicating with it.
+Add the rootCA to your Argo CD custom resource `.spec.sso.rootCA` field. The operator reconciles to this change and updates the `oidc.config` in `argocd-cm` configmap with the PEM encoded root certificate.
+
+!!! note
+    Argo CD server pod should be restarted after updating the `.spec.sso.rootCA`.
+
+Please refer to the below example:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  sso:
+    provider: keycloak
+    rootCA: |
+      ---- BEGIN CERTIFICATE ----
+      This is a dummy certificate
+      Please place this section with appropriate rootCA
+      ---- END CERTIFICATE ----
+  server:
+    route:
+      enabled: true
+```
+
 ## Create
 
 Create a new Argo CD Instance in the `argocd` namespace using the provided example.

--- a/examples/argocd-keycloak-openshift.yaml
+++ b/examples/argocd-keycloak-openshift.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   sso:
     provider: keycloak
-    # uncomment the below line when running operator locally.
-    # verifyTLS: false 
+    verifyTLS: false 
   server:
     route:
       enabled: true


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Single Sign On with GitOps Operator can fail with the error message "x509: certificate signed by unknown authority" under the following circumstances:

You are using RHSSO (KeyCloak) as SSO provider and You are using a self-signed certificate for your route endpoints, or you are using a private CA to issue certificates.

This behavior is a result of a [security fix](https://github.com/argoproj/argo-cd/security/advisories/GHSA-7943-82jg-wmw5) in Argo CD, which enforces a strict validation of TLS certificates on the configued OIDC endpoints.

**Workaround & Mitigation**
There are multiple workarounds available:
For Argo CD Operator 0.4.0, you can disable TLS validation for the OIDC (Keycloak/RHSSO) endpoint in the ArgoCD spec:
```
spec:
  extraConfig:
    oidc.tls.insecure.skip.verify: "true"
```

For Argo CD Operator 0.3.0 or less, you need to patch the `argocd-cm` ConfigMap in your instance's namespace as follows
```
oc patch configmap argocd-cm --patch='{"data": {"oidc.tls.insecure.skip.verify": "true"}}'
```

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes #761 
Closes #761 

**How to test changes / Special notes to the reviewer**:
1. Run the operator locally using `make install run`
2. Run the e2e test using `kubectl kuttl test ./tests/ocp --config ./tests/kuttl-tests.yaml --test 1-001_validate_rhsso`

(or)

3. You can also test this manually by
4. Create the Argo CD Instance using Keycloak as SSO provider.
```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: route
spec:
  sso:
    provider: keycloak
    verifyTLS: false
    rootTLS: "--- Some Dummy Root CA ---"
  server:
    route:
      enabled: true
```
5. Give the operator 3-4 minutes to reconcile.
6. Verify that `rootCA` is added to the oidc.config in `argocd-cm` ConfigMap.
7. Modify the `rootCA` and verify that the operator reconciles the changes.