### PR TITLE
fix: only first problematic instance gets deprecation notice event

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -103,6 +103,12 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 			if err := r.removeDeletionFinalizer(argocd); err != nil {
 				return reconcile.Result{}, err
 			}
+
+			// remove namespace of deleted Argo CD instance from deprecationEventEmissionTracker (if exists) so that if another instance
+			// is created in the same namespace in the future, that instance is appropriately tracked
+			if _, ok := DeprecationEventEmissionTracker[argocd.Namespace]; ok {
+				delete(DeprecationEventEmissionTracker, argocd.Namespace)
+			}
 		}
 		return reconcile.Result{}, nil
 	}

--- a/controllers/argocd/sso_test.go
+++ b/controllers/argocd/sso_test.go
@@ -343,9 +343,7 @@ func TestReconcile_illegalSSOConfiguration(t *testing.T) {
 func TestReconcile_emitEventOnDetectingDeprecatedFields(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
-	SSOSpecDeprecationWarningEmitted = false
-	DexSpecDeprecationWarningEmitted = false
-	DisableDexDeprecationWarningEmitted = false
+	DeprecationEventEmissionTracker = make(map[string]DeprecationEventEmissionStatus)
 
 	disableDexEvent := &corev1.Event{
 		Reason:  "DeprecationNotice",

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1219,6 +1219,13 @@ func namespaceFilterPredicate() predicate.Predicate {
 					log.Info(fmt.Sprintf("Successfully deleted namespace %s from cluster secret", e.Object.GetName()))
 				}
 			}
+
+			// if a namespace is deleted, remove it from deprecationEventEmissionTracker (if exists) so that if a namespace with the same name
+			// is created in the future and contains an Argo CD instance, it will be tracked appropriately
+			if _, ok := DeprecationEventEmissionTracker[e.Object.GetName()]; ok {
+				delete(DeprecationEventEmissionTracker, e.Object.GetName())
+			}
+
 			return false
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

 /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
See https://github.com/argoproj-labs/argocd-operator/pull/795 for details

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
