### PR TITLE
refactor: Remove deprecated .spec.resourceCustomizations

### DIFF
--- a/api/v1alpha1/argocd_conversion.go
+++ b/api/v1alpha1/argocd_conversion.go
@@ -79,7 +79,6 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Redis = v1beta1.ArgoCDRedisSpec(src.Spec.Redis)
 	dst.Spec.Repo = v1beta1.ArgoCDRepoSpec(src.Spec.Repo)
 	dst.Spec.RepositoryCredentials = src.Spec.RepositoryCredentials
-	dst.Spec.ResourceCustomizations = src.Spec.ResourceCustomizations
 	dst.Spec.ResourceHealthChecks = ConvertAlphaToBetaResourceHealthChecks(src.Spec.ResourceHealthChecks)
 	dst.Spec.ResourceIgnoreDifferences = ConvertAlphaToBetaResourceIgnoreDifferences(src.Spec.ResourceIgnoreDifferences)
 	dst.Spec.ResourceActions = ConvertAlphaToBetaResourceActions(src.Spec.ResourceActions)
@@ -147,7 +146,6 @@ func (dst *ArgoCD) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.Redis = ArgoCDRedisSpec(src.Spec.Redis)
 	dst.Spec.Repo = ArgoCDRepoSpec(src.Spec.Repo)
 	dst.Spec.RepositoryCredentials = src.Spec.RepositoryCredentials
-	dst.Spec.ResourceCustomizations = src.Spec.ResourceCustomizations
 	dst.Spec.ResourceHealthChecks = ConvertBetaToAlphaResourceHealthChecks(src.Spec.ResourceHealthChecks)
 	dst.Spec.ResourceIgnoreDifferences = ConvertBetaToAlphaResourceIgnoreDifferences(src.Spec.ResourceIgnoreDifferences)
 	dst.Spec.ResourceActions = ConvertBetaToAlphaResourceActions(src.Spec.ResourceActions)

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -761,6 +761,7 @@ type ArgoCDSpec struct {
 	// RepositoryCredentials are the Git pull credentials to configure Argo CD with upon creation of the cluster.
 	RepositoryCredentials string `json:"repositoryCredentials,omitempty"`
 
+	// Deprecated field. Support dropped in v1beta1 version.
 	// ResourceCustomizations customizes resource behavior. Keys are in the form: group/Kind. Please note that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceCustomizations string `json:"resourceCustomizations,omitempty"`

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -748,10 +748,7 @@ type ArgoCDSpec struct {
 	// RepositoryCredentials are the Git pull credentials to configure Argo CD with upon creation of the cluster.
 	RepositoryCredentials string `json:"repositoryCredentials,omitempty"`
 
-	// ResourceCustomizations customizes resource behavior. Keys are in the form: group/Kind. Please note that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
-	ResourceCustomizations string `json:"resourceCustomizations,omitempty"`
-
+	// Deprecated field. Support dropped in v1beta1 version.
 	// ResourceHealthChecks customizes resource health check behavior.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Health Check Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceHealthChecks []ResourceHealthCheck `json:"resourceHealthChecks,omitempty"`

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -748,7 +748,6 @@ type ArgoCDSpec struct {
 	// RepositoryCredentials are the Git pull credentials to configure Argo CD with upon creation of the cluster.
 	RepositoryCredentials string `json:"repositoryCredentials,omitempty"`
 
-	// Deprecated field. Support dropped in v1beta1 version.
 	// ResourceHealthChecks customizes resource health check behavior.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Health Check Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceHealthChecks []ResourceHealthCheck `json:"resourceHealthChecks,omitempty"`

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -685,9 +685,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: 'ResourceCustomizations customizes resource behavior. Keys are
-          in the form: group/Kind. Please note that this is being deprecated in favor
-          of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.'
+      - description: 'Deprecated field. Support dropped in v1beta1 version. ResourceCustomizations
+          customizes resource behavior. Keys are in the form: group/Kind. Please note
+          that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
+          and ResourceActions.'
         displayName: Resource Customizations'
         path: resourceCustomizations
         x-descriptors:
@@ -1269,8 +1270,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Deprecated field. Support dropped in v1beta1 version. ResourceHealthChecks
-          customizes resource health check behavior.
+      - description: ResourceHealthChecks customizes resource health check behavior.
         displayName: Resource Health Check Customizations'
         path: resourceHealthChecks
         x-descriptors:

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -1262,14 +1262,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: 'ResourceCustomizations customizes resource behavior. Keys are
-          in the form: group/Kind. Please note that this is being deprecated in favor
-          of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.'
-        displayName: Resource Customizations'
-        path: resourceCustomizations
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
         displayName: Resource Exclusions'
@@ -1277,7 +1269,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: ResourceHealthChecks customizes resource health check behavior.
+      - description: Deprecated field. Support dropped in v1beta1 version. ResourceHealthChecks
+          customizes resource health check behavior.
         displayName: Resource Health Check Customizations'
         path: resourceHealthChecks
         x-descriptors:

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -5669,10 +5669,11 @@ spec:
                   type: object
                 type: array
               resourceCustomizations:
-                description: 'ResourceCustomizations customizes resource behavior.
-                  Keys are in the form: group/Kind. Please note that this is being
-                  deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
-                  and ResourceActions.'
+                description: 'Deprecated field. Support dropped in v1beta1 version.
+                  ResourceCustomizations customizes resource behavior. Keys are in
+                  the form: group/Kind. Please note that this is being deprecated
+                  in favor of ResourceHealthChecks, ResourceIgnoreDifferences, and
+                  ResourceActions.'
                 type: string
               resourceExclusions:
                 description: ResourceExclusions is used to completely ignore entire
@@ -12064,8 +12065,8 @@ spec:
                   classes of resource group/kinds.
                 type: string
               resourceHealthChecks:
-                description: Deprecated field. Support dropped in v1beta1 version.
-                  ResourceHealthChecks customizes resource health check behavior.
+                description: ResourceHealthChecks customizes resource health check
+                  behavior.
                 items:
                   description: Resource Customization for custom health check
                   properties:

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -12059,19 +12059,13 @@ spec:
                       type: string
                   type: object
                 type: array
-              resourceCustomizations:
-                description: 'ResourceCustomizations customizes resource behavior.
-                  Keys are in the form: group/Kind. Please note that this is being
-                  deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
-                  and ResourceActions.'
-                type: string
               resourceExclusions:
                 description: ResourceExclusions is used to completely ignore entire
                   classes of resource group/kinds.
                 type: string
               resourceHealthChecks:
-                description: ResourceHealthChecks customizes resource health check
-                  behavior.
+                description: Deprecated field. Support dropped in v1beta1 version.
+                  ResourceHealthChecks customizes resource health check behavior.
                 items:
                   description: Resource Customization for custom health check
                   properties:

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -246,9 +246,6 @@ const (
 	// ArgoCDDefaultRepositoryCredentials is the default repository credentials
 	ArgoCDDefaultRepositoryCredentials = ""
 
-	// ArgoCDDefaultResourceCustomizations is the default resource customizations.
-	ArgoCDDefaultResourceCustomizations = ""
-
 	// ArgoCDDefaultResourceExclusions is the default resource exclusions.
 	ArgoCDDefaultResourceExclusions = ""
 

--- a/common/keys.go
+++ b/common/keys.go
@@ -121,9 +121,6 @@ const (
 	// ArgoCDKeyRelease is the prometheus release key for labels.
 	ArgoCDKeyRelease = "release"
 
-	// ArgoCDKeyResourceCustomizations is the configuration key for resource customizations.
-	ArgoCDKeyResourceCustomizations = "resource.customizations"
-
 	// ArgoCDKeyResourceExclusions is the configuration key for resource exclusions.
 	ArgoCDKeyResourceExclusions = "resource.exclusions"
 

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -12050,19 +12050,13 @@ spec:
                       type: string
                   type: object
                 type: array
-              resourceCustomizations:
-                description: 'ResourceCustomizations customizes resource behavior.
-                  Keys are in the form: group/Kind. Please note that this is being
-                  deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
-                  and ResourceActions.'
-                type: string
               resourceExclusions:
                 description: ResourceExclusions is used to completely ignore entire
                   classes of resource group/kinds.
                 type: string
               resourceHealthChecks:
-                description: ResourceHealthChecks customizes resource health check
-                  behavior.
+                description: Deprecated field. Support dropped in v1beta1 version.
+                  ResourceHealthChecks customizes resource health check behavior.
                 items:
                   description: Resource Customization for custom health check
                   properties:

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -5660,10 +5660,11 @@ spec:
                   type: object
                 type: array
               resourceCustomizations:
-                description: 'ResourceCustomizations customizes resource behavior.
-                  Keys are in the form: group/Kind. Please note that this is being
-                  deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
-                  and ResourceActions.'
+                description: 'Deprecated field. Support dropped in v1beta1 version.
+                  ResourceCustomizations customizes resource behavior. Keys are in
+                  the form: group/Kind. Please note that this is being deprecated
+                  in favor of ResourceHealthChecks, ResourceIgnoreDifferences, and
+                  ResourceActions.'
                 type: string
               resourceExclusions:
                 description: ResourceExclusions is used to completely ignore entire
@@ -12055,8 +12056,8 @@ spec:
                   classes of resource group/kinds.
                 type: string
               resourceHealthChecks:
-                description: Deprecated field. Support dropped in v1beta1 version.
-                  ResourceHealthChecks customizes resource health check behavior.
+                description: ResourceHealthChecks customizes resource health check
+                  behavior.
                 items:
                   description: Resource Customization for custom health check
                   properties:

--- a/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
@@ -439,14 +439,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: 'ResourceCustomizations customizes resource behavior. Keys are
-          in the form: group/Kind. Please note that this is being deprecated in favor
-          of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.'
-        displayName: Resource Customizations'
-        path: resourceCustomizations
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
         displayName: Resource Exclusions'
@@ -454,7 +446,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: ResourceHealthChecks customizes resource health check behavior.
+      - description: Deprecated field. Support dropped in v1beta1 version. ResourceHealthChecks
+          customizes resource health check behavior.
         displayName: Resource Health Check Customizations'
         path: resourceHealthChecks
         x-descriptors:

--- a/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
@@ -446,8 +446,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Deprecated field. Support dropped in v1beta1 version. ResourceHealthChecks
-          customizes resource health check behavior.
+      - description: ResourceHealthChecks customizes resource health check behavior.
         displayName: Resource Health Check Customizations'
         path: resourceHealthChecks
         x-descriptors:
@@ -1041,9 +1040,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: 'ResourceCustomizations customizes resource behavior. Keys are
-          in the form: group/Kind. Please note that this is being deprecated in favor
-          of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.'
+      - description: 'Deprecated field. Support dropped in v1beta1 version. ResourceCustomizations
+          customizes resource behavior. Keys are in the form: group/Kind. Please note
+          that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
+          and ResourceActions.'
         displayName: Resource Customizations'
         path: resourceCustomizations
         x-descriptors:

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1158,10 +1158,9 @@ func containsString(arr []string, s string) bool {
 // DeprecationEventEmissionStatus is meant to track which deprecation events have been emitted already. This is temporary and can be removed in v0.0.6 once we have provided enough
 // deprecation notice
 type DeprecationEventEmissionStatus struct {
-	SSOSpecDeprecationWarningEmitted                bool
-	DexSpecDeprecationWarningEmitted                bool
-	DisableDexDeprecationWarningEmitted             bool
-	ResourceCustomizationsDeprecationWarningEmitted bool
+	SSOSpecDeprecationWarningEmitted    bool
+	DexSpecDeprecationWarningEmitted    bool
+	DisableDexDeprecationWarningEmitted bool
 }
 
 // DeprecationEventEmissionTracker map stores the namespace containing ArgoCD instance as key and DeprecationEventEmissionStatus as value,

--- a/deploy/olm-catalog/argocd-operator/0.8.0/argocd-operator.v0.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.8.0/argocd-operator.v0.8.0.clusterserviceversion.yaml
@@ -685,9 +685,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: 'ResourceCustomizations customizes resource behavior. Keys are
-          in the form: group/Kind. Please note that this is being deprecated in favor
-          of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.'
+      - description: 'Deprecated field. Support dropped in v1beta1 version. ResourceCustomizations
+          customizes resource behavior. Keys are in the form: group/Kind. Please note
+          that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
+          and ResourceActions.'
         displayName: Resource Customizations'
         path: resourceCustomizations
         x-descriptors:
@@ -1269,8 +1270,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: Deprecated field. Support dropped in v1beta1 version. ResourceHealthChecks
-          customizes resource health check behavior.
+      - description: ResourceHealthChecks customizes resource health check behavior.
         displayName: Resource Health Check Customizations'
         path: resourceHealthChecks
         x-descriptors:

--- a/deploy/olm-catalog/argocd-operator/0.8.0/argocd-operator.v0.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.8.0/argocd-operator.v0.8.0.clusterserviceversion.yaml
@@ -1262,14 +1262,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: 'ResourceCustomizations customizes resource behavior. Keys are
-          in the form: group/Kind. Please note that this is being deprecated in favor
-          of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.'
-        displayName: Resource Customizations'
-        path: resourceCustomizations
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
         displayName: Resource Exclusions'
@@ -1277,7 +1269,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: ResourceHealthChecks customizes resource health check behavior.
+      - description: Deprecated field. Support dropped in v1beta1 version. ResourceHealthChecks
+          customizes resource health check behavior.
         displayName: Resource Health Check Customizations'
         path: resourceHealthChecks
         x-descriptors:

--- a/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
@@ -5669,10 +5669,11 @@ spec:
                   type: object
                 type: array
               resourceCustomizations:
-                description: 'ResourceCustomizations customizes resource behavior.
-                  Keys are in the form: group/Kind. Please note that this is being
-                  deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
-                  and ResourceActions.'
+                description: 'Deprecated field. Support dropped in v1beta1 version.
+                  ResourceCustomizations customizes resource behavior. Keys are in
+                  the form: group/Kind. Please note that this is being deprecated
+                  in favor of ResourceHealthChecks, ResourceIgnoreDifferences, and
+                  ResourceActions.'
                 type: string
               resourceExclusions:
                 description: ResourceExclusions is used to completely ignore entire
@@ -12064,8 +12065,8 @@ spec:
                   classes of resource group/kinds.
                 type: string
               resourceHealthChecks:
-                description: Deprecated field. Support dropped in v1beta1 version.
-                  ResourceHealthChecks customizes resource health check behavior.
+                description: ResourceHealthChecks customizes resource health check
+                  behavior.
                 items:
                   description: Resource Customization for custom health check
                   properties:

--- a/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
@@ -12059,19 +12059,13 @@ spec:
                       type: string
                   type: object
                 type: array
-              resourceCustomizations:
-                description: 'ResourceCustomizations customizes resource behavior.
-                  Keys are in the form: group/Kind. Please note that this is being
-                  deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
-                  and ResourceActions.'
-                type: string
               resourceExclusions:
                 description: ResourceExclusions is used to completely ignore entire
                   classes of resource group/kinds.
                 type: string
               resourceHealthChecks:
-                description: ResourceHealthChecks customizes resource health check
-                  behavior.
+                description: Deprecated field. Support dropped in v1beta1 version.
+                  ResourceHealthChecks customizes resource health check behavior.
                 items:
                   description: Resource Customization for custom health check
                   properties:

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -38,7 +38,7 @@ Name | Default | Description
 [**Redis**](#redis-options) | [Object] | Redis configuration options.
 [**ResourceHealthChecks**](#resource-customizations) | [Empty] | Customizes resource health check behavior.
 [**ResourceIgnoreDifferences**](#resource-customizations) | [Empty] | Customizes resource ignore difference behavior.
-[**ResourceActions**](#resource-customizations) | [Empty] | Customizes customizes resource action behavior.
+[**ResourceActions**](#resource-customizations) | [Empty] | Customizes resource action behavior.
 [**ResourceExclusions**](#resource-exclusions) | [Empty] | The configuration to completely ignore entire classes of resource group/kinds.
 [**ResourceInclusions**](#resource-inclusions) | [Empty] | The configuration to configure which resource group/kinds are applied.
 [**ResourceTrackingMethod**](#resource-tracking-method) | `label` | The resource tracking method Argo CD should use.

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -36,7 +36,9 @@ Name | Default | Description
 [**Prometheus**](#prometheus-options) | [Object] | Prometheus configuration options.
 [**RBAC**](#rbac-options) | [Object] | RBAC configuration options.
 [**Redis**](#redis-options) | [Object] | Redis configuration options.
-[**ResourceCustomizations**](#resource-customizations) | [Empty] | Customize resource behavior.
+[**ResourceHealthChecks**](#resource-customizations) | [Object] | Customizes resource health check behavior.
+[**ResourceIgnoreDifferences**](#resource-customizations) | [Object] | Customizes resource ignore difference behavior.
+[**ResourceActions**](#resource-customizations) | [Object] | Customizes customizes resource action behavior.
 [**ResourceExclusions**](#resource-exclusions) | [Empty] | The configuration to completely ignore entire classes of resource group/kinds.
 [**ResourceInclusions**](#resource-inclusions) | [Empty] | The configuration to configure which resource group/kinds are applied.
 [**ResourceTrackingMethod**](#resource-tracking-method) | `label` | The resource tracking method Argo CD should use.
@@ -942,10 +944,10 @@ spec:
 
 ## Resource Customizations
 
-There are two ways to customize resource behavior- the first way, only available with release v0.5.0+, is with subkeys (`resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`), the second is without subkeys (`resourceCustomizations`). `resourceCustomizations` maps directly to the `resource.customizations` field in the `argocd-cm` ConfigMap, while each of the subkeys maps directly to their own field in the `argocd-cm`. `resourceHealthChecks` will map to `resource.customizations.health`, `resourceIgnoreDifferences` to `resource.customizations.ignoreDifferences`, and `resourceActions` to `resource.customizations.actions`.
+Resource behavior can be customized using subkeys (`resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`). Each of the subkeys maps directly to their own field in the `argocd-cm`. `resourceHealthChecks` will map to `resource.customizations.health`, `resourceIgnoreDifferences` to `resource.customizations.ignoreDifferences`, and `resourceActions` to `resource.customizations.actions`.
 
-!!! warning 
-    `resourceCustomizations` is being deprecated, and support will be removed in Argo CD Operator v0.8.0 so is encouraged to use `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead. It is the user's responsibility to not provide conflicting resources if they choose to use both methods of resource customizations. 
+!!! note 
+    `.spec.resourceCustomizations` field is no longer support from Argo CD Operator v0.8.0 onward. Consider using `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead.
 
 ### Resource Customizations (with subkeys)
 
@@ -1143,44 +1145,6 @@ resource.customizations.ignoreDifferences.all: |
   - kube-controller-manager
   jsonPointers:
   - /spec/replicas
-```
-
-### Resource Customizations Example
-
-!!! warning 
-    `resourceCustomizations` is being deprecated, and support will be removed in Argo CD Operator v0.8.0. Please use the new formats `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`.
-
-The following example defines a custom PVC health check in the `argocd-cm` ConfigMap using the `ResourceCustomizations` property on the `ArgoCD` resource.
-
-``` yaml
-apiVersion: argoproj.io/v1alpha1
-kind: ArgoCD
-metadata:
-  name: example-argocd
-  labels:
-    example: resource-customizations
-spec:
-  resourceCustomizations: |
-    PersistentVolumeClaim:
-      health.lua: |
-        hs = {}
-        if obj.status ~= nil then
-          if obj.status.phase ~= nil then
-            if obj.status.phase == "Pending" then
-              hs.status = "Healthy"
-              hs.message = obj.status.phase
-              return hs
-            end
-            if obj.status.phase == "Bound" then
-              hs.status = "Healthy"
-              hs.message = obj.status.phase
-              return hs
-            end
-          end
-        end
-        hs.status = "Progressing"
-        hs.message = "Waiting for certificate"
-        return hs
 ```
 
 ## Resource Exclusions

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -947,7 +947,7 @@ spec:
 Resource behavior can be customized using subkeys (`resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`). Each of the subkeys maps directly to their own field in the `argocd-cm`. `resourceHealthChecks` will map to `resource.customizations.health`, `resourceIgnoreDifferences` to `resource.customizations.ignoreDifferences`, and `resourceActions` to `resource.customizations.actions`.
 
 !!! note 
-    `.spec.resourceCustomizations` field is no longer support from Argo CD Operator v0.8.0 onward. Consider using `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead.
+    `.spec.resourceCustomizations` field is no longer in support from Argo CD Operator v0.8.0 onward. Consider using `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions` instead.
 
 ### Resource Customizations (with subkeys)
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -36,9 +36,9 @@ Name | Default | Description
 [**Prometheus**](#prometheus-options) | [Object] | Prometheus configuration options.
 [**RBAC**](#rbac-options) | [Object] | RBAC configuration options.
 [**Redis**](#redis-options) | [Object] | Redis configuration options.
-[**ResourceHealthChecks**](#resource-customizations) | [Object] | Customizes resource health check behavior.
-[**ResourceIgnoreDifferences**](#resource-customizations) | [Object] | Customizes resource ignore difference behavior.
-[**ResourceActions**](#resource-customizations) | [Object] | Customizes customizes resource action behavior.
+[**ResourceHealthChecks**](#resource-customizations) | [Empty] | Customizes resource health check behavior.
+[**ResourceIgnoreDifferences**](#resource-customizations) | [Empty] | Customizes resource ignore difference behavior.
+[**ResourceActions**](#resource-customizations) | [Empty] | Customizes customizes resource action behavior.
 [**ResourceExclusions**](#resource-exclusions) | [Empty] | The configuration to completely ignore entire classes of resource group/kinds.
 [**ResourceInclusions**](#resource-inclusions) | [Empty] | The configuration to configure which resource group/kinds are applied.
 [**ResourceTrackingMethod**](#resource-tracking-method) | `label` | The resource tracking method Argo CD should use.


### PR DESCRIPTION
**What type of PR is this?**
/kind refactor

**What does this PR do / why we need it**:
Removes deprecated `.spec.resourceCustomizations` way of customizing resource behaviour from ArgoCD CRD. This field was deprecated in favor of new `resourceHealthChecks`, `resourceIgnoreDifferences`, and `resourceActions`. subkeys introduced in #793.

No conversion support from v1alpha1 to v1beta1 has been added since users were informed about its removal in advance. The value of `.spec.resourceCustomizations` in v1alpha1 will be dropped during the conversion to v1beta1.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.
