### PR TITLE
restrict server clusterrole list and watch permissions to only applications

### DIFF
--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -244,6 +244,16 @@ func policyRuleForServerClusterRole() []v1.PolicyRule {
 				"get",
 				"delete",
 				"patch",
+			},
+		},
+		{
+			APIGroups: []string{
+				"argoproj.io",
+			},
+			Resources: []string{
+				"applications",
+			},
+			Verbs: []string{
 				"list",
 				"watch",
 			},


### PR DESCRIPTION
Signed-off-by: ishitasequeira <ishiseq29@gmail.com>

**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
add list and watch only for `applications` resources and  for `argoproj.io` apigroups only for cluster role

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
