### PR TITLE
fix: Update sso eventing logic to stop spam

### DIFF
--- a/controllers/argocd/ingress_test.go
+++ b/controllers/argocd/ingress_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/stretchr/testify/assert"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 func TestReconcileArgoCD_reconcile_ServerIngress_ingressClassName(t *testing.T) {

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -72,7 +72,7 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 
 	// Emit events warning users about deprecation notice for soon-to-be-deprecated fields in the CR
 	if env := os.Getenv("DISABLE_DEX"); env != "" {
-		// Emit event warning users about deprecation notice for `DISABLE_DEX` users if not emitted already
+		// Emit event providing users with deprecation notice for `DISABLE_DEX` if not emitted already
 		if !DisableDexDeprecationWarningEmitted {
 			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`DISABLE_DEX` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex can be enabled/disabled through `.spec.sso`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
 			DisableDexDeprecationWarningEmitted = true
@@ -85,7 +85,7 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 
 	if cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, &v1alpha1.ArgoCDDexSpec{}) {
 
-		// Emit event warning users about deprecation notice for `.spec.dex` users if not emitted already
+		// Emit event providing users with deprecation notice for `.spec.dex` if not emitted already
 		if !DexSpecDeprecationWarningEmitted {
 			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.dex` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex configuration can be managed through `.spec.sso.dex`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
 			DexSpecDeprecationWarningEmitted = true
@@ -99,7 +99,7 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 	if cr.Spec.SSO != nil && (cr.Spec.SSO.Image != "" || cr.Spec.SSO.Version != "" ||
 		cr.Spec.SSO.VerifyTLS != nil || cr.Spec.SSO.Resources != nil) {
 
-		// Emit event warning users about deprecation notice for `.spec.dex` users if not emitted already
+		// Emit event providing users with deprecation notice for `.spec.SSO` subfields if not emitted already
 		if !SSOSpecDeprecationWarningEmitted {
 			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.SSO.Image`, `.spec.SSO.Version`, `.spec.SSO.Resources` and `.spec.SSO.VerifyTLS` are deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Keycloak configuration can be managed through `.spec.sso.keycloak`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
 			SSOSpecDeprecationWarningEmitted = true

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -37,6 +37,10 @@ const (
 )
 
 var (
+	SSOSpecDeprecationWarningEmitted    bool = false
+	DexSpecDeprecationWarningEmitted    bool = false
+	DisableDexDeprecationWarningEmitted bool = false
+
 	templateAPIFound     = false
 	ssoConfigLegalStatus string
 )
@@ -68,31 +72,42 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 
 	// Emit events warning users about deprecation notice for soon-to-be-deprecated fields in the CR
 	if env := os.Getenv("DISABLE_DEX"); env != "" {
-
-		// Emit event warning users about deprecation notice for `DISABLE_DEX` users
-		err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`DISABLE_DEX` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex can be enabled/disabled through `.spec.sso`", "DeprecationNotice", cr.ObjectMeta)
-		if err != nil {
-			return err
+		// Emit event warning users about deprecation notice for `DISABLE_DEX` users if not emitted already
+		if !DisableDexDeprecationWarningEmitted {
+			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`DISABLE_DEX` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex can be enabled/disabled through `.spec.sso`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
+			DisableDexDeprecationWarningEmitted = true
+			if err != nil {
+				return err
+			}
 		}
+
 	}
 
 	if cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, &v1alpha1.ArgoCDDexSpec{}) {
 
-		// Emit event warning users about deprecation notice for `.spec.dex` users
-		err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.dex` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex configuration can be managed through `.spec.sso.dex`", "DeprecationNotice", cr.ObjectMeta)
-		if err != nil {
-			return err
+		// Emit event warning users about deprecation notice for `.spec.dex` users if not emitted already
+		if !DexSpecDeprecationWarningEmitted {
+			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.dex` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex configuration can be managed through `.spec.sso.dex`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
+			DexSpecDeprecationWarningEmitted = true
+			if err != nil {
+				return err
+			}
 		}
+
 	}
 
 	if cr.Spec.SSO != nil && (cr.Spec.SSO.Image != "" || cr.Spec.SSO.Version != "" ||
 		cr.Spec.SSO.VerifyTLS != nil || cr.Spec.SSO.Resources != nil) {
 
-		// Emit event warning users about deprecation notice for `.spec.SSO` field users
-		err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.SSO.Image`, `.spec.SSO.Version`, `.spec.SSO.Resources` and `.spec.SSO.VerifyTLS` are deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Keycloak configuration can be managed through `.spec.sso.keycloak`", "DeprecationNotice", cr.ObjectMeta)
-		if err != nil {
-			return err
+		// Emit event warning users about deprecation notice for `.spec.dex` users if not emitted already
+		if !SSOSpecDeprecationWarningEmitted {
+			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.SSO.Image`, `.spec.SSO.Version`, `.spec.SSO.Resources` and `.spec.SSO.VerifyTLS` are deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Keycloak configuration can be managed through `.spec.sso.keycloak`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
+			SSOSpecDeprecationWarningEmitted = true
+			if err != nil {
+				return err
+			}
 		}
+
 	}
 
 	// case 1

--- a/controllers/argocd/sso_test.go
+++ b/controllers/argocd/sso_test.go
@@ -343,6 +343,10 @@ func TestReconcile_illegalSSOConfiguration(t *testing.T) {
 func TestReconcile_emitEventOnDetectingDeprecatedFields(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
+	SSOSpecDeprecationWarningEmitted = false
+	DexSpecDeprecationWarningEmitted = false
+	DisableDexDeprecationWarningEmitted = false
+
 	disableDexEvent := &corev1.Event{
 		Reason:  "DeprecationNotice",
 		Message: "`DISABLE_DEX` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex can be enabled/disabled through `.spec.sso`",

--- a/controllers/argocdexport/local.go
+++ b/controllers/argocdexport/local.go
@@ -71,5 +71,5 @@ func (r *ReconcileArgoCDExport) reconcilePVC(cr *argoprojv1a1.ArgoCDExport) erro
 
 	// Create event
 	log.Info("creating new event")
-	return argoutil.CreateEvent(r.Client, "Normal", "Exporting", "Created claim for export process.", "PersistentVolumeClaimCreated", cr.ObjectMeta)
+	return argoutil.CreateEvent(r.Client, "Normal", "Exporting", "Created claim for export process.", "PersistentVolumeClaimCreated", cr.ObjectMeta, cr.TypeMeta)
 }

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -52,17 +52,23 @@ func CombineImageTag(img string, tag string) string {
 }
 
 // CreateEvent will create a new Kubernetes Event with the given action, message, reason and involved uid.
-func CreateEvent(client client.Client, eventType, action, message, reason string, meta metav1.ObjectMeta) error {
-	event := newEvent(meta)
+func CreateEvent(client client.Client, eventType, action, message, reason string, ObjectMeta metav1.ObjectMeta, typeMeta metav1.TypeMeta) error {
+	event := newEvent(ObjectMeta)
 	event.Action = action
 	event.Type = eventType
 	event.InvolvedObject = corev1.ObjectReference{
-		Name:      meta.Name,
-		Namespace: meta.Namespace,
-		UID:       meta.UID,
+		Name:            ObjectMeta.Name,
+		Namespace:       ObjectMeta.Namespace,
+		UID:             ObjectMeta.UID,
+		ResourceVersion: ObjectMeta.ResourceVersion,
+		Kind:            typeMeta.Kind,
+		APIVersion:      typeMeta.APIVersion,
 	}
 	event.Message = message
 	event.Reason = reason
+	event.CreationTimestamp = metav1.Now()
+	event.FirstTimestamp = event.CreationTimestamp
+	event.LastTimestamp = event.CreationTimestamp
 	return client.Create(context.TODO(), event)
 }
 

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -52,15 +52,15 @@ func CombineImageTag(img string, tag string) string {
 }
 
 // CreateEvent will create a new Kubernetes Event with the given action, message, reason and involved uid.
-func CreateEvent(client client.Client, eventType, action, message, reason string, ObjectMeta metav1.ObjectMeta, typeMeta metav1.TypeMeta) error {
-	event := newEvent(ObjectMeta)
+func CreateEvent(client client.Client, eventType, action, message, reason string, objectMeta metav1.ObjectMeta, typeMeta metav1.TypeMeta) error {
+	event := newEvent(objectMeta)
 	event.Action = action
 	event.Type = eventType
 	event.InvolvedObject = corev1.ObjectReference{
-		Name:            ObjectMeta.Name,
-		Namespace:       ObjectMeta.Namespace,
-		UID:             ObjectMeta.UID,
-		ResourceVersion: ObjectMeta.ResourceVersion,
+		Name:            objectMeta.Name,
+		Namespace:       objectMeta.Namespace,
+		UID:             objectMeta.UID,
+		ResourceVersion: objectMeta.ResourceVersion,
 		Kind:            typeMeta.Kind,
 		APIVersion:      typeMeta.APIVersion,
 	}

--- a/tests/auxiliary/smtplistener/cmd/listener/serve.go
+++ b/tests/auxiliary/smtplistener/cmd/listener/serve.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+
 	//filelog "smtplistener/internal/log"
 	"smtplistener/internal/processor"
 	"smtplistener/internal/util"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

 /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
This PR updates the logic for SSO related field deprecations in the CR, so that single event is emitted with latest timestamp and CR association so that no. of emitted events is greatly reduced and events have more metadata stored

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #785 
https://issues.redhat.com/browse/GITOPS-2230

**How to test changes / Special notes to the reviewer**:

1. Run the operator against a cluster
2. Create an argo-cd instance and add `.spec.dex.config: test-config` 
3. run `kubectl get events` against that namespace
4. Only single occurrence of deprecation notice event should be present 