### PR TITLE
bug: operator interfering with hpa in autoscale mode for server

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.52.2
           args: --timeout 5m --exclude SA5011
           only-new-issues: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,4 +18,4 @@ linters-settings:
   goimports:
     local-prefixes: github.com/argoproj-labs/argocd-operator
 service:
-  golangci-lint-version: 1.38.0
+  golangci-lint-version: 1.52.2

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -39,22 +39,22 @@ func init() {
 // ArgoCD is the Schema for the argocds API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-//+operator-sdk:csv:customresourcedefinitions:resources={{ArgoCD,v1alpha1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{ArgoCDExport,v1alpha1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{ConfigMap,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{CronJob,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Ingress,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Job,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{PersistentVolumeClaim,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Prometheus,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{ReplicaSet,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Route,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Secret,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Service,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{ServiceMonitor,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ArgoCD,v1alpha1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ArgoCDExport,v1alpha1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ConfigMap,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{CronJob,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Ingress,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Job,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{PersistentVolumeClaim,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Prometheus,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ReplicaSet,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Route,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Secret,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Service,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ServiceMonitor,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,""}}
 type ArgoCD struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -637,7 +637,7 @@ type ArgoCDMonitoringSpec struct {
 	Enabled bool `json:"enabled"`
 }
 
-//ArgoCDNodePlacementSpec is used to specify NodeSelector and Tolerations for Argo CD workloads
+// ArgoCDNodePlacementSpec is used to specify NodeSelector and Tolerations for Argo CD workloads
 type ArgoCDNodePlacementSpec struct {
 	// NodeSelector is a field of PodSpec, it is a map of key value pairs used for node selection
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`

--- a/api/v1alpha1/argocdexport_types.go
+++ b/api/v1alpha1/argocdexport_types.go
@@ -30,22 +30,22 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=argocdexports,scope=Namespaced
-//+operator-sdk:csv:customresourcedefinitions:resources={{ArgoCD,v1alpha1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{ArgoCDExport,v1alpha1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{ConfigMap,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{CronJob,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Ingress,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Job,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{PersistentVolumeClaim,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Prometheus,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{ReplicaSet,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Route,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Secret,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{Service,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{ServiceMonitor,v1,""}}
-//+operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ArgoCD,v1alpha1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ArgoCDExport,v1alpha1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ConfigMap,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{CronJob,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Deployment,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Ingress,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Job,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{PersistentVolumeClaim,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Prometheus,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ReplicaSet,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Route,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Secret,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{Service,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{ServiceMonitor,v1,""}}
+// +operator-sdk:csv:customresourcedefinitions:resources={{StatefulSet,v1,""}}
 type ArgoCDExport struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the argoproj.io v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=argoproj.io
+// +kubebuilder:object:generate=true
+// +groupName=argoproj.io
 package v1alpha1
 
 import (

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1315,8 +1315,10 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoprojv1a1.ArgoCD, use
 			changed = true
 		}
 		if !reflect.DeepEqual(deploy.Spec.Replicas, existing.Spec.Replicas) {
-			existing.Spec.Replicas = deploy.Spec.Replicas
-			changed = true
+			if !cr.Spec.Server.Autoscale.Enabled {
+				existing.Spec.Replicas = deploy.Spec.Replicas
+				changed = true
+			}
 		}
 		if changed {
 			return r.Client.Update(context.TODO(), existing)

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -87,50 +87,71 @@ func TestReconcileArgoCD_reconcileRepoDeployment_replicas(t *testing.T) {
 func TestReconcileArgoCD_reconcile_ServerDeployment_replicas(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
+	var (
+		initalReplicas  int32 = 4
+		updatedReplicas int32 = 5
+	)
+
 	tests := []struct {
-		name          string
-		replicas      int32
-		autoscale     bool
-		expectedNil   bool
-		expectedValue int32
+		name              string
+		initialReplicas   *int32
+		updatedReplicas   *int32
+		autoscale         bool
+		wantFinalReplicas *int32
 	}{
 		{
-			name:          "replicas field in the spec should reflect the number of replicas on the cluster",
-			replicas:      5,
-			autoscale:     false,
-			expectedNil:   false,
-			expectedValue: 5,
+			name:              "deployment spec replicas initially nil, updated by operator, no autoscale",
+			initialReplicas:   nil,
+			updatedReplicas:   &updatedReplicas,
+			autoscale:         false,
+			wantFinalReplicas: &updatedReplicas,
 		},
 		{
-			name:        "replicas should be overriden by autoscale",
-			replicas:    1,
-			autoscale:   true,
-			expectedNil: true,
+			name:              "deployment spec replicas initially not nil, updated by operator, no autoscale",
+			initialReplicas:   &initalReplicas,
+			updatedReplicas:   &updatedReplicas,
+			autoscale:         false,
+			wantFinalReplicas: &updatedReplicas,
+		},
+		{
+			name:              "deployment spec replicas initially nil, ignored by operator with autoscale",
+			initialReplicas:   nil,
+			updatedReplicas:   &updatedReplicas,
+			autoscale:         true,
+			wantFinalReplicas: nil,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+				a.Spec.Server.Replicas = test.initialReplicas
 				a.Spec.Server.Autoscale.Enabled = test.autoscale
-				a.Spec.Server.Replicas = &test.replicas
 			})
 			r := makeTestReconciler(t, a)
 
 			err := r.reconcileServerDeployment(a, false)
 			assert.NoError(t, err)
-
 			deployment := &appsv1.Deployment{}
 			err = r.Client.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-server",
 				Namespace: testNamespace,
 			}, deployment)
 			assert.NoError(t, err)
-			assert.Equal(t, test.expectedNil, deployment.Spec.Replicas == nil)
-			if deployment.Spec.Replicas != nil {
-				assert.Equal(t, test.expectedValue, *deployment.Spec.Replicas)
-			}
+			assert.Equal(t, test.initialReplicas, deployment.Spec.Replicas)
+
+			a.Spec.Server.Replicas = test.updatedReplicas
+			err = r.reconcileServerDeployment(a, false)
+			assert.NoError(t, err)
+
+			deployment = &appsv1.Deployment{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      "argocd-server",
+				Namespace: testNamespace,
+			}, deployment)
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantFinalReplicas, deployment.Spec.Replicas)
+
 		})
 	}
 }

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1303,6 +1303,9 @@ Name | Default | Description
 Enabled | false | Toggle Autoscaling support globally for the Argo CD server component.
 HPA | [Object] | HorizontalPodAutoscaler options for the Argo CD Server component.
 
+!!! note
+    When `.spec.server.autoscale.enabled` is set to `true`, the number of required replicas (if set) in `.spec.server.replicas` will be ignored. The final replica count on the server deployment will be controlled by the Horizontal Pod Autoscaler instead. 
+
 ### Server Command Arguments
 
 Allows a user to pass arguments to Argo CD Server command.


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

/kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
Ports the fixes merged into master in #860  to release-0.6 for a situation when the operator overwrites HPA changes in replicas when autoscale is enabled for server

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
