### PR TITLE
fix: remove managed-by label from terminating namespaces

### DIFF
--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -110,8 +110,13 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 	}
 
 	for _, namespace := range r.ManagedNamespaces.Items {
-		// Skip terminating namespaces.
+		// If encountering a terminating namespace remove managed-by label from it and skip reconciliation - This should trigger
+		// clean-up of roles/rolebindings and removal of namespace from cluster secret
 		if namespace.DeletionTimestamp != nil {
+			if _, ok := namespace.Labels[common.ArgoCDManagedByLabel]; ok {
+				delete(namespace.Labels, common.ArgoCDManagedByLabel)
+				_ = r.Client.Update(context.TODO(), &namespace)
+			}
 			continue
 		}
 

--- a/tests/k8s/1-031_validate_handle_terminating_namespaces/01-install.yaml
+++ b/tests/k8s/1-031_validate_handle_terminating_namespaces/01-install.yaml
@@ -1,0 +1,207 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitops-service-argocd
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  finalizers:
+  - argoproj.io/finalizer
+  name: gitops-service-argocd
+  namespace: gitops-service-argocd
+spec:
+
+  resourceInclusions: |
+    - apiGroups:
+      - ""
+      kinds:
+      - "PersistentVolumeClaim"
+      - "PersistentVolume"
+      - "Secret"
+      - "ConfigMap"
+      - "Pod"
+      - "Endpoint"
+      - "Service"
+      - "ServiceAccounts"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "apps"
+      kinds:
+      - "ReplicaSet"
+      - "StatefulSet"
+      - "DaemonSet"
+      - "Deployment"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "discovery.k8s.io"
+      kinds:
+      - "EndpointSlice"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "networking.k8s.io"
+      kinds:
+      - "Ingress"
+      - "IngressClass"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "rbac.authorization.k8s.io"
+      kinds:
+      - "RoleBinding"
+      - "Role"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "route.openshift.io"
+      kinds:
+      - "Route"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "triggers.tekton.dev"
+      kinds:
+      - "EventListener"
+      - "TriggerTemplate"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "pipelinesascode.tekton.dev"
+      kinds:
+      - "Repository"
+      clusters:
+      - "*"
+  applicationSet:
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  controller:
+    logLevel: "debug"
+    processors: {}
+    resources:
+      limits:
+        cpu: "1"
+        memory: 3Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    sharding: {}
+
+    # May 2022: Argo CD to check for new Git revisions every 1 minute, rather than every 3 minutes. (jonwest@redhat.com)
+    appSync: 60s
+
+#  dex:
+#    enabled: false
+#    openShiftOAuth: false # true
+#    resources:
+#      limits:
+#        cpu: 500m
+#        memory: 256Mi
+#      requests:
+#        cpu: 250m
+#        memory: 128Mi
+  grafana:
+    enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+    route:
+      enabled: false
+  ha:
+    enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  initialSSHKnownHosts: {}
+  prometheus:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  rbac:
+    policy: g, system:authenticated, role:admin
+    scopes: '[groups]'
+  redis:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  repo:
+    logLevel: "debug"
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  server:
+    logLevel: "debug"
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    route:
+      enabled: true
+      tls:
+        termination: reencrypt
+    service:
+      type: ""
+  tls:
+    ca: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jane
+  labels:
+    argocd.argoproj.io/managed-by: gitops-service-argocd
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config-map-2
+  namespace: jane
+  
+  finalizers:
+  - some.random/finalizer
+  
+data: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: john
+  labels:
+    argocd.argoproj.io/managed-by: gitops-service-argocd

--- a/tests/k8s/1-031_validate_handle_terminating_namespaces/02-delete-ns.yaml
+++ b/tests/k8s/1-031_validate_handle_terminating_namespaces/02-delete-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete ns jane
+    ignoreFailure: true
+    timeout: 30

--- a/tests/k8s/1-031_validate_handle_terminating_namespaces/03-assert.yaml
+++ b/tests/k8s/1-031_validate_handle_terminating_namespaces/03-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: gitops-service-argocd
+status:
+  sync:
+    status: Synced

--- a/tests/k8s/1-031_validate_handle_terminating_namespaces/03-create-app.yaml
+++ b/tests/k8s/1-031_validate_handle_terminating_namespaces/03-create-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: gitops-service-argocd
+spec:
+  destination:
+    namespace: john
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: kustomize-guestbook
+    repoURL: https://github.com/argoproj/argocd-example-apps
+    targetRevision: master
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
Signed-off-by: Jaideep Rao <jaideep.r97@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**: 
This PR removes the "managed-by" label from a previously managed now terminating namespace, which triggers the removal of this namespace from the argo-cd instance's cluster secret thus unblocking it from deploying resources to other managed namespaces 
This seems like a cleaner approach than directly deleting the namespace from the cluster secret as we already have existing code paths to achieve this that could be triggered by removing the label from the terminating namespace - and while it is generally not a good idea to delete labels from namespaces (if not added by the operator) however, it maybe okay in this case since the namespace is scheduled for deletion anyway  

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #853?

**How to test changes / Special notes to the reviewer**:
repeat steps documented in linked issue and confirm that app resources are in fact deployed to "John" namespace
