### PR TITLE
refactor: Replace ArgoCD v1alpha1 references with v1beta1

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -28,13 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // getArgoApplicationSetCommand will return the command for the ArgoCD ApplicationSet component.
-func getArgoApplicationSetCommand(cr *argoprojv1a1.ArgoCD) []string {
+func getArgoApplicationSetCommand(cr *argoproj.ArgoCD) []string {
 	cmd := make([]string, 0)
 
 	cmd = append(cmd, "entrypoint.sh")
@@ -58,7 +58,7 @@ func getArgoApplicationSetCommand(cr *argoprojv1a1.ArgoCD) []string {
 	return cmd
 }
 
-func (r *ReconcileArgoCD) reconcileApplicationSetController(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileApplicationSetController(cr *argoproj.ArgoCD) error {
 
 	log.Info("reconciling applicationset serviceaccounts")
 	sa, err := r.reconcileApplicationSetServiceAccount(cr)
@@ -91,7 +91,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetController(cr *argoprojv1a1.Arg
 }
 
 // reconcileApplicationControllerDeployment will ensure the Deployment resource is present for the ArgoCD Application Controller component.
-func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoprojv1a1.ArgoCD, sa *corev1.ServiceAccount) error {
+func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoproj.ArgoCD, sa *corev1.ServiceAccount) error {
 	deploy := newDeploymentWithSuffix("applicationset-controller", "controller", cr)
 
 	setAppSetLabels(&deploy.ObjectMeta)
@@ -185,7 +185,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoprojv1a1.Arg
 
 }
 
-func applicationSetContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
+func applicationSetContainer(cr *argoproj.ArgoCD) corev1.Container {
 	// Global proxy env vars go first
 	appSetEnv := []corev1.EnvVar{{
 		Name: "NAMESPACE",
@@ -254,7 +254,7 @@ func applicationSetContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 	}
 }
 
-func (r *ReconcileArgoCD) reconcileApplicationSetServiceAccount(cr *argoprojv1a1.ArgoCD) (*corev1.ServiceAccount, error) {
+func (r *ReconcileArgoCD) reconcileApplicationSetServiceAccount(cr *argoproj.ArgoCD) (*corev1.ServiceAccount, error) {
 
 	sa := newServiceAccountWithName("applicationset-controller", cr)
 	setAppSetLabels(&sa.ObjectMeta)
@@ -283,7 +283,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetServiceAccount(cr *argoprojv1a1
 	return sa, err
 }
 
-func (r *ReconcileArgoCD) reconcileApplicationSetRole(cr *argoprojv1a1.ArgoCD) (*v1.Role, error) {
+func (r *ReconcileArgoCD) reconcileApplicationSetRole(cr *argoproj.ArgoCD) (*v1.Role, error) {
 
 	policyRules := []v1.PolicyRule{
 
@@ -385,7 +385,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetRole(cr *argoprojv1a1.ArgoCD) (
 	return role, r.Client.Update(context.TODO(), role)
 }
 
-func (r *ReconcileArgoCD) reconcileApplicationSetRoleBinding(cr *argoprojv1a1.ArgoCD, role *v1.Role, sa *corev1.ServiceAccount) error {
+func (r *ReconcileArgoCD) reconcileApplicationSetRoleBinding(cr *argoproj.ArgoCD, role *v1.Role, sa *corev1.ServiceAccount) error {
 
 	name := "applicationset-controller"
 
@@ -428,7 +428,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetRoleBinding(cr *argoprojv1a1.Ar
 	return r.Client.Create(context.TODO(), roleBinding)
 }
 
-func getApplicationSetContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getApplicationSetContainerImage(cr *argoproj.ArgoCD) string {
 	defaultImg, defaultTag := false, false
 
 	img := ""
@@ -458,7 +458,7 @@ func getApplicationSetContainerImage(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getApplicationSetResources will return the ResourceRequirements for the Application Sets container.
-func getApplicationSetResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getApplicationSetResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
 
 	// Allow override of resource requirements from CR
@@ -476,7 +476,7 @@ func setAppSetLabels(obj *metav1.ObjectMeta) {
 }
 
 // reconcileApplicationSetService will ensure that the Service is present for the ApplicationSet webhook and metrics component.
-func (r *ReconcileArgoCD) reconcileApplicationSetService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileApplicationSetService(cr *argoproj.ArgoCD) error {
 	log.Info("reconciling applicationset service")
 
 	svc := newServiceWithSuffix(common.ApplicationSetServiceNameSuffix, common.ApplicationSetServiceNameSuffix, cr)

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -74,7 +74,7 @@ func applicationSetDefaultVolumes() []corev1.Volume {
 func TestReconcileApplicationSet_CreateDeployments(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
-	a.Spec.ApplicationSet = &v1alpha1.ArgoCDApplicationSet{}
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
 
 	r := makeTestReconciler(t, a)
 
@@ -95,7 +95,7 @@ func TestReconcileApplicationSet_CreateDeployments(t *testing.T) {
 	checkExpectedDeploymentValues(t, deployment, &sa, a)
 }
 
-func checkExpectedDeploymentValues(t *testing.T, deployment *appsv1.Deployment, sa *corev1.ServiceAccount, a *v1alpha1.ArgoCD) {
+func checkExpectedDeploymentValues(t *testing.T, deployment *appsv1.Deployment, sa *corev1.ServiceAccount, a *argoproj.ArgoCD) {
 	assert.Equal(t, deployment.Spec.Template.Spec.ServiceAccountName, sa.ObjectMeta.Name)
 	appsetAssertExpectedLabels(t, &deployment.ObjectMeta)
 
@@ -172,7 +172,7 @@ func TestReconcileApplicationSetProxyConfiguration(t *testing.T) {
 	setProxyEnvVars(t)
 
 	a := makeTestArgoCD()
-	a.Spec.ApplicationSet = &v1alpha1.ArgoCDApplicationSet{}
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
 
 	r := makeTestReconciler(t, a)
 
@@ -224,7 +224,7 @@ func TestReconcileApplicationSet_UpdateExistingDeployments(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
 
-	a.Spec.ApplicationSet = &v1alpha1.ArgoCDApplicationSet{}
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
 
 	existingDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -305,18 +305,18 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 
 	tests := []struct {
 		name                   string
-		appSetField            *v1alpha1.ArgoCDApplicationSet
+		appSetField            *argoproj.ArgoCDApplicationSet
 		envVars                map[string]string
 		expectedContainerImage string
 	}{
 		{
 			name:                   "unspecified fields should use default",
-			appSetField:            &v1alpha1.ArgoCDApplicationSet{},
+			appSetField:            &argoproj.ArgoCDApplicationSet{},
 			expectedContainerImage: argoutil.CombineImageTag(common.ArgoCDDefaultArgoImage, common.ArgoCDDefaultArgoVersion),
 		},
 		{
 			name: "ensure that sha hashes are formatted correctly",
-			appSetField: &v1alpha1.ArgoCDApplicationSet{
+			appSetField: &argoproj.ArgoCDApplicationSet{
 				Image:   "custom-image",
 				Version: "sha256:b835999eb5cf75d01a2678cd971095926d9c2566c9ffe746d04b83a6a0a2849f",
 			},
@@ -324,7 +324,7 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 		},
 		{
 			name: "custom image should properly substitute",
-			appSetField: &v1alpha1.ArgoCDApplicationSet{
+			appSetField: &argoproj.ArgoCDApplicationSet{
 				Image:   "custom-image",
 				Version: "custom-version",
 			},
@@ -332,14 +332,14 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 		},
 		{
 			name:                   "verify env var substitution overrides default",
-			appSetField:            &v1alpha1.ArgoCDApplicationSet{},
+			appSetField:            &argoproj.ArgoCDApplicationSet{},
 			envVars:                map[string]string{common.ArgoCDImageEnvName: "custom-env-image"},
 			expectedContainerImage: "custom-env-image",
 		},
 
 		{
 			name: "env var should not override spec fields",
-			appSetField: &v1alpha1.ArgoCDApplicationSet{
+			appSetField: &argoproj.ArgoCDApplicationSet{
 				Image:   "custom-image",
 				Version: "custom-version",
 			},
@@ -500,7 +500,7 @@ func TestReconcileApplicationSet_Service(t *testing.T) {
 
 func TestArgoCDApplicationSetCommand(t *testing.T) {
 	a := makeTestArgoCD()
-	a.Spec.ApplicationSet = &v1alpha1.ArgoCDApplicationSet{}
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
 	r := makeTestReconciler(t, a)
 
 	baseCommand := []string{
@@ -587,7 +587,7 @@ func TestArgoCDApplicationSetCommand(t *testing.T) {
 
 func TestArgoCDApplicationSetEnv(t *testing.T) {
 	a := makeTestArgoCD()
-	a.Spec.ApplicationSet = &v1alpha1.ArgoCDApplicationSet{}
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
 	r := makeTestReconciler(t, a)
 
 	defaultEnv := []corev1.EnvVar{

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/argocd/argocd_controller_test.go
+++ b/controllers/argocd/argocd_controller_test.go
@@ -33,7 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	argov1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -171,7 +171,7 @@ func TestReconcileArgoCD_Reconcile_RemoveManagedByLabelOnArgocdDeletion(t *testi
 }
 
 func deletedAt(now time.Time) argoCDOpt {
-	return func(a *argov1alpha1.ArgoCD) {
+	return func(a *argoproj.ArgoCD) {
 		wrapped := metav1.NewTime(now)
 		a.ObjectMeta.DeletionTimestamp = &wrapped
 	}
@@ -238,12 +238,12 @@ func TestReconcileArgoCD_CleanUp(t *testing.T) {
 }
 
 func addFinalizer(finalizer string) argoCDOpt {
-	return func(a *argov1alpha1.ArgoCD) {
+	return func(a *argoproj.ArgoCD) {
 		a.Finalizers = append(a.Finalizers, finalizer)
 	}
 }
 
-func clusterResources(argocd *argov1alpha1.ArgoCD) []runtime.Object {
+func clusterResources(argocd *argoproj.ArgoCD) []runtime.Object {
 	return []runtime.Object{
 		newClusterRole(common.ArgoCDApplicationControllerComponent, []v1.PolicyRule{}, argocd),
 		newClusterRole(common.ArgoCDServerComponent, []v1.PolicyRule{}, argocd),

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -27,14 +27,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // createRBACConfigMap will create the Argo CD RBAC ConfigMap resource.
-func (r *ReconcileArgoCD) createRBACConfigMap(cm *corev1.ConfigMap, cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) createRBACConfigMap(cm *corev1.ConfigMap, cr *argoproj.ArgoCD) error {
 	data := make(map[string]string)
 	data[common.ArgoCDKeyRBACPolicyCSV] = getRBACPolicy(cr)
 	data[common.ArgoCDKeyRBACPolicyDefault] = getRBACDefaultPolicy(cr)
@@ -48,7 +47,7 @@ func (r *ReconcileArgoCD) createRBACConfigMap(cm *corev1.ConfigMap, cr *argoproj
 }
 
 // getApplicationInstanceLabelKey will return the application instance label key  for the given ArgoCD.
-func getApplicationInstanceLabelKey(cr *argoprojv1a1.ArgoCD) string {
+func getApplicationInstanceLabelKey(cr *argoproj.ArgoCD) string {
 	key := common.ArgoCDDefaultApplicationInstanceLabelKey
 	if len(cr.Spec.ApplicationInstanceLabelKey) > 0 {
 		key = cr.Spec.ApplicationInstanceLabelKey
@@ -57,7 +56,7 @@ func getApplicationInstanceLabelKey(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getCAConfigMapName will return the CA ConfigMap name for the given ArgoCD.
-func getCAConfigMapName(cr *argoprojv1a1.ArgoCD) string {
+func getCAConfigMapName(cr *argoproj.ArgoCD) string {
 	if len(cr.Spec.TLS.CA.ConfigMapName) > 0 {
 		return cr.Spec.TLS.CA.ConfigMapName
 	}
@@ -65,7 +64,7 @@ func getCAConfigMapName(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getConfigManagementPlugins will return the config management plugins for the given ArgoCD.
-func getConfigManagementPlugins(cr *argoprojv1a1.ArgoCD) string {
+func getConfigManagementPlugins(cr *argoproj.ArgoCD) string {
 	plugins := common.ArgoCDDefaultConfigManagementPlugins
 	if len(cr.Spec.ConfigManagementPlugins) > 0 {
 		plugins = cr.Spec.ConfigManagementPlugins
@@ -74,7 +73,7 @@ func getConfigManagementPlugins(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getGATrackingID will return the google analytics tracking ID for the given Argo CD.
-func getGATrackingID(cr *argoprojv1a1.ArgoCD) string {
+func getGATrackingID(cr *argoproj.ArgoCD) string {
 	id := common.ArgoCDDefaultGATrackingID
 	if len(cr.Spec.GATrackingID) > 0 {
 		id = cr.Spec.GATrackingID
@@ -83,7 +82,7 @@ func getGATrackingID(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getHelpChatURL will return the help chat URL for the given Argo CD.
-func getHelpChatURL(cr *argoprojv1a1.ArgoCD) string {
+func getHelpChatURL(cr *argoproj.ArgoCD) string {
 	url := common.ArgoCDDefaultHelpChatURL
 	if len(cr.Spec.HelpChatURL) > 0 {
 		url = cr.Spec.HelpChatURL
@@ -92,7 +91,7 @@ func getHelpChatURL(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getHelpChatText will return the help chat text for the given Argo CD.
-func getHelpChatText(cr *argoprojv1a1.ArgoCD) string {
+func getHelpChatText(cr *argoproj.ArgoCD) string {
 	text := common.ArgoCDDefaultHelpChatText
 	if len(cr.Spec.HelpChatText) > 0 {
 		text = cr.Spec.HelpChatText
@@ -101,7 +100,7 @@ func getHelpChatText(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getKustomizeBuildOptions will return the kuztomize build options for the given ArgoCD.
-func getKustomizeBuildOptions(cr *argoprojv1a1.ArgoCD) string {
+func getKustomizeBuildOptions(cr *argoproj.ArgoCD) string {
 	kbo := common.ArgoCDDefaultKustomizeBuildOptions
 	if len(cr.Spec.KustomizeBuildOptions) > 0 {
 		kbo = cr.Spec.KustomizeBuildOptions
@@ -110,7 +109,7 @@ func getKustomizeBuildOptions(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getOIDCConfig will return the OIDC configuration for the given ArgoCD.
-func getOIDCConfig(cr *argoprojv1a1.ArgoCD) string {
+func getOIDCConfig(cr *argoproj.ArgoCD) string {
 	config := common.ArgoCDDefaultOIDCConfig
 	if len(cr.Spec.OIDCConfig) > 0 {
 		config = cr.Spec.OIDCConfig
@@ -119,7 +118,7 @@ func getOIDCConfig(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getRBACPolicy will return the RBAC policy for the given ArgoCD.
-func getRBACPolicy(cr *argoprojv1a1.ArgoCD) string {
+func getRBACPolicy(cr *argoproj.ArgoCD) string {
 	policy := common.ArgoCDDefaultRBACPolicy
 	if cr.Spec.RBAC.Policy != nil {
 		policy = *cr.Spec.RBAC.Policy
@@ -128,7 +127,7 @@ func getRBACPolicy(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getRBACDefaultPolicy will retun the RBAC default policy for the given ArgoCD.
-func getRBACDefaultPolicy(cr *argoprojv1a1.ArgoCD) string {
+func getRBACDefaultPolicy(cr *argoproj.ArgoCD) string {
 	dp := common.ArgoCDDefaultRBACDefaultPolicy
 	if cr.Spec.RBAC.DefaultPolicy != nil {
 		dp = *cr.Spec.RBAC.DefaultPolicy
@@ -137,7 +136,7 @@ func getRBACDefaultPolicy(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getRBACScopes will return the RBAC scopes for the given ArgoCD.
-func getRBACScopes(cr *argoprojv1a1.ArgoCD) string {
+func getRBACScopes(cr *argoproj.ArgoCD) string {
 	scopes := common.ArgoCDDefaultRBACScopes
 	if cr.Spec.RBAC.Scopes != nil {
 		scopes = *cr.Spec.RBAC.Scopes
@@ -146,7 +145,7 @@ func getRBACScopes(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getResourceCustomizations loads Resource Customizations from argocd-cm ConfigMap
-func getResourceCustomizations(cr *argoprojv1a1.ArgoCD) string {
+func getResourceCustomizations(cr *argoproj.ArgoCD) string {
 	rc := common.ArgoCDDefaultResourceCustomizations
 	if cr.Spec.ResourceCustomizations != "" {
 		rc = cr.Spec.ResourceCustomizations
@@ -156,7 +155,7 @@ func getResourceCustomizations(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getResourceHealthChecks loads health customizations to `resource.customizations.health` from argocd-cm ConfigMap
-func getResourceHealthChecks(cr *argoprojv1a1.ArgoCD) map[string]string {
+func getResourceHealthChecks(cr *argoproj.ArgoCD) map[string]string {
 	healthCheck := make(map[string]string)
 	if cr.Spec.ResourceHealthChecks != nil {
 		resourceHealthChecks := cr.Spec.ResourceHealthChecks
@@ -170,11 +169,11 @@ func getResourceHealthChecks(cr *argoprojv1a1.ArgoCD) map[string]string {
 }
 
 // getResourceIgnoreDifferences loads ignore differences customizations to `resource.customizations.ignoreDifferences` from argocd-cm ConfigMap
-func getResourceIgnoreDifferences(cr *argoprojv1a1.ArgoCD) (map[string]string, error) {
+func getResourceIgnoreDifferences(cr *argoproj.ArgoCD) (map[string]string, error) {
 	ignoreDiff := make(map[string]string)
 	if cr.Spec.ResourceIgnoreDifferences != nil {
 		resourceIgnoreDiff := cr.Spec.ResourceIgnoreDifferences
-		if !reflect.DeepEqual(resourceIgnoreDiff.All, &v1alpha1.IgnoreDifferenceCustomization{}) {
+		if !reflect.DeepEqual(resourceIgnoreDiff.All, &argoproj.IgnoreDifferenceCustomization{}) {
 			subkey := "resource.customizations.ignoreDifferences.all"
 			bytes, err := yaml.Marshal(resourceIgnoreDiff.All)
 			if err != nil {
@@ -197,7 +196,7 @@ func getResourceIgnoreDifferences(cr *argoprojv1a1.ArgoCD) (map[string]string, e
 }
 
 // getResourceActions loads custom actions to `resource.customizations.actions` from argocd-cm ConfigMap
-func getResourceActions(cr *argoprojv1a1.ArgoCD) map[string]string {
+func getResourceActions(cr *argoproj.ArgoCD) map[string]string {
 	action := make(map[string]string)
 	if cr.Spec.ResourceActions != nil {
 		resourceAction := cr.Spec.ResourceActions
@@ -211,7 +210,7 @@ func getResourceActions(cr *argoprojv1a1.ArgoCD) map[string]string {
 }
 
 // getResourceExclusions will return the resource exclusions for the given ArgoCD.
-func getResourceExclusions(cr *argoprojv1a1.ArgoCD) string {
+func getResourceExclusions(cr *argoproj.ArgoCD) string {
 	re := common.ArgoCDDefaultResourceExclusions
 	if cr.Spec.ResourceExclusions != "" {
 		re = cr.Spec.ResourceExclusions
@@ -220,7 +219,7 @@ func getResourceExclusions(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getResourceInclusions will return the resource inclusions for the given ArgoCD.
-func getResourceInclusions(cr *argoprojv1a1.ArgoCD) string {
+func getResourceInclusions(cr *argoproj.ArgoCD) string {
 	re := common.ArgoCDDefaultResourceInclusions
 	if cr.Spec.ResourceInclusions != "" {
 		re = cr.Spec.ResourceInclusions
@@ -229,9 +228,9 @@ func getResourceInclusions(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getResourceTrackingMethod will return the resource tracking method for the given ArgoCD.
-func getResourceTrackingMethod(cr *argoprojv1a1.ArgoCD) string {
-	rtm := argoprojv1a1.ParseResourceTrackingMethod(cr.Spec.ResourceTrackingMethod)
-	if rtm == argoprojv1a1.ResourceTrackingMethodInvalid {
+func getResourceTrackingMethod(cr *argoproj.ArgoCD) string {
+	rtm := argoproj.ParseResourceTrackingMethod(cr.Spec.ResourceTrackingMethod)
+	if rtm == argoproj.ResourceTrackingMethodInvalid {
 		log.Info(fmt.Sprintf("Found '%s' as resource tracking method, which is invalid. Using default 'label' method.", cr.Spec.ResourceTrackingMethod))
 	} else if cr.Spec.ResourceTrackingMethod != "" {
 		log.Info(fmt.Sprintf("Found '%s' as tracking method", cr.Spec.ResourceTrackingMethod))
@@ -242,7 +241,7 @@ func getResourceTrackingMethod(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getInitialRepositories will return the initial repositories for the given ArgoCD.
-func getInitialRepositories(cr *argoprojv1a1.ArgoCD) string {
+func getInitialRepositories(cr *argoproj.ArgoCD) string {
 	repos := common.ArgoCDDefaultRepositories
 	if len(cr.Spec.InitialRepositories) > 0 {
 		repos = cr.Spec.InitialRepositories
@@ -251,7 +250,7 @@ func getInitialRepositories(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getRepositoryCredentials will return the repository credentials for the given ArgoCD.
-func getRepositoryCredentials(cr *argoprojv1a1.ArgoCD) string {
+func getRepositoryCredentials(cr *argoproj.ArgoCD) string {
 	repos := common.ArgoCDDefaultRepositoryCredentials
 	if len(cr.Spec.RepositoryCredentials) > 0 {
 		repos = cr.Spec.RepositoryCredentials
@@ -260,7 +259,7 @@ func getRepositoryCredentials(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getSSHKnownHosts will return the SSH Known Hosts data for the given ArgoCD.
-func getInitialSSHKnownHosts(cr *argoprojv1a1.ArgoCD) string {
+func getInitialSSHKnownHosts(cr *argoproj.ArgoCD) string {
 	skh := common.ArgoCDDefaultSSHKnownHosts
 	if cr.Spec.InitialSSHKnownHosts.ExcludeDefaultHosts {
 		skh = ""
@@ -272,7 +271,7 @@ func getInitialSSHKnownHosts(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getTLSCerts will return the TLS certs for the given ArgoCD.
-func getInitialTLSCerts(cr *argoprojv1a1.ArgoCD) map[string]string {
+func getInitialTLSCerts(cr *argoproj.ArgoCD) map[string]string {
 	certs := make(map[string]string)
 	if len(cr.Spec.TLS.InitialCerts) > 0 {
 		certs = cr.Spec.TLS.InitialCerts
@@ -281,7 +280,7 @@ func getInitialTLSCerts(cr *argoprojv1a1.ArgoCD) map[string]string {
 }
 
 // newConfigMap returns a new ConfigMap instance for the given ArgoCD.
-func newConfigMap(cr *argoprojv1a1.ArgoCD) *corev1.ConfigMap {
+func newConfigMap(cr *argoproj.ArgoCD) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -292,7 +291,7 @@ func newConfigMap(cr *argoprojv1a1.ArgoCD) *corev1.ConfigMap {
 }
 
 // newConfigMapWithName creates a new ConfigMap with the given name for the given ArgCD.
-func newConfigMapWithName(name string, cr *argoprojv1a1.ArgoCD) *corev1.ConfigMap {
+func newConfigMapWithName(name string, cr *argoproj.ArgoCD) *corev1.ConfigMap {
 	cm := newConfigMap(cr)
 	cm.ObjectMeta.Name = name
 
@@ -305,12 +304,12 @@ func newConfigMapWithName(name string, cr *argoprojv1a1.ArgoCD) *corev1.ConfigMa
 
 // newConfigMapWithName creates a new ConfigMap with the given suffix appended to the name.
 // The name for the CongifMap is based on the name of the given ArgCD.
-func newConfigMapWithSuffix(suffix string, cr *argoprojv1a1.ArgoCD) *corev1.ConfigMap {
+func newConfigMapWithSuffix(suffix string, cr *argoproj.ArgoCD) *corev1.ConfigMap {
 	return newConfigMapWithName(fmt.Sprintf("%s-%s", cr.ObjectMeta.Name, suffix), cr)
 }
 
 // reconcileConfigMaps will ensure that all ArgoCD ConfigMaps are present.
-func (r *ReconcileArgoCD) reconcileConfigMaps(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) reconcileConfigMaps(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	if err := r.reconcileArgoConfigMap(cr); err != nil {
 		return err
 	}
@@ -344,7 +343,7 @@ func (r *ReconcileArgoCD) reconcileConfigMaps(cr *argoprojv1a1.ArgoCD, useTLSFor
 
 // reconcileCAConfigMap will ensure that the Certificate Authority ConfigMap is present.
 // This ConfigMap holds the CA Certificate data for client use.
-func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(getCAConfigMapName(cr), cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		return nil // ConfigMap found, do nothing
@@ -367,7 +366,7 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileConfiguration will ensure that the main ConfigMap for ArgoCD is present.
-func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
 
 	cm.Data = make(map[string]string)
@@ -482,7 +481,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 			if err := r.reconcileDexConfiguration(existingCM, cr); err != nil {
 				return err
 			}
-		} else if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == v1alpha1.SSOProviderTypeKeycloak {
+		} else if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
 			// retain oidc.config during reconcilliation when keycloak is configured
 			cm.Data[common.ArgoCDKeyOIDCConfig] = existingCM.Data[common.ArgoCDKeyOIDCConfig]
 		}
@@ -498,7 +497,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoprojv1a1.ArgoCD) error 
 }
 
 // reconcileGrafanaConfiguration will ensure that the Grafana configuration ConfigMap is present.
-func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoproj.ArgoCD) error {
 	if !cr.Spec.Grafana.Enabled {
 		return nil // Grafana not enabled, do nothing.
 	}
@@ -544,7 +543,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoprojv1a1.ArgoCD)
 }
 
 // reconcileGrafanaDashboards will ensure that the Grafana dashboards ConfigMap is present.
-func (r *ReconcileArgoCD) reconcileGrafanaDashboards(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileGrafanaDashboards(cr *argoproj.ArgoCD) error {
 	if !cr.Spec.Grafana.Enabled {
 		return nil // Grafana not enabled, do nothing.
 	}
@@ -580,7 +579,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaDashboards(cr *argoprojv1a1.ArgoCD) er
 }
 
 // reconcileRBAC will ensure that the ArgoCD RBAC ConfigMap is present.
-func (r *ReconcileArgoCD) reconcileRBAC(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRBAC(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDRBACConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		return r.reconcileRBACConfigMap(cm, cr)
@@ -589,7 +588,7 @@ func (r *ReconcileArgoCD) reconcileRBAC(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileRBACConfigMap will ensure that the RBAC ConfigMap is syncronized with the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileRBACConfigMap(cm *corev1.ConfigMap, cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRBACConfigMap(cm *corev1.ConfigMap, cr *argoproj.ArgoCD) error {
 	changed := false
 	// Policy CSV
 	if cr.Spec.RBAC.Policy != nil && cm.Data[common.ArgoCDKeyRBACPolicyCSV] != *cr.Spec.RBAC.Policy {
@@ -623,7 +622,7 @@ func (r *ReconcileArgoCD) reconcileRBACConfigMap(cm *corev1.ConfigMap, cr *argop
 }
 
 // reconcileRedisConfiguration will ensure that all of the Redis ConfigMaps are present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileRedisConfiguration(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) reconcileRedisConfiguration(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	if err := r.reconcileRedisHAConfigMap(cr, useTLSForRedis); err != nil {
 		return err
 	}
@@ -634,7 +633,7 @@ func (r *ReconcileArgoCD) reconcileRedisConfiguration(cr *argoprojv1a1.ArgoCD, u
 }
 
 // reconcileRedisHAConfigMap will ensure that the Redis HA Health ConfigMap is present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	cm := newConfigMapWithName(common.ArgoCDRedisHAHealthConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		if !cr.Spec.HA.Enabled {
@@ -661,7 +660,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoC
 }
 
 // reconcileRedisHAConfigMap will ensure that the Redis HA ConfigMap is present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileRedisHAConfigMap(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) reconcileRedisHAConfigMap(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	cm := newConfigMapWithName(common.ArgoCDRedisHAConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		if !cr.Spec.HA.Enabled {
@@ -689,7 +688,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAConfigMap(cr *argoprojv1a1.ArgoCD, use
 	return r.Client.Create(context.TODO(), cm)
 }
 
-func (r *ReconcileArgoCD) recreateRedisHAConfigMap(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) recreateRedisHAConfigMap(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	cm := newConfigMapWithName(common.ArgoCDRedisHAConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		if err := r.Client.Delete(context.TODO(), cm); err != nil {
@@ -699,7 +698,7 @@ func (r *ReconcileArgoCD) recreateRedisHAConfigMap(cr *argoprojv1a1.ArgoCD, useT
 	return r.reconcileRedisHAConfigMap(cr, useTLSForRedis)
 }
 
-func (r *ReconcileArgoCD) recreateRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) recreateRedisHAHealthConfigMap(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	cm := newConfigMapWithName(common.ArgoCDRedisHAHealthConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		if err := r.Client.Delete(context.TODO(), cm); err != nil {
@@ -710,7 +709,7 @@ func (r *ReconcileArgoCD) recreateRedisHAHealthConfigMap(cr *argoprojv1a1.ArgoCD
 }
 
 // reconcileSSHKnownHosts will ensure that the ArgoCD SSH Known Hosts ConfigMap is present.
-func (r *ReconcileArgoCD) reconcileSSHKnownHosts(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileSSHKnownHosts(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDKnownHostsConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		return nil // ConfigMap found, move along...
@@ -727,7 +726,7 @@ func (r *ReconcileArgoCD) reconcileSSHKnownHosts(cr *argoprojv1a1.ArgoCD) error 
 }
 
 // reconcileTLSCerts will ensure that the ArgoCD TLS Certs ConfigMap is present.
-func (r *ReconcileArgoCD) reconcileTLSCerts(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileTLSCerts(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDTLSCertsConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		return nil // ConfigMap found, move along...
@@ -742,7 +741,7 @@ func (r *ReconcileArgoCD) reconcileTLSCerts(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileGPGKeysConfigMap creates a gpg-keys config map
-func (r *ReconcileArgoCD) reconcileGPGKeysConfigMap(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileGPGKeysConfigMap(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDGPGKeysConfigMapName, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
 		return nil

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -29,8 +29,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -127,7 +126,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 
 	defaultConfigMapData := map[string]string{
 		"application.instanceLabelKey":       common.ArgoCDDefaultApplicationInstanceLabelKey,
-		"application.resourceTrackingMethod": argoprojv1alpha1.ResourceTrackingMethodLabel.String(),
+		"application.resourceTrackingMethod": argoproj.ResourceTrackingMethodLabel.String(),
 		"admin.enabled":                      "true",
 		"configManagementPlugins":            "",
 		"dex.config":                         "",
@@ -158,8 +157,8 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 		},
 		{
 			"with-banner",
-			[]argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
-				a.Spec.Banner = &argoprojv1alpha1.Banner{
+			[]argoCDOpt{func(a *argoproj.ArgoCD) {
+				a.Spec.Banner = &argoproj.Banner{
 					Content: "Custom Styles - Banners",
 				}
 			}},
@@ -170,8 +169,8 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 		},
 		{
 			"with-banner-and-url",
-			[]argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
-				a.Spec.Banner = &argoprojv1alpha1.Banner{
+			[]argoCDOpt{func(a *argoproj.ArgoCD) {
+				a.Spec.Banner = &argoproj.Banner{
 					Content: "Custom Styles - Banners",
 					URL:     "https://argo-cd.readthedocs.io/en/stable/operator-manual/custom-styles/#banners",
 				}
@@ -185,8 +184,8 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 
 	for _, tt := range cmdTests {
 		a := makeTestArgoCD(tt.opts...)
-		a.Spec.SSO = &argoprojv1alpha1.ArgoCDSSOSpec{
-			Provider: argoprojv1alpha1.SSOProviderTypeDex,
+		a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
 		}
 		r := makeTestReconciler(t, a)
 
@@ -275,7 +274,7 @@ func TestReconcileArgoCDCM_withRepoCredentials(t *testing.T) {
 
 func TestReconcileArgoCD_reconcileArgoConfigMap_withDisableAdmin(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.DisableAdmin = true
 	})
 	r := makeTestReconciler(t, a)
@@ -300,14 +299,14 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		updateCrSpecFunc func(cr *argoprojv1alpha1.ArgoCD)
+		updateCrSpecFunc func(cr *argoproj.ArgoCD)
 	}{
 		{
 			name: "dex config using .spec.sso.provider=dex + .spec.sso.dex",
-			updateCrSpecFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			updateCrSpecFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -325,10 +324,10 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 				}},
 			}
 
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
-				a.Spec.SSO = &argoprojv1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+				a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: false,
 					},
 				}
@@ -376,19 +375,19 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexDisabled(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		argoCD *argoprojv1alpha1.ArgoCD
+		argoCD *argoproj.ArgoCD
 	}{
 		{
 			name: "dex disabled by removing .spec.sso",
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			}),
 		},
 		{
 			name: "dex disabled by switching provider",
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeKeycloak,
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
 		},
@@ -421,19 +420,19 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_dexConfigDeletedwhenDexDisabled(
 
 	tests := []struct {
 		name              string
-		updateCrFunc      func(cr *argoprojv1alpha1.ArgoCD)
-		argoCD            *argoprojv1alpha1.ArgoCD
+		updateCrFunc      func(cr *argoproj.ArgoCD)
+		argoCD            *argoproj.ArgoCD
 		wantConfigRemoved bool
 	}{
 		{
 			name: "dex disabled by removing .spec.sso.provider",
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						Config: "test-dex-config",
 					},
 				}
@@ -442,15 +441,15 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_dexConfigDeletedwhenDexDisabled(
 		},
 		{
 			name: "dex disabled by switching provider",
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeKeycloak,
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -510,12 +509,12 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_dexConfigDeletedwhenDexDisabled(
 
 func TestReconcileArgoCD_reconcileArgoConfigMap_withKustomizeVersions(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
-		kv := argoprojv1alpha1.KustomizeVersionSpec{
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		kv := argoproj.KustomizeVersionSpec{
 			Version: "v4.1.0",
 			Path:    "/path/to/kustomize-4.1",
 		}
-		var kvs []argoprojv1alpha1.KustomizeVersionSpec
+		var kvs []argoproj.KustomizeVersionSpec
 		kvs = append(kvs, kv)
 		a.Spec.KustomizeVersions = kvs
 	})
@@ -538,7 +537,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withKustomizeVersions(t *testing
 
 func TestReconcileArgoCD_reconcileGPGKeysConfigMap(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.DisableAdmin = true
 	})
 	r := makeTestReconciler(t, a)
@@ -573,7 +572,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 		assert.NoError(t, err)
 
 		rtm, ok := cm.Data[common.ArgoCDKeyResourceTrackingMethod]
-		assert.Equal(t, argoprojv1alpha1.ResourceTrackingMethodLabel.String(), rtm)
+		assert.Equal(t, argoproj.ResourceTrackingMethodLabel.String(), rtm)
 		assert.True(t, ok)
 	})
 
@@ -585,12 +584,12 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 		assert.NoError(t, err)
 
 		rtm, ok := cm.Data[common.ArgoCDKeyResourceTrackingMethod]
-		assert.Equal(t, argoprojv1alpha1.ResourceTrackingMethodLabel.String(), rtm)
+		assert.Equal(t, argoproj.ResourceTrackingMethodLabel.String(), rtm)
 		assert.True(t, ok)
 	})
 
 	t.Run("Set tracking method to annotation+label", func(t *testing.T) {
-		a.Spec.ResourceTrackingMethod = argoprojv1alpha1.ResourceTrackingMethodAnnotationAndLabel.String()
+		a.Spec.ResourceTrackingMethod = argoproj.ResourceTrackingMethodAnnotationAndLabel.String()
 		err = r.reconcileArgoConfigMap(a)
 		assert.NoError(t, err)
 
@@ -602,11 +601,11 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 
 		rtm, ok := cm.Data[common.ArgoCDKeyResourceTrackingMethod]
 		assert.True(t, ok)
-		assert.Equal(t, argoprojv1alpha1.ResourceTrackingMethodAnnotationAndLabel.String(), rtm)
+		assert.Equal(t, argoproj.ResourceTrackingMethodAnnotationAndLabel.String(), rtm)
 	})
 
 	t.Run("Set tracking method to annotation", func(t *testing.T) {
-		a.Spec.ResourceTrackingMethod = argoprojv1alpha1.ResourceTrackingMethodAnnotation.String()
+		a.Spec.ResourceTrackingMethod = argoproj.ResourceTrackingMethodAnnotation.String()
 		err = r.reconcileArgoConfigMap(a)
 		assert.NoError(t, err)
 
@@ -618,7 +617,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 
 		rtm, ok := cm.Data[common.ArgoCDKeyResourceTrackingMethod]
 		assert.True(t, ok)
-		assert.Equal(t, argoprojv1alpha1.ResourceTrackingMethodAnnotation.String(), rtm)
+		assert.Equal(t, argoproj.ResourceTrackingMethodAnnotation.String(), rtm)
 	})
 
 	// Invalid value sets the default "label"
@@ -635,7 +634,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 
 		rtm, ok := cm.Data[common.ArgoCDKeyResourceTrackingMethod]
 		assert.True(t, ok)
-		assert.Equal(t, argoprojv1alpha1.ResourceTrackingMethodLabel.String(), rtm)
+		assert.Equal(t, argoproj.ResourceTrackingMethodLabel.String(), rtm)
 	})
 
 }
@@ -645,7 +644,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceInclusions(t *testin
 	customizations := "testing: testing"
 	updatedCustomizations := "updated-testing: updated-testing"
 
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.ResourceInclusions = customizations
 	})
 	r := makeTestReconciler(t, a)
@@ -683,7 +682,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceInclusions(t *testin
 func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceCustomizations(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	customizations := "testing: testing"
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.ResourceCustomizations = customizations
 	})
 	r := makeTestReconciler(t, a)
@@ -718,7 +717,7 @@ managedfieldsmanagers:
 - b
 `
 
-	health := []argoprojv1alpha1.ResourceHealthCheck{
+	health := []argoproj.ResourceHealthCheck{
 		{
 			Group: "healthFoo",
 			Kind:  "healthFoo",
@@ -730,7 +729,7 @@ managedfieldsmanagers:
 			Check: "healthBar",
 		},
 	}
-	actions := []argoprojv1alpha1.ResourceAction{
+	actions := []argoproj.ResourceAction{
 		{
 			Group:  "actionsFoo",
 			Kind:   "actionsFoo",
@@ -742,17 +741,17 @@ managedfieldsmanagers:
 			Action: "actionsBar",
 		},
 	}
-	ignoreDifferences := argoprojv1alpha1.ResourceIgnoreDifference{
-		All: &v1alpha1.IgnoreDifferenceCustomization{
+	ignoreDifferences := argoproj.ResourceIgnoreDifference{
+		All: &argoproj.IgnoreDifferenceCustomization{
 			JqPathExpressions:     []string{"a", "b"},
 			JsonPointers:          []string{"a", "b"},
 			ManagedFieldsManagers: []string{"a", "b"},
 		},
-		ResourceIdentifiers: []argoprojv1alpha1.ResourceIdentifiers{
+		ResourceIdentifiers: []argoproj.ResourceIdentifiers{
 			{
 				Group: "ignoreDiffBar",
 				Kind:  "ignoreDiffBar",
-				Customization: v1alpha1.IgnoreDifferenceCustomization{
+				Customization: argoproj.IgnoreDifferenceCustomization{
 					JqPathExpressions:     []string{"a", "b"},
 					JsonPointers:          []string{"a", "b"},
 					ManagedFieldsManagers: []string{"a", "b"},
@@ -761,7 +760,7 @@ managedfieldsmanagers:
 		},
 	}
 
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.ResourceHealthChecks = health
 		a.Spec.ResourceActions = actions
 		a.Spec.ResourceIgnoreDifferences = &ignoreDifferences
@@ -806,12 +805,12 @@ func TestReconcile_emitEventOnDeprecatedResourceCustomizations(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		argoCD     *argoprojv1alpha1.ArgoCD
+		argoCD     *argoproj.ArgoCD
 		wantEvents []*corev1.Event
 	}{
 		{
 			name: "ResourceCustomizations used",
-			argoCD: makeTestArgoCD(func(ac *argoprojv1alpha1.ArgoCD) {
+			argoCD: makeTestArgoCD(func(ac *argoproj.ArgoCD) {
 				ac.Spec.ResourceCustomizations = "testing: testing"
 			}),
 			wantEvents: []*corev1.Event{resourceCustomizationsEvent},

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 
 	corev1 "k8s.io/api/core/v1"
@@ -132,7 +132,7 @@ func (r *ReconcileArgoCD) namespaceResourceMapper(o client.Object) []reconcile.R
 
 	labels := o.GetLabels()
 	if v, ok := labels[common.ArgoCDManagedByLabel]; ok {
-		argocds := &argoprojv1alpha1.ArgoCDList{}
+		argocds := &argoproj.ArgoCDList{}
 		if err := r.Client.List(context.TODO(), argocds, &client.ListOptions{Namespace: v}); err != nil {
 			return result
 		}
@@ -161,7 +161,7 @@ func (r *ReconcileArgoCD) clusterSecretResourceMapper(o client.Object) []reconci
 
 	labels := o.GetLabels()
 	if v, ok := labels[common.ArgoCDSecretTypeLabel]; ok && v == "cluster" {
-		argocds := &argoprojv1alpha1.ArgoCDList{}
+		argocds := &argoproj.ArgoCDList{}
 		if err := r.Client.List(context.TODO(), argocds, &client.ListOptions{Namespace: o.GetNamespace()}); err != nil {
 			return result
 		}

--- a/controllers/argocd/custommapper_test.go
+++ b/controllers/argocd/custommapper_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 
 	corev1 "k8s.io/api/core/v1"
@@ -104,7 +104,7 @@ func TestReconcileArgoCD_clusterRoleBindingMapper(t *testing.T) {
 }
 
 func TestReconcileArgoCD_tlsSecretMapperRepoServer(t *testing.T) {
-	argocd := &v1alpha1.ArgoCD{
+	argocd := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd",
 			Namespace: "argocd-operator",
@@ -321,7 +321,7 @@ func TestReconcileArgoCD_tlsSecretMapperRepoServer(t *testing.T) {
 }
 
 func TestReconcileArgoCD_tlsSecretMapperRedis(t *testing.T) {
-	argocd := &v1alpha1.ArgoCD{
+	argocd := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd",
 			Namespace: "argocd-operator",

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -23,7 +23,8 @@ import (
 	"strings"
 	"time"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
@@ -38,7 +39,7 @@ import (
 // getArgoCDRepoServerReplicas will return the size value for the argocd-repo-server replica count if it
 // has been set in argocd CR. Otherwise, nil is returned if the replicas is not set in the argocd CR or
 // replicas value is < 0.
-func getArgoCDRepoServerReplicas(cr *argoprojv1a1.ArgoCD) *int32 {
+func getArgoCDRepoServerReplicas(cr *argoproj.ArgoCD) *int32 {
 	if cr.Spec.Repo.Replicas != nil && *cr.Spec.Repo.Replicas >= 0 {
 		return cr.Spec.Repo.Replicas
 	}
@@ -49,14 +50,14 @@ func getArgoCDRepoServerReplicas(cr *argoprojv1a1.ArgoCD) *int32 {
 // getArgoCDServerReplicas will return the size value for the argocd-server replica count if it
 // has been set in argocd CR. Otherwise, nil is returned if the replicas is not set in the argocd CR or
 // replicas value is < 0. If Autoscale is enabled, the value for replicas in the argocd CR will be ignored.
-func getArgoCDServerReplicas(cr *argoprojv1a1.ArgoCD) *int32 {
+func getArgoCDServerReplicas(cr *argoproj.ArgoCD) *int32 {
 	if !cr.Spec.Server.Autoscale.Enabled && cr.Spec.Server.Replicas != nil && *cr.Spec.Server.Replicas >= 0 {
 		return cr.Spec.Server.Replicas
 	}
 	return nil
 }
 
-func (r *ReconcileArgoCD) getArgoCDExport(cr *argoprojv1a1.ArgoCD) *argoprojv1a1.ArgoCDExport {
+func (r *ReconcileArgoCD) getArgoCDExport(cr *argoproj.ArgoCD) *argoprojv1alpha1.ArgoCDExport {
 	if cr.Spec.Import == nil {
 		return nil
 	}
@@ -66,14 +67,14 @@ func (r *ReconcileArgoCD) getArgoCDExport(cr *argoprojv1a1.ArgoCD) *argoprojv1a1
 		namespace = *cr.Spec.Import.Namespace
 	}
 
-	export := &argoprojv1a1.ArgoCDExport{}
+	export := &argoprojv1alpha1.ArgoCDExport{}
 	if argoutil.IsObjectFound(r.Client, namespace, cr.Spec.Import.Name, export) {
 		return export
 	}
 	return nil
 }
 
-func getArgoExportSecretName(export *argoprojv1a1.ArgoCDExport) string {
+func getArgoExportSecretName(export *argoprojv1alpha1.ArgoCDExport) string {
 	name := argoutil.NameWithSuffix(export.ObjectMeta, "export")
 	if export.Spec.Storage != nil && len(export.Spec.Storage.SecretName) > 0 {
 		name = export.Spec.Storage.SecretName
@@ -81,14 +82,14 @@ func getArgoExportSecretName(export *argoprojv1a1.ArgoCDExport) string {
 	return name
 }
 
-func getArgoImportBackend(client client.Client, cr *argoprojv1a1.ArgoCD) string {
+func getArgoImportBackend(client client.Client, cr *argoproj.ArgoCD) string {
 	backend := common.ArgoCDExportStorageBackendLocal
 	namespace := cr.ObjectMeta.Namespace
 	if cr.Spec.Import != nil && cr.Spec.Import.Namespace != nil && len(*cr.Spec.Import.Namespace) > 0 {
 		namespace = *cr.Spec.Import.Namespace
 	}
 
-	export := &argoprojv1a1.ArgoCDExport{}
+	export := &argoprojv1alpha1.ArgoCDExport{}
 	if argoutil.IsObjectFound(client, namespace, cr.Spec.Import.Name, export) {
 		if export.Spec.Storage != nil && len(export.Spec.Storage.Backend) > 0 {
 			backend = export.Spec.Storage.Backend
@@ -98,7 +99,7 @@ func getArgoImportBackend(client client.Client, cr *argoprojv1a1.ArgoCD) string 
 }
 
 // getArgoImportCommand will return the command for the ArgoCD import process.
-func getArgoImportCommand(client client.Client, cr *argoprojv1a1.ArgoCD) []string {
+func getArgoImportCommand(client client.Client, cr *argoproj.ArgoCD) []string {
 	cmd := make([]string, 0)
 	cmd = append(cmd, "uid_entrypoint.sh")
 	cmd = append(cmd, "argocd-operator-util")
@@ -107,7 +108,7 @@ func getArgoImportCommand(client client.Client, cr *argoprojv1a1.ArgoCD) []strin
 	return cmd
 }
 
-func getArgoImportContainerEnv(cr *argoprojv1a1.ArgoCDExport) []corev1.EnvVar {
+func getArgoImportContainerEnv(cr *argoprojv1alpha1.ArgoCDExport) []corev1.EnvVar {
 	env := make([]corev1.EnvVar, 0)
 
 	switch cr.Spec.Storage.Backend {
@@ -141,7 +142,7 @@ func getArgoImportContainerEnv(cr *argoprojv1a1.ArgoCDExport) []corev1.EnvVar {
 }
 
 // getArgoImportContainerImage will return the container image for the Argo CD import process.
-func getArgoImportContainerImage(cr *argoprojv1a1.ArgoCDExport) string {
+func getArgoImportContainerImage(cr *argoprojv1alpha1.ArgoCDExport) string {
 	img := common.ArgoCDDefaultExportJobImage
 	if len(cr.Spec.Image) > 0 {
 		img = cr.Spec.Image
@@ -173,7 +174,7 @@ func getArgoImportVolumeMounts() []corev1.VolumeMount {
 }
 
 // getArgoImportVolumes will return the Volumes for the given ArgoCDExport.
-func getArgoImportVolumes(cr *argoprojv1a1.ArgoCDExport) []corev1.Volume {
+func getArgoImportVolumes(cr *argoprojv1alpha1.ArgoCDExport) []corev1.Volume {
 	volumes := make([]corev1.Volume, 0)
 
 	if cr.Spec.Storage != nil && cr.Spec.Storage.Backend == common.ArgoCDExportStorageBackendLocal {
@@ -225,7 +226,7 @@ func getArgoRedisArgs(useTLS bool) []string {
 }
 
 // getArgoRepoCommand will return the command for the ArgoCD Repo component.
-func getArgoRepoCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) []string {
+func getArgoRepoCommand(cr *argoproj.ArgoCD, useTLSForRedis bool) []string {
 	cmd := make([]string, 0)
 
 	cmd = append(cmd, "uid_entrypoint.sh")
@@ -272,7 +273,7 @@ func getArgoCmpServerInitCommand() []string {
 }
 
 // getArgoServerCommand will return the command for the ArgoCD server component.
-func getArgoServerCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) []string {
+func getArgoServerCommand(cr *argoproj.ArgoCD, useTLSForRedis bool) []string {
 	cmd := make([]string, 0)
 	cmd = append(cmd, "argocd-server")
 
@@ -341,17 +342,17 @@ func isMergable(extraArgs []string, cmd []string) error {
 }
 
 // getDexServerAddress will return the Dex server address.
-func getDexServerAddress(cr *argoprojv1a1.ArgoCD) string {
+func getDexServerAddress(cr *argoproj.ArgoCD) string {
 	return fmt.Sprintf("https://%s", fqdnServiceRef("dex-server", common.ArgoCDDefaultDexHTTPPort, cr))
 }
 
 // getRepoServerAddress will return the Argo CD repo server address.
-func getRepoServerAddress(cr *argoprojv1a1.ArgoCD) string {
+func getRepoServerAddress(cr *argoproj.ArgoCD) string {
 	return fqdnServiceRef("repo-server", common.ArgoCDDefaultRepoServerPort, cr)
 }
 
 // newDeployment returns a new Deployment instance for the given ArgoCD.
-func newDeployment(cr *argoprojv1a1.ArgoCD) *appsv1.Deployment {
+func newDeployment(cr *argoproj.ArgoCD) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -362,7 +363,7 @@ func newDeployment(cr *argoprojv1a1.ArgoCD) *appsv1.Deployment {
 }
 
 // newDeploymentWithName returns a new Deployment instance for the given ArgoCD using the given name.
-func newDeploymentWithName(name string, component string, cr *argoprojv1a1.ArgoCD) *appsv1.Deployment {
+func newDeploymentWithName(name string, component string, cr *argoproj.ArgoCD) *appsv1.Deployment {
 	deploy := newDeployment(cr)
 	deploy.ObjectMeta.Name = name
 
@@ -397,12 +398,12 @@ func newDeploymentWithName(name string, component string, cr *argoprojv1a1.ArgoC
 }
 
 // newDeploymentWithSuffix returns a new Deployment instance for the given ArgoCD using the given suffix.
-func newDeploymentWithSuffix(suffix string, component string, cr *argoprojv1a1.ArgoCD) *appsv1.Deployment {
+func newDeploymentWithSuffix(suffix string, component string, cr *argoproj.ArgoCD) *appsv1.Deployment {
 	return newDeploymentWithName(fmt.Sprintf("%s-%s", cr.Name, suffix), component, cr)
 }
 
 // reconcileDeployments will ensure that all Deployment resources are present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileDeployments(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) reconcileDeployments(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 
 	if err := r.reconcileDexDeployment(cr); err != nil {
 		log.Error(err, "error reconciling dex deployment")
@@ -437,7 +438,7 @@ func (r *ReconcileArgoCD) reconcileDeployments(cr *argoprojv1a1.ArgoCD, useTLSFo
 }
 
 // reconcileGrafanaDeployment will ensure the Deployment resource is present for the ArgoCD Grafana component.
-func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoproj.ArgoCD) error {
 	deploy := newDeploymentWithSuffix("grafana", "grafana", cr)
 	deploy.Spec.Replicas = getGrafanaReplicas(cr)
 	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
@@ -569,7 +570,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoprojv1a1.ArgoCD) er
 }
 
 // reconcileRedisDeployment will ensure the Deployment resource is present for the ArgoCD Redis component.
-func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoprojv1a1.ArgoCD, useTLS bool) error {
+func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS bool) error {
 	deploy := newDeploymentWithSuffix("redis", "redis", cr)
 
 	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
@@ -669,7 +670,7 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoprojv1a1.ArgoCD, useT
 }
 
 // reconcileRedisHAProxyDeployment will ensure the Deployment resource is present for the Redis HA Proxy component.
-func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) error {
 	deploy := newDeploymentWithSuffix("redis-ha-haproxy", "redis", cr)
 
 	deploy.Spec.Template.Spec.Affinity = &corev1.Affinity{
@@ -875,7 +876,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoprojv1a1.ArgoC
 }
 
 // reconcileRepoDeployment will ensure the Deployment resource is present for the ArgoCD Repo component.
-func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	deploy := newDeploymentWithSuffix("repo-server", "repo-server", cr)
 	automountToken := false
 	if cr.Spec.Repo.MountSAToken {
@@ -1177,7 +1178,7 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoprojv1a1.ArgoCD, useTL
 }
 
 // reconcileServerDeployment will ensure the Deployment resource is present for the ArgoCD Server component.
-func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	deploy := newDeploymentWithSuffix("server", "server", cr)
 	serverEnv := cr.Spec.Server.Env
 	serverEnv = argoutil.EnvMerge(serverEnv, proxyEnvVars(), false)

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -22,8 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 const (
@@ -61,7 +60,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_replicas(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Repo.Replicas = &test.replicas
 			})
 			r := makeTestReconciler(t, a)
@@ -123,7 +122,7 @@ func TestReconcileArgoCD_reconcile_ServerDeployment_replicas(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Server.Replicas = test.initialReplicas
 				a.Spec.Server.Autoscale.Enabled = test.autoscale
 			})
@@ -159,11 +158,11 @@ func TestReconcileArgoCD_reconcile_ServerDeployment_replicas(t *testing.T) {
 func TestReconcileArgoCD_reconcileRepoDeployment_loglevel(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
-	repoDeps := []*argoprojv1alpha1.ArgoCD{
-		makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	repoDeps := []*argoproj.ArgoCD{
+		makeTestArgoCD(func(a *argoproj.ArgoCD) {
 			a.Spec.Repo.LogLevel = "warn"
 		}),
-		makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		makeTestArgoCD(func(a *argoproj.ArgoCD) {
 			a.Spec.Repo.LogLevel = "error"
 		}),
 		makeTestArgoCD(),
@@ -234,7 +233,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_volumes(t *testing.T) {
 		}
 
 		logf.SetLogger(ZapLogger(true))
-		a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 			a.Spec.Repo.Volumes = []corev1.Volume{customVolume}
 		})
 		r := makeTestReconciler(t, a)
@@ -407,7 +406,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 		}
 
 		logf.SetLogger(ZapLogger(true))
-		a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 			a.Spec.Repo.VolumeMounts = []corev1.VolumeMount{testMount}
 		})
 		r := makeTestReconciler(t, a)
@@ -427,7 +426,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 
 func TestReconcileArgoCD_reconcileRepoDeployment_initContainers(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		ic := corev1.Container{
 			Name:  "test-init-container",
 			Image: "test-image",
@@ -555,11 +554,11 @@ func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
 	t.Setenv("no_proxy", testNoProxy)
 
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Grafana.Enabled = true
-		a.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-			Provider: v1alpha1.SSOProviderTypeDex,
-			Dex: &v1alpha1.ArgoCDDexSpec{
+		a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
+			Dex: &argoproj.ArgoCDDexSpec{
 				Config: "test",
 			},
 		}
@@ -584,11 +583,11 @@ func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
 func TestReconcileArgoCD_reconcileDeployments_proxy_update_existing(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Grafana.Enabled = true
-		a.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-			Provider: v1alpha1.SSOProviderTypeDex,
-			Dex: &v1alpha1.ArgoCDDexSpec{
+		a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
+			Dex: &argoproj.ArgoCDDexSpec{
 				Config: "test",
 			},
 		}
@@ -627,7 +626,7 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy(t *testing.T) {
 	t.Setenv("no_proxy", testNoProxy)
 
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.HA.Enabled = true
 	})
 	r := makeTestReconciler(t, a)
@@ -644,7 +643,7 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy_with_resources(t *testing
 	t.Setenv("no_proxy", testNoProxy)
 
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCDWithResources(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCDWithResources(func(a *argoproj.ArgoCD) {
 		a.Spec.HA.Enabled = true
 	})
 	r := makeTestReconciler(t, a)
@@ -780,8 +779,8 @@ func Test_proxyEnvVars(t *testing.T) {
 
 func TestReconcileArgoCD_reconcileDeployment_nodePlacement(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD((func(a *argoprojv1alpha1.ArgoCD) {
-		a.Spec.NodePlacement = &argoprojv1alpha1.ArgoCDNodePlacementSpec{
+	a := makeTestArgoCD((func(a *argoproj.ArgoCD) {
+		a.Spec.NodePlacement = &argoproj.ArgoCDNodePlacementSpec{
 			NodeSelector: deploymentDefaultNodeSelector(),
 			Tolerations:  deploymentDefaultTolerations(),
 		}
@@ -861,7 +860,7 @@ func TestReconcileArgocd_reconcileRepoServerRedisTLS(t *testing.T) {
 
 	t.Run("with DisableTLSVerification = true", func(t *testing.T) {
 		logf.SetLogger(ZapLogger(true))
-		a := makeTestArgoCD(func(cd *argoprojv1alpha1.ArgoCD) {
+		a := makeTestArgoCD(func(cd *argoproj.ArgoCD) {
 			cd.Spec.Redis.DisableTLSVerification = true
 		})
 		r := makeTestReconciler(t, a)
@@ -1102,7 +1101,7 @@ func TestArgoCDServerCommand_isMergable(t *testing.T) {
 
 func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Server.Insecure = true
 	})
 	r := makeTestReconciler(t, a)
@@ -1190,7 +1189,7 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
-	a = makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a = makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Server.Insecure = true
 	})
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
@@ -1359,7 +1358,7 @@ func TestReconcileArgoCD_reconcileRedisDeployment_with_error(t *testing.T) {
 }
 
 func operationProcessors(n int32) argoCDOpt {
-	return func(a *argoprojv1alpha1.ArgoCD) {
+	return func(a *argoproj.ArgoCD) {
 		a.Spec.Controller.Processors.Operation = n
 	}
 }
@@ -1424,7 +1423,7 @@ func Test_UpdateNodePlacement(t *testing.T) {
 }
 
 func parallelismLimit(n int32) argoCDOpt {
-	return func(a *argoprojv1alpha1.ArgoCD) {
+	return func(a *argoproj.ArgoCD) {
 		a.Spec.Controller.ParallelismLimit = n
 	}
 }
@@ -1487,7 +1486,7 @@ func assertNotFound(t *testing.T, err error) {
 }
 
 func controllerProcessors(n int32) argoCDOpt {
-	return func(a *argoprojv1alpha1.ArgoCD) {
+	return func(a *argoproj.ArgoCD) {
 		a.Spec.Controller.Processors.Status = n
 	}
 }
@@ -1672,7 +1671,7 @@ func TestReconcileArgoCD_reconcile_RepoServerChanges(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Repo.MountSAToken = test.mountSAToken
 				a.Spec.Repo.ServiceAccount = test.serviceAccount
 			})

--- a/controllers/argocd/dexUtil.go
+++ b/controllers/argocd/dexUtil.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -23,7 +23,7 @@ import (
 // that if the spec is not configured.
 // 3. the default is configured in common.ArgoCDDefaultDexVersion and
 // common.ArgoCDDefaultDexImage.
-func getDexContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getDexContainerImage(cr *argoproj.ArgoCD) string {
 	defaultImg, defaultTag := false, false
 
 	img := ""
@@ -53,18 +53,18 @@ func getDexContainerImage(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getDexOAuthRedirectURI will return the OAuth redirect URI for the Dex server.
-func (r *ReconcileArgoCD) getDexOAuthRedirectURI(cr *argoprojv1a1.ArgoCD) string {
+func (r *ReconcileArgoCD) getDexOAuthRedirectURI(cr *argoproj.ArgoCD) string {
 	uri := r.getArgoServerURI(cr)
 	return uri + common.ArgoCDDefaultDexOAuthRedirectPath
 }
 
 // getDexOAuthClientID will return the OAuth client ID for the given ArgoCD.
-func getDexOAuthClientID(cr *argoprojv1a1.ArgoCD) string {
+func getDexOAuthClientID(cr *argoproj.ArgoCD) string {
 	return fmt.Sprintf("system:serviceaccount:%s:%s", cr.Namespace, fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDDefaultDexServiceAccountName))
 }
 
 // getDexResources will return the ResourceRequirements for the Dex container.
-func getDexResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getDexResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 
 	resources := v1.ResourceRequirements{}
 
@@ -76,7 +76,7 @@ func getDexResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
 	return resources
 }
 
-func getDexConfig(cr *argoprojv1a1.ArgoCD) string {
+func getDexConfig(cr *argoproj.ArgoCD) string {
 	config := common.ArgoCDDefaultDexConfig
 
 	// Allow override of config from CR

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -13,8 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
@@ -24,21 +23,21 @@ func TestReconcileArgoCD_reconcileDexDeployment_with_dex_disabled(t *testing.T) 
 	tests := []struct {
 		name       string
 		setEnvFunc func(*testing.T, string)
-		argoCD     *argoprojv1alpha1.ArgoCD
+		argoCD     *argoproj.ArgoCD
 	}{
 		{
 			name:       "dex disabled by not specifying .spec.sso.provider=dex",
 			setEnvFunc: nil,
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			}),
 		},
 		{
 			name:       "dex disabled by specifying different provider",
 			setEnvFunc: nil,
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeKeycloak,
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
 		},
@@ -67,21 +66,21 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 	tests := []struct {
 		name                  string
 		setEnvFunc            func(*testing.T, string)
-		updateCrFunc          func(cr *argoprojv1alpha1.ArgoCD)
+		updateCrFunc          func(cr *argoproj.ArgoCD)
 		updateEnvFunc         func(*testing.T, string)
-		argoCD                *argoprojv1alpha1.ArgoCD
+		argoCD                *argoproj.ArgoCD
 		wantDeploymentDeleted bool
 	}{
 		{
 			name:       "dex disabled by removing .spec.sso",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -91,15 +90,15 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 		{
 			name:       "dex disabled by switching provider",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeKeycloak,
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -148,15 +147,15 @@ func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
 	tests := []struct {
 		name       string
 		setEnvFunc func(*testing.T, string)
-		argoCD     *argoprojv1alpha1.ArgoCD
+		argoCD     *argoproj.ArgoCD
 	}{
 		{
 			name:       "dex with resources - .spec.sso.provider=dex",
 			setEnvFunc: nil,
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
@@ -210,8 +209,8 @@ func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
 func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
-	a.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-		Provider: argoprojv1alpha1.SSOProviderTypeDex,
+	a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+		Provider: argoproj.SSOProviderTypeDex,
 	}
 	r := makeTestReconciler(t, a)
 	assert.NoError(t, r.reconcileDexDeployment(a))
@@ -404,28 +403,28 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 	tests := []struct {
 		name         string
 		setEnvFunc   func(*testing.T, string)
-		updateCrFunc func(cr *argoprojv1alpha1.ArgoCD)
-		argoCD       *argoprojv1alpha1.ArgoCD
+		updateCrFunc func(cr *argoproj.ArgoCD)
+		argoCD       *argoproj.ArgoCD
 		wantPodSpec  corev1.PodSpec
 	}{
 		{
 			name:       "update dex deployment - .spec.sso.provider=dex + .spec.sso.dex",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
 				cr.Spec.Image = "justatest"
 				cr.Spec.Version = "latest"
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						Image:   "testdex",
 						Version: "v0.0.1",
 					},
 				}
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -471,21 +470,21 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 	tests := []struct {
 		name               string
 		setEnvFunc         func(*testing.T, string)
-		updateCrFunc       func(cr *argoprojv1alpha1.ArgoCD)
+		updateCrFunc       func(cr *argoproj.ArgoCD)
 		updateEnvFunc      func(*testing.T, string)
-		argoCD             *argoprojv1alpha1.ArgoCD
+		argoCD             *argoproj.ArgoCD
 		wantServiceDeleted bool
 	}{
 		{
 			name:       "dex disabled by removing .spec.sso",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -495,15 +494,15 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 		{
 			name:       "dex disabled by switching provider",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeKeycloak,
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -553,21 +552,21 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 	tests := []struct {
 		name                      string
 		setEnvFunc                func(*testing.T, string)
-		updateCrFunc              func(cr *argoprojv1alpha1.ArgoCD)
+		updateCrFunc              func(cr *argoproj.ArgoCD)
 		updateEnvFunc             func(*testing.T, string)
-		argoCD                    *argoprojv1alpha1.ArgoCD
+		argoCD                    *argoproj.ArgoCD
 		wantServiceAccountDeleted bool
 	}{
 		{
 			name:       "dex disabled by removing .spec.sso",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -577,15 +576,15 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 		{
 			name:       "dex disabled by switching provider",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeKeycloak,
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -636,21 +635,21 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 	tests := []struct {
 		name            string
 		setEnvFunc      func(*testing.T, string)
-		updateCrFunc    func(cr *argoprojv1alpha1.ArgoCD)
+		updateCrFunc    func(cr *argoproj.ArgoCD)
 		updateEnvFunc   func(*testing.T, string)
-		argoCD          *argoprojv1alpha1.ArgoCD
+		argoCD          *argoproj.ArgoCD
 		wantRoleDeleted bool
 	}{
 		{
 			name:       "dex disabled by removing .spec.sso",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -660,15 +659,15 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 		{
 			name:       "dex disabled by switching provider",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeKeycloak,
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -724,21 +723,21 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 	tests := []struct {
 		name                   string
 		setEnvFunc             func(*testing.T, string)
-		updateCrFunc           func(cr *argoprojv1alpha1.ArgoCD)
+		updateCrFunc           func(cr *argoproj.ArgoCD)
 		updateEnvFunc          func(*testing.T, string)
-		argoCD                 *argoprojv1alpha1.ArgoCD
+		argoCD                 *argoproj.ArgoCD
 		wantRoleBindingDeleted bool
 	}{
 		{
 			name:       "dex disabled by removing .spec.sso",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -748,15 +747,15 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 		{
 			name:       "dex disabled by switching provider",
 			setEnvFunc: nil,
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: v1alpha1.SSOProviderTypeKeycloak,
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			},
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}

--- a/controllers/argocd/grafana.go
+++ b/controllers/argocd/grafana.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sethvargo/go-password/password"
 	appsv1 "k8s.io/api/apps/v1"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
@@ -60,7 +60,7 @@ func generateGrafanaSecretKey() ([]byte, error) {
 }
 
 // getGrafanaHost will return the hostname value for Grafana.
-func getGrafanaHost(cr *argoprojv1a1.ArgoCD) string {
+func getGrafanaHost(cr *argoproj.ArgoCD) string {
 	host := nameWithSuffix("grafana", cr)
 	if len(cr.Spec.Grafana.Host) > 0 {
 		host = cr.Spec.Grafana.Host
@@ -69,7 +69,7 @@ func getGrafanaHost(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getGrafanaReplicas will return the size value for the Grafana replica count.
-func getGrafanaReplicas(cr *argoprojv1a1.ArgoCD) *int32 {
+func getGrafanaReplicas(cr *argoproj.ArgoCD) *int32 {
 	replicas := common.ArgoCDDefaultGrafanaReplicas
 	if cr.Spec.Grafana.Size != nil {
 		if *cr.Spec.Grafana.Size >= 0 && *cr.Spec.Grafana.Size != replicas {
@@ -89,7 +89,7 @@ func getGrafanaConfigPath() string {
 }
 
 // hasGrafanaSpecChanged will return true if the supported properties differs in the actual versus the desired state.
-func hasGrafanaSpecChanged(actual *appsv1.Deployment, desired *argoprojv1a1.ArgoCD) bool {
+func hasGrafanaSpecChanged(actual *appsv1.Deployment, desired *argoproj.ArgoCD) bool {
 	// Replica count
 	if desired.Spec.Grafana.Size != nil { // Replica count specified in desired state
 		if *desired.Spec.Grafana.Size >= 0 && *actual.Spec.Replicas != *desired.Spec.Grafana.Size {

--- a/controllers/argocd/hooks.go
+++ b/controllers/argocd/hooks.go
@@ -3,7 +3,7 @@ package argocd
 import (
 	"sync"
 
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 var (
@@ -12,7 +12,7 @@ var (
 )
 
 // Hook changes resources as they are created or updated by the reconciler.
-type Hook func(*argoprojv1alpha1.ArgoCD, interface{}, string) error
+type Hook func(*argoproj.ArgoCD, interface{}, string) error
 
 // Register adds a modifier for updating resources during reconciliation.
 func Register(h ...Hook) {
@@ -22,7 +22,7 @@ func Register(h ...Hook) {
 }
 
 // nolint:unparam
-func applyReconcilerHook(cr *argoprojv1alpha1.ArgoCD, i interface{}, hint string) error {
+func applyReconcilerHook(cr *argoproj.ArgoCD, i interface{}, hint string) error {
 	mutex.Lock()
 	defer mutex.Unlock()
 	for _, v := range hooks {

--- a/controllers/argocd/hooks_test.go
+++ b/controllers/argocd/hooks_test.go
@@ -8,13 +8,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/rbac/v1"
 
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 var errMsg = errors.New("this is a test error")
 
-func testDeploymentHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, s string) error {
+func testDeploymentHook(cr *argoproj.ArgoCD, v interface{}, s string) error {
 	switch o := v.(type) {
 	case *appsv1.Deployment:
 		var replicas int32 = 3
@@ -23,7 +23,7 @@ func testDeploymentHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, s string) er
 	return nil
 }
 
-func testClusterRoleHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, s string) error {
+func testClusterRoleHook(cr *argoproj.ArgoCD, v interface{}, s string) error {
 	switch o := v.(type) {
 	case *v1.ClusterRole:
 		o.Rules = append(o.Rules, policyRuleForApplicationController()...)
@@ -31,7 +31,7 @@ func testClusterRoleHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, s string) e
 	return nil
 }
 
-func testRoleHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, s string) error {
+func testRoleHook(cr *argoproj.ArgoCD, v interface{}, s string) error {
 	switch o := v.(type) {
 	case *v1.Role:
 		if o.Name == cr.Name+"-"+common.ArgoCDApplicationControllerComponent {
@@ -41,7 +41,7 @@ func testRoleHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, s string) error {
 	return nil
 }
 
-func testErrorHook(cr *argoprojv1alpha1.ArgoCD, v interface{}, s string) error {
+func testErrorHook(cr *argoproj.ArgoCD, v interface{}, s string) error {
 	return errMsg
 }
 

--- a/controllers/argocd/hpa.go
+++ b/controllers/argocd/hpa.go
@@ -21,7 +21,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -32,7 +32,7 @@ var (
 	tcup        int32 = 50
 )
 
-func newHorizontalPodAutoscaler(cr *argoprojv1a1.ArgoCD) *autoscaling.HorizontalPodAutoscaler {
+func newHorizontalPodAutoscaler(cr *argoproj.ArgoCD) *autoscaling.HorizontalPodAutoscaler {
 	return &autoscaling.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -42,7 +42,7 @@ func newHorizontalPodAutoscaler(cr *argoprojv1a1.ArgoCD) *autoscaling.Horizontal
 	}
 }
 
-func newHorizontalPodAutoscalerWithName(name string, cr *argoprojv1a1.ArgoCD) *autoscaling.HorizontalPodAutoscaler {
+func newHorizontalPodAutoscalerWithName(name string, cr *argoproj.ArgoCD) *autoscaling.HorizontalPodAutoscaler {
 	hpa := newHorizontalPodAutoscaler(cr)
 	hpa.ObjectMeta.Name = name
 
@@ -53,12 +53,12 @@ func newHorizontalPodAutoscalerWithName(name string, cr *argoprojv1a1.ArgoCD) *a
 	return hpa
 }
 
-func newHorizontalPodAutoscalerWithSuffix(suffix string, cr *argoprojv1a1.ArgoCD) *autoscaling.HorizontalPodAutoscaler {
+func newHorizontalPodAutoscalerWithSuffix(suffix string, cr *argoproj.ArgoCD) *autoscaling.HorizontalPodAutoscaler {
 	return newHorizontalPodAutoscalerWithName(nameWithSuffix(suffix, cr), cr)
 }
 
 // reconcileServerHPA will ensure that the HorizontalPodAutoscaler is present for the Argo CD Server component, and reconcile any detected changes.
-func (r *ReconcileArgoCD) reconcileServerHPA(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServerHPA(cr *argoproj.ArgoCD) error {
 
 	defaultHPA := newHorizontalPodAutoscalerWithSuffix("server", cr)
 	defaultHPA.Spec = autoscaling.HorizontalPodAutoscalerSpec{
@@ -108,7 +108,7 @@ func (r *ReconcileArgoCD) reconcileServerHPA(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileAutoscalers will ensure that all HorizontalPodAutoscalers are present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileAutoscalers(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileAutoscalers(cr *argoproj.ArgoCD) error {
 	if err := r.reconcileServerHPA(cr); err != nil {
 		return err
 	}

--- a/controllers/argocd/ingress.go
+++ b/controllers/argocd/ingress.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -37,7 +37,7 @@ func getPathOrDefault(path string) string {
 }
 
 // newIngress returns a new Ingress instance for the given ArgoCD.
-func newIngress(cr *argoprojv1a1.ArgoCD) *networkingv1.Ingress {
+func newIngress(cr *argoproj.ArgoCD) *networkingv1.Ingress {
 	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -48,7 +48,7 @@ func newIngress(cr *argoprojv1a1.ArgoCD) *networkingv1.Ingress {
 }
 
 // newIngressWithName returns a new Ingress with the given name and ArgoCD.
-func newIngressWithName(name string, cr *argoprojv1a1.ArgoCD) *networkingv1.Ingress {
+func newIngressWithName(name string, cr *argoproj.ArgoCD) *networkingv1.Ingress {
 	ingress := newIngress(cr)
 	ingress.ObjectMeta.Name = name
 
@@ -60,12 +60,12 @@ func newIngressWithName(name string, cr *argoprojv1a1.ArgoCD) *networkingv1.Ingr
 }
 
 // newIngressWithSuffix returns a new Ingress with the given name suffix for the ArgoCD.
-func newIngressWithSuffix(suffix string, cr *argoprojv1a1.ArgoCD) *networkingv1.Ingress {
+func newIngressWithSuffix(suffix string, cr *argoproj.ArgoCD) *networkingv1.Ingress {
 	return newIngressWithName(fmt.Sprintf("%s-%s", cr.Name, suffix), cr)
 }
 
 // reconcileIngresses will ensure that all ArgoCD Ingress resources are present.
-func (r *ReconcileArgoCD) reconcileIngresses(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileIngresses(cr *argoproj.ArgoCD) error {
 	if err := r.reconcileArgoServerIngress(cr); err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (r *ReconcileArgoCD) reconcileIngresses(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileArgoServerIngress will ensure that the ArgoCD Server Ingress is present.
-func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("server", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
 		if !cr.Spec.Server.Ingress.Enabled {
@@ -166,7 +166,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoprojv1a1.ArgoCD) er
 }
 
 // reconcileArgoServerGRPCIngress will ensure that the ArgoCD Server GRPC Ingress is present.
-func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("grpc", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
 		if !cr.Spec.Server.GRPC.Ingress.Enabled {
@@ -241,7 +241,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoprojv1a1.ArgoCD
 }
 
 // reconcileGrafanaIngress will ensure that the ArgoCD Server GRPC Ingress is present.
-func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("grafana", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
 		if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Ingress.Enabled {
@@ -318,7 +318,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoprojv1a1.ArgoCD) error
 }
 
 // reconcilePrometheusIngress will ensure that the Prometheus Ingress is present.
-func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("prometheus", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
 		if !cr.Spec.Prometheus.Enabled || !cr.Spec.Prometheus.Ingress.Enabled {
@@ -392,7 +392,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoprojv1a1.ArgoCD) er
 }
 
 // reconcileApplicationSetControllerIngress will ensure that the ApplicationSetController Ingress is present.
-func (r *ReconcileArgoCD) reconcileApplicationSetControllerIngress(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileApplicationSetControllerIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix(common.ApplicationSetServiceNameSuffix, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
 		if cr.Spec.ApplicationSet == nil || !cr.Spec.ApplicationSet.WebhookServer.Ingress.Enabled {

--- a/controllers/argocd/ingress_test.go
+++ b/controllers/argocd/ingress_test.go
@@ -9,8 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
@@ -36,7 +35,7 @@ func TestReconcileArgoCD_reconcile_ServerIngress_ingressClassName(t *testing.T) 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Server.Ingress.Enabled = true
 				a.Spec.Server.Ingress.IngressClassName = test.ingressClassName
 			})
@@ -78,7 +77,7 @@ func TestReconcileArgoCD_reconcile_ServerGRPCIngress_ingressClassName(t *testing
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Server.GRPC.Ingress.Enabled = true
 				a.Spec.Server.GRPC.Ingress.IngressClassName = test.ingressClassName
 			})
@@ -120,7 +119,7 @@ func TestReconcileArgoCD_reconcile_GrafanaIngress_ingressClassName(t *testing.T)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Grafana.Enabled = true
 				a.Spec.Grafana.Ingress.Enabled = true
 				a.Spec.Grafana.Ingress.IngressClassName = test.ingressClassName
@@ -163,7 +162,7 @@ func TestReconcileArgoCD_reconcile_PrometheusIngress_ingressClassName(t *testing
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Prometheus.Enabled = true
 				a.Spec.Prometheus.Ingress.Enabled = true
 				a.Spec.Prometheus.Ingress.IngressClassName = test.ingressClassName
@@ -187,9 +186,9 @@ func TestReconcileArgoCD_reconcile_PrometheusIngress_ingressClassName(t *testing
 func TestReconcileApplicationSetService_Ingress(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
-	obj := v1alpha1.ArgoCDApplicationSet{
-		WebhookServer: v1alpha1.WebhookServerSpec{
-			Ingress: v1alpha1.ArgoCDIngressSpec{
+	obj := argoproj.ArgoCDApplicationSet{
+		WebhookServer: argoproj.WebhookServerSpec{
+			Ingress: argoproj.ArgoCDIngressSpec{
 				Enabled: true,
 			},
 		},

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"os"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
@@ -164,7 +164,7 @@ type CustomKeycloakAPIRealm struct {
 // that if the spec is not configured.
 // 3. the default is configured in common.ArgoCDKeycloakVersion and
 // common.ArgoCDKeycloakImageName.
-func getKeycloakContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getKeycloakContainerImage(cr *argoproj.ArgoCD) string {
 	defaultImg, defaultTag := false, false
 
 	img := ""
@@ -248,7 +248,7 @@ func defaultKeycloakResources() corev1.ResourceRequirements {
 }
 
 // getKeycloakResources will return the ResourceRequirements for the Keycloak container.
-func getKeycloakResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getKeycloakResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 
 	// Default values for Keycloak resources requirements.
 	resources := defaultKeycloakResources()
@@ -261,7 +261,7 @@ func getKeycloakResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
 	return resources
 }
 
-func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
+func getKeycloakContainer(cr *argoproj.ArgoCD) corev1.Container {
 	envVars := []corev1.EnvVar{
 		{Name: "SSO_HOSTNAME", Value: "${SSO_HOSTNAME}"},
 		{Name: "DB_MIN_POOL_SIZE", Value: "${DB_MIN_POOL_SIZE}"},
@@ -334,7 +334,7 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 	}
 }
 
-func getKeycloakDeploymentConfigTemplate(cr *argoprojv1a1.ArgoCD) *appsv1.DeploymentConfig {
+func getKeycloakDeploymentConfigTemplate(cr *argoproj.ArgoCD) *appsv1.DeploymentConfig {
 	ns := cr.Namespace
 	var medium corev1.StorageMedium = "Memory"
 	keycloakContainer := getKeycloakContainer(cr)
@@ -478,7 +478,7 @@ func getKeycloakRouteTemplate(ns string) *routev1.Route {
 	}
 }
 
-func newKeycloakTemplateInstance(cr *argoprojv1a1.ArgoCD) (*template.TemplateInstance, error) {
+func newKeycloakTemplateInstance(cr *argoproj.ArgoCD) (*template.TemplateInstance, error) {
 	tpl, err := newKeycloakTemplate(cr)
 	if err != nil {
 		return nil, err
@@ -494,7 +494,7 @@ func newKeycloakTemplateInstance(cr *argoprojv1a1.ArgoCD) (*template.TemplateIns
 	}, nil
 }
 
-func newKeycloakTemplate(cr *argoprojv1a1.ArgoCD) (template.Template, error) {
+func newKeycloakTemplate(cr *argoproj.ArgoCD) (template.Template, error) {
 	ns := cr.Namespace
 	tmpl := template.Template{}
 	configMapTemplate := getKeycloakConfigMapTemplate(ns)
@@ -575,7 +575,7 @@ func newKeycloakTemplate(cr *argoprojv1a1.ArgoCD) (template.Template, error) {
 	return tmpl, err
 }
 
-func newKeycloakIngress(cr *argoprojv1a1.ArgoCD) *networkingv1.Ingress {
+func newKeycloakIngress(cr *argoproj.ArgoCD) *networkingv1.Ingress {
 
 	pathType := networkingv1.PathTypeImplementationSpecific
 
@@ -623,7 +623,7 @@ func newKeycloakIngress(cr *argoprojv1a1.ArgoCD) *networkingv1.Ingress {
 	}
 }
 
-func newKeycloakService(cr *argoprojv1a1.ArgoCD) *corev1.Service {
+func newKeycloakService(cr *argoproj.ArgoCD) *corev1.Service {
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -653,7 +653,7 @@ func getKeycloakContainerEnv() []corev1.EnvVar {
 	}
 }
 
-func newKeycloakDeployment(cr *argoprojv1a1.ArgoCD) *k8sappsv1.Deployment {
+func newKeycloakDeployment(cr *argoproj.ArgoCD) *k8sappsv1.Deployment {
 
 	var replicas int32 = 1
 	return &k8sappsv1.Deployment{
@@ -706,7 +706,7 @@ func newKeycloakDeployment(cr *argoprojv1a1.ArgoCD) *k8sappsv1.Deployment {
 	}
 }
 
-func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoproj.ArgoCD) error {
 
 	// Create Keycloak Ingress
 	ing := newKeycloakIngress(cr)
@@ -769,7 +769,7 @@ func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // prepares a keycloak config which is used in creating keycloak realm configuration.
-func (r *ReconcileArgoCD) prepareKeycloakConfig(cr *argoprojv1a1.ArgoCD) (*keycloakConfig, error) {
+func (r *ReconcileArgoCD) prepareKeycloakConfig(cr *argoproj.ArgoCD) (*keycloakConfig, error) {
 
 	var tlsVerification bool
 	// Get keycloak hostname from route.
@@ -847,7 +847,7 @@ func (r *ReconcileArgoCD) prepareKeycloakConfig(cr *argoprojv1a1.ArgoCD) (*keycl
 }
 
 // prepares a keycloak config which is used in creating keycloak realm configuration for kubernetes.
-func (r *ReconcileArgoCD) prepareKeycloakConfigForK8s(cr *argoprojv1a1.ArgoCD) (*keycloakConfig, error) {
+func (r *ReconcileArgoCD) prepareKeycloakConfigForK8s(cr *argoproj.ArgoCD) (*keycloakConfig, error) {
 
 	// Get keycloak hostname from ingress.
 	// keycloak hostname is required to post realm configuration to keycloak when keycloak cannot be accessed using service name
@@ -1017,7 +1017,7 @@ func createRealmConfig(cfg *keycloakConfig) ([]byte, error) {
 }
 
 // Gets Keycloak Server cert. This cert is used to authenticate the api calls to the Keycloak service.
-func (r *ReconcileArgoCD) getKCServerCert(cr *argoprojv1a1.ArgoCD) ([]byte, error) {
+func (r *ReconcileArgoCD) getKCServerCert(cr *argoproj.ArgoCD) ([]byte, error) {
 
 	sslCertsSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1043,7 +1043,7 @@ func getOAuthClient(ns string) string {
 }
 
 // Updates OIDC configuration for ArgoCD.
-func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoprojv1a1.ArgoCD, kRouteURL string) error {
+func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoproj.ArgoCD, kRouteURL string) error {
 
 	// Update the ArgoCD client secret for OIDC in argocd-secret.
 	argoCDSecret := &corev1.Secret{
@@ -1189,7 +1189,7 @@ func handleKeycloakPodDeletion(dc *oappsv1.DeploymentConfig) error {
 	return nil
 }
 
-func (r *ReconcileArgoCD) reconcileKeycloakConfiguration(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileKeycloakConfiguration(cr *argoproj.ArgoCD) error {
 
 	// TemplateAPI is available, Install keycloak using openshift templates.
 	if IsTemplateAPIAvailable() {
@@ -1207,7 +1207,7 @@ func (r *ReconcileArgoCD) reconcileKeycloakConfiguration(cr *argoprojv1a1.ArgoCD
 	return nil
 }
 
-func deleteKeycloakConfiguration(cr *argoprojv1a1.ArgoCD) error {
+func deleteKeycloakConfiguration(cr *argoproj.ArgoCD) error {
 
 	// If SSO is installed using OpenShift templates.
 	if IsTemplateAPIAvailable() {
@@ -1226,7 +1226,7 @@ func deleteKeycloakConfiguration(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // Delete Keycloak configuration for OpenShift
-func deleteKeycloakConfigForOpenShift(cr *argoprojv1a1.ArgoCD) error {
+func deleteKeycloakConfigForOpenShift(cr *argoproj.ArgoCD) error {
 	cfg, err := config.GetConfig()
 	if err != nil {
 		log.Error(err, fmt.Sprintf("unable to get k8s config for ArgoCD %s in namespace %s",
@@ -1264,7 +1264,7 @@ func deleteKeycloakConfigForOpenShift(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // Delete OpenShift OAuthClient
-func deleteOAuthClient(cr *argoprojv1a1.ArgoCD) error {
+func deleteOAuthClient(cr *argoproj.ArgoCD) error {
 
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -1307,7 +1307,7 @@ func deleteOAuthClient(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // Delete Keycloak configuration for Kubernetes
-func deleteKeycloakConfigForK8s(cr *argoprojv1a1.ArgoCD) error {
+func deleteKeycloakConfigForK8s(cr *argoproj.ArgoCD) error {
 
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -1354,7 +1354,7 @@ func deleteKeycloakConfigForK8s(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // Installs and configures Keycloak for OpenShift
-func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoproj.ArgoCD) error {
 
 	templateInstanceRef, err := newKeycloakTemplateInstance(cr)
 	if err != nil {
@@ -1473,7 +1473,7 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoprojv1a1.ArgoCD)
 }
 
 // Installs and configures Keycloak for Kubernetes
-func (r *ReconcileArgoCD) reconcileKeycloak(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileKeycloak(cr *argoproj.ArgoCD) error {
 
 	err := r.newKeycloakInstance(cr)
 	if err != nil {

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -26,9 +26,7 @@ import (
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoappv1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -86,8 +84,8 @@ func TestKeycloakContainerImage(t *testing.T) {
 		name               string
 		setEnvVarFunc      func(*testing.T, string)
 		envVar             string
-		argoCD             *argoprojv1alpha1.ArgoCD
-		updateCrFunc       func(cr *argoprojv1alpha1.ArgoCD)
+		argoCD             *argoproj.ArgoCD
+		updateCrFunc       func(cr *argoproj.ArgoCD)
 		templateAPIFound   bool
 		wantContainerImage string
 	}{
@@ -95,9 +93,9 @@ func TestKeycloakContainerImage(t *testing.T) {
 			name:          "no .spec.sso, no ArgoCDKeycloakImageEnvName env var set",
 			setEnvVarFunc: nil,
 			envVar:        "",
-			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
+			argoCD: makeArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
 			updateCrFunc:       nil,
@@ -108,9 +106,9 @@ func TestKeycloakContainerImage(t *testing.T) {
 			name:          "no .spec.sso, no ArgoCDKeycloakImageEnvName env var set - for OCP",
 			setEnvVarFunc: nil,
 			envVar:        "",
-			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
+			argoCD: makeArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
 			updateCrFunc:       nil,
@@ -123,9 +121,9 @@ func TestKeycloakContainerImage(t *testing.T) {
 				t.Setenv(common.ArgoCDKeycloakImageEnvName, s)
 			},
 			envVar: "envImage:latest",
-			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
+			argoCD: makeArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
 			updateCrFunc:       nil,
@@ -138,15 +136,15 @@ func TestKeycloakContainerImage(t *testing.T) {
 				t.Setenv(common.ArgoCDKeycloakImageEnvName, s)
 			},
 			envVar: "envImage:latest",
-			argoCD: makeArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
+			argoCD: makeArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
-					Keycloak: &v1alpha1.ArgoCDKeycloakSpec{
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
+					Keycloak: &argoproj.ArgoCDKeycloakSpec{
 						Image:   "crImage",
 						Version: "crVersion",
 					},
@@ -181,7 +179,7 @@ func TestNewKeycloakTemplateInstance(t *testing.T) {
 	defer removeTemplateAPI()
 
 	a := makeTestArgoCD()
-	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
+	a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 		Provider: "keycloak",
 	}
 	tmplInstance, err := newKeycloakTemplateInstance(a)
@@ -197,7 +195,7 @@ func TestNewKeycloakTemplate(t *testing.T) {
 	defer removeTemplateAPI()
 
 	a := makeTestArgoCD()
-	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
+	a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 		Provider: "keycloak",
 	}
 	tmpl, err := newKeycloakTemplate(a)
@@ -213,7 +211,7 @@ func TestNewKeycloakTemplate_testDeploymentConfig(t *testing.T) {
 	defer removeTemplateAPI()
 
 	a := makeTestArgoCD()
-	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
+	a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 		Provider: "keycloak",
 	}
 	dc := getKeycloakDeploymentConfigTemplate(a)
@@ -246,7 +244,7 @@ func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
 	defer removeTemplateAPI()
 
 	a := makeTestArgoCD()
-	a.Spec.SSO = &argoappv1.ArgoCDSSOSpec{
+	a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 		Provider: "keycloak",
 	}
 	kc := getKeycloakContainer(a)
@@ -262,15 +260,15 @@ func TestKeycloakResources(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		argoCD        *argoprojv1alpha1.ArgoCD
-		updateCrFunc  func(cr *argoprojv1alpha1.ArgoCD)
+		argoCD        *argoproj.ArgoCD
+		updateCrFunc  func(cr *argoproj.ArgoCD)
 		wantResources corev1.ResourceRequirements
 	}{
 		{
 			name: "default",
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
 			updateCrFunc:  nil,
@@ -278,14 +276,14 @@ func TestKeycloakResources(t *testing.T) {
 		},
 		{
 			name: "override with .spec.sso.keycloak",
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
-			updateCrFunc: func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Keycloak: &v1alpha1.ArgoCDKeycloakSpec{
+			updateCrFunc: func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Keycloak: &argoproj.ArgoCDKeycloakSpec{
 						Resources: &fR,
 					},
 				}
@@ -374,24 +372,24 @@ func TestKeycloak_testServerCert(t *testing.T) {
 func TestKeycloakConfigVerifyTLSForOpenShift(t *testing.T) {
 	tests := []struct {
 		name             string
-		argoCD           *v1alpha1.ArgoCD
+		argoCD           *argoproj.ArgoCD
 		desiredVerifyTLS bool
 	}{
 		{
 			name: ".spec.sso.keycloak.verifyTLS nil",
-			argoCD: makeTestArgoCD(func(ac *argoprojv1alpha1.ArgoCD) {
-				ac.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
+			argoCD: makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+				ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
 				}
 			}),
 			desiredVerifyTLS: true,
 		},
 		{
 			name: ".spec.sso.keycloak.verifyTLS false",
-			argoCD: makeTestArgoCD(func(ac *argoprojv1alpha1.ArgoCD) {
-				ac.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
-					Keycloak: &v1alpha1.ArgoCDKeycloakSpec{
+			argoCD: makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+				ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
+					Keycloak: &argoproj.ArgoCDKeycloakSpec{
 						VerifyTLS: boolPtr(false),
 					},
 				}
@@ -400,10 +398,10 @@ func TestKeycloakConfigVerifyTLSForOpenShift(t *testing.T) {
 		},
 		{
 			name: ".spec.sso.keycloak.verifyTLS true",
-			argoCD: makeTestArgoCD(func(ac *argoprojv1alpha1.ArgoCD) {
-				ac.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoappv1.SSOProviderTypeKeycloak,
-					Keycloak: &v1alpha1.ArgoCDKeycloakSpec{
+			argoCD: makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+				ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
+					Keycloak: &argoproj.ArgoCDKeycloakSpec{
 						VerifyTLS: boolPtr(true),
 					},
 				}
@@ -469,7 +467,7 @@ func TestKeycloakConfigVerifyTLSForOpenShift(t *testing.T) {
 
 func TestKeycloak_NodeLabelSelector(t *testing.T) {
 	a := makeTestArgoCDForKeycloak()
-	a.Spec.NodePlacement = &argoappv1.ArgoCDNodePlacementSpec{
+	a.Spec.NodePlacement = &argoproj.ArgoCDNodePlacementSpec{
 		NodeSelector: deploymentDefaultNodeSelector(),
 		Tolerations:  deploymentDefaultTolerations(),
 	}

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -14,12 +14,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
-func (r *ReconcileArgoCD) reconcileNotificationsController(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileNotificationsController(cr *argoproj.ArgoCD) error {
 
 	log.Info("reconciling notifications serviceaccount")
 	sa, err := r.reconcileNotificationsServiceAccount(cr)
@@ -61,7 +61,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsController(cr *argoprojv1a1.Argo
 // RoleBinding and deployment are dependent on these resouces. During deletion the order is reversed.
 // Deployment and RoleBinding must be deleted before the role and sa. deleteNotificationsResources will only be called during
 // delete events, so we don't need to worry about duplicate, recurring reconciliation calls
-func (r *ReconcileArgoCD) deleteNotificationsResources(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) deleteNotificationsResources(cr *argoproj.ArgoCD) error {
 
 	sa := &corev1.ServiceAccount{}
 	role := &rbacv1.Role{}
@@ -112,7 +112,7 @@ func (r *ReconcileArgoCD) deleteNotificationsResources(cr *argoprojv1a1.ArgoCD) 
 	return nil
 }
 
-func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoprojv1a1.ArgoCD) (*corev1.ServiceAccount, error) {
+func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoproj.ArgoCD) (*corev1.ServiceAccount, error) {
 
 	sa := newServiceAccountWithName(common.ArgoCDNotificationsControllerComponent, cr)
 
@@ -147,7 +147,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoprojv1a1.
 	return sa, nil
 }
 
-func (r *ReconcileArgoCD) reconcileNotificationsRole(cr *argoprojv1a1.ArgoCD) (*rbacv1.Role, error) {
+func (r *ReconcileArgoCD) reconcileNotificationsRole(cr *argoproj.ArgoCD) (*rbacv1.Role, error) {
 
 	policyRules := policyRuleForNotificationsController()
 	desiredRole := newRole(common.ArgoCDNotificationsControllerComponent, policyRules, cr)
@@ -194,7 +194,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsRole(cr *argoprojv1a1.ArgoCD) (*
 	return desiredRole, nil
 }
 
-func (r *ReconcileArgoCD) reconcileNotificationsRoleBinding(cr *argoprojv1a1.ArgoCD, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
+func (r *ReconcileArgoCD) reconcileNotificationsRoleBinding(cr *argoproj.ArgoCD, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
 
 	desiredRoleBinding := newRoleBindingWithname(common.ArgoCDNotificationsControllerComponent, cr)
 	desiredRoleBinding.RoleRef = rbacv1.RoleRef{
@@ -255,7 +255,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsRoleBinding(cr *argoprojv1a1.Arg
 	return nil
 }
 
-func (r *ReconcileArgoCD) reconcileNotificationsDeployment(cr *argoprojv1a1.ArgoCD, sa *corev1.ServiceAccount) error {
+func (r *ReconcileArgoCD) reconcileNotificationsDeployment(cr *argoproj.ArgoCD, sa *corev1.ServiceAccount) error {
 
 	desiredDeployment := newDeploymentWithSuffix("notifications-controller", "controller", cr)
 
@@ -434,7 +434,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsDeployment(cr *argoprojv1a1.Argo
 
 // reconcileNotificationsConfigMap only creates/deletes the argocd-notifications-cm based on whether notifications is enabled/disabled in the CR
 // It does not reconcile/overwrite any fields or information in the configmap itself
-func (r *ReconcileArgoCD) reconcileNotificationsConfigMap(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileNotificationsConfigMap(cr *argoproj.ArgoCD) error {
 
 	desiredConfigMap := newConfigMapWithName("argocd-notifications-cm", cr)
 	desiredConfigMap.Data = getDefaultNotificationsConfig()
@@ -480,7 +480,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsConfigMap(cr *argoprojv1a1.ArgoC
 
 // reconcileNotificationsSecret only creates/deletes the argocd-notifications-secret based on whether notifications is enabled/disabled in the CR
 // It does not reconcile/overwrite any fields or information in the secret itself
-func (r *ReconcileArgoCD) reconcileNotificationsSecret(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileNotificationsSecret(cr *argoproj.ArgoCD) error {
 
 	desiredSecret := argoutil.NewSecretWithName(cr, "argocd-notifications-secret")
 
@@ -523,7 +523,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsSecret(cr *argoprojv1a1.ArgoCD) 
 	return nil
 }
 
-func getNotificationsCommand(cr *argoprojv1a1.ArgoCD) []string {
+func getNotificationsCommand(cr *argoproj.ArgoCD) []string {
 
 	cmd := make([]string, 0)
 	cmd = append(cmd, "argocd-notifications")
@@ -535,7 +535,7 @@ func getNotificationsCommand(cr *argoprojv1a1.ArgoCD) []string {
 }
 
 // getNotificationsResources will return the ResourceRequirements for the Notifications container.
-func getNotificationsResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getNotificationsResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
 
 	// Allow override of resource requirements from CR

--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -15,14 +15,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 func TestReconcileNotifications_CreateRoles(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Notifications.Enabled = true
 	})
 
@@ -54,7 +54,7 @@ func TestReconcileNotifications_CreateRoles(t *testing.T) {
 
 func TestReconcileNotifications_CreateServiceAccount(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Notifications.Enabled = true
 	})
 
@@ -85,7 +85,7 @@ func TestReconcileNotifications_CreateServiceAccount(t *testing.T) {
 
 func TestReconcileNotifications_CreateRoleBinding(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Notifications.Enabled = true
 	})
 	r := makeTestReconciler(t, a)
@@ -121,7 +121,7 @@ func TestReconcileNotifications_CreateRoleBinding(t *testing.T) {
 
 func TestReconcileNotifications_CreateDeployments(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Notifications.Enabled = true
 	})
 
@@ -232,7 +232,7 @@ func TestReconcileNotifications_CreateDeployments(t *testing.T) {
 
 func TestReconcileNotifications_CreateSecret(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Notifications.Enabled = true
 	})
 
@@ -257,7 +257,7 @@ func TestReconcileNotifications_CreateSecret(t *testing.T) {
 
 func TestReconcileNotifications_CreateConfigMap(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Notifications.Enabled = true
 	})
 
@@ -290,7 +290,7 @@ func TestReconcileNotifications_testEnvVars(t *testing.T) {
 			Value: "bar",
 		},
 	}
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Notifications.Enabled = true
 		a.Spec.Notifications.Env = envMap
 	})
@@ -348,7 +348,7 @@ func TestReconcileNotifications_testEnvVars(t *testing.T) {
 func TestReconcileNotifications_testLogLevel(t *testing.T) {
 
 	testLogLevel := "debug"
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Notifications.Enabled = true
 		a.Spec.Notifications.LogLevel = testLogLevel
 	})

--- a/controllers/argocd/notifications_util.go
+++ b/controllers/argocd/notifications_util.go
@@ -1,6 +1,6 @@
 package argocd
 
-import argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+import argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 
 // getDefaultNotificationsConfig returns a map that contains default triggers and template configurations for argocd-notifications-cm
 func getDefaultNotificationsConfig() map[string]string {
@@ -546,7 +546,7 @@ teams:
 // getArgoCDNotificationsControllerReplicas will return the size value for the argocd-notifications-controller replica count if it
 // has been set in argocd CR. Otherwise, nil is returned if the replicas is not set in the argocd CR or
 // replicas value is < 0.
-func getArgoCDNotificationsControllerReplicas(cr *argoprojv1a1.ArgoCD) *int32 {
+func getArgoCDNotificationsControllerReplicas(cr *argoproj.ArgoCD) *int32 {
 	if cr.Spec.Notifications.Replicas != nil && *cr.Spec.Notifications.Replicas >= 0 {
 		return cr.Spec.Notifications.Replicas
 	}

--- a/controllers/argocd/prometheus.go
+++ b/controllers/argocd/prometheus.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -31,7 +31,7 @@ import (
 var prometheusAPIFound = false
 
 // getPrometheusHost will return the hostname value for Prometheus.
-func getPrometheusHost(cr *argoprojv1a1.ArgoCD) string {
+func getPrometheusHost(cr *argoproj.ArgoCD) string {
 	host := nameWithSuffix("prometheus", cr)
 	if len(cr.Spec.Prometheus.Host) > 0 {
 		host = cr.Spec.Prometheus.Host
@@ -40,7 +40,7 @@ func getPrometheusHost(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getPrometheusSize will return the size value for the Prometheus replica count.
-func getPrometheusReplicas(cr *argoprojv1a1.ArgoCD) *int32 {
+func getPrometheusReplicas(cr *argoproj.ArgoCD) *int32 {
 	replicas := common.ArgoCDDefaultPrometheusReplicas
 	if cr.Spec.Prometheus.Size != nil {
 		if *cr.Spec.Prometheus.Size >= 0 && *cr.Spec.Prometheus.Size != replicas {
@@ -56,7 +56,7 @@ func IsPrometheusAPIAvailable() bool {
 }
 
 // hasPrometheusSpecChanged will return true if the supported properties differs in the actual versus the desired state.
-func hasPrometheusSpecChanged(actual *monitoringv1.Prometheus, desired *argoprojv1a1.ArgoCD) bool {
+func hasPrometheusSpecChanged(actual *monitoringv1.Prometheus, desired *argoproj.ArgoCD) bool {
 	// Replica count
 	if desired.Spec.Prometheus.Size != nil && *desired.Spec.Prometheus.Size >= 0 { // Valid replica count specified in desired state
 		if actual.Spec.Replicas != nil { // Actual replicas value is set
@@ -85,7 +85,7 @@ func verifyPrometheusAPI() error {
 }
 
 // newPrometheus returns a new Prometheus instance for the given ArgoCD.
-func newPrometheus(cr *argoprojv1a1.ArgoCD) *monitoringv1.Prometheus {
+func newPrometheus(cr *argoproj.ArgoCD) *monitoringv1.Prometheus {
 	return &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -96,7 +96,7 @@ func newPrometheus(cr *argoprojv1a1.ArgoCD) *monitoringv1.Prometheus {
 }
 
 // newServiceMonitor returns a new ServiceMonitor instance.
-func newServiceMonitor(cr *argoprojv1a1.ArgoCD) *monitoringv1.ServiceMonitor {
+func newServiceMonitor(cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -107,7 +107,7 @@ func newServiceMonitor(cr *argoprojv1a1.ArgoCD) *monitoringv1.ServiceMonitor {
 }
 
 // newServiceMonitorWithName returns a new ServiceMonitor instance for the given ArgoCD using the given name.
-func newServiceMonitorWithName(name string, cr *argoprojv1a1.ArgoCD) *monitoringv1.ServiceMonitor {
+func newServiceMonitorWithName(name string, cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
 	svcmon := newServiceMonitor(cr)
 	svcmon.ObjectMeta.Name = name
 
@@ -120,12 +120,12 @@ func newServiceMonitorWithName(name string, cr *argoprojv1a1.ArgoCD) *monitoring
 }
 
 // newServiceMonitorWithSuffix returns a new ServiceMonitor instance for the given ArgoCD using the given suffix.
-func newServiceMonitorWithSuffix(suffix string, cr *argoprojv1a1.ArgoCD) *monitoringv1.ServiceMonitor {
+func newServiceMonitorWithSuffix(suffix string, cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
 	return newServiceMonitorWithName(fmt.Sprintf("%s-%s", cr.Name, suffix), cr)
 }
 
 // reconcileMetricsServiceMonitor will ensure that the ServiceMonitor is present for the ArgoCD metrics Service.
-func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoproj.ArgoCD) error {
 	sm := newServiceMonitorWithSuffix(common.ArgoCDKeyMetrics, cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm) {
 		if !cr.Spec.Prometheus.Enabled {
@@ -157,7 +157,7 @@ func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoprojv1a1.ArgoCD
 }
 
 // reconcilePrometheus will ensure that Prometheus is present for ArgoCD metrics.
-func (r *ReconcileArgoCD) reconcilePrometheus(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcilePrometheus(cr *argoproj.ArgoCD) error {
 	prometheus := newPrometheus(cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, prometheus.Name, prometheus) {
 		if !cr.Spec.Prometheus.Enabled {
@@ -186,7 +186,7 @@ func (r *ReconcileArgoCD) reconcilePrometheus(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileRepoServerServiceMonitor will ensure that the ServiceMonitor is present for the Repo Server metrics Service.
-func (r *ReconcileArgoCD) reconcileRepoServerServiceMonitor(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRepoServerServiceMonitor(cr *argoproj.ArgoCD) error {
 	sm := newServiceMonitorWithSuffix("repo-server-metrics", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm) {
 		if !cr.Spec.Prometheus.Enabled {
@@ -218,7 +218,7 @@ func (r *ReconcileArgoCD) reconcileRepoServerServiceMonitor(cr *argoprojv1a1.Arg
 }
 
 // reconcileServerMetricsServiceMonitor will ensure that the ServiceMonitor is present for the ArgoCD Server metrics Service.
-func (r *ReconcileArgoCD) reconcileServerMetricsServiceMonitor(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServerMetricsServiceMonitor(cr *argoproj.ArgoCD) error {
 	sm := newServiceMonitorWithSuffix("server-metrics", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm) {
 		if !cr.Spec.Prometheus.Enabled {
@@ -250,7 +250,7 @@ func (r *ReconcileArgoCD) reconcileServerMetricsServiceMonitor(cr *argoprojv1a1.
 }
 
 // reconcilePrometheusRule reconciles the PrometheusRule that triggers alerts based on workload statuses
-func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 
 	promRule := newPrometheusRule(cr.Namespace, "argocd-component-status-alert")
 

--- a/controllers/argocd/prometheus_test.go
+++ b/controllers/argocd/prometheus_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
@@ -15,13 +15,13 @@ import (
 func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 	tests := []struct {
 		name              string
-		argocd            *argoprojv1alpha1.ArgoCD
+		argocd            *argoproj.ArgoCD
 		wantPromRuleFound bool
 		existingPromRule  bool
 	}{
 		{
 			name: "monitoring enabled, no existing prom rule",
-			argocd: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
+			argocd: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
 				cr.Spec.Monitoring.Enabled = true
 			}),
 			existingPromRule:  false,
@@ -29,7 +29,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 		},
 		{
 			name: "monitoring disabled, no existing prom rule",
-			argocd: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
+			argocd: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
 				cr.Spec.Monitoring.Enabled = false
 			}),
 			existingPromRule:  false,
@@ -37,7 +37,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 		},
 		{
 			name: "monitoring enabled, existing prom rule",
-			argocd: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
+			argocd: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
 				cr.Spec.Monitoring.Enabled = true
 			}),
 			existingPromRule:  true,
@@ -45,7 +45,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 		},
 		{
 			name: "monitoring disabled, existing prom rule",
-			argocd: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
+			argocd: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
 				cr.Spec.Monitoring.Enabled = false
 			}),
 			existingPromRule:  true,

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -14,13 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // newRole returns a new Role instance.
-func newRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.Role {
+func newRole(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) *v1.Role {
 	return &v1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateResourceName(name, cr),
@@ -31,7 +31,7 @@ func newRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.Ro
 	}
 }
 
-func newRoleForApplicationSourceNamespaces(namespace string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.Role {
+func newRoleForApplicationSourceNamespaces(namespace string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) *v1.Role {
 	return &v1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getRoleNameForApplicationSourceNamespaces(namespace, cr),
@@ -42,16 +42,16 @@ func newRoleForApplicationSourceNamespaces(namespace string, rules []v1.PolicyRu
 	}
 }
 
-func generateResourceName(argoComponentName string, cr *argoprojv1a1.ArgoCD) string {
+func generateResourceName(argoComponentName string, cr *argoproj.ArgoCD) string {
 	return cr.Name + "-" + argoComponentName
 }
 
 // GenerateUniqueResourceName generates unique names for cluster scoped resources
-func GenerateUniqueResourceName(argoComponentName string, cr *argoprojv1a1.ArgoCD) string {
+func GenerateUniqueResourceName(argoComponentName string, cr *argoproj.ArgoCD) string {
 	return cr.Name + "-" + cr.Namespace + "-" + argoComponentName
 }
 
-func newClusterRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.ClusterRole {
+func newClusterRole(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) *v1.ClusterRole {
 	return &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        GenerateUniqueResourceName(name, cr),
@@ -63,7 +63,7 @@ func newClusterRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD)
 }
 
 // reconcileRoles will ensure that all ArgoCD Service Accounts are configured.
-func (r *ReconcileArgoCD) reconcileRoles(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRoles(cr *argoproj.ArgoCD) error {
 	params := getPolicyRuleList(r.Client)
 
 	for _, param := range params {
@@ -98,7 +98,7 @@ func (r *ReconcileArgoCD) reconcileRoles(cr *argoprojv1a1.ArgoCD) error {
 
 // reconcileRole, reconciles the policy rules for different ArgoCD components, for each namespace
 // Managed by a single instance of ArgoCD.
-func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) ([]*v1.Role, error) {
+func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule, cr *argoproj.ArgoCD) ([]*v1.Role, error) {
 	var roles []*v1.Role
 
 	// create policy rules for each namespace
@@ -113,7 +113,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 			continue
 		}
 
-		list := &argoprojv1a1.ArgoCDList{}
+		list := &argoproj.ArgoCDList{}
 		listOption := &client.ListOptions{Namespace: namespace.Name}
 		err := r.Client.List(context.TODO(), list, listOption)
 		if err != nil {
@@ -186,7 +186,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 	return roles, nil
 }
 
-func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name string, policyRules []v1.PolicyRule, cr *argoproj.ArgoCD) error {
 	var roles []*v1.Role
 
 	// create policy rules for each source namespace for ArgoCD Server
@@ -272,7 +272,7 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 	return nil
 }
 
-func (r *ReconcileArgoCD) reconcileClusterRole(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) (*v1.ClusterRole, error) {
+func (r *ReconcileArgoCD) reconcileClusterRole(name string, policyRules []v1.PolicyRule, cr *argoproj.ArgoCD) (*v1.ClusterRole, error) {
 	allowed := false
 	if allowedNamespace(cr.Namespace, os.Getenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES")) {
 		allowed = true

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
@@ -140,7 +140,7 @@ func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.
 	logf.SetLogger(ZapLogger(true))
 	sourceNamespace := "newNamespaceTest"
 	a := makeTestArgoCD()
-	a.Spec = v1alpha1.ArgoCDSpec{
+	a.Spec = argoproj.ArgoCDSpec{
 		SourceNamespaces: []string{
 			sourceNamespace,
 		},

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -14,13 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // newClusterRoleBinding returns a new ClusterRoleBinding instance.
-func newClusterRoleBinding(cr *argoprojv1a1.ArgoCD) *v1.ClusterRoleBinding {
+func newClusterRoleBinding(cr *argoproj.ArgoCD) *v1.ClusterRoleBinding {
 	return &v1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Name,
@@ -31,7 +31,7 @@ func newClusterRoleBinding(cr *argoprojv1a1.ArgoCD) *v1.ClusterRoleBinding {
 }
 
 // newClusterRoleBindingWithname creates a new ClusterRoleBinding with the given name for the given ArgCD.
-func newClusterRoleBindingWithname(name string, cr *argoprojv1a1.ArgoCD) *v1.ClusterRoleBinding {
+func newClusterRoleBindingWithname(name string, cr *argoproj.ArgoCD) *v1.ClusterRoleBinding {
 	roleBinding := newClusterRoleBinding(cr)
 	roleBinding.Name = GenerateUniqueResourceName(name, cr)
 
@@ -43,7 +43,7 @@ func newClusterRoleBindingWithname(name string, cr *argoprojv1a1.ArgoCD) *v1.Clu
 }
 
 // newRoleBinding returns a new RoleBinding instance.
-func newRoleBinding(cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
+func newRoleBinding(cr *argoproj.ArgoCD) *v1.RoleBinding {
 	return &v1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Name,
@@ -55,7 +55,7 @@ func newRoleBinding(cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
 }
 
 // newRoleBindingForSupportNamespaces returns a new RoleBinding instance.
-func newRoleBindingForSupportNamespaces(cr *argoprojv1a1.ArgoCD, namespace string) *v1.RoleBinding {
+func newRoleBindingForSupportNamespaces(cr *argoproj.ArgoCD, namespace string) *v1.RoleBinding {
 	return &v1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        getRoleBindingNameForSourceNamespaces(cr.Name, cr.Namespace, namespace),
@@ -71,7 +71,7 @@ func getRoleBindingNameForSourceNamespaces(argocdName, argocdNamespace, targetNa
 }
 
 // newRoleBindingWithname creates a new RoleBinding with the given name for the given ArgCD.
-func newRoleBindingWithname(name string, cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
+func newRoleBindingWithname(name string, cr *argoproj.ArgoCD) *v1.RoleBinding {
 	roleBinding := newRoleBinding(cr)
 	roleBinding.ObjectMeta.Name = fmt.Sprintf("%s-%s", cr.Name, name)
 
@@ -83,7 +83,7 @@ func newRoleBindingWithname(name string, cr *argoprojv1a1.ArgoCD) *v1.RoleBindin
 }
 
 // reconcileRoleBindings will ensure that all ArgoCD RoleBindings are configured.
-func (r *ReconcileArgoCD) reconcileRoleBindings(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRoleBindings(cr *argoproj.ArgoCD) error {
 	params := getPolicyRuleList(r.Client)
 
 	for _, param := range params {
@@ -97,7 +97,7 @@ func (r *ReconcileArgoCD) reconcileRoleBindings(cr *argoprojv1a1.ArgoCD) error {
 
 // reconcileRoleBinding, creates RoleBindings for every role and associates it with the right ServiceAccount.
 // This would create RoleBindings for all the namespaces managed by the ArgoCD instance.
-func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) error {
 	var sa *corev1.ServiceAccount
 	var error error
 
@@ -120,7 +120,7 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 			continue
 		}
 
-		list := &argoprojv1a1.ArgoCDList{}
+		list := &argoproj.ArgoCDList{}
 		listOption := &client.ListOptions{Namespace: namespace.Name}
 		err := r.Client.List(context.TODO(), list, listOption)
 		if err != nil {
@@ -234,7 +234,7 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 				continue
 			}
 
-			list := &argoprojv1a1.ArgoCDList{}
+			list := &argoproj.ArgoCDList{}
 			listOption := &client.ListOptions{Namespace: namespace.Name}
 			err := r.Client.List(context.TODO(), list, listOption)
 			if err != nil {
@@ -319,12 +319,12 @@ func getCustomRoleName(name string) string {
 }
 
 // Returns the name of the role for the source namespaces for ArgoCDServer in the format of "sourceNamespace_targetNamespace_argocd-server"
-func getRoleNameForApplicationSourceNamespaces(targetNamespace string, cr *argoprojv1a1.ArgoCD) string {
+func getRoleNameForApplicationSourceNamespaces(targetNamespace string, cr *argoproj.ArgoCD) string {
 	return fmt.Sprintf("%s_%s", cr.Name, targetNamespace)
 }
 
 // newRoleBindingWithNameForApplicationSourceNamespaces creates a new RoleBinding with the given name for the source namespaces of ArgoCD Server.
-func newRoleBindingWithNameForApplicationSourceNamespaces(namespace string, cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
+func newRoleBindingWithNameForApplicationSourceNamespaces(namespace string, cr *argoproj.ArgoCD) *v1.RoleBinding {
 	roleBinding := newRoleBindingForSupportNamespaces(cr, namespace)
 
 	labels := roleBinding.ObjectMeta.Labels
@@ -334,7 +334,7 @@ func newRoleBindingWithNameForApplicationSourceNamespaces(namespace string, cr *
 	return roleBinding
 }
 
-func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.ClusterRole, cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.ClusterRole, cr *argoproj.ArgoCD) error {
 
 	// get expected name
 	roleBinding := newClusterRoleBindingWithname(name, cr)

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
@@ -215,7 +215,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_forSourceNamespaces(t *testing.T) 
 	logf.SetLogger(ZapLogger(true))
 	sourceNamespace := "newNamespaceTest"
 	a := makeTestArgoCD()
-	a.Spec = v1alpha1.ArgoCDSpec{
+	a.Spec = argoproj.ArgoCDSpec{
 		SourceNamespaces: []string{
 			sourceNamespace,
 		},

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -46,7 +46,7 @@ func verifyRouteAPI() error {
 }
 
 // newRoute returns a new Route instance for the given ArgoCD.
-func newRoute(cr *argoprojv1a1.ArgoCD) *routev1.Route {
+func newRoute(cr *argoproj.ArgoCD) *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -57,7 +57,7 @@ func newRoute(cr *argoprojv1a1.ArgoCD) *routev1.Route {
 }
 
 // newRouteWithName returns a new Route with the given name and ArgoCD.
-func newRouteWithName(name string, cr *argoprojv1a1.ArgoCD) *routev1.Route {
+func newRouteWithName(name string, cr *argoproj.ArgoCD) *routev1.Route {
 	route := newRoute(cr)
 	route.ObjectMeta.Name = name
 
@@ -69,12 +69,12 @@ func newRouteWithName(name string, cr *argoprojv1a1.ArgoCD) *routev1.Route {
 }
 
 // newRouteWithSuffix returns a new Route with the given name suffix for the ArgoCD.
-func newRouteWithSuffix(suffix string, cr *argoprojv1a1.ArgoCD) *routev1.Route {
+func newRouteWithSuffix(suffix string, cr *argoproj.ArgoCD) *routev1.Route {
 	return newRouteWithName(fmt.Sprintf("%s-%s", cr.Name, suffix), cr)
 }
 
 // reconcileRoutes will ensure that all ArgoCD Routes are present.
-func (r *ReconcileArgoCD) reconcileRoutes(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRoutes(cr *argoproj.ArgoCD) error {
 	if err := r.reconcileGrafanaRoute(cr); err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func (r *ReconcileArgoCD) reconcileRoutes(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileGrafanaRoute will ensure that the ArgoCD Grafana Route is present.
-func (r *ReconcileArgoCD) reconcileGrafanaRoute(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileGrafanaRoute(cr *argoproj.ArgoCD) error {
 	route := newRouteWithSuffix("grafana", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route) {
 		if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Route.Enabled {
@@ -157,7 +157,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaRoute(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcilePrometheusRoute will ensure that the ArgoCD Prometheus Route is present.
-func (r *ReconcileArgoCD) reconcilePrometheusRoute(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcilePrometheusRoute(cr *argoproj.ArgoCD) error {
 	route := newRouteWithSuffix("prometheus", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route) {
 		if !cr.Spec.Prometheus.Enabled || !cr.Spec.Prometheus.Route.Enabled {
@@ -214,7 +214,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRoute(cr *argoprojv1a1.ArgoCD) erro
 }
 
 // reconcileServerRoute will ensure that the ArgoCD Server Route is present.
-func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoproj.ArgoCD) error {
 
 	route := newRouteWithSuffix("server", cr)
 	found := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)
@@ -291,7 +291,7 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileApplicationSetControllerWebhookRoute will ensure that the ArgoCD Server Route is present.
-func (r *ReconcileArgoCD) reconcileApplicationSetControllerWebhookRoute(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileApplicationSetControllerWebhookRoute(cr *argoproj.ArgoCD) error {
 	name := fmt.Sprintf("%s-%s", common.ApplicationSetServiceNameSuffix, "webhook")
 	route := newRouteWithSuffix(name, cr)
 	found := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -20,14 +20,14 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
-	argov1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 func TestReconcileRouteSetLabels(t *testing.T) {
 	routeAPIFound = true
 	ctx := context.Background()
 	logf.SetLogger(ZapLogger(true))
-	argoCD := makeArgoCD(func(a *argov1alpha1.ArgoCD) {
+	argoCD := makeArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Server.Route.Enabled = true
 		labels := make(map[string]string)
 		labels["my-key"] = "my-value"
@@ -62,7 +62,7 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 	routeAPIFound = true
 	ctx := context.Background()
 	logf.SetLogger(ZapLogger(true))
-	argoCD := makeArgoCD(func(a *argov1alpha1.ArgoCD) {
+	argoCD := makeArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Server.Route.Enabled = true
 	})
 	objs := []runtime.Object{
@@ -133,7 +133,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 	routeAPIFound = true
 	ctx := context.Background()
 	logf.SetLogger(ZapLogger(true))
-	argoCD := makeArgoCD(func(a *argov1alpha1.ArgoCD) {
+	argoCD := makeArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Server.Route.Enabled = true
 		a.Spec.Server.Insecure = true
 	})
@@ -201,10 +201,10 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 	}
 }
 
-func makeReconciler(t *testing.T, acd *argov1alpha1.ArgoCD, objs ...runtime.Object) *ReconcileArgoCD {
+func makeReconciler(t *testing.T, acd *argoproj.ArgoCD, objs ...runtime.Object) *ReconcileArgoCD {
 	t.Helper()
 	s := scheme.Scheme
-	s.AddKnownTypes(argov1alpha1.GroupVersion, acd)
+	s.AddKnownTypes(argoproj.GroupVersion, acd)
 	routev1.Install(s)
 	configv1.Install(s)
 	cl := fake.NewFakeClient(objs...)
@@ -214,13 +214,13 @@ func makeReconciler(t *testing.T, acd *argov1alpha1.ArgoCD, objs ...runtime.Obje
 	}
 }
 
-func makeArgoCD(opts ...func(*argov1alpha1.ArgoCD)) *argov1alpha1.ArgoCD {
-	argoCD := &argov1alpha1.ArgoCD{
+func makeArgoCD(opts ...func(*argoproj.ArgoCD)) *argoproj.ArgoCD {
+	argoCD := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testArgoCDName,
 			Namespace: testNamespace,
 		},
-		Spec: argov1alpha1.ArgoCDSpec{},
+		Spec: argoproj.ArgoCDSpec{},
 	}
 	for _, o := range opts {
 		o(argoCD)

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -29,8 +29,7 @@ import (
 	argopass "github.com/argoproj/argo-cd/v2/util/password"
 	tlsutil "github.com/operator-framework/operator-sdk/pkg/tls"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
@@ -80,7 +79,7 @@ func nowNano() string {
 }
 
 // newCASecret creates a new CA secret with the given suffix for the given ArgoCD.
-func newCASecret(cr *argoprojv1a1.ArgoCD) (*corev1.Secret, error) {
+func newCASecret(cr *argoproj.ArgoCD) (*corev1.Secret, error) {
 	secret := argoutil.NewTLSSecret(cr, "ca")
 
 	key, err := argoutil.NewPrivateKey()
@@ -104,7 +103,7 @@ func newCASecret(cr *argoprojv1a1.ArgoCD) (*corev1.Secret, error) {
 }
 
 // newCertificateSecret creates a new secret using the given name suffix for the given TLS certificate.
-func newCertificateSecret(suffix string, caCert *x509.Certificate, caKey *rsa.PrivateKey, cr *argoprojv1a1.ArgoCD) (*corev1.Secret, error) {
+func newCertificateSecret(suffix string, caCert *x509.Certificate, caKey *rsa.PrivateKey, cr *argoproj.ArgoCD) (*corev1.Secret, error) {
 	secret := argoutil.NewTLSSecret(cr, suffix)
 
 	key, err := argoutil.NewPrivateKey()
@@ -146,7 +145,7 @@ func newCertificateSecret(suffix string, caCert *x509.Certificate, caKey *rsa.Pr
 }
 
 // reconcileArgoSecret will ensure that the Argo CD Secret is present.
-func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoproj.ArgoCD) error {
 	clusterSecret := argoutil.NewSecretWithSuffix(cr, "cluster")
 	secret := argoutil.NewSecretWithName(cr, common.ArgoCDSecretName)
 
@@ -184,7 +183,7 @@ func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
 		common.ArgoCDKeyTLSPrivateKey:      tlsSecret.Data[common.ArgoCDKeyTLSPrivateKey],
 	}
 
-	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == v1alpha1.SSOProviderTypeDex {
+	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
 		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
 		if err != nil {
 			return nil
@@ -199,7 +198,7 @@ func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileClusterMainSecret will ensure that the main Secret is present for the Argo CD cluster.
-func (r *ReconcileArgoCD) reconcileClusterMainSecret(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileClusterMainSecret(cr *argoproj.ArgoCD) error {
 	secret := argoutil.NewSecretWithSuffix(cr, "cluster")
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, secret.Name, secret) {
 		return nil // Secret found, do nothing
@@ -221,7 +220,7 @@ func (r *ReconcileArgoCD) reconcileClusterMainSecret(cr *argoprojv1a1.ArgoCD) er
 }
 
 // reconcileClusterTLSSecret ensures the TLS Secret is created for the ArgoCD cluster.
-func (r *ReconcileArgoCD) reconcileClusterTLSSecret(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileClusterTLSSecret(cr *argoproj.ArgoCD) error {
 	secret := argoutil.NewTLSSecret(cr, "tls")
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, secret.Name, secret) {
 		return nil // Secret found, do nothing
@@ -256,7 +255,7 @@ func (r *ReconcileArgoCD) reconcileClusterTLSSecret(cr *argoprojv1a1.ArgoCD) err
 }
 
 // reconcileClusterCASecret ensures the CA Secret is created for the ArgoCD cluster.
-func (r *ReconcileArgoCD) reconcileClusterCASecret(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileClusterCASecret(cr *argoproj.ArgoCD) error {
 	secret := argoutil.NewSecretWithSuffix(cr, "ca")
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, secret.Name, secret) {
 		return nil // Secret found, do nothing
@@ -274,7 +273,7 @@ func (r *ReconcileArgoCD) reconcileClusterCASecret(cr *argoprojv1a1.ArgoCD) erro
 }
 
 // reconcileClusterSecrets will reconcile all Secret resources for the ArgoCD cluster.
-func (r *ReconcileArgoCD) reconcileClusterSecrets(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileClusterSecrets(cr *argoproj.ArgoCD) error {
 	if err := r.reconcileClusterMainSecret(cr); err != nil {
 		return err
 	}
@@ -299,7 +298,7 @@ func (r *ReconcileArgoCD) reconcileClusterSecrets(cr *argoprojv1a1.ArgoCD) error
 }
 
 // reconcileExistingArgoSecret will ensure that the Argo CD Secret is up to date.
-func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, secret *corev1.Secret, clusterSecret *corev1.Secret, tlsSecret *corev1.Secret) error {
+func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoproj.ArgoCD, secret *corev1.Secret, clusterSecret *corev1.Secret, tlsSecret *corev1.Secret) error {
 	changed := false
 
 	if secret.Data == nil {
@@ -334,7 +333,7 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 		changed = true
 	}
 
-	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == v1alpha1.SSOProviderTypeDex {
+	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
 		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
 		if err != nil {
 			return err
@@ -360,7 +359,7 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoprojv1a1.ArgoCD, s
 }
 
 // reconcileGrafanaSecret will ensure that the Grafana Secret is present.
-func (r *ReconcileArgoCD) reconcileGrafanaSecret(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileGrafanaSecret(cr *argoproj.ArgoCD) error {
 	if !cr.Spec.Grafana.Enabled {
 		return nil // Grafana not enabled, do nothing.
 	}
@@ -422,7 +421,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaSecret(cr *argoprojv1a1.ArgoCD) error 
 }
 
 // reconcileClusterPermissionsSecret ensures ArgoCD instance is namespace-scoped
-func (r *ReconcileArgoCD) reconcileClusterPermissionsSecret(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileClusterPermissionsSecret(cr *argoproj.ArgoCD) error {
 	var clusterConfigInstance bool
 	secret := argoutil.NewSecretWithSuffix(cr, "default-cluster-config")
 	secret.Labels[common.ArgoCDSecretTypeLabel] = "cluster"
@@ -503,7 +502,7 @@ func (r *ReconcileArgoCD) reconcileClusterPermissionsSecret(cr *argoprojv1a1.Arg
 // has changed since our last reconciliation loop. It does so by comparing the
 // checksum of tls.crt and tls.key in the status of the ArgoCD CR against the
 // values calculated from the live state in the cluster.
-func (r *ReconcileArgoCD) reconcileRepoServerTLSSecret(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRepoServerTLSSecret(cr *argoproj.ArgoCD) error {
 	var tlsSecretObj corev1.Secret
 	var sha256sum string
 
@@ -571,7 +570,7 @@ func (r *ReconcileArgoCD) reconcileRepoServerTLSSecret(cr *argoprojv1a1.ArgoCD) 
 // has changed since our last reconciliation loop. It does so by comparing the
 // checksum of tls.crt and tls.key in the status of the ArgoCD CR against the
 // values calculated from the live state in the cluster.
-func (r *ReconcileArgoCD) reconcileRedisTLSSecret(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) error {
+func (r *ReconcileArgoCD) reconcileRedisTLSSecret(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
 	var tlsSecretObj corev1.Secret
 	var sha256sum string
 
@@ -670,7 +669,7 @@ func (r *ReconcileArgoCD) reconcileRedisTLSSecret(cr *argoprojv1a1.ArgoCD, useTL
 }
 
 // reconcileSecrets will reconcile all ArgoCD Secret resources.
-func (r *ReconcileArgoCD) reconcileSecrets(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileSecrets(cr *argoproj.ArgoCD) error {
 	if err := r.reconcileClusterSecrets(cr); err != nil {
 		return err
 	}
@@ -682,7 +681,7 @@ func (r *ReconcileArgoCD) reconcileSecrets(cr *argoprojv1a1.ArgoCD) error {
 	return nil
 }
 
-func (r *ReconcileArgoCD) getClusterSecrets(cr *argoprojv1a1.ArgoCD) (*corev1.SecretList, error) {
+func (r *ReconcileArgoCD) getClusterSecrets(cr *argoproj.ArgoCD) (*corev1.SecretList, error) {
 
 	clusterSecrets := &corev1.SecretList{}
 	opts := &client.ListOptions{

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -17,14 +17,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 func Test_newCASecret(t *testing.T) {
-	cr := &argoprojv1alpha1.ArgoCD{
+	cr := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-argocd",
 			Namespace: "argocd",
@@ -55,7 +54,7 @@ func byteMapKeys(m map[string][]byte) []string {
 }
 
 func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
-	argocd := &v1alpha1.ArgoCD{
+	argocd := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd",
 			Namespace: "argocd-operator",
@@ -209,7 +208,7 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 }
 
 func Test_ReconcileArgoCD_ReconcileExistingArgoSecret(t *testing.T) {
-	argocd := &v1alpha1.ArgoCD{
+	argocd := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd",
 			Namespace: "argocd-operator",
@@ -249,7 +248,7 @@ func Test_ReconcileArgoCD_ReconcileExistingArgoSecret(t *testing.T) {
 }
 
 func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
-	argocd := &v1alpha1.ArgoCD{
+	argocd := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd",
 			Namespace: "argocd-operator",

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -23,13 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // getArgoServerServiceType will return the server Service type for the ArgoCD.
-func getArgoServerServiceType(cr *argoprojv1a1.ArgoCD) corev1.ServiceType {
+func getArgoServerServiceType(cr *argoproj.ArgoCD) corev1.ServiceType {
 	if len(cr.Spec.Server.Service.Type) > 0 {
 		return cr.Spec.Server.Service.Type
 	}
@@ -37,7 +37,7 @@ func getArgoServerServiceType(cr *argoprojv1a1.ArgoCD) corev1.ServiceType {
 }
 
 // newService returns a new Service for the given ArgoCD instance.
-func newService(cr *argoprojv1a1.ArgoCD) *corev1.Service {
+func newService(cr *argoproj.ArgoCD) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -48,7 +48,7 @@ func newService(cr *argoprojv1a1.ArgoCD) *corev1.Service {
 }
 
 // newServiceWithName returns a new Service instance for the given ArgoCD using the given name.
-func newServiceWithName(name string, component string, cr *argoprojv1a1.ArgoCD) *corev1.Service {
+func newServiceWithName(name string, component string, cr *argoproj.ArgoCD) *corev1.Service {
 	svc := newService(cr)
 	svc.ObjectMeta.Name = name
 
@@ -61,12 +61,12 @@ func newServiceWithName(name string, component string, cr *argoprojv1a1.ArgoCD) 
 }
 
 // newServiceWithSuffix returns a new Service instance for the given ArgoCD using the given suffix.
-func newServiceWithSuffix(suffix string, component string, cr *argoprojv1a1.ArgoCD) *corev1.Service {
+func newServiceWithSuffix(suffix string, component string, cr *argoproj.ArgoCD) *corev1.Service {
 	return newServiceWithName(fmt.Sprintf("%s-%s", cr.Name, suffix), component, cr)
 }
 
 // reconcileGrafanaService will ensure that the Service for Grafana is present.
-func (r *ReconcileArgoCD) reconcileGrafanaService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileGrafanaService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("grafana", "grafana", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
 		if !cr.Spec.Grafana.Enabled {
@@ -102,7 +102,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaService(cr *argoprojv1a1.ArgoCD) error
 }
 
 // reconcileMetricsService will ensure that the Service for the Argo CD application controller metrics is present.
-func (r *ReconcileArgoCD) reconcileMetricsService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileMetricsService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("metrics", "metrics", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
 		// Service found, do nothing
@@ -129,7 +129,7 @@ func (r *ReconcileArgoCD) reconcileMetricsService(cr *argoprojv1a1.ArgoCD) error
 }
 
 // reconcileRedisHAAnnounceServices will ensure that the announce Services are present for Redis when running in HA mode.
-func (r *ReconcileArgoCD) reconcileRedisHAAnnounceServices(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRedisHAAnnounceServices(cr *argoproj.ArgoCD) error {
 	for i := int32(0); i < common.ArgoCDDefaultRedisHAReplicas; i++ {
 		svc := newServiceWithSuffix(fmt.Sprintf("redis-ha-announce-%d", i), "redis", cr)
 		if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
@@ -180,7 +180,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAAnnounceServices(cr *argoprojv1a1.Argo
 }
 
 // reconcileRedisHAMasterService will ensure that the "master" Service is present for Redis when running in HA mode.
-func (r *ReconcileArgoCD) reconcileRedisHAMasterService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRedisHAMasterService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("redis-ha", "redis", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
 		if !cr.Spec.HA.Enabled {
@@ -218,7 +218,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAMasterService(cr *argoprojv1a1.ArgoCD)
 }
 
 // reconcileRedisHAProxyService will ensure that the HA Proxy Service is present for Redis when running in HA mode.
-func (r *ReconcileArgoCD) reconcileRedisHAProxyService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRedisHAProxyService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("redis-ha-haproxy", "redis", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
 
@@ -258,7 +258,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyService(cr *argoprojv1a1.ArgoCD) 
 }
 
 // reconcileRedisHAServices will ensure that all required Services are present for Redis when running in HA mode.
-func (r *ReconcileArgoCD) reconcileRedisHAServices(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRedisHAServices(cr *argoproj.ArgoCD) error {
 
 	if err := r.reconcileRedisHAAnnounceServices(cr); err != nil {
 		return err
@@ -275,7 +275,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAServices(cr *argoprojv1a1.ArgoCD) erro
 }
 
 // reconcileRedisService will ensure that the Service for Redis is present.
-func (r *ReconcileArgoCD) reconcileRedisService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRedisService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("redis", "redis", cr)
 
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
@@ -354,7 +354,7 @@ func ensureAutoTLSAnnotation(svc *corev1.Service, secretName string, enabled boo
 }
 
 // reconcileRepoService will ensure that the Service for the Argo CD repo server is present.
-func (r *ReconcileArgoCD) reconcileRepoService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileRepoService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("repo-server", "repo-server", cr)
 
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
@@ -391,7 +391,7 @@ func (r *ReconcileArgoCD) reconcileRepoService(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileServerMetricsService will ensure that the Service for the Argo CD server metrics is present.
-func (r *ReconcileArgoCD) reconcileServerMetricsService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServerMetricsService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("server-metrics", "server", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
 		return nil // Service found, do nothing
@@ -417,7 +417,7 @@ func (r *ReconcileArgoCD) reconcileServerMetricsService(cr *argoprojv1a1.ArgoCD)
 }
 
 // reconcileServerService will ensure that the Service is present for the Argo CD server component.
-func (r *ReconcileArgoCD) reconcileServerService(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServerService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("server", "server", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
 		if ensureAutoTLSAnnotation(svc, common.ArgoCDServerTLSSecretName, cr.Spec.Server.WantsAutoTLS()) {
@@ -455,7 +455,7 @@ func (r *ReconcileArgoCD) reconcileServerService(cr *argoprojv1a1.ArgoCD) error 
 }
 
 // reconcileServices will ensure that all Services are present for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileServices(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServices(cr *argoproj.ArgoCD) error {
 
 	if err := r.reconcileDexService(cr); err != nil {
 		log.Error(err, "error reconciling dex service")

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -24,13 +24,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // newServiceAccount returns a new ServiceAccount instance.
-func newServiceAccount(cr *argoprojv1a1.ArgoCD) *corev1.ServiceAccount {
+func newServiceAccount(cr *argoproj.ArgoCD) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -41,7 +41,7 @@ func newServiceAccount(cr *argoprojv1a1.ArgoCD) *corev1.ServiceAccount {
 }
 
 // newServiceAccountWithName creates a new ServiceAccount with the given name for the given ArgCD.
-func newServiceAccountWithName(name string, cr *argoprojv1a1.ArgoCD) *corev1.ServiceAccount {
+func newServiceAccountWithName(name string, cr *argoproj.ArgoCD) *corev1.ServiceAccount {
 	sa := newServiceAccount(cr)
 	sa.ObjectMeta.Name = getServiceAccountName(cr.Name, name)
 
@@ -57,7 +57,7 @@ func getServiceAccountName(crName, name string) string {
 }
 
 // reconcileServiceAccounts will ensure that all ArgoCD Service Accounts are configured.
-func (r *ReconcileArgoCD) reconcileServiceAccounts(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServiceAccounts(cr *argoproj.ArgoCD) error {
 	params := getPolicyRuleList(r.Client)
 
 	for _, param := range params {
@@ -77,7 +77,7 @@ func (r *ReconcileArgoCD) reconcileServiceAccounts(cr *argoprojv1a1.ArgoCD) erro
 	return nil
 }
 
-func (r *ReconcileArgoCD) reconcileServiceAccountClusterPermissions(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServiceAccountClusterPermissions(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) error {
 	var role *v1.ClusterRole
 	var err error
 
@@ -93,11 +93,11 @@ func (r *ReconcileArgoCD) reconcileServiceAccountClusterPermissions(name string,
 	return r.reconcileClusterRoleBinding(name, role, cr)
 }
 
-func (r *ReconcileArgoCD) reconcileServiceAccountPermissions(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileServiceAccountPermissions(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) error {
 	return r.reconcileRoleBinding(name, rules, cr)
 }
 
-func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoprojv1a1.ArgoCD) (*corev1.ServiceAccount, error) {
+func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoproj.ArgoCD) (*corev1.ServiceAccount, error) {
 	sa := newServiceAccountWithName(name, cr)
 
 	exists := true

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -21,8 +21,7 @@ import (
 	template "github.com/openshift/api/template/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
@@ -58,7 +57,7 @@ func verifyTemplateAPI() error {
 // The operator must support `.spec.sso.dex` fields for dex, and `.spec.sso.keycloak` fields for keycloak.
 // The operator must identify edge cases involving partial configurations of specs, spec mismatch with
 // active provider, contradicting configuration etc, and throw the appropriate errors.
-func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileSSO(cr *argoproj.ArgoCD) error {
 
 	// reset ssoConfigLegalStatus at the beginning of each SSO reconciliation round
 	ssoConfigLegalStatus = ssoLegalUnknown
@@ -76,7 +75,7 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 		isError := false
 
 		// case 2
-		if cr.Spec.SSO.Provider.ToLower() == v1alpha1.SSOProviderTypeDex {
+		if cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
 			// Relevant SSO settings at play are `.spec.sso.dex` fields, `.spec.sso.keycloak`
 
 			if cr.Spec.SSO.Dex == nil || (cr.Spec.SSO.Dex != nil && !cr.Spec.SSO.Dex.OpenShiftOAuth && cr.Spec.SSO.Dex.Config == "") {
@@ -100,7 +99,7 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 		}
 
 		// case 3
-		if cr.Spec.SSO.Provider.ToLower() == v1alpha1.SSOProviderTypeKeycloak {
+		if cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
 			// Relevant SSO settings at play are `.spec.sso.keycloak` fields, `.spec.sso.dex`
 
 			if cr.Spec.SSO.Dex != nil {
@@ -136,10 +135,10 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 		}
 
 		// case 5
-		if cr.Spec.SSO.Provider.ToLower() != v1alpha1.SSOProviderTypeDex && cr.Spec.SSO.Provider.ToLower() != v1alpha1.SSOProviderTypeKeycloak {
+		if cr.Spec.SSO.Provider.ToLower() != argoproj.SSOProviderTypeDex && cr.Spec.SSO.Provider.ToLower() != argoproj.SSOProviderTypeKeycloak {
 			// `.spec.sso.provider` contains unsupported value
 
-			errMsg = fmt.Sprintf("Unsupported SSO provider type. Supported providers are %s and %s", v1alpha1.SSOProviderTypeDex, v1alpha1.SSOProviderTypeKeycloak)
+			errMsg = fmt.Sprintf("Unsupported SSO provider type. Supported providers are %s and %s", argoproj.SSOProviderTypeDex, argoproj.SSOProviderTypeKeycloak)
 			err = errors.New(illegalSSOConfiguration + errMsg)
 			log.Error(err, fmt.Sprintf("Unsupported SSO provider type for Argo CD %s in namespace %s.", cr.Name, cr.Namespace))
 			ssoConfigLegalStatus = ssoLegalFailed // set global indicator that SSO config has gone wrong
@@ -154,7 +153,7 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 
 	// reconcile resources based on enabled provider
 	// keycloak
-	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoprojv1a1.SSOProviderTypeKeycloak {
+	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
 
 		// Trigger reconciliation of any Dex resources so they get deleted
 		if err := r.reconcileDexResources(cr); err != nil && !apiErrors.IsNotFound(err) {
@@ -183,16 +182,16 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoprojv1a1.ArgoCD) error {
 	return nil
 }
 
-func (r *ReconcileArgoCD) deleteSSOConfiguration(newCr *argoprojv1a1.ArgoCD, oldCr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) deleteSSOConfiguration(newCr *argoproj.ArgoCD, oldCr *argoproj.ArgoCD) error {
 
 	log.Info("uninstalling existing SSO configuration")
 
-	if oldCr.Spec.SSO.Provider.ToLower() == argoprojv1a1.SSOProviderTypeKeycloak {
+	if oldCr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
 		if err := deleteKeycloakConfiguration(newCr); err != nil {
 			log.Error(err, "Unable to delete existing keycloak configuration")
 			return err
 		}
-	} else if oldCr.Spec.SSO.Provider.ToLower() == argoprojv1a1.SSOProviderTypeDex {
+	} else if oldCr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
 		// Trigger reconciliation of Dex resources so they get deleted
 		if err := r.deleteDexResources(newCr); err != nil {
 			log.Error(err, "Unable to reconcile necessary resources for uninstallation of Dex")

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
 	"github.com/google/go-cmp/cmp"
@@ -238,8 +239,8 @@ func TestReconcileArgoCD_reconcileApplicationController_withUpgrade(t *testing.T
 
 func TestReconcileArgoCD_reconcileApplicationController_withResources(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCDWithResources(func(a *argoprojv1alpha1.ArgoCD) {
-		a.Spec.Import = &argoprojv1alpha1.ArgoCDImportSpec{
+	a := makeTestArgoCDWithResources(func(a *argoproj.ArgoCD) {
+		a.Spec.Import = &argoproj.ArgoCDImportSpec{
 			Name: "testimport",
 		}
 	})
@@ -302,12 +303,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
-		sharding argoprojv1alpha1.ArgoCDApplicationControllerShardSpec
+		sharding argoproj.ArgoCDApplicationControllerShardSpec
 		replicas int32
 		vars     []corev1.EnvVar
 	}{
 		{
-			sharding: argoprojv1alpha1.ArgoCDApplicationControllerShardSpec{
+			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
 				Enabled:  false,
 				Replicas: 3,
 			},
@@ -317,7 +318,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			},
 		},
 		{
-			sharding: argoprojv1alpha1.ArgoCDApplicationControllerShardSpec{
+			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
 				Enabled:  true,
 				Replicas: 1,
 			},
@@ -328,7 +329,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			},
 		},
 		{
-			sharding: argoprojv1alpha1.ArgoCDApplicationControllerShardSpec{
+			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
 				Enabled:  true,
 				Replicas: 3,
 			},
@@ -341,7 +342,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 	}
 
 	for _, st := range tests {
-		a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 			a.Spec.Controller.Sharding = st.sharding
 		})
 		r := makeTestReconciler(t, a)
@@ -380,7 +381,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withAppSync(t *testing.T
 		{Name: "HOME", Value: "/home/argocd"},
 	}
 
-	a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		a.Spec.Controller.AppSync = &metav1.Duration{Duration: time.Minute * 10}
 	})
 	r := makeTestReconciler(t, a)
@@ -489,12 +490,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withDynamicSharding(t *t
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
-		sharding         argoprojv1alpha1.ArgoCDApplicationControllerShardSpec
+		sharding         argoproj.ArgoCDApplicationControllerShardSpec
 		expectedReplicas int32
 		vars             []corev1.EnvVar
 	}{
 		{
-			sharding: argoprojv1alpha1.ArgoCDApplicationControllerShardSpec{
+			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
 				Enabled:               false,
 				Replicas:              1,
 				DynamicScalingEnabled: boolPtr(true),
@@ -506,7 +507,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withDynamicSharding(t *t
 		},
 		{
 			// Replicas less than minimum shards
-			sharding: argoprojv1alpha1.ArgoCDApplicationControllerShardSpec{
+			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
 				Enabled:               false,
 				Replicas:              1,
 				DynamicScalingEnabled: boolPtr(true),
@@ -518,7 +519,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withDynamicSharding(t *t
 		},
 		{
 			// Replicas more than maximum shards
-			sharding: argoprojv1alpha1.ArgoCDApplicationControllerShardSpec{
+			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
 				Enabled:               false,
 				Replicas:              1,
 				DynamicScalingEnabled: boolPtr(true),
@@ -531,7 +532,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withDynamicSharding(t *t
 	}
 
 	for _, st := range tests {
-		a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 			a.Spec.Controller.Sharding = st.sharding
 		})
 

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -26,12 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // reconcileStatus will ensure that all of the Status properties are updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatus(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatus(cr *argoproj.ArgoCD) error {
 	if err := r.reconcileStatusApplicationController(cr); err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (r *ReconcileArgoCD) reconcileStatus(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileStatusApplicationController will ensure that the ApplicationController Status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusApplicationController(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusApplicationController(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	ss := newStatefulSetWithSuffix("application-controller", "application-controller", cr)
@@ -94,7 +94,7 @@ func (r *ReconcileArgoCD) reconcileStatusApplicationController(cr *argoprojv1a1.
 }
 
 // reconcileStatusDex will ensure that the Dex status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusDex(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusDex(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("dex-server", "dex-server", cr)
@@ -117,7 +117,7 @@ func (r *ReconcileArgoCD) reconcileStatusDex(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileStatusKeycloak will ensure that the Keycloak status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusKeycloak(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusKeycloak(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	if IsTemplateAPIAvailable() {
@@ -158,7 +158,7 @@ func (r *ReconcileArgoCD) reconcileStatusKeycloak(cr *argoprojv1a1.ArgoCD) error
 }
 
 // reconcileStatusApplicationSetController will ensure that the ApplicationSet controller status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusApplicationSetController(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusApplicationSetController(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("applicationset-controller", "controller", cr)
@@ -180,16 +180,16 @@ func (r *ReconcileArgoCD) reconcileStatusApplicationSetController(cr *argoprojv1
 }
 
 // reconcileStatusSSOConfig will ensure that the SSOConfig status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusSSO(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusSSO(cr *argoproj.ArgoCD) error {
 
 	// set status to track ssoConfigLegalStatus so it is always up to date with latest sso situation
 	status := ssoConfigLegalStatus
 
 	// perform dex/keycloak status reconciliation only if sso configurations are legal
 	if status == ssoLegalSuccess {
-		if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoprojv1a1.SSOProviderTypeDex {
+		if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
 			return r.reconcileStatusDex(cr)
-		} else if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoprojv1a1.SSOProviderTypeKeycloak {
+		} else if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
 			return r.reconcileStatusKeycloak(cr)
 		}
 	} else {
@@ -204,7 +204,7 @@ func (r *ReconcileArgoCD) reconcileStatusSSO(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileStatusPhase will ensure that the Status Phase is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoproj.ArgoCD) error {
 	var phase string
 
 	if cr.Status.ApplicationController == "Running" && cr.Status.Redis == "Running" && cr.Status.Repo == "Running" && cr.Status.Server == "Running" {
@@ -221,7 +221,7 @@ func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileStatusRedis will ensure that the Redis status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusRedis(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusRedis(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	if !cr.Spec.HA.Enabled {
@@ -255,7 +255,7 @@ func (r *ReconcileArgoCD) reconcileStatusRedis(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileStatusRepo will ensure that the Repo status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusRepo(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusRepo(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("repo-server", "repo-server", cr)
@@ -277,7 +277,7 @@ func (r *ReconcileArgoCD) reconcileStatusRepo(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileStatusServer will ensure that the Server status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusServer(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusServer(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("server", "server", cr)
@@ -300,7 +300,7 @@ func (r *ReconcileArgoCD) reconcileStatusServer(cr *argoprojv1a1.ArgoCD) error {
 }
 
 // reconcileStatusNotifications will ensure that the Notifications status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusNotifications(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusNotifications(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("notifications-controller", "controller", cr)
@@ -326,7 +326,7 @@ func (r *ReconcileArgoCD) reconcileStatusNotifications(cr *argoprojv1a1.ArgoCD) 
 }
 
 // reconcileStatusHost will ensure that the host status is updated for the given ArgoCD.
-func (r *ReconcileArgoCD) reconcileStatusHost(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileStatusHost(cr *argoproj.ArgoCD) error {
 	cr.Status.Host = ""
 
 	if (cr.Spec.Server.Route.Enabled || cr.Spec.Server.Ingress.Enabled) && IsRouteAPIAvailable() {

--- a/controllers/argocd/status_test.go
+++ b/controllers/argocd/status_test.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 
 	oappsv1 "github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -81,15 +80,15 @@ func TestReconcileArgoCD_reconcileStatusSSO(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		argoCD        *argoprojv1alpha1.ArgoCD
+		argoCD        *argoproj.ArgoCD
 		wantSSOStatus string
 	}{
 		{
 			name: "both dex and keycloak configured",
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeKeycloak,
-					Dex: &v1alpha1.ArgoCDDexSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeKeycloak,
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -98,26 +97,26 @@ func TestReconcileArgoCD_reconcileStatusSSO(t *testing.T) {
 		},
 		{
 			name: "sso provider dex but no .spec.sso.dex provided",
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-					Provider: argoprojv1alpha1.SSOProviderTypeDex,
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
 				}
 			}),
 			wantSSOStatus: "Failed",
 		},
 		{
 			name: "no sso configured",
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
 				cr.Spec.SSO = nil
 			}),
 			wantSSOStatus: "Unknown",
 		},
 		{
 			name: "unsupported sso configured",
-			argoCD: makeTestArgoCD(func(cr *argoprojv1alpha1.ArgoCD) {
-				cr.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 					Provider: "Unsupported",
-					Dex: &v1alpha1.ArgoCDDexSpec{
+					Dex: &argoproj.ArgoCDDexSpec{
 						OpenShiftOAuth: true,
 					},
 				}
@@ -175,7 +174,7 @@ func TestReconcileArgoCD_reconcileStatusHost(t *testing.T) {
 
 			routeAPIFound = test.testRouteAPIFound
 
-			a := makeTestArgoCD(func(a *argoprojv1alpha1.ArgoCD) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Server.Route.Enabled = test.routeEnabled
 				a.Spec.Server.Ingress.Enabled = test.ingressEnabled
 			})
@@ -278,7 +277,7 @@ func TestReconcileArgoCD_reconcileStatusApplicationSetController(t *testing.T) {
 	assert.NoError(t, r.reconcileStatusApplicationSetController(a))
 	assert.Equal(t, "Unknown", a.Status.ApplicationSetController)
 
-	a.Spec.ApplicationSet = &v1alpha1.ArgoCDApplicationSet{}
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
 	assert.NoError(t, r.reconcileApplicationSetController(a))
 	assert.NoError(t, r.reconcileStatusApplicationSetController(a))
 	assert.Equal(t, "Pending", a.Status.ApplicationSetController)

--- a/controllers/argocd/testing.go
+++ b/controllers/argocd/testing.go
@@ -37,6 +37,7 @@ import (
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 const (
@@ -51,6 +52,7 @@ func ZapLogger(development bool) logr.Logger {
 
 func makeTestReconciler(t *testing.T, objs ...runtime.Object) *ReconcileArgoCD {
 	s := scheme.Scheme
+	assert.NoError(t, argoproj.AddToScheme(s))
 	assert.NoError(t, argoprojv1alpha1.AddToScheme(s))
 
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
@@ -60,10 +62,10 @@ func makeTestReconciler(t *testing.T, objs ...runtime.Object) *ReconcileArgoCD {
 	}
 }
 
-type argoCDOpt func(*argoprojv1alpha1.ArgoCD)
+type argoCDOpt func(*argoproj.ArgoCD)
 
-func makeTestArgoCD(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
-	a := &argoprojv1alpha1.ArgoCD{
+func makeTestArgoCD(opts ...argoCDOpt) *argoproj.ArgoCD {
+	a := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testArgoCDName,
 			Namespace: testNamespace,
@@ -75,18 +77,18 @@ func makeTestArgoCD(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
 	return a
 }
 
-func makeTestArgoCDForKeycloak() *argoprojv1alpha1.ArgoCD {
-	a := &argoprojv1alpha1.ArgoCD{
+func makeTestArgoCDForKeycloak() *argoproj.ArgoCD {
+	a := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testArgoCDName,
 			Namespace: testNamespace,
 		},
-		Spec: argoprojv1alpha1.ArgoCDSpec{
-			SSO: &argoprojv1alpha1.ArgoCDSSOSpec{
+		Spec: argoproj.ArgoCDSpec{
+			SSO: &argoproj.ArgoCDSSOSpec{
 				Provider: "keycloak",
 			},
-			Server: argoprojv1alpha1.ArgoCDServerSpec{
-				Route: argoprojv1alpha1.ArgoCDRouteSpec{
+			Server: argoproj.ArgoCDServerSpec{
+				Route: argoproj.ArgoCDRouteSpec{
 					Enabled: true,
 				},
 			},
@@ -95,26 +97,26 @@ func makeTestArgoCDForKeycloak() *argoprojv1alpha1.ArgoCD {
 	return a
 }
 
-func makeTestArgoCDWithResources(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
-	a := &argoprojv1alpha1.ArgoCD{
+func makeTestArgoCDWithResources(opts ...argoCDOpt) *argoproj.ArgoCD {
+	a := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testArgoCDName,
 			Namespace: testNamespace,
 		},
-		Spec: argoprojv1alpha1.ArgoCDSpec{
-			ApplicationSet: &argoprojv1alpha1.ArgoCDApplicationSet{
+		Spec: argoproj.ArgoCDSpec{
+			ApplicationSet: &argoproj.ArgoCDApplicationSet{
 				Resources: makeTestApplicationSetResources(),
 			},
-			HA: argoprojv1alpha1.ArgoCDHASpec{
+			HA: argoproj.ArgoCDHASpec{
 				Resources: makeTestHAResources(),
 			},
-			SSO: &argoprojv1alpha1.ArgoCDSSOSpec{
+			SSO: &argoproj.ArgoCDSSOSpec{
 				Provider: "dex",
-				Dex: &argoprojv1alpha1.ArgoCDDexSpec{
+				Dex: &argoproj.ArgoCDDexSpec{
 					Resources: makeTestDexResources(),
 				},
 			},
-			Controller: argoprojv1alpha1.ArgoCDApplicationControllerSpec{
+			Controller: argoproj.ArgoCDApplicationControllerSpec{
 				Resources: makeTestControllerResources(),
 			},
 		},
@@ -181,7 +183,7 @@ func makeTestPolicyRules() []v1.PolicyRule {
 
 func initialCerts(t *testing.T, host string) argoCDOpt {
 	t.Helper()
-	return func(a *argoprojv1alpha1.ArgoCD) {
+	return func(a *argoproj.ArgoCD) {
 		key, err := argoutil.NewPrivateKey()
 		assert.NoError(t, err)
 		cert, err := argoutil.NewSelfSignedCACertificate(a.Name, key)

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -31,8 +31,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
@@ -105,7 +104,7 @@ func generateArgoServerSessionKey() ([]byte, error) {
 }
 
 // getArgoApplicationControllerResources will return the ResourceRequirements for the Argo CD application controller container.
-func getArgoApplicationControllerResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getArgoApplicationControllerResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
 
 	// Allow override of resource requirements from CR
@@ -117,7 +116,7 @@ func getArgoApplicationControllerResources(cr *argoprojv1a1.ArgoCD) corev1.Resou
 }
 
 // getArgoApplicationControllerCommand will return the command for the ArgoCD Application Controller component.
-func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) []string {
+func getArgoApplicationControllerCommand(cr *argoproj.ArgoCD, useTLSForRedis bool) []string {
 	cmd := []string{
 		"argocd-application-controller",
 		"--operation-processors", fmt.Sprint(getArgoServerOperationProcessors(cr)),
@@ -151,7 +150,7 @@ func getArgoApplicationControllerCommand(cr *argoprojv1a1.ArgoCD, useTLSForRedis
 }
 
 // getArgoContainerImage will return the container image for ArgoCD.
-func getArgoContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getArgoContainerImage(cr *argoproj.ArgoCD) string {
 	defaultTag, defaultImg := false, false
 	img := cr.Spec.Image
 	if img == "" {
@@ -182,7 +181,7 @@ func getArgoContainerImage(cr *argoprojv1a1.ArgoCD) string {
 // that if the spec is not configured.
 // 3. the default is configured in common.ArgoCDDefaultRepoServerVersion and
 // common.ArgoCDDefaultRepoServerImage.
-func getRepoServerContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getRepoServerContainerImage(cr *argoproj.ArgoCD) string {
 	defaultImg, defaultTag := false, false
 	img := cr.Spec.Repo.Image
 	if img == "" {
@@ -202,7 +201,7 @@ func getRepoServerContainerImage(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getArgoRepoResources will return the ResourceRequirements for the Argo CD Repo server container.
-func getArgoRepoResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getArgoRepoResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
 
 	// Allow override of resource requirements from CR
@@ -214,20 +213,20 @@ func getArgoRepoResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
 }
 
 // getArgoServerInsecure returns the insecure value for the ArgoCD Server component.
-func getArgoServerInsecure(cr *argoprojv1a1.ArgoCD) bool {
+func getArgoServerInsecure(cr *argoproj.ArgoCD) bool {
 	return cr.Spec.Server.Insecure
 }
 
-func isRepoServerTLSVerificationRequested(cr *argoprojv1a1.ArgoCD) bool {
+func isRepoServerTLSVerificationRequested(cr *argoproj.ArgoCD) bool {
 	return cr.Spec.Repo.VerifyTLS
 }
 
-func isRedisTLSVerificationDisabled(cr *argoprojv1a1.ArgoCD) bool {
+func isRedisTLSVerificationDisabled(cr *argoproj.ArgoCD) bool {
 	return cr.Spec.Redis.DisableTLSVerification
 }
 
 // getArgoServerGRPCHost will return the GRPC host for the given ArgoCD.
-func getArgoServerGRPCHost(cr *argoprojv1a1.ArgoCD) string {
+func getArgoServerGRPCHost(cr *argoproj.ArgoCD) string {
 	host := nameWithSuffix("grpc", cr)
 	if len(cr.Spec.Server.GRPC.Host) > 0 {
 		host = cr.Spec.Server.GRPC.Host
@@ -236,7 +235,7 @@ func getArgoServerGRPCHost(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getArgoServerHost will return the host for the given ArgoCD.
-func getArgoServerHost(cr *argoprojv1a1.ArgoCD) string {
+func getArgoServerHost(cr *argoproj.ArgoCD) string {
 	host := cr.Name
 	if len(cr.Spec.Server.Host) > 0 {
 		host = cr.Spec.Server.Host
@@ -245,7 +244,7 @@ func getArgoServerHost(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getArgoServerResources will return the ResourceRequirements for the Argo CD server container.
-func getArgoServerResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getArgoServerResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
 
 	if cr.Spec.Server.Autoscale.Enabled {
@@ -271,7 +270,7 @@ func getArgoServerResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements
 
 // getArgoServerURI will return the URI for the ArgoCD server.
 // The hostname for argocd-server is from the route, ingress, an external hostname or service name in that order.
-func (r *ReconcileArgoCD) getArgoServerURI(cr *argoprojv1a1.ArgoCD) string {
+func (r *ReconcileArgoCD) getArgoServerURI(cr *argoproj.ArgoCD) string {
 	host := nameWithSuffix("server", cr) // Default to service name
 
 	// Use the external hostname provided by the user
@@ -299,7 +298,7 @@ func (r *ReconcileArgoCD) getArgoServerURI(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getArgoServerOperationProcessors will return the numeric Operation Processors value for the ArgoCD Server.
-func getArgoServerOperationProcessors(cr *argoprojv1a1.ArgoCD) int32 {
+func getArgoServerOperationProcessors(cr *argoproj.ArgoCD) int32 {
 	op := common.ArgoCDDefaultServerOperationProcessors
 	if cr.Spec.Controller.Processors.Operation > op {
 		op = cr.Spec.Controller.Processors.Operation
@@ -308,7 +307,7 @@ func getArgoServerOperationProcessors(cr *argoprojv1a1.ArgoCD) int32 {
 }
 
 // getArgoServerStatusProcessors will return the numeric Status Processors value for the ArgoCD Server.
-func getArgoServerStatusProcessors(cr *argoprojv1a1.ArgoCD) int32 {
+func getArgoServerStatusProcessors(cr *argoproj.ArgoCD) int32 {
 	sp := common.ArgoCDDefaultServerStatusProcessors
 	if cr.Spec.Controller.Processors.Status > sp {
 		sp = cr.Spec.Controller.Processors.Status
@@ -317,7 +316,7 @@ func getArgoServerStatusProcessors(cr *argoprojv1a1.ArgoCD) int32 {
 }
 
 // getArgoControllerParellismLimit returns the parallelism limit for the application controller
-func getArgoControllerParellismLimit(cr *argoprojv1a1.ArgoCD) int32 {
+func getArgoControllerParellismLimit(cr *argoproj.ArgoCD) int32 {
 	pl := common.ArgoCDDefaultControllerParallelismLimit
 	if cr.Spec.Controller.ParallelismLimit > 0 {
 		pl = cr.Spec.Controller.ParallelismLimit
@@ -326,7 +325,7 @@ func getArgoControllerParellismLimit(cr *argoprojv1a1.ArgoCD) int32 {
 }
 
 // getGrafanaContainerImage will return the container image for the Grafana server.
-func getGrafanaContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getGrafanaContainerImage(cr *argoproj.ArgoCD) string {
 	defaultTag, defaultImg := false, false
 	img := cr.Spec.Grafana.Image
 	if img == "" {
@@ -346,7 +345,7 @@ func getGrafanaContainerImage(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getGrafanaResources will return the ResourceRequirements for the Grafana container.
-func getGrafanaResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getGrafanaResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
 
 	// Allow override of resource requirements from CR
@@ -382,7 +381,7 @@ func getRedisConf(useTLSForRedis bool) string {
 }
 
 // getRedisContainerImage will return the container image for the Redis server.
-func getRedisContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getRedisContainerImage(cr *argoproj.ArgoCD) string {
 	defaultImg, defaultTag := false, false
 	img := cr.Spec.Redis.Image
 	if img == "" {
@@ -401,7 +400,7 @@ func getRedisContainerImage(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getRedisHAContainerImage will return the container image for the Redis server in HA mode.
-func getRedisHAContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getRedisHAContainerImage(cr *argoproj.ArgoCD) string {
 	defaultImg, defaultTag := false, false
 	img := cr.Spec.Redis.Image
 	if img == "" {
@@ -420,12 +419,12 @@ func getRedisHAContainerImage(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getRedisHAProxyAddress will return the Redis HA Proxy service address for the given ArgoCD.
-func getRedisHAProxyAddress(cr *argoprojv1a1.ArgoCD) string {
+func getRedisHAProxyAddress(cr *argoproj.ArgoCD) string {
 	return fqdnServiceRef("redis-ha-haproxy", common.ArgoCDDefaultRedisPort, cr)
 }
 
 // getRedisHAProxyContainerImage will return the container image for the Redis HA Proxy.
-func getRedisHAProxyContainerImage(cr *argoprojv1a1.ArgoCD) string {
+func getRedisHAProxyContainerImage(cr *argoproj.ArgoCD) string {
 	defaultImg, defaultTag := false, false
 	img := cr.Spec.HA.RedisProxyImage
 	if len(img) <= 0 {
@@ -448,7 +447,7 @@ func getRedisHAProxyContainerImage(cr *argoprojv1a1.ArgoCD) string {
 
 // getRedisInitScript will load the redis init script from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisInitScript(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) string {
+func getRedisInitScript(cr *argoproj.ArgoCD, useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/init.sh.tpl", getRedisConfigPath())
 	vars := map[string]string{
 		"ServiceName": nameWithSuffix("redis-ha", cr),
@@ -465,7 +464,7 @@ func getRedisInitScript(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) string {
 
 // getRedisHAProxySConfig will load the Redis HA Proxy configuration from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisHAProxyConfig(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) string {
+func getRedisHAProxyConfig(cr *argoproj.ArgoCD, useTLSForRedis bool) string {
 	path := fmt.Sprintf("%s/haproxy.cfg.tpl", getRedisConfigPath())
 	vars := map[string]string{
 		"ServiceName": nameWithSuffix("redis-ha", cr),
@@ -482,7 +481,7 @@ func getRedisHAProxyConfig(cr *argoprojv1a1.ArgoCD, useTLSForRedis bool) string 
 
 // getRedisHAProxyScript will load the Redis HA Proxy init script from a template on disk for the given ArgoCD.
 // If an error occurs, an empty string value will be returned.
-func getRedisHAProxyScript(cr *argoprojv1a1.ArgoCD) string {
+func getRedisHAProxyScript(cr *argoproj.ArgoCD) string {
 	path := fmt.Sprintf("%s/haproxy_init.sh.tpl", getRedisConfigPath())
 	vars := map[string]string{
 		"ServiceName": nameWithSuffix("redis-ha", cr),
@@ -497,7 +496,7 @@ func getRedisHAProxyScript(cr *argoprojv1a1.ArgoCD) string {
 }
 
 // getRedisResources will return the ResourceRequirements for the Redis container.
-func getRedisResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getRedisResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
 
 	// Allow override of resource requirements from CR
@@ -509,7 +508,7 @@ func getRedisResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
 }
 
 // getRedisHAResources will return the ResourceRequirements for the Redis HA.
-func getRedisHAResources(cr *argoprojv1a1.ArgoCD) corev1.ResourceRequirements {
+func getRedisHAResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
 
 	// Allow override of resource requirements from CR
@@ -581,7 +580,7 @@ func getSentinelLivenessScript(useTLSForRedis bool) string {
 }
 
 // getRedisServerAddress will return the Redis service address for the given ArgoCD.
-func getRedisServerAddress(cr *argoprojv1a1.ArgoCD) string {
+func getRedisServerAddress(cr *argoproj.ArgoCD) string {
 	if cr.Spec.HA.Enabled {
 		return getRedisHAProxyAddress(cr)
 	}
@@ -608,13 +607,13 @@ func loadTemplateFile(path string, params map[string]string) (string, error) {
 // nameWithSuffix will return a name based on the given ArgoCD. The given suffix is appended to the generated name.
 // Example: Given an ArgoCD with the name "example-argocd", providing the suffix "foo" would result in the value of
 // "example-argocd-foo" being returned.
-func nameWithSuffix(suffix string, cr *argoprojv1a1.ArgoCD) string {
+func nameWithSuffix(suffix string, cr *argoproj.ArgoCD) string {
 	return fmt.Sprintf("%s-%s", cr.Name, suffix)
 }
 
 // fqdnServiceRef will return the FQDN referencing a specific service name, as set up by the operator, with the
 // given port.
-func fqdnServiceRef(service string, port int, cr *argoprojv1a1.ArgoCD) string {
+func fqdnServiceRef(service string, port int, cr *argoproj.ArgoCD) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", nameWithSuffix(service, cr), cr.Namespace, port)
 }
 
@@ -640,7 +639,7 @@ func InspectCluster() error {
 }
 
 // reconcileCertificateAuthority will reconcile all Certificate Authority resources.
-func (r *ReconcileArgoCD) reconcileCertificateAuthority(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileCertificateAuthority(cr *argoproj.ArgoCD) error {
 	log.Info("reconciling CA secret")
 	if err := r.reconcileClusterCASecret(cr); err != nil {
 		return err
@@ -653,7 +652,7 @@ func (r *ReconcileArgoCD) reconcileCertificateAuthority(cr *argoprojv1a1.ArgoCD)
 	return nil
 }
 
-func (r *ReconcileArgoCD) redisShouldUseTLS(cr *argoprojv1a1.ArgoCD) bool {
+func (r *ReconcileArgoCD) redisShouldUseTLS(cr *argoproj.ArgoCD) bool {
 	var tlsSecretObj corev1.Secret
 	tlsSecretName := types.NamespacedName{Namespace: cr.Namespace, Name: common.ArgoCDRedisServerTLSSecretName}
 	err := r.Client.Get(context.TODO(), tlsSecretName, &tlsSecretObj)
@@ -703,7 +702,7 @@ func (r *ReconcileArgoCD) redisShouldUseTLS(cr *argoprojv1a1.ArgoCD) bool {
 }
 
 // reconcileResources will reconcile common ArgoCD resources.
-func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileResources(cr *argoproj.ArgoCD) error {
 
 	// we reconcile SSO first so that we can catch and throw errors for any illegal SSO configurations right away, and return control from here
 	// preventing dex resources from getting created anyway through the other function calls, effectively bypassing the SSO checks
@@ -833,7 +832,7 @@ func (r *ReconcileArgoCD) reconcileResources(cr *argoprojv1a1.ArgoCD) error {
 	return nil
 }
 
-func (r *ReconcileArgoCD) deleteClusterResources(cr *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) deleteClusterResources(cr *argoproj.ArgoCD) error {
 	selector, err := argocdInstanceSelector(cr.Name)
 	if err != nil {
 		return err
@@ -904,7 +903,7 @@ func argocdInstanceSelector(name string) (labels.Selector, error) {
 	return selector.Add(*requirement), nil
 }
 
-func (r *ReconcileArgoCD) removeDeletionFinalizer(argocd *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) removeDeletionFinalizer(argocd *argoproj.ArgoCD) error {
 	argocd.Finalizers = removeString(argocd.GetFinalizers(), common.ArgoCDDeletionFinalizer)
 	if err := r.Client.Update(context.TODO(), argocd); err != nil {
 		return fmt.Errorf("failed to remove deletion finalizer from %s: %w", argocd.Name, err)
@@ -912,7 +911,7 @@ func (r *ReconcileArgoCD) removeDeletionFinalizer(argocd *argoprojv1a1.ArgoCD) e
 	return nil
 }
 
-func (r *ReconcileArgoCD) addDeletionFinalizer(argocd *argoprojv1a1.ArgoCD) error {
+func (r *ReconcileArgoCD) addDeletionFinalizer(argocd *argoproj.ArgoCD) error {
 	argocd.Finalizers = append(argocd.Finalizers, common.ArgoCDDeletionFinalizer)
 	if err := r.Client.Update(context.TODO(), argocd); err != nil {
 		return fmt.Errorf("failed to add deletion finalizer for %s: %w", argocd.Name, err)
@@ -968,11 +967,11 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 
 	deleteSSOPred := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			newCR, ok := e.ObjectNew.(*argoprojv1a1.ArgoCD)
+			newCR, ok := e.ObjectNew.(*argoproj.ArgoCD)
 			if !ok {
 				return false
 			}
-			oldCR, ok := e.ObjectOld.(*argoprojv1a1.ArgoCD)
+			oldCR, ok := e.ObjectOld.(*argoproj.ArgoCD)
 			if !ok {
 				return false
 			}
@@ -1002,11 +1001,11 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 	// field. When a change is detected that results in notifications being disabled, we trigger deletion of notifications resources
 	deleteNotificationsPred := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			newCR, ok := e.ObjectNew.(*argoprojv1a1.ArgoCD)
+			newCR, ok := e.ObjectNew.(*argoproj.ArgoCD)
 			if !ok {
 				return false
 			}
-			oldCR, ok := e.ObjectOld.(*argoprojv1a1.ArgoCD)
+			oldCR, ok := e.ObjectOld.(*argoproj.ArgoCD)
 			if !ok {
 				return false
 			}
@@ -1022,7 +1021,7 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 	}
 
 	// Watch for changes to primary resource ArgoCD
-	bldr.For(&argoprojv1a1.ArgoCD{}, builder.WithPredicates(deleteSSOPred, deleteNotificationsPred))
+	bldr.For(&argoproj.ArgoCD{}, builder.WithPredicates(deleteSSOPred, deleteNotificationsPred))
 
 	// Watch for changes to ConfigMap sub-resources owned by ArgoCD instances.
 	bldr.Owns(&corev1.ConfigMap{})
@@ -1088,7 +1087,7 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 		// Watch for the changes to Deployment Config
 		bldr.Watches(&source.Kind{Type: &oappsv1.DeploymentConfig{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
-			OwnerType:    &argoprojv1a1.ArgoCD{},
+			OwnerType:    &argoproj.ArgoCD{},
 		},
 			builder.WithPredicates(deploymentConfigPred))
 	}
@@ -1591,7 +1590,7 @@ func contains(s []string, g string) bool {
 }
 
 // getApplicationSetHTTPServerHost will return the host for the given ArgoCD.
-func getApplicationSetHTTPServerHost(cr *argoprojv1a1.ArgoCD) string {
+func getApplicationSetHTTPServerHost(cr *argoproj.ArgoCD) string {
 	host := cr.Name
 	if len(cr.Spec.ApplicationSet.WebhookServer.Host) > 0 {
 		host = cr.Spec.ApplicationSet.WebhookServer.Host

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -10,8 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
@@ -34,7 +33,7 @@ var imageTests = []struct {
 	pre       func(t *testing.T)
 	opts      []argoCDOpt
 	want      string
-	imageFunc func(a *argoprojv1alpha1.ArgoCD) string
+	imageFunc func(a *argoproj.ArgoCD) string
 }{
 	{
 		name:      "dex default configuration",
@@ -45,10 +44,10 @@ var imageTests = []struct {
 		name:      "dex spec configuration",
 		imageFunc: getDexContainerImage,
 		want:      dexTestImage,
-		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
-			a.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-				Provider: v1alpha1.SSOProviderTypeDex,
-				Dex: &v1alpha1.ArgoCDDexSpec{
+		opts: []argoCDOpt{func(a *argoproj.ArgoCD) {
+			a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+				Provider: argoproj.SSOProviderTypeDex,
+				Dex: &argoproj.ArgoCDDexSpec{
 					Image:   "testing/dex",
 					Version: "latest",
 				},
@@ -71,7 +70,7 @@ var imageTests = []struct {
 	{
 		name:      "argo spec configuration",
 		imageFunc: getArgoContainerImage,
-		want:      argoTestImage, opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+		want:      argoTestImage, opts: []argoCDOpt{func(a *argoproj.ArgoCD) {
 			a.Spec.Image = "testing/argocd"
 			a.Spec.Version = "latest"
 		}},
@@ -93,7 +92,7 @@ var imageTests = []struct {
 		name:      "grafana spec configuration",
 		imageFunc: getGrafanaContainerImage,
 		want:      grafanaTestImage,
-		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+		opts: []argoCDOpt{func(a *argoproj.ArgoCD) {
 			a.Spec.Grafana.Image = "testing/grafana"
 			a.Spec.Grafana.Version = "latest"
 		}},
@@ -115,7 +114,7 @@ var imageTests = []struct {
 		name:      "redis spec configuration",
 		imageFunc: getRedisContainerImage,
 		want:      redisTestImage,
-		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+		opts: []argoCDOpt{func(a *argoproj.ArgoCD) {
 			a.Spec.Redis.Image = "testing/redis"
 			a.Spec.Redis.Version = "latest"
 		}},
@@ -139,7 +138,7 @@ var imageTests = []struct {
 		name:      "redis ha spec configuration",
 		imageFunc: getRedisHAContainerImage,
 		want:      redisHATestImage,
-		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+		opts: []argoCDOpt{func(a *argoproj.ArgoCD) {
 			a.Spec.Redis.Image = "testing/redis"
 			a.Spec.Redis.Version = "latest-ha"
 		}},
@@ -163,7 +162,7 @@ var imageTests = []struct {
 		name:      "redis ha proxy spec configuration",
 		imageFunc: getRedisHAProxyContainerImage,
 		want:      redisHAProxyTestImage,
-		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+		opts: []argoCDOpt{func(a *argoproj.ArgoCD) {
 			a.Spec.HA.RedisProxyImage = "testing/redis-ha-haproxy"
 			a.Spec.HA.RedisProxyVersion = "latest-ha"
 		}},
@@ -207,7 +206,7 @@ var argoServerURITests = []struct {
 	{
 		name:         "test with external host name",
 		routeEnabled: false,
-		opts: []argoCDOpt{func(a *argoprojv1alpha1.ArgoCD) {
+		opts: []argoCDOpt{func(a *argoproj.ArgoCD) {
 			a.Spec.Server.Host = "test-host-name"
 		}},
 		want: "https://test-host-name",
@@ -587,7 +586,7 @@ func TestSetManagedNamespaces(t *testing.T) {
 
 func TestSetManagedSourceNamespaces(t *testing.T) {
 	a := makeTestArgoCD()
-	a.Spec = v1alpha1.ArgoCDSpec{
+	a.Spec = argoproj.ArgoCDSpec{
 		SourceNamespaces: []string{
 			"test-namespace-1",
 		},
@@ -642,10 +641,10 @@ func generateEncodedPEM(t *testing.T, host string) []byte {
 // TestReconcileArgoCD_reconcileDexOAuthClientSecret This test make sures that if dex is enabled a service account is created with token stored in a secret which is used for oauth
 func TestReconcileArgoCD_reconcileDexOAuthClientSecret(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD(func(ac *argoprojv1alpha1.ArgoCD) {
-		ac.Spec.SSO = &v1alpha1.ArgoCDSSOSpec{
-			Provider: v1alpha1.SSOProviderTypeDex,
-			Dex: &v1alpha1.ArgoCDDexSpec{
+	a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+		ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
+			Dex: &argoproj.ArgoCDDexSpec{
 				OpenShiftOAuth: true,
 			},
 		}

--- a/controllers/argocdexport/export.go
+++ b/controllers/argocdexport/export.go
@@ -20,8 +20,8 @@ import (
 	"github.com/sethvargo/go-password/password"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
@@ -38,7 +38,7 @@ func generateBackupKey() ([]byte, error) {
 }
 
 // reconcileExport will ensure that the resources for the export process are present for the ArgoCDExport.
-func (r *ReconcileArgoCDExport) reconcileExport(cr *argoprojv1a1.ArgoCDExport) error {
+func (r *ReconcileArgoCDExport) reconcileExport(cr *argoprojv1alpha1.ArgoCDExport) error {
 	log.Info("reconciling export secret")
 	if err := r.reconcileExportSecret(cr); err != nil {
 		return err
@@ -60,10 +60,10 @@ func (r *ReconcileArgoCDExport) reconcileExport(cr *argoprojv1a1.ArgoCDExport) e
 }
 
 // reconcileExportSecret will ensure that the Secret used for the export process is present.
-func (r *ReconcileArgoCDExport) reconcileExportSecret(cr *argoprojv1a1.ArgoCDExport) error {
+func (r *ReconcileArgoCDExport) reconcileExportSecret(cr *argoprojv1alpha1.ArgoCDExport) error {
 	name := argoutil.FetchStorageSecretName(cr)
 	// Dummy CR to retrieve secret
-	a := &argoprojv1a1.ArgoCD{}
+	a := &argoproj.ArgoCD{}
 	a.ObjectMeta = cr.ObjectMeta
 	secret := argoutil.NewSecretWithName(a, name)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, name, secret) {

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -26,14 +26,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argocd"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // getArgoExportCommand will return the command for the ArgoCD export process.
-func getArgoExportCommand(cr *argoprojv1a1.ArgoCDExport) []string {
+func getArgoExportCommand(cr *argoproj.ArgoCDExport) []string {
 	cmd := make([]string, 0)
 	cmd = append(cmd, "uid_entrypoint.sh")
 	cmd = append(cmd, "argocd-operator-util")
@@ -42,7 +42,7 @@ func getArgoExportCommand(cr *argoprojv1a1.ArgoCDExport) []string {
 	return cmd
 }
 
-func getArgoExportContainerEnv(cr *argoprojv1a1.ArgoCDExport) []corev1.EnvVar {
+func getArgoExportContainerEnv(cr *argoproj.ArgoCDExport) []corev1.EnvVar {
 	env := make([]corev1.EnvVar, 0)
 
 	switch cr.Spec.Storage.Backend {
@@ -76,7 +76,7 @@ func getArgoExportContainerEnv(cr *argoprojv1a1.ArgoCDExport) []corev1.EnvVar {
 }
 
 // getArgoExportContainerImage will return the container image for ArgoCD.
-func getArgoExportContainerImage(cr *argoprojv1a1.ArgoCDExport) string {
+func getArgoExportContainerImage(cr *argoproj.ArgoCDExport) string {
 	img := cr.Spec.Image
 	if len(img) <= 0 {
 		img = common.ArgoCDDefaultExportJobImage
@@ -108,7 +108,7 @@ func getArgoExportVolumeMounts() []corev1.VolumeMount {
 }
 
 // getArgoSecretVolume will return the Secret Volume for the export process.
-func getArgoSecretVolume(name string, cr *argoprojv1a1.ArgoCDExport) corev1.Volume {
+func getArgoSecretVolume(name string, cr *argoproj.ArgoCDExport) corev1.Volume {
 	volume := corev1.Volume{
 		Name: name,
 	}
@@ -123,7 +123,7 @@ func getArgoSecretVolume(name string, cr *argoprojv1a1.ArgoCDExport) corev1.Volu
 }
 
 // getArgoStorageVolume will return the storage Volume for the export process.
-func getArgoStorageVolume(name string, cr *argoprojv1a1.ArgoCDExport) corev1.Volume {
+func getArgoStorageVolume(name string, cr *argoproj.ArgoCDExport) corev1.Volume {
 	volume := corev1.Volume{
 		Name: name,
 	}
@@ -144,7 +144,7 @@ func getArgoStorageVolume(name string, cr *argoprojv1a1.ArgoCDExport) corev1.Vol
 }
 
 // newJob returns a new Job instance for the given ArgoCDExport.
-func newJob(cr *argoprojv1a1.ArgoCDExport) *batchv1.Job {
+func newJob(cr *argoproj.ArgoCDExport) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -155,7 +155,7 @@ func newJob(cr *argoprojv1a1.ArgoCDExport) *batchv1.Job {
 }
 
 // newCronJob returns a new CronJob instance for the given ArgoCDExport.
-func newCronJob(cr *argoprojv1a1.ArgoCDExport) *batchv1.CronJob {
+func newCronJob(cr *argoproj.ArgoCDExport) *batchv1.CronJob {
 	return &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -165,7 +165,7 @@ func newCronJob(cr *argoprojv1a1.ArgoCDExport) *batchv1.CronJob {
 	}
 }
 
-func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string, client client.Client) corev1.PodSpec {
+func newExportPodSpec(cr *argoproj.ArgoCDExport, argocdName string, client client.Client) corev1.PodSpec {
 	pod := corev1.PodSpec{}
 
 	boolPtr := func(value bool) *bool {
@@ -210,7 +210,7 @@ func newExportPodSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string, client c
 	return pod
 }
 
-func newPodTemplateSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string, client client.Client) corev1.PodTemplateSpec {
+func newPodTemplateSpec(cr *argoproj.ArgoCDExport, argocdName string, client client.Client) corev1.PodTemplateSpec {
 	return corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
@@ -222,7 +222,7 @@ func newPodTemplateSpec(cr *argoprojv1a1.ArgoCDExport, argocdName string, client
 }
 
 // reconcileCronJob will ensure that the CronJob for the ArgoCDExport is present.
-func (r *ReconcileArgoCDExport) reconcileCronJob(cr *argoprojv1a1.ArgoCDExport) error {
+func (r *ReconcileArgoCDExport) reconcileCronJob(cr *argoproj.ArgoCDExport) error {
 	if cr.Spec.Storage == nil {
 		return nil // Do nothing if storage options not set
 	}
@@ -257,7 +257,7 @@ func (r *ReconcileArgoCDExport) reconcileCronJob(cr *argoprojv1a1.ArgoCDExport) 
 }
 
 // reconcileJob will ensure that the Job for the ArgoCDExport is present.
-func (r *ReconcileArgoCDExport) reconcileJob(cr *argoprojv1a1.ArgoCDExport) error {
+func (r *ReconcileArgoCDExport) reconcileJob(cr *argoproj.ArgoCDExport) error {
 	if cr.Spec.Storage == nil {
 		return nil // Do nothing if storage options not set
 	}
@@ -288,7 +288,7 @@ func (r *ReconcileArgoCDExport) reconcileJob(cr *argoprojv1a1.ArgoCDExport) erro
 }
 
 func (r *ReconcileArgoCDExport) argocdName(namespace string) (string, error) {
-	argocds := &argoprojv1a1.ArgoCDList{}
+	argocds := &argoproj.ArgoCDList{}
 	if err := r.Client.List(context.TODO(), argocds, &client.ListOptions{Namespace: namespace}); err != nil {
 		return "", err
 	}

--- a/controllers/argocdexport/local.go
+++ b/controllers/argocdexport/local.go
@@ -22,13 +22,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 // reconcileLocalStorage will ensure the PersistentVolumeClaim is present for the ArgoCDExport.
-func (r *ReconcileArgoCDExport) reconcileLocalStorage(cr *argoprojv1a1.ArgoCDExport) error {
+func (r *ReconcileArgoCDExport) reconcileLocalStorage(cr *argoproj.ArgoCDExport) error {
 	if cr.Spec.Storage == nil || strings.ToLower(cr.Spec.Storage.Backend) != common.ArgoCDExportStorageBackendLocal {
 		return nil // Do nothing if storage or local options not set
 	}
@@ -41,7 +41,7 @@ func (r *ReconcileArgoCDExport) reconcileLocalStorage(cr *argoprojv1a1.ArgoCDExp
 }
 
 // reconcilePVC will ensure that the PVC for the ArgoCDExport is present.
-func (r *ReconcileArgoCDExport) reconcilePVC(cr *argoprojv1a1.ArgoCDExport) error {
+func (r *ReconcileArgoCDExport) reconcilePVC(cr *argoproj.ArgoCDExport) error {
 	if cr.Status.Phase == common.ArgoCDStatusCompleted {
 		return nil // Nothing to see here, move along...
 	}

--- a/controllers/argocdexport/reconcile.go
+++ b/controllers/argocdexport/reconcile.go
@@ -20,11 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 )
 
 // reconcileArgoCDExportResources will reconcile all ArgoCDExport resources for the give CR.
-func (r *ReconcileArgoCDExport) reconcileArgoCDExportResources(cr *argoprojv1a1.ArgoCDExport) error {
+func (r *ReconcileArgoCDExport) reconcileArgoCDExportResources(cr *argoproj.ArgoCDExport) error {
 	if err := r.validateExport(cr); err != nil {
 		return err
 	}

--- a/controllers/argocdexport/storage.go
+++ b/controllers/argocdexport/storage.go
@@ -17,14 +17,14 @@ package argocdexport
 import (
 	"context"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 // reconcileStorage will ensure that the storage options for the ArgoCDExport are present.
-func (r *ReconcileArgoCDExport) reconcileStorage(cr *argoprojv1a1.ArgoCDExport) error {
+func (r *ReconcileArgoCDExport) reconcileStorage(cr *argoproj.ArgoCDExport) error {
 	if cr.Spec.Storage == nil {
-		cr.Spec.Storage = &argoprojv1a1.ArgoCDExportStorageSpec{
+		cr.Spec.Storage = &argoproj.ArgoCDExportStorageSpec{
 			Backend: common.ArgoCDExportStorageBackendLocal,
 		}
 		return r.Client.Update(context.TODO(), cr)

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
@@ -79,7 +80,7 @@ func FetchObject(client client.Client, namespace string, name string, obj client
 }
 
 // FetchStorageSecretName will return the name of the Secret to use for the export process.
-func FetchStorageSecretName(export *argoprojv1a1.ArgoCDExport) string {
+func FetchStorageSecretName(export *argoprojv1alpha1.ArgoCDExport) string {
 	name := NameWithSuffix(export.ObjectMeta, "export")
 	if export.Spec.Storage != nil && len(export.Spec.Storage.SecretName) > 0 {
 		name = export.Spec.Storage.SecretName
@@ -108,13 +109,13 @@ func newEvent(meta metav1.ObjectMeta) *corev1.Event {
 }
 
 // LabelsForCluster returns the labels for all cluster resources.
-func LabelsForCluster(cr *argoprojv1a1.ArgoCD) map[string]string {
+func LabelsForCluster(cr *argoproj.ArgoCD) map[string]string {
 	labels := common.DefaultLabels(cr.Name)
 	return labels
 }
 
 // annotationsForCluster returns the annotations for all cluster resources.
-func AnnotationsForCluster(cr *argoprojv1a1.ArgoCD) map[string]string {
+func AnnotationsForCluster(cr *argoproj.ArgoCD) map[string]string {
 	annotations := common.DefaultAnnotations(cr.Name, cr.Namespace)
 	for key, val := range cr.ObjectMeta.Annotations {
 		annotations[key] = val

--- a/controllers/argoutil/resource_test.go
+++ b/controllers/argoutil/resource_test.go
@@ -20,13 +20,13 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 func TestDefaultAnnotations(t *testing.T) {
 	type args struct {
-		cr *argoprojv1a1.ArgoCD
+		cr *argoproj.ArgoCD
 	}
 	tests := []struct {
 		name string
@@ -36,7 +36,7 @@ func TestDefaultAnnotations(t *testing.T) {
 		{
 			name: "simple annotations",
 			args: args{
-				&argoprojv1a1.ArgoCD{
+				&argoproj.ArgoCD{
 					ObjectMeta: v1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "bar",

--- a/controllers/argoutil/secret.go
+++ b/controllers/argoutil/secret.go
@@ -21,28 +21,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	argoprojv1a1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 // FetchSecret will retrieve the object with the given Name using the provided client.
 // The result will be returned.
 func FetchSecret(client client.Client, meta metav1.ObjectMeta, name string) (*corev1.Secret, error) {
-	a := &argoprojv1a1.ArgoCD{}
+	a := &argoproj.ArgoCD{}
 	a.ObjectMeta = meta
 	secret := NewSecretWithName(a, name)
 	return secret, FetchObject(client, meta.Namespace, name, secret)
 }
 
 // NewTLSSecret returns a new TLS Secret based on the given metadata with the provided suffix on the Name.
-func NewTLSSecret(cr *argoprojv1a1.ArgoCD, suffix string) *corev1.Secret {
+func NewTLSSecret(cr *argoproj.ArgoCD, suffix string) *corev1.Secret {
 	secret := NewSecretWithSuffix(cr, suffix)
 	secret.Type = corev1.SecretTypeTLS
 	return secret
 }
 
 // NewSecret returns a new Secret based on the given metadata.
-func NewSecret(cr *argoprojv1a1.ArgoCD) *corev1.Secret {
+func NewSecret(cr *argoproj.ArgoCD) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: LabelsForCluster(cr),
@@ -52,7 +52,7 @@ func NewSecret(cr *argoprojv1a1.ArgoCD) *corev1.Secret {
 }
 
 // NewSecretWithName returns a new Secret based on the given metadata with the provided Name.
-func NewSecretWithName(cr *argoprojv1a1.ArgoCD, name string) *corev1.Secret {
+func NewSecretWithName(cr *argoproj.ArgoCD, name string) *corev1.Secret {
 	secret := NewSecret(cr)
 
 	secret.ObjectMeta.Name = name
@@ -63,6 +63,6 @@ func NewSecretWithName(cr *argoprojv1a1.ArgoCD, name string) *corev1.Secret {
 }
 
 // NewSecretWithSuffix returns a new Secret based on the given metadata with the provided suffix on the Name.
-func NewSecretWithSuffix(cr *argoprojv1a1.ArgoCD, suffix string) *corev1.Secret {
+func NewSecretWithSuffix(cr *argoproj.ArgoCD, suffix string) *corev1.Secret {
 	return NewSecretWithName(cr, fmt.Sprintf("%s-%s", cr.Name, suffix))
 }

--- a/controllers/suite_testx.go
+++ b/controllers/suite_testx.go
@@ -29,7 +29,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	argoprojiov1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	v1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
+	v1beta1 "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -61,10 +62,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = argoprojiov1alpha1.AddToScheme(scheme.Scheme)
+	err = v1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = argoprojiov1alpha1.AddToScheme(scheme.Scheme)
+	err = v1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring

**What does this PR do / why we need it**:
Follow up PR for #964 to replace `v1alpha1` references of `ArgoCD` to `v1beta1`. 

Change:
Update the import path & references to use `argoproj` for v1beta1 ArgoCD API.

Note: `v1alpha1` references are not updated in kuttl tests. 