### PR TITLE
fix: Dex resource cleanup when .spec.dex & DISABLE_DEX is set

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -334,7 +334,7 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 		changed = true
 	}
 
-	if cr.Spec.Dex != nil || (cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex) {
+	if UseDex(cr) || (cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex) {
 		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
 		if err != nil {
 			return err

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -184,7 +184,7 @@ func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
 		common.ArgoCDKeyTLSPrivateKey:      tlsSecret.Data[common.ArgoCDKeyTLSPrivateKey],
 	}
 
-	if cr.Spec.Dex != nil || (cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex) {
+	if UseDex(cr) || (cr.Spec.SSO != nil && cr.Spec.SSO.Provider == v1alpha1.SSOProviderTypeDex) {
 		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
 		if err != nil {
 			return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
The secret reconciliation code doesn't respect `DISABLE_DEX` env var causing the entire resource reconciliation loop to sometimes break due to which the dex resources are not cleaned up properly. This happens mainly when a  dex deployment exists(configured using `.spec.dex`) and is disabled using `DISABLE_DEX=true`. The sso reconciliation code doesn’t handle  deletion in such case, https://github.com/argoproj-labs/argocd-operator/blob/19b9bdc50655746c74d99d8017a6c938fe5bd602/controllers/argocd/sso.go#L133-L136 due to which deletion is deferred to main resource reconciliation https://github.com/argoproj-labs/argocd-operator/blob/19b9bdc50655746c74d99d8017a6c938fe5bd602/controllers/argocd/util.go#L717-L771 loop which starts deletion of dex role & service account before deployment & secret. By the time main reconciliation loops starts reconciling secrets and if dex service account is deleted, the secret reconciliation breaks with `"error": "ServiceAccount \"argocd-argocd-dex-server\" not found"` causing entire loop to break.

This PR fixes the issue by ensuring secret reconciliation considers `DISABLE_DEX` env var while reconciling secrets so that reconciliation loop doesn't break due to already deleted dex service account.

**Which issue(s) this PR fixes**:

Fixes #920

**How to test changes / Special notes to the reviewer**:
