### PR TITLE
fix: host url for Ingress in the .status feild on OpenShift (#)

### DIFF
--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -268,7 +268,7 @@ func (r *ReconcileArgoCD) reconcileStatusHost(cr *argoprojv1a1.ArgoCD) error {
 				// conditions exist and type is RouteAdmitted
 				if len(route.Status.Ingress[0].Conditions) > 0 && route.Status.Ingress[0].Conditions[0].Type == routev1.RouteAdmitted {
 					if route.Status.Ingress[0].Conditions[0].Status == corev1.ConditionTrue {
-						cr.Status.Host = route.Status.Ingress[0].Host
+						cr.Status.Host = route.Spec.Host
 						cr.Status.Phase = "Available"
 					} else {
 						cr.Status.Host = ""
@@ -277,7 +277,7 @@ func (r *ReconcileArgoCD) reconcileStatusHost(cr *argoprojv1a1.ArgoCD) error {
 				} else {
 					// no conditions are available
 					if route.Status.Ingress[0].Host != "" {
-						cr.Status.Host = route.Status.Ingress[0].Host
+						cr.Status.Host = route.Spec.Host
 						cr.Status.Phase = "Available"
 					} else {
 						cr.Status.Host = "Unavailable"

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -16,7 +16,6 @@ package argocd
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"strings"
 
@@ -253,14 +252,6 @@ func (r *ReconcileArgoCD) reconcileStatusNotifications(cr *argoprojv1a1.ArgoCD) 
 func (r *ReconcileArgoCD) reconcileStatusHost(cr *argoprojv1a1.ArgoCD) error {
 	cr.Status.Host = ""
 	cr.Status.Phase = "Available"
-
-	// Log an error if a user configures route on a platform where route API does not exist.
-	// This is a misconfiguration.
-	if cr.Spec.Server.Route.Enabled && !IsRouteAPIAvailable() {
-		err := errors.New("Misconfiguration:")
-		log.Error(err, "Routes not available in non-OpenShift environments, please use Ingresses instead")
-		return nil
-	}
 
 	if (cr.Spec.Server.Route.Enabled || cr.Spec.Server.Ingress.Enabled) && IsRouteAPIAvailable() {
 		route := newRouteWithSuffix("server", cr)

--- a/controllers/argocd/status_test.go
+++ b/controllers/argocd/status_test.go
@@ -152,6 +152,9 @@ func TestReconcileArgoCD_reconcileStatusHost(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testArgoCDName + "-server",
 					Namespace: testNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/name": testArgoCDName + "-server",
+					},
 				},
 				Spec: routev1.RouteSpec{
 					Host: "argocd",

--- a/examples/argocd-ingress-openshift.yaml
+++ b/examples/argocd-ingress-openshift.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: ingress
+spec:
+  server:
+    host: test-crane.apps.rhoms-4.12-112804.dev.openshiftappsvc.org
+    grpc:
+      ingress:
+        enabled: true
+    ingress:
+      enabled: true
+      tls:
+       - hosts:
+          - test-crane
+    insecure: true

--- a/tests/ocp/1-002_verify_hostname_with_ingress/01-argocd-ingress.yaml
+++ b/tests/ocp/1-002_verify_hostname_with_ingress/01-argocd-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: example-argocd
+spec:
+  server:
+    host: test-crane.apps.rh-4.12-111111.dev.openshift.org
+    grpc:
+      ingress:
+        enabled: true
+    ingress:
+      enabled: true
+      tls:
+       - hosts:
+          - test-crane

--- a/tests/ocp/1-002_verify_hostname_with_ingress/01-assert.yaml
+++ b/tests/ocp/1-002_verify_hostname_with_ingress/01-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+  host: test-crane.apps.rh-4.12-111111.dev.openshift.org
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-argocd-server

--- a/tests/ocp/1-003_verify_hostname_with_route/01-argocd-route.yaml
+++ b/tests/ocp/1-003_verify_hostname_with_route/01-argocd-route.yaml
@@ -1,0 +1,11 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: example-argocd
+spec:
+  server:
+    host: test-crane.apps.rh-4.12-111111.dev.openshift.org
+    route:
+      enabled: true

--- a/tests/ocp/1-003_verify_hostname_with_route/01-assert.yaml
+++ b/tests/ocp/1-003_verify_hostname_with_route/01-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+  host: test-crane.apps.rh-4.12-111111.dev.openshift.org


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
Fixes #816 
Closes #816 

**How to test changes / Special notes to the reviewer**:
Refer #816 

**Additionally you can also run the newly added automation tests on your OCP platform**
- `kubectl kuttl test ./tests/ocp --config ./tests/kuttl-tests.yaml --test 1-002_verify_hostname_with_ingress`
-  `kubectl kuttl test ./tests/ocp --config ./tests/kuttl-tests.yaml --test 1-003_verify_hostname_with_route`
