### PR TITLE
fix: Reconcile Dex client secret when .spec.dex is set (#877)

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -184,7 +184,7 @@ func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
 		common.ArgoCDKeyTLSPrivateKey:      tlsSecret.Data[common.ArgoCDKeyTLSPrivateKey],
 	}
 
-	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex {
+	if cr.Spec.Dex != nil || (cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex) {
 		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
 		if err != nil {
 			return nil

--- a/tests/ocp/1-005_validate_dex_clientsecret_deprecated/01-assert.yaml
+++ b/tests/ocp/1-005_validate_dex_clientsecret_deprecated/01-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-argocd-argocd-dex-server

--- a/tests/ocp/1-005_validate_dex_clientsecret_deprecated/01-install.yaml
+++ b/tests/ocp/1-005_validate_dex_clientsecret_deprecated/01-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  dex:
+    openShiftOAuth: true

--- a/tests/ocp/1-005_validate_dex_clientsecret_deprecated/02-verify-clientsecret.yaml
+++ b/tests/ocp/1-005_validate_dex_clientsecret_deprecated/02-verify-clientsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    # This test validates the Dex Client Secret copied by the operator from dex serviceaccount token secret in to argocd-secret.
+    # To verify the behavior we should first get the token secret name of the dex service account.
+    secret=$(oc get -n $NAMESPACE sa example-argocd-argocd-dex-server -o json | jq -r '.secrets' | grep token | sed 's/    "name": "//g' | sed 's/"//g')
+    
+    # Extract the clientSecret 
+    expectedClientSecret=$(oc get secret $secret -n $NAMESPACE -o json | jq -r '.data.token')
+    
+    # actualClientSecret is the value of the secret in argocd-secret where argocd-operator should copy the secret from
+    actualClientSecret=$(oc get secret argocd-secret -o json -n $NAMESPACE | jq -r '.data."oidc.dex.clientSecret"')
+    
+    # Verify
+    if $expectedClientSecret != $actualClientSecret; then
+      echo "Error: Dex Client Secret for OIDC is not valid"
+      exit 1
+    fi


### PR DESCRIPTION
Signed-off-by: jannfis <jann@mistrust.net>
(cherry picked from commit a359b7c62a88ace46dc3259ebb4add91f148483f)

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
