### PR TITLE
add build.os config for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,3 +8,7 @@ mkdocs:
 python:
   install:
     - requirements: docs/requirements.txt
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.7"


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement
 /kind documentation

**What does this PR do / why we need it**:
The build.image config key on .readthedocs.yaml has been deprecated, and will be removed on October 16, 2023. Even though we weren't using it, we still have to have this key otherwise our docs will break. 

I used the same configuration that argocd upstream has: https://github.com/argoproj/argo-cd/blob/master/.readthedocs.yml 