### PR TITLE
fix: broken Argo CD Export for AWS (#774)

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && \
     apt-get install -y curl python3-pip && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Install the AWS CLI
+RUN pip3 install awscli
+
 # Install the Google Cloud SDK (CLI)
 RUN curl -sL https://sdk.cloud.google.com > /tmp/install.sh && \
     bash /tmp/install.sh --disable-prompts --install-dir=/home/argocd && \


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Fixes #774 
Closes #774 

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
Fixes #774 

**How to test changes / Special notes to the reviewer**:
1. I have built a new version of Argo CD Export by updating the DockerFile with AWS CLI installation(Please look for Files Changed Section).
2. Update the `defaults.go` -> 
`ArgoCDDefaultExportJobImage`  -> `quay.io/aveerama/argocd-operator-util`
`ArgoCDDefaultExportJobVersion` -> `sha256:5ed626b270ea3316c831e7945f2f00bb3335490a7e63240442e897b43133bb5d`
3. Run `make install run`
4. Create an Argo CD Instance using
```
kubectl apply -f examples/<choose-from-multiple-examples>
```
5. Create AWS secret and Argo CD Export using
```
kubectl apply -f examples/argocdexport-aws.yaml
```
6. Wait for the operator to reconcile the Argo CD Export CR and create the export pod.
7.  Look into the Argo CD Export pod logs.
```
exporting argo-cd
creating argo-cd backup
encrypting argo-cd backup
pushing argo-cd backup to aws
make_bucket: ***********
upload: ../../backups/argocd-backup.yaml to s3://********/argocd-backup.yaml
```
    