### PR TITLE
Fixed timestamp in log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.8.2
+	go.uber.org/zap v1.24.0
 	golang.org/x/mod v0.10.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.1
@@ -66,7 +67,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -84,6 +85,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
-		TimeEncoder: zapcore.ISO8601TimeEncoder,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement


**What does this PR do / why we need it**:
Our log timestamp is not human readable.

**Which issue(s) this PR fixes**:

Fixes #?
[GITOPS-2898: Operator logs should have human readable timestamps
](https://issues.redhat.com/browse/GITOPS-2898)
**How to test changes / Special notes to the reviewer**:
1. Have a k8s cluster running.
2. Go to argocd-operator/ directory and run `make install run`. Observe the timestamps are in RFC3339 format e.g. `2023-06-27T07:12:48-04:00`.