### PR TITLE
chore: Update Release manifests back to the 0.5.0 bundle folder (#827)

### DIFF
--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -1091,7 +1091,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/argoprojlabs/argocd-operator:v0.5.0
+                image: quay.io/argoprojlabs/argocd-operator@sha256:2f5c0d4567607266ccacb91d8c2e3b18c2afe0edaf55855dcb1a06b02173b520
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1172,10 +1172,10 @@ spec:
   - name: Operator Source Code
     url: https://github.com/argoproj-labs/argocd-operator
   maintainers:
-  - email: jfischer@redhat.com
-    name: Jann Fischer
+  - email: aveerama@redhat.com
+    name: Abhishek Veeramalla
   maturity: alpha
   provider:
     name: Argo CD Community
-  replaces: argocd-operator.v0.3.0
+  replaces: argocd-operator.v0.4.0
   version: 0.5.0

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -1091,7 +1091,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/argoprojlabs/argocd-operator@sha256:2f5c0d4567607266ccacb91d8c2e3b18c2afe0edaf55855dcb1a06b02173b520
+                image: quay.io/argoprojlabs/argocd-operator:v0.5.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -119,7 +119,7 @@ const (
 	ArgoCDDefaultExportJobImage = "quay.io/argoprojlabs/argocd-operator-util"
 
 	// ArgoCDDefaultExportJobVersion is the export job container image tag to use when not specified.
-	ArgoCDDefaultExportJobVersion = "sha256:133b064fc01154efd6b1a1698571b0e461d4b515245bbff3350bbb186a7f6935" // 0.4.0
+	ArgoCDDefaultExportJobVersion = "sha256:6f80965a2bef1c80875be0995b18d9be5a6ad4af841cbc170ed3c60101a7deb2" // 0.5.0
 
 	// ArgoCDDefaultExportLocalCapicity is the default capacity to use for local export.
 	ArgoCDDefaultExportLocalCapicity = "2Gi"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,6 +11,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:2f5c0d4567607266ccacb91d8c2e3b18c2afe0edaf55855dcb1a06b02173b520
-  name: controller
+- name: controller
   newName: quay.io/argoprojlabs/argocd-operator
+  newTag: v0.5.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,6 +11,6 @@ configMapGenerator:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
+- digest: sha256:2f5c0d4567607266ccacb91d8c2e3b18c2afe0edaf55855dcb1a06b02173b520
+  name: controller
   newName: quay.io/argoprojlabs/argocd-operator
-  newTag: v0.5.0

--- a/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
@@ -749,10 +749,10 @@ spec:
   - name: Operator Source Code
     url: https://github.com/argoproj-labs/argocd-operator
   maintainers:
-  - email: jfischer@redhat.com
-    name: Jann Fischer
+  - email: aveerama@redhat.com
+    name: Abhishek Veeramalla
   maturity: alpha
   provider:
     name: Argo CD Community
-  replaces: argocd-operator.v0.3.0
-  version: 0.0.0
+  replaces: argocd-operator.v0.4.0
+  version: 0.5.0

--- a/deploy/catalog_source.yaml
+++ b/deploy/catalog_source.yaml
@@ -4,6 +4,6 @@ metadata:
   name: argocd-catalog
 spec:
   sourceType: grpc
-  image: quay.io/argoprojlabs/argocd-operator-registry@sha256:a541110c0d2bde77e19643cf191d82937d4ed6e96f3bc2c38d2126f27351cb46 # replace with your index image
+  image: quay.io/argoprojlabs/argocd-operator-registry@sha256:dcf6d07ed5c8b840fb4a6e9019eacd88cd0913bc3c8caa104d3414a2e9972002 # replace with your index image
   displayName: Argo CD Operators
   publisher: Argo CD Community

--- a/deploy/olm-catalog/argocd-operator/0.5.0/argocd-operator.v0.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.5.0/argocd-operator.v0.5.0.clusterserviceversion.yaml
@@ -1091,7 +1091,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/argoprojlabs/argocd-operator:v0.5.0
+                image: quay.io/argoprojlabs/argocd-operator@sha256:2f5c0d4567607266ccacb91d8c2e3b18c2afe0edaf55855dcb1a06b02173b520
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -1172,10 +1172,10 @@ spec:
   - name: Operator Source Code
     url: https://github.com/argoproj-labs/argocd-operator
   maintainers:
-  - email: jfischer@redhat.com
-    name: Jann Fischer
+  - email: aveerama@redhat.com
+    name: Abhishek Veeramalla
   maturity: alpha
   provider:
     name: Argo CD Community
-  replaces: argocd-operator.v0.3.0
+  replaces: argocd-operator.v0.4.0
   version: 0.5.0

--- a/deploy/olm-catalog/argocd-operator/0.5.0/argocd-operator.v0.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.5.0/argocd-operator.v0.5.0.clusterserviceversion.yaml
@@ -1091,7 +1091,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/argoprojlabs/argocd-operator@sha256:2f5c0d4567607266ccacb91d8c2e3b18c2afe0edaf55855dcb1a06b02173b520
+                image: quay.io/argoprojlabs/argocd-operator:v0.5.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/deploy/olm-catalog/argocd-operator/argocd-operator.package.yaml
+++ b/deploy/olm-catalog/argocd-operator/argocd-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: argocd-operator.v0.4.0
+- currentCSV: argocd-operator.v0.5.0
   name: alpha
 defaultChannel: alpha
 packageName: argocd-operator

--- a/deploy/registry/Dockerfile
+++ b/deploy/registry/Dockerfile
@@ -1,13 +1,9 @@
 # upstream-registry-builder v1.26.2
-FROM quay.io/operator-framework/upstream-registry-builder@sha256:dc3ef48c8f6d90ea9654cd2ac5e32afbb777d6395b29f55f9976b201b62e4145 as builder
+FROM quay.io/operator-framework/upstream-registry-builder@sha256:dc3ef48c8f6d90ea9654cd2ac5e32afbb777d6395b29f55f9976b201b62e4145
 
 COPY manifests manifests
 RUN ./bin/initializer -o ./bundles.db
 
-FROM scratch
-COPY --from=builder /build/bundles.db /bundles.db
-COPY --from=builder /build/bin/registry-server /registry-server
-COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 EXPOSE 50051
-ENTRYPOINT ["/registry-server"]
-CMD ["--database", "bundles.db"]
+ENTRYPOINT ["/bin/registry-server"]
+CMD ["--database", "/bundles.db"]


### PR DESCRIPTION
Signed-off-by: iam-veeramalla <abhishek.veeramalla@gmail.com>

**What type of PR is this?**
> /kind chore

**What does this PR do / why we need it**:
As part of the release process, we update the Release manifests back to the bundle folder.

Please refer to the last point of the below doc
https://argocd-operator.readthedocs.io/en/latest/release-process/

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
