### PR TITLE
chore: Add timeline to remove deprecated resourceCustomizations

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -414,7 +414,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 
 		// Emit event providing users with deprecation notice for ResourceCustomization if not emitted already
 		if currentInstanceEventEmissionStatus, ok := DeprecationEventEmissionTracker[cr.Namespace]; !ok || !currentInstanceEventEmissionStatus.ResourceCustomizationsDeprecationWarningEmitted {
-			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "ResourceCustomizations is deprecated, and support will be removed in Argo CD Operator v0.7.0/OpenShift GitOps v1.10.0. Please use the new formats `ResourceHealthChecks`, `ResourceIgnoreDifferences`, and `ResourceActions`.", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
+			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "ResourceCustomizations is deprecated, and support will be removed in Argo CD Operator v0.8.0/OpenShift GitOps v1.10.0. Please use the new formats `ResourceHealthChecks`, `ResourceIgnoreDifferences`, and `ResourceActions`.", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
 			if err != nil {
 				return err
 			}

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -414,7 +414,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 
 		// Emit event providing users with deprecation notice for ResourceCustomization if not emitted already
 		if currentInstanceEventEmissionStatus, ok := DeprecationEventEmissionTracker[cr.Namespace]; !ok || !currentInstanceEventEmissionStatus.ResourceCustomizationsDeprecationWarningEmitted {
-			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "ResourceCustomizations is deprecated, please use the new formats `ResourceHealthChecks`, `ResourceIgnoreDifferences`, and `ResourceActions` instead.", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
+			err := argoutil.CreateEvent(r.Client, "Warning", "Deprecated", "ResourceCustomizations is deprecated, and support will be removed in Argo CD Operator v0.7.0/OpenShift GitOps v1.10.0. Please use the new formats `ResourceHealthChecks`, `ResourceIgnoreDifferences`, and `ResourceActions`.", "DeprecationNotice", cr.ObjectMeta, cr.TypeMeta)
 			if err != nil {
 				return err
 			}

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1008,7 +1008,7 @@ spec:
 There are two ways to customize resource behavior- the first way, only available with release v0.5.0+, is with subkeys (`resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`), the second is without subkeys (`resourceCustomizations`). `resourceCustomizations` maps directly to the `resource.customizations` field in the `argocd-cm` ConfigMap, while each of the subkeys maps directly to their own field in the `argocd-cm`. `resourceHealthChecks` will map to `resource.customizations.health`, `resourceIgnoreDifferences` to `resource.customizations.ignoreDifferences`, and `resourceActions` to `resource.customizations.actions`.
 
 !!! warning 
-    `resourceCustomizations` is being deprecated, and support will be removed in Argo CD Operator v0.7.0 so is encouraged to use `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead. It is the user's responsibility to not provide conflicting resources if they choose to use both methods of resource customizations. 
+    `resourceCustomizations` is being deprecated, and support will be removed in Argo CD Operator v0.8.0 so is encouraged to use `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead. It is the user's responsibility to not provide conflicting resources if they choose to use both methods of resource customizations. 
 
 ### Resource Customizations (with subkeys) Example
 
@@ -1149,7 +1149,7 @@ resource.customizations.actions.apps_Deployment: |
 ### Resource Customizations Example
 
 !!! warning 
-    `resourceCustomizations` is being deprecated, and support will be removed in Argo CD Operator v0.7.0. Please use the new formats `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`.
+    `resourceCustomizations` is being deprecated, and support will be removed in Argo CD Operator v0.8.0. Please use the new formats `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`.
 
 The following example defines a custom PVC health check in the `argocd-cm` ConfigMap using the `ResourceCustomizations` property on the `ArgoCD` resource.
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1008,7 +1008,7 @@ spec:
 There are two ways to customize resource behavior- the first way, only available with release v0.5.0+, is with subkeys (`resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`), the second is without subkeys (`resourceCustomizations`). `resourceCustomizations` maps directly to the `resource.customizations` field in the `argocd-cm` ConfigMap, while each of the subkeys maps directly to their own field in the `argocd-cm`. `resourceHealthChecks` will map to `resource.customizations.health`, `resourceIgnoreDifferences` to `resource.customizations.ignoreDifferences`, and `resourceActions` to `resource.customizations.actions`.
 
 !!! warning 
-    `resourceCustomizations` is being deprecated so is encouraged to use `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead. It is the user's responsibility to not provide conflicting resources if they choose to use both methods of resource customizations. 
+    `resourceCustomizations` is being deprecated, and support will be removed in Argo CD Operator v0.7.0 so is encouraged to use `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead. It is the user's responsibility to not provide conflicting resources if they choose to use both methods of resource customizations. 
 
 ### Resource Customizations (with subkeys) Example
 
@@ -1149,7 +1149,7 @@ resource.customizations.actions.apps_Deployment: |
 ### Resource Customizations Example
 
 !!! warning 
-    `resourceCustomizations` is being deprecated in favor of `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`.
+    `resourceCustomizations` is being deprecated, and support will be removed in Argo CD Operator v0.7.0. Please use the new formats `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`.
 
 The following example defines a custom PVC health check in the `argocd-cm` ConfigMap using the `ResourceCustomizations` property on the `ArgoCD` resource.
 


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
This PR adds removal timeline for deprecated `resourceCustomizations`. The `resourceCustomizations` was deprecated in `v0.5.0` and is planned to be removed in `v0.8.0`.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:
1. Run the operator locally using make install run
2. Create a argocd instance using deprecated `resourceCustomizations` field
   > eg: https://argocd-operator.readthedocs.io/en/latest/reference/argocd/#resource-customizations-example
3. Execute `kubectl get events | grep ResourceCustomizations`
4. Observe that deprecation event was emitted
   ```
   9m19s       Warning   DeprecationNotice         argocd/example-argocd                               ResourceCustomizations is deprecated, and support will be removed in Argo CD Operator v0.8.0/OpenShift GitOps v1.10.0. Please use the new formats `ResourceHealthChecks`, `ResourceIgnoreDifferences`, and `ResourceActions`.
   ``` 