### PR TITLE
fix: Revert appSync type implemented in #926

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -98,7 +98,7 @@ type ArgoCDApplicationControllerSpec struct {
 	// Set this to a duration, e.g. 10m or 600s to control the synchronisation
 	// frequency.
 	// +optional
-	AppSync string `json:"appSync,omitempty"`
+	AppSync *metav1.Duration `json:"appSync,omitempty"`
 
 	// Sharding contains the options for the Application Controller sharding configuration.
 	Sharding ArgoCDApplicationControllerShardSpec `json:"sharding,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -26,6 +26,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -99,6 +100,11 @@ func (in *ArgoCDApplicationControllerSpec) DeepCopyInto(out *ArgoCDApplicationCo
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.AppSync != nil {
+		in, out := &in.AppSync, &out.AppSync
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 	in.Sharding.DeepCopyInto(&out.Sharding)
 	if in.Env != nil {

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -448,10 +449,10 @@ func getArgoControllerContainerEnv(cr *argoprojv1a1.ArgoCD) []corev1.EnvVar {
 		})
 	}
 
-	if cr.Spec.Controller.AppSync != "" {
+	if cr.Spec.Controller.AppSync != nil {
 		env = append(env, corev1.EnvVar{
 			Name:  "ARGOCD_RECONCILIATION_TIMEOUT",
-			Value: cr.Spec.Controller.AppSync,
+			Value: strconv.FormatInt(int64(cr.Spec.Controller.AppSync.Seconds()), 10) + "s",
 		})
 	}
 

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -375,12 +376,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 func TestReconcileArgoCD_reconcileApplicationController_withAppSync(t *testing.T) {
 
 	expectedEnv := []corev1.EnvVar{
-		{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "10m"},
+		{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "600s"},
 		{Name: "HOME", Value: "/home/argocd"},
 	}
 
 	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
-		a.Spec.Controller.AppSync = "10m"
+		a.Spec.Controller.AppSync = &metav1.Duration{Duration: time.Minute * 10}
 	})
 	r := makeTestReconciler(t, a)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What does this PR do / why we need it**:
I've implemented a breaking API change in #926 . This PR reverts the appSync type back to `metav1.Duration` and leaves the API as it was before.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes -

**How to test changes / Special notes to the reviewer**:
Set the `controller.appSync` value to 1 minute and verify that the controller performs reconciliation every minute instead of the default 3 minutes.