### PR TITLE
feat: upgrade the registery base image to v1.26.2 (#800)

### DIFF
--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,5 +1,5 @@
-# upstream-registry-builder v1.13.4
-FROM quay.io/operator-framework/upstream-registry-builder@sha256:ec1f9ec32f0d011b4fae7ac765ab85cf7eb84fc866f5540c9747a4cbe3688d65 as builder
+# upstream-registry-builder v1.26.2
+FROM quay.io/operator-framework/upstream-registry-builder@sha256:dc3ef48c8f6d90ea9654cd2ac5e32afbb777d6395b29f55f9976b201b62e4145 as builder
 
 COPY manifests manifests
 RUN ./bin/initializer -o ./bundles.db


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
Fixes #800 

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
Fixes #800 

**How to test changes / Special notes to the reviewer**:
1. Deploy a local Kubernetes cluster with version v1.25.z
2. Add OLM plugin or install OLM (steps vary from distribution to distributions) 
     - If you are on minikube, you can install OLM using the minikube addon.
3. Try installing the v0.4.0 of argocd-operator , it should fail with the error mentioned in #800 
4. Replace registry image mentioned below in the `catalogsource` and verify that operator is running.