### PR TITLE
chore: Add docs for namespace scoped and cluster scoped privileges

### DIFF
--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -196,19 +196,22 @@ By default Argo CD instance is provided the following permissions
 * Argo CD is provided the following cluster scoped permissions because Argo CD requires cluster-wide read privileges on resources to function properly. (Please see [RBAC](https://argo-cd.readthedocs.io/en/stable/operator-manual/security/#cluster-rbac) section for more details.)
 
 ```yaml
- - verbs:
-    - get
-    - list
-    - watch
-   apiGroups:
-    - '*'
-   resources:
-    - '*'
- - verbs:
-    - get
-    - list
-   nonResourceURLs:
-    - '*'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: <argocd-instance-name>
+    app.kubernetes.io/name: <argocd-instance-name>
+    app.kubernetes.io/part-of: argocd
+  name: <argocd-instance-name>-argocd-application-controller
+  namespace: <argocd-instance-namespace>
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
 ```
 
 ## Cluster Scoped Instance

--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -186,3 +186,109 @@ See the [routes][docs_routes] documentation for steps to configure the Route sup
 [docs_ingress]:./ingress.md
 [docs_routes]:./routes.md
 [argocd_reference]:../reference/argocd.md
+
+### Default Permissions provided to Argo CD instance
+
+By default Argo CD instance is provided the following permissions
+
+* Argo CD instance is provided with ADMIN privileges for the namespace it is installed in. For instance, if an Argo CD instance is deployed in **foo** namespace, it will have **ADMIN privileges** to manage resources for that namespace.
+
+* Argo CD is provided the following cluster scoped permissions because Argo CD requires cluster-wide read privileges on resources to function properly. (Please see [RBAC](https://argo-cd.readthedocs.io/en/stable/operator-manual/security/#cluster-rbac) section for more details.)
+
+```yaml
+ - verbs:
+    - get
+    - list
+    - watch
+   apiGroups:
+    - '*'
+   resources:
+    - '*'
+ - verbs:
+    - get
+    - list
+   nonResourceURLs:
+    - '*'
+```
+
+## Cluster Scoped Instance
+
+The Argo CD instance created above can also be used to manage the cluster scoped resources by adding the namespace of the Argo CD instance to the `ARGOCD_CLUSTER_CONFIG_NAMESPACES` environment variable of subscription resource as shown below.
+
+```yml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: argocd-operator
+spec:
+  config:
+   env: 
+    - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+      value: <list of namespaces of cluster-scoped Argo CD instances>
+  channel: alpha
+  name: argocd-operator
+  source: argocd-catalog
+  sourceNamespace: olm
+```
+
+### In-built permissions for cluster configuration
+
+Argo CD is granted the following permissions using a cluster role when it is configured as cluster-scoped instance. **Argo CD is not granted cluster-admin**.
+
+Please note that these permissions are in addition to the `admin` privileges that Argo CD has to the namespace in which it is installed.
+
+```yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <argocd-instance-name>-<namespace>-argocd-application-controller
+  labels:
+    app.kubernetes.io/managed-by: <argocd-instance-namespace>
+    app.kubernetes.io/name: <argocd-instance-namespace>
+    app.kubernetes.io/part-of: argocd
+rules:
+  - verbs:
+      - '*'
+    apiGroups:
+      - '*'
+    resources:
+      - '*'
+```
+
+### Additional permissions
+
+Users can extend the permissions granted to Argo CD application controller by creating cluster roles with additional permissions and then a new cluster role binding to associate them to the service account.
+
+For example, user can extend the permissions for an Argo CD instance to be able to list the secrets for all namespaces by creating the below resources.
+
+#### Cluster Role
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # "namespace" omitted since ClusterRoles are not namespaced
+  name: secrets-cluster-role
+rules:
+- apiGroups: [""] #specifies core api groups
+  resources: ["secrets"]
+  verbs: ["*"]
+```
+
+#### Cluster Role Binding
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+# This cluster role binding allows Service Account to read secrets in any namespace.
+kind: ClusterRoleBinding
+metadata:
+  name: read-secrets-global
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: secrets-cluster-role # Name of cluster role to be referenced
+subjects:
+- kind: ServiceAccount
+  name: <argocd-instance-service-account-name>
+  namespace: <argocd-instance-namespace>
+```

--- a/docs/usage/deploy-to-different-namespaces.md
+++ b/docs/usage/deploy-to-different-namespaces.md
@@ -1,6 +1,6 @@
 # Deploy resources to a different namespace
 
-To grant Argo CD the permissions to manage resources in multiple namespaces, we need to configure the namespace with a label `argocd.argoproj.io/managed-by` and the value being the namespace of the Argo CD instance meant to manage the namespace.
+To grant Argo CD the permissions to manage resources in multiple namespaces, we need to configure the namespace with a label `argocd.argoproj.io/managed-by` and the value being the namespace of the managing Argo CD instance.
 
 For example, If Argo CD instance deployed in the namespace `foo` wants to manage resources in namespace `bar`. Update the namespace `bar` as shown below.
 

--- a/docs/usage/deploy-to-different-namespaces.md
+++ b/docs/usage/deploy-to-different-namespaces.md
@@ -1,0 +1,14 @@
+# Deploy resources to a different namespace
+
+To grant Argo CD the permissions to manage resources in multiple namespaces, we need to configure the namespace with a label `argocd.argoproj.io/managed-by` and the value being the namespace of the Argo CD instance meant to manage the namespace.
+
+For example, If Argo CD instance deployed in the namespace `foo` wants to manage resources in namespace `bar`. Update the namespace `bar` as shown below.
+
+```yml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bar
+  labels:
+    argocd.argoproj.io/managed-by: foo // namespace of the Argo CD instance
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
     - Basics: usage/basics.md
     - Config Management: usage/config_management_2.0.md
     - Custom Tooling: usage/customization.md
+    - Deploy Resources to Different Namespaces: usage/deploy-to-different-namespaces.md
     - Export: usage/export.md
     - ExtraConfig: usage/extra-config.md
     - High Availability: usage/ha.md


### PR DESCRIPTION
**What type of PR is this?**
This PR updates the docs w.r.t 
> /kind documentation

**What does this PR do / why we need it**:

This PR adds docs for the below features
 - Default Permissions for a namespace scoped Argo CD Installation
 - How to configure an Argo CD instance to cluster scoped
 - Default Permissions for a cluster scoped Argo CD Instance
 - How to extend the permissions of an Argo CD Instance to deploy additional resources
 - How can Argo CD deploy resources to different namespaces

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:
- Install Mkdocs
- Run `mkdocs serve`

![Screenshot 2023-04-04 at 4 54 12 PM](https://user-images.githubusercontent.com/43399466/229777296-e1bec0f2-77ee-4adb-b9a1-fbc5034b81e4.png)

![Screenshot 2023-04-04 at 4 54 59 PM](https://user-images.githubusercontent.com/43399466/229777323-79404bbb-a029-4fa7-b7b6-801288e5c750.png)
