### PR TITLE
fix: dex client secret is not updated in the argocd-secret intermittently

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -335,11 +335,13 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 	}
 
 	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex {
-		if secret.Data[common.ArgoCDDexSecretKey] == nil {
-			dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
-			if err != nil {
-				return nil
-			}
+		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
+		if err != nil {
+			return nil
+		}
+		actual := string(secret.Data[common.ArgoCDDexSecretKey])
+		expected := *dexOIDCClientSecret
+		if actual != expected {
 			secret.Data[common.ArgoCDDexSecretKey] = []byte(*dexOIDCClientSecret)
 			changed = true
 		}

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -337,13 +337,15 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex {
 		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
 		if err != nil {
-			return nil
+			return err
 		}
 		actual := string(secret.Data[common.ArgoCDDexSecretKey])
-		expected := *dexOIDCClientSecret
-		if actual != expected {
-			secret.Data[common.ArgoCDDexSecretKey] = []byte(*dexOIDCClientSecret)
-			changed = true
+		if dexOIDCClientSecret != nil {
+			expected := *dexOIDCClientSecret
+			if actual != expected {
+				secret.Data[common.ArgoCDDexSecretKey] = []byte(*dexOIDCClientSecret)
+				changed = true
+			}
 		}
 	}
 

--- a/tests/ocp/1-004_validate_dex_clientsecret/01-assert.yaml
+++ b/tests/ocp/1-004_validate_dex_clientsecret/01-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-argocd-argocd-dex-server

--- a/tests/ocp/1-004_validate_dex_clientsecret/01-install.yaml
+++ b/tests/ocp/1-004_validate_dex_clientsecret/01-install.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  sso:
+    provider: dex
+    dex:
+     openShiftOAuth: true

--- a/tests/ocp/1-004_validate_dex_clientsecret/02-verify-clientsecret.yaml
+++ b/tests/ocp/1-004_validate_dex_clientsecret/02-verify-clientsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    # This test validates the Dex Client Secret copied by the operator from dex serviceaccount token secret in to argocd-secret.
+    # To verify the behavior we should first get the token secret name of the dex service account.
+    secret=$(oc get -n $NAMESPACE sa example-argocd-argocd-dex-server -o json | jq -r '.secrets' | grep token | sed 's/    "name": "//g' | sed 's/"//g')
+    
+    # Extract the clientSecret 
+    expectedClientSecret=$(oc get secret $secret -n $NAMESPACE -o json | jq -r '.data.token')
+    
+    # actualClientSecret is the value of the secret in argocd-secret where argocd-operator should copy the secret from
+    actualClientSecret=$(oc get secret argocd-secret -o json -n $NAMESPACE | jq -r '.data."oidc.dex.clientSecret"')
+    
+    # Verify
+    if $expectedClientSecret != $actualClientSecret; then
+      echo "Error: Dex Client Secret for OIDC is not valid"
+      exit 1
+    fi


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This PR will fix the issue with `dex client secret is not updated in the argocd-secret intermittently.`
The actual enhancement of securing the dex client secret (OIDC) is part of #847 

This looks like a race condition or sometimes when operator tries to get the dex client secret from Argo CD dex service account (from the secret named token) the token secret is not created by then. This can be fixed in the reconciliation of existing Argo CD secret which is called much later multiple times.
This is an intermittent behavior and can be reproduced more on the bundle installation rather than the local installation.

**Have you updated the necessary documentation?**
NA

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-2714

**How to test changes / Special notes to the reviewer**:
I have added a new automation test which will validate the behavior
**Run the below test**
`kubectl kuttl test ./tests/ocp --config ./tests/kuttl-tests.yaml --test 1-004_validate_dex_clientsecret`