### PR TITLE
fix: replace kube-rbac-proxy image tag v0.8.0 with its digest equivalent (#510)

### DIFF
--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -1085,7 +1085,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/deploy/olm-catalog/argocd-operator/0.7.0/argocd-operator.v0.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.7.0/argocd-operator.v0.7.0.clusterserviceversion.yaml
@@ -1085,7 +1085,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This PR fixes installation in environments that require images to be mirrored by digest rather than tag, such as openshift in a "restricted" network install.

Note that this PR includes modifying older CSV versions.  I'm not sure that's kosher.  If not, please free to leave out that part, or kick it back to me for fixing.

**Have you updated the necessary documentation?**

N/A

**Which issue(s) this PR fixes**:

Fixes #510 

**How to test changes / Special notes to the reviewer**:

Issue #510 includes a description of how to test that the actual problem is fixed.

That said, it's a lot of work. It should also be possible to upgrade an existing installation, and just look at the output of 
```
ns=argocd; # or whatever
kubectl -n $ns get po -l control-plane=controller-manager;
kubectl -n $ns get po -l control-plane=controller-manager -o json | jq '.items[].spec.containers[0].image' -r
```
If the pod is running and has a kube-rbac-proxy image specified by digest instead of tag, you know it's working.
