### PR TITLE
fix: ExecTimeout parameter not respected

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -882,7 +882,7 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD, useTL
 	// Environment specified in the CR take precedence over everything else
 	repoEnv = argoutil.EnvMerge(repoEnv, proxyEnvVars(), false)
 	if cr.Spec.Repo.ExecTimeout != nil {
-		repoEnv = argoutil.EnvMerge(repoEnv, []corev1.EnvVar{{Name: "ARGOCD_EXEC_TIMEOUT", Value: fmt.Sprintf("%d" + "s", *cr.Spec.Repo.ExecTimeout)}}, true)
+		repoEnv = argoutil.EnvMerge(repoEnv, []corev1.EnvVar{{Name: "ARGOCD_EXEC_TIMEOUT", Value: fmt.Sprintf("%ds", *cr.Spec.Repo.ExecTimeout)}}, true)
 	}
 
 	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -882,7 +882,7 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD, useTL
 	// Environment specified in the CR take precedence over everything else
 	repoEnv = argoutil.EnvMerge(repoEnv, proxyEnvVars(), false)
 	if cr.Spec.Repo.ExecTimeout != nil {
-		repoEnv = argoutil.EnvMerge(repoEnv, []corev1.EnvVar{{Name: "ARGOCD_EXEC_TIMEOUT", Value: fmt.Sprintf("%d", *cr.Spec.Repo.ExecTimeout)}}, true)
+		repoEnv = argoutil.EnvMerge(repoEnv, []corev1.EnvVar{{Name: "ARGOCD_EXEC_TIMEOUT", Value: fmt.Sprintf("%d" + "s", *cr.Spec.Repo.ExecTimeout)}}, true)
 	}
 
 	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -316,7 +316,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 3)
 		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "FOO", Value: "BAR"})
 		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "BAR", Value: "FOO"})
-		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "ARGOCD_EXEC_TIMEOUT", Value: "600"})
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "ARGOCD_EXEC_TIMEOUT", Value: "600s"})
 	})
 
 	t.Run("ExecTimeout set", func(t *testing.T) {
@@ -336,7 +336,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 1)
-		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "ARGOCD_EXEC_TIMEOUT", Value: "600"})
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "ARGOCD_EXEC_TIMEOUT", Value: "600s"})
 	})
 
 	t.Run("ExecTimeout set with env set explicitly", func(t *testing.T) {
@@ -347,7 +347,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		a.Spec.Repo.Env = []corev1.EnvVar{
 			{
 				Name:  "ARGOCD_EXEC_TIMEOUT",
-				Value: "20",
+				Value: "20s",
 			},
 		}
 		r := makeTestReconciler(t, a)
@@ -362,7 +362,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 1)
-		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "ARGOCD_EXEC_TIMEOUT", Value: "600"})
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "ARGOCD_EXEC_TIMEOUT", Value: "600s"})
 	})
 	t.Run("ExecTimeout not set", func(t *testing.T) {
 		logf.SetLogger(ZapLogger(true))

--- a/tests/k8s/1-011_validate_repo_exec_timeout/02-change-exec-timeout.yaml
+++ b/tests/k8s/1-011_validate_repo_exec_timeout/02-change-exec-timeout.yaml
@@ -4,4 +4,4 @@ metadata:
   name: argocd
 spec:
   repo:
-    execTimeout: 300
+    execTimeout: 300s

--- a/tests/k8s/1-011_validate_repo_exec_timeout/02-change-exec-timeout.yaml
+++ b/tests/k8s/1-011_validate_repo_exec_timeout/02-change-exec-timeout.yaml
@@ -4,4 +4,4 @@ metadata:
   name: argocd
 spec:
   repo:
-    execTimeout: 300s
+    execTimeout: 300

--- a/tests/k8s/1-011_validate_repo_exec_timeout/04-check-workload-env.yaml
+++ b/tests/k8s/1-011_validate_repo_exec_timeout/04-check-workload-env.yaml
@@ -5,7 +5,7 @@ commands:
 - script: |
     timeout=$(kubectl get -n $NAMESPACE deployment argocd-repo-server -o json \
       | jq -r '.spec.template.spec.containers[0].env[]|select(.name=="ARGOCD_EXEC_TIMEOUT").value')
-    if test "$timeout" != "300"; then
-      echo "Assertion failed. Timeout should be 300, is '$timeout'"
+    if test "$timeout" != "300s"; then
+      echo "Assertion failed. Timeout should be 300s, is '$timeout'"
       exit 1
     fi

--- a/tests/k8s/1-011_validate_repo_exec_timeout/04-check-workload-env.yaml
+++ b/tests/k8s/1-011_validate_repo_exec_timeout/04-check-workload-env.yaml
@@ -5,7 +5,7 @@ commands:
 - script: |
     timeout=$(kubectl get -n $NAMESPACE deployment argocd-repo-server -o json \
       | jq -r '.spec.template.spec.containers[0].env[]|select(.name=="ARGOCD_EXEC_TIMEOUT").value')
-    if test "$timeout" != "300"; then
+    if test "$timeout" != "300s"; then
       echo "Assertion failed. Timeout should be 300, is '$timeout'"
       exit 1
     fi

--- a/tests/k8s/1-011_validate_repo_exec_timeout/04-check-workload-env.yaml
+++ b/tests/k8s/1-011_validate_repo_exec_timeout/04-check-workload-env.yaml
@@ -5,7 +5,7 @@ commands:
 - script: |
     timeout=$(kubectl get -n $NAMESPACE deployment argocd-repo-server -o json \
       | jq -r '.spec.template.spec.containers[0].env[]|select(.name=="ARGOCD_EXEC_TIMEOUT").value')
-    if test "$timeout" != "300s"; then
+    if test "$timeout" != "300"; then
       echo "Assertion failed. Timeout should be 300, is '$timeout'"
       exit 1
     fi


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
This will fix issue with correct value for ARGOCD_EXEC_TIMEOUT environment variable. Currently ExecTimeout option in Repo-server sets ARGOCD_EXEC_TIMEOUT as integer value. According to argocd docs: https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/ - ARGOCD_EXEC_TIMEOUT "... value should be in Go time duration string format, for example, 2m30s."

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-operator/issues/875

**How to test changes / Special notes to the reviewer**:
Check value of ARGOCD_EXEC_TIMEOUT in argocd-repo-server - it should be in Go time duration string format