### PR TITLE
Fixing discrepancy between Applicationset Controller Pod ContainerPort (8000) and Service TargetPort (8080) for metrics

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -224,7 +224,7 @@ func applicationSetContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 				Name:          "webhook",
 			},
 			{
-				ContainerPort: 8000,
+				ContainerPort: 8080,
 				Name:          "metrics",
 			},
 		},


### PR DESCRIPTION
Signed-off-by: rjeczkow [rjeczkow@gmail.com](mailto:rjeczkow@gmail.com)

Fixing discrepancy between Applicationset Controller [Pod ContainerPort](https://github.com/argoproj-labs/argocd-operator/blob/master/controllers/argocd/applicationset.go#L227) (8000) and [Service TargetPort](https://github.com/argoproj-labs/argocd-operator/blob/master/controllers/argocd/applicationset.go#L498) (8080) for metrics

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Setting ContainerPort for ApplicationSet container to 8080 in order to make it consistent with the ApplicationSet service TargetPort

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-2411

Fixes #?


**How to test changes / Special notes to the reviewer**:
