### PR TITLE
GITOPS-2480: Added HOME env var to application controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/_output
 
 kubeconfig
 kuttl-test.json
+
+# Desktop Services Store in macOS system
+.DS_Store

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -426,6 +426,11 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoprojv1a1.ArgoCD) err
 func getArgoControllerContainerEnv(cr *argoprojv1a1.ArgoCD) []corev1.EnvVar {
 	env := make([]corev1.EnvVar, 0)
 
+	env = append(env, corev1.EnvVar{
+		Name:  "HOME",
+		Value: "/home/argocd",
+	})
+
 	if cr.Spec.Controller.Sharding.Enabled {
 		env = append(env, corev1.EnvVar{
 			Name:  "ARGOCD_CONTROLLER_REPLICAS",
@@ -662,7 +667,7 @@ func (r *ReconcileArgoCD) triggerStatefulSetRollout(sts *appsv1.StatefulSet, key
 	return r.Client.Update(context.TODO(), sts)
 }
 
-//to update nodeSelector and tolerations in reconciler
+// to update nodeSelector and tolerations in reconciler
 func updateNodePlacementStateful(existing *appsv1.StatefulSet, ss *appsv1.StatefulSet, changed *bool) {
 	if !reflect.DeepEqual(existing.Spec.Template.Spec.NodeSelector, ss.Spec.Template.Spec.NodeSelector) {
 		existing.Spec.Template.Spec.NodeSelector = ss.Spec.Template.Spec.NodeSelector

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -295,7 +295,9 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 				Replicas: 3,
 			},
 			replicas: 1,
-			vars:     nil,
+			vars: []corev1.EnvVar{
+				{Name: "HOME", Value: "/home/argocd"},
+			},
 		},
 		{
 			sharding: argoprojv1alpha1.ArgoCDApplicationControllerShardSpec{
@@ -305,6 +307,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			replicas: 1,
 			vars: []corev1.EnvVar{
 				{Name: "ARGOCD_CONTROLLER_REPLICAS", Value: "1"},
+				{Name: "HOME", Value: "/home/argocd"},
 			},
 		},
 		{
@@ -315,6 +318,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			replicas: 3,
 			vars: []corev1.EnvVar{
 				{Name: "ARGOCD_CONTROLLER_REPLICAS", Value: "3"},
+				{Name: "HOME", Value: "/home/argocd"},
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
GITOPS-2480

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes GITOPS-2480

**How to test changes / Special notes to the reviewer**:
1. Create an argocd instance in a namespace which doesn't have cluster admin permission.
2. Run `kubectl get pods -A -v=20` command in the argocd-application-controller terminal.
3. Confirm that there's no `.kube: permission denied` error
