### PR TITLE
Gitops 2874 fix kuttl test 083

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -102,7 +102,7 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 				}
 			}
 
-			if err := r.removeUnmanagedSourceNamespaceResources(argocd); err != nil {
+			if err := r.removeUnmanagedSourceNamespaceResources(ctx, argocd); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to remove resources from sourceNamespaces, error: %w", err)
 			}
 
@@ -138,7 +138,7 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if err := r.reconcileResources(argocd); err != nil {
+	if err := r.reconcileResources(ctx, argocd); err != nil {
 		// Error reconciling ArgoCD sub-resources - requeue the request.
 		return reconcile.Result{}, err
 	}

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -112,9 +112,7 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 
 			// remove namespace of deleted Argo CD instance from deprecationEventEmissionTracker (if exists) so that if another instance
 			// is created in the same namespace in the future, that instance is appropriately tracked
-			if _, ok := DeprecationEventEmissionTracker[argocd.Namespace]; ok {
-				delete(DeprecationEventEmissionTracker, argocd.Namespace)
-			}
+			delete(DeprecationEventEmissionTracker, argocd.Namespace)
 		}
 		return reconcile.Result{}, nil
 	}

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -411,7 +411,7 @@ func (r *ReconcileArgoCD) reconcileDexService(cr *argoprojv1a1.ArgoCD) error {
 // and deletion of dex resources based on the specified configuration of dex
 func (r *ReconcileArgoCD) reconcileDexResources(cr *argoprojv1a1.ArgoCD) error {
 
-	if _, err := r.reconcileRole(common.ArgoCDDexServerComponent, policyRuleForDexServer(), cr); err != nil {
+	if err := r.reconcileRole(common.ArgoCDDexServerComponent, policyRuleForDexServer(), cr); err != nil {
 		log.Error(err, "error reconciling dex role")
 	}
 

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -934,7 +934,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 				test.setEnvFunc(t, "false")
 			}
 
-			_, err := r.reconcileRole(common.ArgoCDDexServerComponent, rules, test.argoCD)
+			err := r.reconcileRole(common.ArgoCDDexServerComponent, rules, test.argoCD)
 			assert.NoError(t, err)
 
 			// ensure role was created correctly
@@ -948,7 +948,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 				test.updateCrFunc(test.argoCD)
 			}
 
-			_, err = r.reconcileRole(common.ArgoCDDexServerComponent, rules, test.argoCD)
+			err = r.reconcileRole(common.ArgoCDDexServerComponent, rules, test.argoCD)
 			assert.NoError(t, err)
 
 			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: test.argoCD.Namespace}, role)

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -135,7 +135,7 @@ func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.
 
 	workloadIdentifier := common.ArgoCDServerComponent
 	expectedRules := policyRuleForServerApplicationSourceNamespaces()
-	_, err := r.reconcileRoleForApplicationSourceNamespaces(ctx, workloadIdentifier, expectedRules, a)
+	err := r.reconcileRoleForApplicationSourceNamespaces(ctx, workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
 	expectedName := getRoleNameForApplicationSourceNamespaces(sourceNamespace, a)

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -125,6 +125,7 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	sourceNamespace := "newNamespaceTest"
+	ctx := context.Background()
 	a := makeTestArgoCD()
 	a.Spec = v1alpha1.ArgoCDSpec{
 		SourceNamespaces: []string{
@@ -137,7 +138,7 @@ func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.
 
 	workloadIdentifier := common.ArgoCDServerComponent
 	expectedRules := policyRuleForServerApplicationSourceNamespaces()
-	_, err := r.reconcileRoleForApplicationSourceNamespaces(workloadIdentifier, expectedRules, a)
+	_, err := r.reconcileRoleForApplicationSourceNamespaces(ctx, workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
 	expectedName := getRoleNameForApplicationSourceNamespaces(sourceNamespace, a)

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -98,15 +98,14 @@ func (r *ReconcileArgoCD) reconcileRoleBindings(cr *argoprojv1a1.ArgoCD) error {
 // reconcileRoleBinding, creates RoleBindings for every role and associates it with the right ServiceAccount.
 // This would create RoleBindings for all the namespaces managed by the ArgoCD instance.
 func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
-	var sa *corev1.ServiceAccount
-	var error error
-
-	if sa, error = r.reconcileServiceAccount(name, cr); error != nil {
-		return error
+	sa, err := r.reconcileServiceAccount(name, cr)
+	if err != nil {
+		return err
 	}
 
-	if _, error = r.reconcileRole(name, rules, cr); error != nil {
-		return error
+	err = r.reconcileRole(name, rules, cr)
+	if err != nil {
+		return err
 	}
 
 	for _, namespace := range r.ManagedNamespaces.Items {

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -58,7 +58,7 @@ func newRoleBinding(cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
 func newRoleBindingForSupportNamespaces(cr *argoprojv1a1.ArgoCD, namespace string) *v1.RoleBinding {
 	return &v1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        getRoleBindingNameForSourceNamespaces(cr.Name, cr.Namespace, namespace),
+			Name:        getRoleBindingNameForSourceNamespaces(cr.Name, namespace),
 			Labels:      argoutil.LabelsForCluster(cr),
 			Annotations: argoutil.AnnotationsForCluster(cr),
 			Namespace:   namespace,
@@ -66,7 +66,7 @@ func newRoleBindingForSupportNamespaces(cr *argoprojv1a1.ArgoCD, namespace strin
 	}
 }
 
-func getRoleBindingNameForSourceNamespaces(argocdName, argocdNamespace, targetNamespace string) string {
+func getRoleBindingNameForSourceNamespaces(argocdName, targetNamespace string) string {
 	return fmt.Sprintf("%s_%s", argocdName, targetNamespace)
 }
 
@@ -242,7 +242,7 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 			}
 
 			// get expected name
-			roleBinding := newRoleBindingWithNameForApplicationSourceNamespaces(name, namespace.Name, cr)
+			roleBinding := newRoleBindingWithNameForApplicationSourceNamespaces(namespace.Name, cr)
 			roleBinding.Namespace = namespace.Name
 
 			roleBinding.RoleRef = v1.RoleRef{
@@ -323,7 +323,7 @@ func getRoleNameForApplicationSourceNamespaces(targetNamespace string, cr *argop
 }
 
 // newRoleBindingWithNameForApplicationSourceNamespaces creates a new RoleBinding with the given name for the source namespaces of ArgoCD Server.
-func newRoleBindingWithNameForApplicationSourceNamespaces(name, namespace string, cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
+func newRoleBindingWithNameForApplicationSourceNamespaces(namespace string, cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
 	roleBinding := newRoleBindingForSupportNamespaces(cr, namespace)
 
 	labels := roleBinding.ObjectMeta.Labels

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -219,7 +219,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_forSourceNamespaces(t *testing.T) 
 	assert.NoError(t, r.reconcileRoleBinding(workloadIdentifier, p, a))
 
 	roleBinding := &rbacv1.RoleBinding{}
-	expectedName := getRoleBindingNameForSourceNamespaces(a.Name, a.Namespace, sourceNamespace)
+	expectedName := getRoleBindingNameForSourceNamespaces(a.Name, sourceNamespace)
 
 	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: sourceNamespace}, roleBinding))
 

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -888,7 +888,7 @@ func (r *ReconcileArgoCD) removeManagedByLabelFromNamespaces(namespace string) e
 		}
 		delete(ns.Labels, common.ArgoCDManagedByLabel)
 		if err := r.Client.Update(context.TODO(), ns); err != nil {
-			log.Error(err, fmt.Sprintf("failed to remove label from namespace [%s]", ns.Name))
+			return fmt.Errorf("failed to remove label from namespace [%s]: %w", ns.Name, err)
 		}
 	}
 	return nil

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1253,9 +1253,7 @@ func namespaceFilterPredicate() predicate.Predicate {
 
 			// if a namespace is deleted, remove it from deprecationEventEmissionTracker (if exists) so that if a namespace with the same name
 			// is created in the future and contains an Argo CD instance, it will be tracked appropriately
-			if _, ok := DeprecationEventEmissionTracker[e.Object.GetName()]; ok {
-				delete(DeprecationEventEmissionTracker, e.Object.GetName())
-			}
+			delete(DeprecationEventEmissionTracker, e.Object.GetName())
 
 			return false
 		},
@@ -1423,9 +1421,7 @@ func (r *ReconcileArgoCD) removeUnmanagedSourceNamespaceResources(ctx context.Co
 			if err := r.cleanupUnmanagedSourceNamespaceResources(ctx, cr, ns); err != nil {
 				return fmt.Errorf("error cleaning up resources for namespace %s: %v", ns, err)
 			}
-			if _, exists := r.ManagedSourceNamespaces[ns]; exists {
-				delete(r.ManagedSourceNamespaces, ns)
-			}
+			delete(r.ManagedSourceNamespaces, ns)
 		}
 	}
 	return nil
@@ -1461,7 +1457,7 @@ func (r *ReconcileArgoCD) cleanupUnmanagedSourceNamespaceResources(ctx context.C
 
 	// Delete RoleBindings for SourceNamespaces
 	existingRoleBinding := &v1.RoleBinding{}
-	roleBindingName := getRoleBindingNameForSourceNamespaces(cr.Name, cr.Namespace, namespace.Name)
+	roleBindingName := getRoleBindingNameForSourceNamespaces(cr.Name, namespace.Name)
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: roleBindingName, Namespace: namespace.Name}, existingRoleBinding); err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get the rolebinding associated with %s: %v", common.ArgoCDServerComponent, err)

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -703,7 +703,7 @@ func (r *ReconcileArgoCD) redisShouldUseTLS(cr *argoprojv1a1.ArgoCD) bool {
 }
 
 // reconcileResources will reconcile common ArgoCD resources.
-func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileResources(ctx context.Context, cr *argoprojv1a1.ArgoCD) error {
 
 	// reconcile SSO first, because dex resources get reconciled through other function calls as well, not just through reconcileSSO (this is important
 	// so that dex resources can be appropriately cleaned up when DISABLE_DEX is set to true and the operator pod restarts but doesn't enter
@@ -721,7 +721,7 @@ func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
 	}
 
 	log.Info("reconciling roles")
-	if err := r.reconcileRoles(cr); err != nil {
+	if err := r.reconcileRoles(ctx, cr); err != nil {
 		log.Info(err.Error())
 		return err
 	}
@@ -1412,33 +1412,28 @@ func (r *ReconcileArgoCD) setManagedSourceNamespaces(cr *argoproj.ArgoCD) error 
 
 // removeUnmanagedSourceNamespaceResources cleansup resources from SourceNamespaces if namespace is not managed by argocd instance.
 // It also removes the managed-by-cluster-argocd label from the namespace
-func (r *ReconcileArgoCD) removeUnmanagedSourceNamespaceResources(cr *argoproj.ArgoCD) error {
-
-	for ns, _ := range r.ManagedSourceNamespaces {
+func (r *ReconcileArgoCD) removeUnmanagedSourceNamespaceResources(ctx context.Context, cr *argoproj.ArgoCD) error {
+	for ns := range r.ManagedSourceNamespaces {
 		managedNamespace := false
 		if cr.GetDeletionTimestamp() == nil {
-			for _, namespace := range cr.Spec.SourceNamespaces {
-				if namespace == ns {
-					managedNamespace = true
-					break
-				}
-			}
+			managedNamespace = contains(cr.Spec.SourceNamespaces, ns)
 		}
 
 		if !managedNamespace {
-			if err := r.cleanupUnmanagedSourceNamespaceResources(cr, ns); err != nil {
-				log.Error(err, fmt.Sprintf("error cleaning up resources for namespace %s", ns))
-				continue
+			if err := r.cleanupUnmanagedSourceNamespaceResources(ctx, cr, ns); err != nil {
+				return fmt.Errorf("error cleaning up resources for namespace %s: %v", ns, err)
 			}
-			delete(r.ManagedSourceNamespaces, ns)
+			if _, exists := r.ManagedSourceNamespaces[ns]; exists {
+				delete(r.ManagedSourceNamespaces, ns)
+			}
 		}
 	}
 	return nil
 }
 
-func (r *ReconcileArgoCD) cleanupUnmanagedSourceNamespaceResources(cr *argoproj.ArgoCD, ns string) error {
+func (r *ReconcileArgoCD) cleanupUnmanagedSourceNamespaceResources(ctx context.Context, cr *argoproj.ArgoCD, ns string) error {
 	namespace := corev1.Namespace{}
-	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: ns}, &namespace); err != nil {
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: ns}, &namespace); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
@@ -1446,33 +1441,34 @@ func (r *ReconcileArgoCD) cleanupUnmanagedSourceNamespaceResources(cr *argoproj.
 	}
 	// Remove managed-by-cluster-argocd from the namespace
 	delete(namespace.Labels, common.ArgoCDManagedByClusterArgoCDLabel)
-	if err := r.Client.Update(context.TODO(), &namespace); err != nil {
-		log.Error(err, fmt.Sprintf("failed to remove label from namespace [%s]", namespace.Name))
+	if err := r.Client.Update(ctx, &namespace); err != nil {
+		return fmt.Errorf("failed to remove label from namespace [%s]: %v", namespace.Name, err)
 	}
 
 	// Delete Roles for SourceNamespaces
 	existingRole := v1.Role{}
 	roleName := getRoleNameForApplicationSourceNamespaces(namespace.Name, cr)
-	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: roleName, Namespace: namespace.Name}, &existingRole); err != nil {
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: roleName, Namespace: namespace.Name}, &existingRole); err != nil {
 		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to fetch the role for the service account associated with %s : %s", common.ArgoCDServerComponent, err)
+			return fmt.Errorf("failed to fetch the role for the service account associated with %s: %v", common.ArgoCDServerComponent, err)
 		}
 	}
 	if existingRole.Name != "" {
-		if err := r.Client.Delete(context.TODO(), &existingRole); err != nil {
+		if err := r.Client.Delete(ctx, &existingRole); err != nil {
 			return err
 		}
 	}
+
 	// Delete RoleBindings for SourceNamespaces
 	existingRoleBinding := &v1.RoleBinding{}
 	roleBindingName := getRoleBindingNameForSourceNamespaces(cr.Name, cr.Namespace, namespace.Name)
-	if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: roleBindingName, Namespace: namespace.Name}, existingRoleBinding); err != nil {
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: roleBindingName, Namespace: namespace.Name}, existingRoleBinding); err != nil {
 		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get the rolebinding associated with %s : %s", common.ArgoCDServerComponent, err)
+			return fmt.Errorf("failed to get the rolebinding associated with %s: %v", common.ArgoCDServerComponent, err)
 		}
 	}
 	if existingRoleBinding.Name != "" {
-		if err := r.Client.Delete(context.TODO(), existingRoleBinding); err != nil {
+		if err := r.Client.Delete(ctx, existingRoleBinding); err != nil {
 			return err
 		}
 	}

--- a/tests/k8s/1-024_validate_apps_in_any_namespace/01-argocd-with-source-namespaces.yaml
+++ b/tests/k8s/1-024_validate_apps_in_any_namespace/01-argocd-with-source-namespaces.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/tests/k8s/1-024_validate_apps_in_any_namespace/01-assert.yaml
+++ b/tests/k8s/1-024_validate_apps_in_any_namespace/01-assert.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/tests/k8s/1-024_validate_apps_in_any_namespace/02-assert.yaml
+++ b/tests/k8s/1-024_validate_apps_in_any_namespace/02-assert.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/tests/k8s/1-024_validate_apps_in_any_namespace/02-errors.yaml
+++ b/tests/k8s/1-024_validate_apps_in_any_namespace/02-errors.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/tests/k8s/1-024_validate_apps_in_any_namespace/03-assert.yaml
+++ b/tests/k8s/1-024_validate_apps_in_any_namespace/03-assert.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/tests/k8s/1-024_validate_apps_in_any_namespace/03-delete-argocd.yaml
+++ b/tests/k8s/1-024_validate_apps_in_any_namespace/03-delete-argocd.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
@@ -8,4 +7,4 @@ delete:
   namespace: central-argocd
 commands:
   # Sleep to allow resources to be completely deleted
-  - command: sleep 30s
+  - script: sleep 30

--- a/tests/k8s/1-024_validate_apps_in_any_namespace/03-errors.yaml
+++ b/tests/k8s/1-024_validate_apps_in_any_namespace/03-errors.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/tests/k8s/1-024_validate_apps_in_any_namespace/99-delete.yaml
+++ b/tests/k8s/1-024_validate_apps_in_any_namespace/99-delete.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 delete:
@@ -12,4 +11,4 @@ delete:
   kind: Namespace
   name: central-argocd
 commands:
-  - command: sleep 30s
+  - script: sleep 30


### PR DESCRIPTION
What type of PR is this?

/kind bug

What does this PR do / why we need it:
gitops-operator 1-083_validate_apps_in_any_namespace test is being flaky.

Which issue(s) this PR fixes:
GITOPS-2874

Fixes #?
1-083_validate_apps_in_any_namespace test

How to test changes / Special notes to the reviewer:
kuttl test sequential/1-083_validate_apps_in_any_namespace shouldn't be flaky or fail anymore.
