### PR TITLE
fix: remove default help chat url and text

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -164,10 +164,10 @@ const (
 	ArgoCDDefaultGrafanaVersion = "sha256:afef23a1b4cf159ec3180aac3ad693c10e560657313bfe3ec81f344ace6d2f05" // 6.7.2
 
 	// ArgoCDDefaultHelpChatURL is the default help chat URL.
-	ArgoCDDefaultHelpChatURL = "https://mycorp.slack.com/argo-cd"
+	ArgoCDDefaultHelpChatURL = ""
 
 	// ArgoCDDefaultHelpChatText is the default help chat text.
-	ArgoCDDefaultHelpChatText = "Chat now!"
+	ArgoCDDefaultHelpChatText = ""
 
 	// ArgoCDDefaultIngressPath is the path to use for the Ingress when not specified.
 	ArgoCDDefaultIngressPath = "/"


### PR DESCRIPTION
Signed-off-by: saumeya <saumeyakatyal@gmail.com>

**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:

Right now there is a default dummy value for help chat url and text. This button leads to dummy page and is not good user experience. The default should hence be blank and in case the user wants to add the help chat , they can do so using the argocd CR

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #762 

**How to test changes / Special notes to the reviewer**:
`make install run` and check there is no button for help chat