### PR TITLE
fix: Reconcile Dex client secret when .spec.dex is set and argocd-secret exists 

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -334,7 +334,7 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 		changed = true
 	}
 
-	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex {
+	if cr.Spec.Dex != nil || (cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex) {
 		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
 		if err != nil {
 			return err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This is a follow up PR to https://github.com/argoproj-labs/argocd-operator/pull/877 for handling dex client secret when argocd-secret exists (Upgrade path issue)

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-2761

**How to test changes / Special notes to the reviewer**:
