### PR TITLE
upgrade to argocd v2.6.3 (#865)

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,5 +1,5 @@
-# Argo CD v2.6.1
-FROM quay.io/argoproj/argocd@sha256:7c8a4f49b7bda99e5b8f4b44dbc6a46b87ebb0f8696c5027aaaf9bbbd022ac7f as argocd
+# Argo CD v2.6.3
+FROM quay.io/argoproj/argocd@sha256:0fd690bd7b89bd6f947b4000de33abd53ebcd36b57216f1c675a1127707b5eef as argocd
 
 # Final Image
 FROM docker.io/library/ubuntu:22.04

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -61,7 +61,7 @@ const (
 	ArgoCDDefaultArgoImage = "quay.io/argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:7c8a4f49b7bda99e5b8f4b44dbc6a46b87ebb0f8696c5027aaaf9bbbd022ac7f" // v2.6.1
+	ArgoCDDefaultArgoVersion = "sha256:0fd690bd7b89bd6f947b4000de33abd53ebcd36b57216f1c675a1127707b5eef" // v2.6.3
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-operator
 go 1.18
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.6.1
+	github.com/argoproj/argo-cd/v2 v2.6.3
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.m
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/argoproj/argo-cd/v2 v2.6.1 h1:fp+ounx6DczbWvfhZ7LCvVOxMQbksoKRFdfqdHHcu+U=
-github.com/argoproj/argo-cd/v2 v2.6.1/go.mod h1:wkQAcIEXpgP8F45T/9UwwHhhLz2KgITba0NOby4NTPQ=
+github.com/argoproj/argo-cd/v2 v2.6.3 h1:XEvGDnGRroAw5mKKUTcfIbTmjmhL0hEsVh1+vkytrLo=
+github.com/argoproj/argo-cd/v2 v2.6.3/go.mod h1:wkQAcIEXpgP8F45T/9UwwHhhLz2KgITba0NOby4NTPQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
Signed-off-by: Regina Scott [rescott@redhat.com](mailto:rescott@redhat.com)
(cherry picked from commit https://github.com/argoproj-labs/argocd-operator/commit/6e748cc94afc5a6881cd230d9087203ede627aca)

What type of PR is this?
/kind chore

What does this PR do / why we need it:
cherry picks https://github.com/argoproj-labs/argocd-operator/pull/865 to release v0.6.0