### PR TITLE
fix: Emit sso deprecation event only once for each instance that needs it

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -100,6 +100,12 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 				}
 			}
 
+			// remove namespace of deleted Argo CD instance from deprecationEventEmissionTracker (if exists) so that if another instance
+			// is created in the same namespace in the future, that instance is appropriately tracked
+			if _, ok := DeprecationEventEmissionTracker[argocd.Namespace]; ok {
+				delete(DeprecationEventEmissionTracker, argocd.Namespace)
+			}
+
 			if err := r.removeDeletionFinalizer(argocd); err != nil {
 				return reconcile.Result{}, err
 			}

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
@@ -349,7 +348,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 
 		// If no dexConfig expressed but openShiftOAuth is requested through either `.spec.dex` or `.spec.sso.dex`, use default
 		// openshift dex config
-		if dexConfig == "" && (cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, &v1alpha1.ArgoCDDexSpec{}) && cr.Spec.Dex.OpenShiftOAuth ||
+		if dexConfig == "" && (cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, &argoprojv1a1.ArgoCDDexSpec{}) && cr.Spec.Dex.OpenShiftOAuth ||
 			(cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth)) {
 			cfg, err := r.getOpenShiftDexConfig(cr)
 			if err != nil {
@@ -388,7 +387,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 			if err := r.reconcileDexConfiguration(existingCM, cr); err != nil {
 				return err
 			}
-		} else if cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeKeycloak {
+		} else if cr.Spec.SSO != nil && cr.Spec.SSO.Provider == argoprojv1a1.SSOProviderTypeKeycloak {
 			// retain oidc.config during reconcilliation when keycloak is configured
 			cm.Data[common.ArgoCDKeyOIDCConfig] = existingCM.Data[common.ArgoCDKeyOIDCConfig]
 		}

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
@@ -35,14 +34,14 @@ type DexConnector struct {
 // backward compatibility and not introducing breaking changes to existing user workflows
 func UseDex(cr *argoprojv1a1.ArgoCD) bool {
 	if cr.Spec.SSO != nil {
-		return cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex
+		return cr.Spec.SSO.Provider == argoprojv1a1.SSOProviderTypeDex
 	}
 	if isDexDisabled() {
 		return false
 	}
 	// we don't care about the case where dex is enabled either explicitly through DISABLE_DEX (or implicitly due to the flag being unset)
 	// in terms of creation/deletion of resources unless there is existing configuration in place that must be honored
-	if cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, v1alpha1.ArgoCDDexSpec{}) && (len(cr.Spec.Dex.Config) > 0 || cr.Spec.Dex.OpenShiftOAuth) {
+	if cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, argoprojv1a1.ArgoCDDexSpec{}) && (len(cr.Spec.Dex.Config) > 0 || cr.Spec.Dex.OpenShiftOAuth) {
 		return true
 	}
 	return false
@@ -112,7 +111,7 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 
 	// If no dexConfig expressed but openShiftOAuth is requested through either `.spec.dex` or `.spec.sso.dex`, use default
 	// openshift dex config
-	if len(desired) <= 0 && (cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, &v1alpha1.ArgoCDDexSpec{}) && cr.Spec.Dex.OpenShiftOAuth ||
+	if len(desired) <= 0 && (cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, &argoprojv1a1.ArgoCDDexSpec{}) && cr.Spec.Dex.OpenShiftOAuth ||
 		cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth) {
 		cfg, err := r.getOpenShiftDexConfig(cr)
 		if err != nil {
@@ -151,7 +150,7 @@ func (r *ReconcileArgoCD) getOpenShiftDexConfig(cr *argoprojv1a1.ArgoCD) (string
 	groups := []string{}
 
 	// Allow override of groups from CR
-	if cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, v1alpha1.ArgoCDDexSpec{}) && cr.Spec.Dex.Groups != nil {
+	if cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, argoprojv1a1.ArgoCDDexSpec{}) && cr.Spec.Dex.Groups != nil {
 		groups = cr.Spec.Dex.Groups
 	} else if cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.Groups != nil {
 		groups = cr.Spec.SSO.Dex.Groups
@@ -185,7 +184,7 @@ func (r *ReconcileArgoCD) getOpenShiftDexConfig(cr *argoprojv1a1.ArgoCD) (string
 func (r *ReconcileArgoCD) reconcileDexServiceAccount(cr *argoprojv1a1.ArgoCD) error {
 
 	// if openShiftOAuth set to false in both `.spec.dex` and `.spec.sso.dex`, no need to configure it
-	if (cr.Spec.Dex == nil || reflect.DeepEqual(cr.Spec.Dex, &v1alpha1.ArgoCDDexSpec{}) || !cr.Spec.Dex.OpenShiftOAuth) &&
+	if (cr.Spec.Dex == nil || reflect.DeepEqual(cr.Spec.Dex, &argoprojv1a1.ArgoCDDexSpec{}) || !cr.Spec.Dex.OpenShiftOAuth) &&
 		(cr.Spec.SSO == nil || cr.Spec.SSO.Dex == nil || !cr.Spec.SSO.Dex.OpenShiftOAuth) {
 		return nil // OpenShift OAuth not enabled, move along...
 	}

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -36,10 +36,23 @@ const (
 	multipleSSOConfiguration string = "multiple SSO configuration: "
 )
 
+// DeprecationEventEmissionStatus is meant to track which deprecation events have been emitted already. This is temporary and can be removed in v0.0.6 once we have provided enough
+// deprecation notice
+type DeprecationEventEmissionStatus struct {
+	SSOSpecDeprecationWarningEmitted    bool
+	DexSpecDeprecationWarningEmitted    bool
+	DisableDexDeprecationWarningEmitted bool
+}
+
 var (
 	templateAPIFound     = false
 	ssoConfigLegalStatus string
 )
+
+// DeprecationEventEmissionTracker map stores the namespace containing ArgoCD instance as key and DeprecationEventEmissionStatus as value,
+// where DeprecationEventEmissionStatus tracks the events that have been emitted for the instance in the particular namespace.
+// This is temporary and can be removed in v0.0.6 when we remove the deprecated fields.
+var DeprecationEventEmissionTracker = make(map[string]DeprecationEventEmissionStatus)
 
 // IsTemplateAPIAvailable returns true if the template API is present.
 func IsTemplateAPIAvailable() bool {
@@ -66,32 +79,61 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 	// reset ssoConfigLegalStatus at the beginning of each SSO reconciliation round
 	ssoConfigLegalStatus = ssoLegalUnknown
 
-	// Emit events warning users about deprecation notice for soon-to-be-deprecated fields in the CR
-	if env := os.Getenv("DISABLE_DEX"); env != "" {
+	// Emit events warning users about deprecation notice for soon-to-be-removed fields in the CR if being used
 
-		// Emit event warning users about deprecation notice for `DISABLE_DEX` users
-		err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`DISABLE_DEX` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex can be enabled/disabled through `.spec.sso`", "DeprecationNotice", cr.ObjectMeta)
-		if err != nil {
-			return err
+	if env := os.Getenv("DISABLE_DEX"); env != "" {
+		// Emit event for each instance providing users with deprecation notice for `DISABLE_DEX` if not emitted already
+		if currentInstanceEventEmissionStatus, ok := DeprecationEventEmissionTracker[cr.Namespace]; !ok || !currentInstanceEventEmissionStatus.DisableDexDeprecationWarningEmitted {
+			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`DISABLE_DEX` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex can be enabled/disabled through `.spec.sso`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
+			if err != nil {
+				return err
+			}
+
+			if !ok {
+				currentInstanceEventEmissionStatus = DeprecationEventEmissionStatus{DisableDexDeprecationWarningEmitted: true}
+			} else {
+				currentInstanceEventEmissionStatus.DisableDexDeprecationWarningEmitted = true
+			}
+			DeprecationEventEmissionTracker[cr.Namespace] = currentInstanceEventEmissionStatus
 		}
+
 	}
 
 	if cr.Spec.Dex != nil && !reflect.DeepEqual(cr.Spec.Dex, &v1alpha1.ArgoCDDexSpec{}) {
 
-		// Emit event warning users about deprecation notice for `.spec.dex` users
-		err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.dex` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex configuration can be managed through `.spec.sso.dex`", "DeprecationNotice", cr.ObjectMeta)
-		if err != nil {
-			return err
+		// Emit event for each instance providing users with deprecation notice for `.spec.dex` if not emitted already
+		if currentInstanceEventEmissionStatus, ok := DeprecationEventEmissionTracker[cr.Namespace]; !ok || !currentInstanceEventEmissionStatus.DexSpecDeprecationWarningEmitted {
+			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.dex` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex configuration can be managed through `.spec.sso.dex`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
+			if err != nil {
+				return err
+			}
+
+			if !ok {
+				currentInstanceEventEmissionStatus = DeprecationEventEmissionStatus{DexSpecDeprecationWarningEmitted: true}
+			} else {
+				currentInstanceEventEmissionStatus.DexSpecDeprecationWarningEmitted = true
+			}
+			DeprecationEventEmissionTracker[cr.Namespace] = currentInstanceEventEmissionStatus
 		}
+
 	}
 
 	if cr.Spec.SSO != nil && (cr.Spec.SSO.Image != "" || cr.Spec.SSO.Version != "" ||
 		cr.Spec.SSO.VerifyTLS != nil || cr.Spec.SSO.Resources != nil) {
 
-		// Emit event warning users about deprecation notice for `.spec.SSO` field users
-		err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.SSO.Image`, `.spec.SSO.Version`, `.spec.SSO.Resources` and `.spec.SSO.VerifyTLS` are deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Keycloak configuration can be managed through `.spec.sso.keycloak`", "DeprecationNotice", cr.ObjectMeta)
-		if err != nil {
-			return err
+		// Emit event for each instance providing users with deprecation notice for `.spec.SSO` subfields if not emitted already
+		if currentInstanceEventEmissionStatus, ok := DeprecationEventEmissionTracker[cr.Namespace]; !ok || !currentInstanceEventEmissionStatus.SSOSpecDeprecationWarningEmitted {
+			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "`.spec.SSO.Image`, `.spec.SSO.Version`, `.spec.SSO.Resources` and `.spec.SSO.VerifyTLS` are deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Keycloak configuration can be managed through `.spec.sso.keycloak`", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
+			if err != nil {
+				return err
+			}
+
+			if !ok {
+				currentInstanceEventEmissionStatus = DeprecationEventEmissionStatus{SSOSpecDeprecationWarningEmitted: true}
+			} else {
+				currentInstanceEventEmissionStatus.SSOSpecDeprecationWarningEmitted = true
+			}
+			DeprecationEventEmissionTracker[cr.Namespace] = currentInstanceEventEmissionStatus
 		}
 	}
 

--- a/controllers/argocd/sso_test.go
+++ b/controllers/argocd/sso_test.go
@@ -349,6 +349,8 @@ func TestReconcile_illegalSSOConfiguration(t *testing.T) {
 func TestReconcile_emitEventOnDetectingDeprecatedFields(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
+	DeprecationEventEmissionTracker = make(map[string]DeprecationEventEmissionStatus)
+
 	disableDexEvent := &corev1.Event{
 		Reason:  "DeprecationNotice",
 		Message: "`DISABLE_DEX` is deprecated, and support will be removed in Argo CD Operator v0.6.0/OpenShift GitOps v1.9.0. Dex can be enabled/disabled through `.spec.sso`",

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1219,6 +1219,13 @@ func namespaceFilterPredicate() predicate.Predicate {
 					log.Info(fmt.Sprintf("Successfully deleted namespace %s from cluster secret", e.Object.GetName()))
 				}
 			}
+
+			// if a namespace is deleted, remove it from deprecationEventEmissionTracker (if exists) so that if a namespace with the same name
+			// is created in the future and contains an Argo CD instance, it will be tracked appropriately
+			if _, ok := DeprecationEventEmissionTracker[e.Object.GetName()]; ok {
+				delete(DeprecationEventEmissionTracker, e.Object.GetName())
+			}
+
 			return false
 		},
 	}

--- a/controllers/argocdexport/local.go
+++ b/controllers/argocdexport/local.go
@@ -71,5 +71,5 @@ func (r *ReconcileArgoCDExport) reconcilePVC(cr *argoprojv1a1.ArgoCDExport) erro
 
 	// Create event
 	log.Info("creating new event")
-	return argoutil.CreateEvent(r.Client, "Normal", "Exporting", "Created claim for export process.", "PersistentVolumeClaimCreated", cr.ObjectMeta)
+	return argoutil.CreateEvent(r.Client, "Normal", "Exporting", "Created claim for export process.", "PersistentVolumeClaimCreated", cr.ObjectMeta, cr.TypeMeta)
 }

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -52,17 +52,23 @@ func CombineImageTag(img string, tag string) string {
 }
 
 // CreateEvent will create a new Kubernetes Event with the given action, message, reason and involved uid.
-func CreateEvent(client client.Client, eventType, action, message, reason string, meta metav1.ObjectMeta) error {
-	event := newEvent(meta)
+func CreateEvent(client client.Client, eventType, action, message, reason string, objectMeta metav1.ObjectMeta, typeMeta metav1.TypeMeta) error {
+	event := newEvent(objectMeta)
 	event.Action = action
 	event.Type = eventType
 	event.InvolvedObject = corev1.ObjectReference{
-		Name:      meta.Name,
-		Namespace: meta.Namespace,
-		UID:       meta.UID,
+		Name:            objectMeta.Name,
+		Namespace:       objectMeta.Namespace,
+		UID:             objectMeta.UID,
+		ResourceVersion: objectMeta.ResourceVersion,
+		Kind:            typeMeta.Kind,
+		APIVersion:      typeMeta.APIVersion,
 	}
 	event.Message = message
 	event.Reason = reason
+	event.CreationTimestamp = metav1.Now()
+	event.FirstTimestamp = event.CreationTimestamp
+	event.LastTimestamp = event.CreationTimestamp
 	return client.Create(context.TODO(), event)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

 /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
This PR fixes a flaw in an earlier fix meant to stop the spamming of SSO related deprecation notice events. 

**Original issue:** operator would spam the cluster with deprecation warning events when it identifies deprecated fields in use
**Original fix**: stopped the spamming but made it so that only the first problematic instance would receive deprecation notice events, operator would stop emitting them completely after that point and subsequent instances would not be notified at all.
**Current fix:** ensures that every problematic instance sees exactly one event generated per deprecated field - such that all instance owners are sufficiently notified and no one is spammed with events. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Run operator
2. Create multiple argo-cd instances in different namespaces, and ensure they contain either `.spec.dex` or `.spec.sso.verifyTLS` or both (for e.g)
3. Ensure that there is only 1 deprecation notice event created for each deprecated field, in each namespace 
4. Delete argo-cd instance in one of the namespaces and re-create it with the same faults, another set of events should be generated
5. Delete one of the namespaces containing argo-cd instance and recreate it with the same name and new argo-cd instance with the same faults. Confirm that another set of events is generated.  