### PR TITLE
Add system-level configuration docs and fix minor typo

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -962,35 +962,44 @@ There are two ways to customize resource behavior- the first way, only available
 !!! warning 
     `resourceCustomizations` is being deprecated so is encouraged to use `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead. It is the user's responsibility to not provide conflicting resources if they choose to use both methods of resource customizations. 
 
-### Resource Customizations (with subkeys) Example
+### Resource Customizations (with subkeys)
 
-Keys for `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` are in the form (respectively): `resource.customizations.health.<group_kind>`, `resource.customizations.ignoreDifferences.<group_kind>`, and `resource.customizations.actions.<group_kind>`. The following example defines a custom health check, custom action, and an ignoreDifferences config in the `argocd-cm` ConfigMap. Additionally, `.spec.resourceIgnoreDifferences.all` allows you to apply these specified settings to all resources managed by this Argo CD instance.
+Keys for `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` are in the form (respectively): `resource.customizations.health.<group_kind>`, `resource.customizations.ignoreDifferences.<group_kind>`, and `resource.customizations.actions.<group_kind>`.
 
-``` yaml
-apiVersion: argoproj.io/v1alpha1
-kind: ArgoCD
-metadata:
-  name: argocd
+#### Application Level Configuration
+
+Argo CD allows ignoring differences at a specific JSON path, using [RFC6902 JSON patches](https://tools.ietf.org/html/rfc6902) and [JQ path expressions](https://stedolan.github.io/jq/manual/#path(path_expression)). It is also possible to ignore differences from fields owned by specific managers defined in `metadata.managedFields` in live resources.
+
+The following sample application is configured to ignore differences in `spec.replicas` for all deployments:
+
+```yaml
 spec:
   resourceIgnoreDifferences:
-    all:
-      jsonPointers:
-        - /spec/replicas
-      managedFieldsManagers:
-        - kube-controller-manager
     resourceIdentifiers:
-      - group: admissionregistration.k8s.io
-        kind: MutatingWebhookConfiguration
-        customization:
-          jqPathExpressions:
-            - '.webhooks[]?.clientConfig.caBundle'
-      - group: apps
-        kind: Deployment
-        customization:
-          managedFieldsManagers:
-            - kube-controller-manager
-          jsonPointers:
-            - /spec/replicas
+    - group: apps
+      kind: Deployment
+      customization:
+        jsonPointers:
+        - /spec/replicas
+```
+
+Note that the `group` field relates to the [Kubernetes API group](https://kubernetes.io/docs/reference/using-api/#api-groups) without the version.
+
+To ignore elements of a list, you can use JQ path expressions to identify list items based on item content:
+```yaml
+spec:
+  resourceIgnoreDifferences:
+    resourceIdentifiers:
+    - group: apps
+      kind: Deployment
+      customization:
+        jqPathExpressions:
+        - .spec.template.spec.initContainers[] | select(.name == "injected-init-container")
+```
+
+The following example defines a custom health check in the `argocd-cm` ConfigMap:
+``` yaml
+spec:
   resourceHealthChecks:
     - group: certmanager.k8s.io
       kind: Certificate
@@ -1015,6 +1024,11 @@ spec:
         hs.status = "Progressing"
         hs.message = "Waiting for certificate"
         return hs
+```
+
+The following example defines a custom action in the `argocd-cm` ConfigMap:
+``` yaml
+spec:
   resourceActions:
     - group: apps
       kind: Deployment
@@ -1037,24 +1051,15 @@ spec:
             obj.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"] = os.date("!%Y-%m-%dT%XZ")
             return obj
 ```
- After applying these changes your `argocd-cm` Configmap should contain the following fields: 
+
+After applying these changes your `argocd-cm` Configmap should contain the following fields: 
 
 ```
-resource.customizations.ignoreDifferences.all: |
+resource.customizations.ignoreDifferences.apps_Deployment: |
   jsonPointers:
   - /spec/replicas
-  managedFieldsManagers:
-  - kube-controller-manager
-
-resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
-  jqpathexpressions:
-  - '.webhooks[]?.clientConfig.caBundle'
-
-resource.customizations.ignoreDifferences.apps_deployments: |
-  managedFieldsManagers:
-  - kube-controller-manager
-  jsonPointers:
-  - /spec/replicas
+  jqPathExpressions:
+  - .spec.template.spec.initContainers[] | select(.name == "injected-init-container")
 
 resource.customizations.health.certmanager.k8s.io_Certificate: |
   hs = {}
@@ -1096,6 +1101,63 @@ resource.customizations.actions.apps_Deployment: |
       end
       obj.spec.template.metadata.annotations["kubectl.kubernetes.io/restartedAt"] = os.date("!%Y-%m-%dT%XZ")
       return obj
+```
+
+#### System-Level Configuration
+The comparison of resources with well-known issues can be customized at a system level. Ignored differences can be configured for a specified group and kind in `resource.customizations` key of `argocd-cm` ConfigMap. Following is an example of a customization which ignores the `caBundle` field of a `MutatingWebhookConfiguration` webhooks:
+
+```yaml
+spec:
+  resourceIgnoreDifferences:
+    resourceIdentifiers:
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      customization:
+        jqPathExpressions:
+        - '.webhooks[]?.clientConfig.caBundle'
+```
+
+Resource customization can also be configured to ignore all differences made by a `managedField.manager` at the system level. The example bellow shows how to configure ArgoCD to ignore changes made by `kube-controller-manager` in `Deployment` resources.
+
+```yaml
+spec:
+  resourceIgnoreDifferences:
+    resourceIdentifiers:
+    - group: apps
+      kind: Deployment
+      customization:
+        managedFieldsManagers:
+        - kube-controller-manager
+```
+
+It is possible to configure ignoreDifferences to be applied to all resources in every Application managed by an ArgoCD instance. In order to do so, resource customizations can be configured like in the example below:
+
+```yaml
+spec:
+  resourceIgnoreDifferences:
+    all:
+      managedFieldsManagers:
+        - kube-controller-manager
+      jsonPointers:
+        - /spec/replicas
+```
+
+After applying these changes your `argocd-cm` Configmap should contain the following fields: 
+
+```
+resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
+  jqPathExpressions:
+  - '.webhooks[]?.clientConfig.caBundle'
+
+resource.customizations.ignoreDifferences.apps_Deployment: |
+  managedFieldsManagers:
+  - kube-controller-manager
+
+resource.customizations.ignoreDifferences.all: |
+  managedFieldsManagers:
+  - kube-controller-manager
+  jsonPointers:
+  - /spec/replicas
 ```
 
 ### Resource Customizations Example
@@ -1410,6 +1472,39 @@ Provider | [Empty] | The name of the provider used to configure Single sign-on. 
 Resources | `Requests`: CPU=500m, Mem=512Mi, `Limits`: CPU=1000m, Mem=1024Mi | The container compute resources.
 VerifyTLS | true | Whether to enforce strict TLS checking when communicating with Keycloak service.
 Version | OpenShift - `sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3` (7.5.1) <br/> Kubernetes - `sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9` (15.0.2) | The tag to use with the keycloak container image.
+
+## System-Level Configuration
+
+The comparison of resources with well-known issues can be customized at a system level. Ignored differences can be configured for a specified group and kind
+in `resource.customizations` key of `argocd-cm` ConfigMap. Following is an example of a customization which ignores the `caBundle` field
+of a `MutatingWebhookConfiguration` webhooks:
+
+```yaml
+data:
+  resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
+    jqPathExpressions:
+    - '.webhooks[]?.clientConfig.caBundle'
+```
+
+Resource customization can also be configured to ignore all differences made by a `managedFieldsManager` at the system level. The example bellow shows how to configure ArgoCD to ignore changes made by `kube-controller-manager` in `Deployment` resources.
+
+```yaml
+data:
+  resource.customizations.ignoreDifferences.apps_Deployment: |
+    managedFieldsManagers:
+    - kube-controller-manager
+```
+
+It is possible to configure ignoreDifferences to be applied to all resources in every Application managed by an ArgoCD instance. In order to do so, resource customizations can be configured like in the example bellow:
+
+```yaml
+data:
+  resource.customizations.ignoreDifferences.all: |
+    managedFieldsManagers:
+    - kube-controller-manager
+    jsonPointers:
+    - /spec/replicas
+```
 
 ## TLS Options
 

--- a/tests/k8s/1-025_validate_resource_ignore_differences/01-argocd-with-resource-ignore-difference.yaml
+++ b/tests/k8s/1-025_validate_resource_ignore_differences/01-argocd-with-resource-ignore-difference.yaml
@@ -16,7 +16,7 @@ spec:
           - abc
     resourceIdentifiers:
       - group: apps
-        kind: deployments
+        kind: Deployment
         customization:
           jqPathExpressions:
             - xyz

--- a/tests/k8s/1-025_validate_resource_ignore_differences/01-assert.yaml
+++ b/tests/k8s/1-025_validate_resource_ignore_differences/01-assert.yaml
@@ -24,7 +24,7 @@ data:
     managedfieldsmanagers:
     - xyz
     - abc
-  resource.customizations.ignoreDifferences.apps_deployments: |
+  resource.customizations.ignoreDifferences.apps_Deployment: |
     jqpathexpressions:
     - xyz
     - abc


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug
> /kind documentation

**What does this PR do / why we need it**:
This adds system-level configuration documentation that relates to resource customization. 
Also fixes a typo from "deployments" to "Deployment" in some `kind` fields. 

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-2463 
