### PR TITLE
feat: Remove Argo CD as a base Image from the Export Dockerfile

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,24 +1,43 @@
-# Argo CD v2.5.3
-FROM quay.io/argoproj/argocd@sha256:8283a9f06033c2377dc61b03daf4994a3ab961c53d79ed32b9aebadf79bb4858
+FROM quay.io/argoproj/argocd as argocd
+
+# Final Image
+FROM docker.io/library/ubuntu:22.04
 
 USER root
 
-# Ensure system dependencies are installed
-RUN apt-get update && \
-    apt-get install -y curl python3-pip && \
+ENV ARGOCD_USER_ID=999
+
+RUN groupadd -g $ARGOCD_USER_ID argocd && \
+    useradd -r -u $ARGOCD_USER_ID -g argocd argocd && \
+    mkdir -p /home/argocd && \
+    chown argocd:0 /home/argocd && \
+    chmod g=u /home/argocd && \
+    apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y \
+    git git-lfs tini curl python3-pip gpg tzdata && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install the AWS CLI
 RUN pip3 install awscli
+
+# Install the Microsoft Azure CLI
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install the Google Cloud SDK (CLI)
 RUN curl -sL https://sdk.cloud.google.com > /tmp/install.sh && \
     bash /tmp/install.sh --disable-prompts --install-dir=/home/argocd && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install the Microsoft Azure CLI
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ENV PATH="/usr/local/google-cloud-sdk/bin:${PATH}" 
+
+COPY entrypoint.sh /usr/local/bin/uid_entrypoint.sh
+RUN chmod +x /usr/local/bin/uid_entrypoint.sh
+
+# Install Argo CD CLI from argocd
+COPY --from=argocd /usr/local/bin/argocd /usr/local/bin/argocd
 
 # Copy util wrapper script
 COPY util.sh /usr/local/bin/argocd-operator-util

--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/argoproj/argocd as argocd
+# Argo CD v2.5.4
+FROM quay.io/argoproj/argocd@sha256:d5c4f7542580f275ea92fd07da8569cfe9fb6e49b75bbefef01255ccc4b77d57 as argocd
 
 # Final Image
 FROM docker.io/library/ubuntu:22.04

--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -6,6 +6,7 @@ FROM docker.io/library/ubuntu:22.04
 USER root
 
 ENV ARGOCD_USER_ID=999
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN groupadd -g $ARGOCD_USER_ID argocd && \
     useradd -r -u $ARGOCD_USER_ID -g argocd argocd && \

--- a/build/util/entrypoint.sh
+++ b/build/util/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# If we're started as PID 1, we should wrap command execution through tini to
+# prevent leakage of orphaned processes ("zombies").
+if test "$$" = "1"; then
+	exec tini -- $@
+else
+	exec "$@"
+fi

--- a/build/util/util.sh
+++ b/build/util/util.sh
@@ -61,7 +61,7 @@ push_aws () {
     echo "pushing argo-cd backup to aws"
     BACKUP_BUCKET_NAME=`cat /secrets/aws.bucket.name`
     BACKUP_BUCKET_URI="s3://${BACKUP_BUCKET_NAME}"
-    aws s3 mb ${BACKUP_BUCKET_URI}
+    aws s3 mb ${BACKUP_BUCKET_URI} --region us-east-1
     aws s3api put-public-access-block --bucket ${BACKUP_BUCKET_NAME} --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
     aws s3 cp ${BACKUP_ENCRYPT_LOCATION} ${BACKUP_BUCKET_URI}/${BACKUP_FILENAME}
 }

--- a/docs/usage/export.md
+++ b/docs/usage/export.md
@@ -205,6 +205,7 @@ metadata:
 type: Opaque
 data:
   aws.bucket.name: ...
+  aws.bucket.region: ...
   aws.access.key.id: ...
   aws.secret.access.key: ....
 ```
@@ -214,6 +215,10 @@ The following properties must exist on the Secret referenced in the `ArgoCDExpor
 **aws.bucket.name**
 
 The name of the AWS S3 bucket. This should be the name of the bucket only, do not prefix the value `s3://`, as the operator will handle this automatically.
+
+**aws.bucket.region**
+
+The region of the AWS S3 bucket.
 
 **aws.access.key.id**
 

--- a/examples/argocdexport-aws.yaml
+++ b/examples/argocdexport-aws.yaml
@@ -9,6 +9,7 @@ data:
   aws.bucket.name: ZXhhbXBsZS1hcmdvY2RleHBvcnQ=
   aws.access.key.id: YWNjZXNzX2tleV9pZA==
   aws.secret.access.key: c2VjcmV0X2FjY2Vzc19rZXk=
+  aws.bucket.region: dXMtd2VzdC0x
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCDExport


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Closes #182 
Closes #279 
Closes #596 

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
Fixes #182 
Fixes #279 
Fixes #596 

**How to test changes / Special notes to the reviewer**:
1. Pull the PR on to your local and build a export image using `make util-build`
(or)
You can alternatively use the image that I built for testing 
Image - abhishekf5/argocdexportimage
Version - "sha256:c468e2ce7d9c740b6704239fcbc2bfb853c127dbf8b133e322cb2ddc889c84d2"

2. Copy the util image SHA and update to the defaults.go 
- `ArgoCDDefaultExportJobImage`
- `ArgoCDDefaultExportJobVersion`

3. Run the Argo CD Operator using `make install run`
4. Verify the util image for back up to your favorite cloud provider.


`logs which shows s3 bucket is **NOT** created if it already exist`

```
argocd-operator aveerama$ kubectl logs example-argocdexport-xvr2q 
exporting argo-cd
creating argo-cd backup
encrypting argo-cd backup
pushing argo-cd backup to aws
upload: ../../backups/argocd-backup.yaml to s3://rk-testargoexport-todayrrr/argocd-backup.yaml
argo-cd export complete
```

`logs which shows s3 bucket **is** created if it already exist`

```
argocd-operator aveerama$ kubectl logs example-argocdexport-7ph7x 
exporting argo-cd
creating argo-cd backup
encrypting argo-cd backup
pushing argo-cd backup to aws
make_bucket: rk-testargoexport-todayrrr
upload: ../../backups/argocd-backup.yaml to s3://rk-testargoexport-todayrrr/argocd-backup.yaml
argo-cd export complete
```
