### PR TITLE
Fix 1-014_validate_parallelism_limit for local test

### DIFF
--- a/tests/k8s/1-014_validate_parallelism_limit/02-check-deployment.yaml
+++ b/tests/k8s/1-014_validate_parallelism_limit/02-check-deployment.yaml
@@ -4,10 +4,15 @@ commands:
 - script: sleep 30
 - script: |
     set -e
-    expected=10
-    wlCommand=$(kubectl get -n $NAMESPACE statefulset/argocd-application-controller -o jsonpath='{.spec.template.spec.containers[0].command}'| jq -r '.[]' )
-    if ! echo "$wlCommand" | grep -qPz -- "--kubectl-parallelism-limit\\n${expected}(\$|\\n)"; then
+    expected="10"
+    wlCommand=$(kubectl get -n $NAMESPACE statefulset/argocd-application-controller -o jsonpath='{.spec.template.spec.containers[0].command}'| jq -r '.[]')
+    if ! echo "$wlCommand" | grep -Fxq -- "--kubectl-parallelism-limit"; then
       echo "Incorrect or missing --kubectl-parallelism-limit detected."
+      echo "$wlCommand"
+      exit 1
+    fi
+    if ! echo "$wlCommand" | grep -Fxq -- "$expected"; then
+      echo "Incorrect value for --kubectl-parallelism-limit detected."
       echo "$wlCommand"
       exit 1
     fi

--- a/tests/k8s/1-014_validate_parallelism_limit/04-check-deployment.yaml
+++ b/tests/k8s/1-014_validate_parallelism_limit/04-check-deployment.yaml
@@ -4,10 +4,15 @@ commands:
 - script: sleep 30
 - script: |
     set -e
-    expected=20
-    wlCommand=$(kubectl get -n $NAMESPACE statefulset/argocd-application-controller -o jsonpath='{.spec.template.spec.containers[0].command}'| jq -r '.[]' )
-    if ! echo "$wlCommand" | grep -qPz -- "--kubectl-parallelism-limit\\n${expected}(\$|\\n)"; then
+    expected="20"
+    wlCommand=$(kubectl get -n $NAMESPACE statefulset/argocd-application-controller -o jsonpath='{.spec.template.spec.containers[0].command}'| jq -r '.[]')
+    if ! echo "$wlCommand" | grep -Fxq -- "--kubectl-parallelism-limit"; then
       echo "Incorrect or missing --kubectl-parallelism-limit detected."
+      echo "$wlCommand"
+      exit 1
+    fi
+    if ! echo "$wlCommand" | grep -Fxq -- "$expected"; then
+      echo "Incorrect value for --kubectl-parallelism-limit detected."
       echo "$wlCommand"
       exit 1
     fi

--- a/tests/k8s/1-014_validate_parallelism_limit/06-check-deployment.yaml
+++ b/tests/k8s/1-014_validate_parallelism_limit/06-check-deployment.yaml
@@ -7,10 +7,15 @@ commands:
 - script: sleep 30
 - script: |
     set -e
-    expected=10
-    wlCommand=$(kubectl get -n $NAMESPACE statefulset/argocd-application-controller -o jsonpath='{.spec.template.spec.containers[0].command}'| jq -r '.[]' )
-    if ! echo "$wlCommand" | grep -qPz -- "--kubectl-parallelism-limit\\n${expected}(\$|\\n)"; then
+    expected="10"
+    wlCommand=$(kubectl get -n $NAMESPACE statefulset/argocd-application-controller -o jsonpath='{.spec.template.spec.containers[0].command}'| jq -r '.[]')
+    if ! echo "$wlCommand" | grep -Fxq -- "--kubectl-parallelism-limit"; then
       echo "Incorrect or missing --kubectl-parallelism-limit detected."
+      echo "$wlCommand"
+      exit 1
+    fi
+    if ! echo "$wlCommand" | grep -Fxq -- "$expected"; then
+      echo "Incorrect value for --kubectl-parallelism-limit detected."
       echo "$wlCommand"
       exit 1
     fi


### PR DESCRIPTION
**What type of PR is this?**

/kind bug



**What does this PR do / why we need it**:
This PR fixes 1-014_validate_parallelism_limit failure. When run this test locally, it shows below error in logs.
```
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | grep: invalid option -- P
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment |      [-e pattern] [-f file] [--binary-files=value] [--color=when]
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment |      [--context[=num]] [--directories=action] [--label] [--line-buffered]
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment |      [--null] [pattern] [file ...]
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | Incorrect or missing --kubectl-parallelism-limit detected.
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | argocd-application-controller
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | --operation-processors
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | 10
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | --redis
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | argocd-redis.kuttl-test-intimate-yeti.svc.cluster.local:6379
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | --repo-server
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | argocd-repo-server.kuttl-test-intimate-yeti.svc.cluster.local:8081
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | --status-processors
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | 20
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | --kubectl-parallelism-limit
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | 10
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | --loglevel
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | info
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | --logformat
logger.go:42: 15:31:37 | 1-014_validate_parallelism_limit/2-check-deployment | text
case.go:364: failed in step 2-check-deployment
```

This PR fixes the unsupported grep option issue and makes sure it passes test locally.