### PR TITLE
bug: fix proper reconciliation of hpa object

### DIFF
--- a/controllers/argocd/hpa.go
+++ b/controllers/argocd/hpa.go
@@ -16,6 +16,7 @@ package argocd
 
 import (
 	"context"
+	"reflect"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +24,12 @@ import (
 	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
+)
+
+var (
+	maxReplicas int32 = 3
+	minReplicas int32 = 1
+	tcup        int32 = 50
 )
 
 func newHorizontalPodAutoscaler(cr *argoprojv1a1.ArgoCD) *autoscaling.HorizontalPodAutoscaler {
@@ -50,39 +57,54 @@ func newHorizontalPodAutoscalerWithSuffix(suffix string, cr *argoprojv1a1.ArgoCD
 	return newHorizontalPodAutoscalerWithName(nameWithSuffix(suffix, cr), cr)
 }
 
-// reconcileServerHPA will ensure that the HorizontalPodAutoscaler is present for the Argo CD Server component.
+// reconcileServerHPA will ensure that the HorizontalPodAutoscaler is present for the Argo CD Server component, and reconcile any detected changes.
 func (r *ReconcileArgoCD) reconcileServerHPA(cr *argoprojv1a1.ArgoCD) error {
-	hpa := newHorizontalPodAutoscalerWithSuffix("server", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, hpa.Name, hpa) {
+
+	defaultHPA := newHorizontalPodAutoscalerWithSuffix("server", cr)
+	defaultHPA.Spec = autoscaling.HorizontalPodAutoscalerSpec{
+		MaxReplicas:                    maxReplicas,
+		MinReplicas:                    &minReplicas,
+		TargetCPUUtilizationPercentage: &tcup,
+		ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       nameWithSuffix("server", cr),
+		},
+	}
+
+	existingHPA := newHorizontalPodAutoscalerWithSuffix("server", cr)
+	if argoutil.IsObjectFound(r.Client, cr.Namespace, existingHPA.Name, existingHPA) {
 		if !cr.Spec.Server.Autoscale.Enabled {
-			return r.Client.Delete(context.TODO(), hpa) // HorizontalPodAutoscaler found but globally disabled, delete it.
+			return r.Client.Delete(context.TODO(), existingHPA) // HorizontalPodAutoscaler found but globally disabled, delete it.
 		}
-		return nil // HorizontalPodAutoscaler found and configured, nothing do to, move along...
+
+		changed := false
+		// HorizontalPodAutoscaler found, reconcile if necessary changes detected
+		if cr.Spec.Server.Autoscale.HPA != nil {
+			if !reflect.DeepEqual(existingHPA.Spec, cr.Spec.Server.Autoscale.HPA) {
+				existingHPA.Spec = *cr.Spec.Server.Autoscale.HPA
+				changed = true
+			}
+		}
+
+		if changed {
+			return r.Client.Update(context.TODO(), existingHPA)
+		}
+
+		// HorizontalPodAutoscaler found, no changes detected
+		return nil
 	}
 
 	if !cr.Spec.Server.Autoscale.Enabled {
 		return nil // AutoScale not enabled, move along...
 	}
 
+	// AutoScale enabled, no existing HPA found, create
 	if cr.Spec.Server.Autoscale.HPA != nil {
-		hpa.Spec = *cr.Spec.Server.Autoscale.HPA
-	} else {
-		hpa.Spec.MaxReplicas = 3
-
-		var minrReplicas int32 = 1
-		hpa.Spec.MinReplicas = &minrReplicas
-
-		var tcup int32 = 50
-		hpa.Spec.TargetCPUUtilizationPercentage = &tcup
-
-		hpa.Spec.ScaleTargetRef = autoscaling.CrossVersionObjectReference{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-			Name:       nameWithSuffix("server", cr),
-		}
+		defaultHPA.Spec = *cr.Spec.Server.Autoscale.HPA
 	}
 
-	return r.Client.Create(context.TODO(), hpa)
+	return r.Client.Create(context.TODO(), defaultHPA)
 }
 
 // reconcileAutoscalers will ensure that all HorizontalPodAutoscalers are present for the given ArgoCD.

--- a/controllers/argocd/hpa_test.go
+++ b/controllers/argocd/hpa_test.go
@@ -1,0 +1,91 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	autoscaling "k8s.io/api/autoscaling/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	min     int32 = 5
+	max     int32 = 8
+	cpuUtil int32 = 45
+)
+
+func TestReconcileHPA(t *testing.T) {
+
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+	r := makeTestReconciler(t, a)
+
+	existingHPA := newHorizontalPodAutoscalerWithSuffix("server", a)
+
+	defaultHPASpec := autoscaling.HorizontalPodAutoscalerSpec{
+		MaxReplicas:                    maxReplicas,
+		MinReplicas:                    &minReplicas,
+		TargetCPUUtilizationPercentage: &tcup,
+		ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       nameWithSuffix("server", a),
+		},
+	}
+
+	updatedHPASpec := autoscaling.HorizontalPodAutoscalerSpec{
+		MaxReplicas:                    max,
+		MinReplicas:                    &min,
+		TargetCPUUtilizationPercentage: &cpuUtil,
+		ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       nameWithSuffix("server", a),
+		},
+	}
+
+	err := r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-server",
+		Namespace: testNamespace,
+	}, existingHPA)
+	assert.True(t, errors.IsNotFound(err))
+
+	a.Spec.Server.Autoscale.Enabled = true
+
+	err = r.reconcileServerHPA(a)
+	assert.NoError(t, err)
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-server",
+		Namespace: testNamespace,
+	}, existingHPA)
+	assert.NoError(t, err)
+	assert.Equal(t, defaultHPASpec, existingHPA.Spec)
+
+	a.Spec.Server.Autoscale.HPA = &updatedHPASpec
+
+	err = r.reconcileServerHPA(a)
+	assert.NoError(t, err)
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-server",
+		Namespace: testNamespace,
+	}, existingHPA)
+	assert.NoError(t, err)
+	assert.Equal(t, updatedHPASpec, existingHPA.Spec)
+
+	a.Spec.Server.Autoscale.Enabled = false
+
+	err = r.reconcileServerHPA(a)
+	assert.NoError(t, err)
+
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-server",
+		Namespace: testNamespace,
+	}, existingHPA)
+	assert.True(t, errors.IsNotFound(err))
+
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:
port https://github.com/argoproj-labs/argocd-operator/pull/870 to 0.6 branch
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
