### PR TITLE
feat: upgrade RH-SSO from 7.5 to 7.6

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -183,11 +183,11 @@ const (
 	ArgoCDKeycloakVersion = "sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9"
 
 	// ArgoCDKeycloakImageForOpenShift is the default Keycloak Image used for the OpenShift platform when not specified.
-	ArgoCDKeycloakImageForOpenShift = "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8"
+	ArgoCDKeycloakImageForOpenShift = "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8"
 
 	// ArgoCDKeycloakVersionForOpenShift is the default Keycloak version used for the OpenShift platform when not specified.
-	// Version: 7.5.1
-	ArgoCDKeycloakVersionForOpenShift = "sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3"
+	// Version: 7.6-25
+	ArgoCDKeycloakVersionForOpenShift = "sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d"
 
 	// ArgoCDDefaultOIDCConfig is the default OIDC configuration.
 	ArgoCDDefaultOIDCConfig = ""

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -282,7 +282,7 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 		Image:           getKeycloakContainerImage(cr),
 		ImagePullPolicy: "Always",
 		LivenessProbe: &corev1.Probe{
-			FailureThreshold: 3,
+			TimeoutSeconds: 120,
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
@@ -302,7 +302,7 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 			{ContainerPort: 8888, Name: "ping", Protocol: "TCP"},
 		},
 		ReadinessProbe: &corev1.Probe{
-			FailureThreshold: 20,
+			TimeoutSeconds: 120,
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
@@ -312,7 +312,6 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 					},
 				},
 			},
-			InitialDelaySeconds: 60,
 		},
 		Resources: getKeycloakResources(cr),
 		VolumeMounts: []corev1.VolumeMount{
@@ -326,12 +325,18 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 				Name:      "service-ca",
 				ReadOnly:  true,
 			},
+			{
+				Name:      "sso-probe-netrc-volume",
+				MountPath: "/mnt/rh-sso",
+				ReadOnly:  false,
+			},
 		},
 	}
 }
 
 func getKeycloakDeploymentConfigTemplate(cr *argoprojv1a1.ArgoCD) *appsv1.DeploymentConfig {
 	ns := cr.Namespace
+	var medium corev1.StorageMedium = "Memory"
 	keycloakContainer := getKeycloakContainer(cr)
 
 	dc := &appsv1.DeploymentConfig{
@@ -398,6 +403,14 @@ func getKeycloakDeploymentConfigTemplate(cr *argoprojv1a1.ArgoCD) *appsv1.Deploy
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "${APPLICATION_NAME}-service-ca",
 									},
+								},
+							},
+						},
+						{
+							Name: "sso-probe-netrc-volume",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: medium,
 								},
 							},
 						},

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -107,7 +107,7 @@ func TestKeycloakContainerImage(t *testing.T) {
 			}),
 			updateCrFunc:       nil,
 			templateAPIFound:   true,
-			wantContainerImage: "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3",
+			wantContainerImage: "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d",
 		},
 		{
 			name: "ArgoCDKeycloakImageEnvName env var set",
@@ -243,7 +243,7 @@ func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
 	}
 	kc := getKeycloakContainer(a)
 	assert.Equal(t,
-		"registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3", kc.Image)
+		"registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d", kc.Image)
 	assert.Equal(t, corev1.PullAlways, kc.ImagePullPolicy)
 	assert.Equal(t, "${APPLICATION_NAME}", kc.Name)
 }

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -55,6 +55,14 @@ var (
 				},
 			},
 		},
+		{
+			Name: "sso-probe-netrc-volume",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: "Memory",
+				},
+			},
+		},
 	}
 )
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1539,7 +1539,7 @@ The following properties are available for configuring Keycloak Single sign-on p
 
 Name | Default | Description
 --- | --- | ---
-Image | OpenShift - `registry.redhat.io/rh-sso-7/sso75-openshift-rhel8` <br/> Kuberentes - `quay.io/keycloak/keycloak` | The container image for keycloak. This overrides the `ARGOCD_KEYCLOAK_IMAGE` environment variable.
+Image | OpenShift - `registry.redhat.io/rh-sso-7/sso76-openshift-rhel8` <br/> Kuberentes - `quay.io/keycloak/keycloak` | The container image for keycloak. This overrides the `ARGOCD_KEYCLOAK_IMAGE` environment variable.
 Resources | `Requests`: CPU=500m, Mem=512Mi, `Limits`: CPU=1000m, Mem=1024Mi | The container compute resources.
 RootCA | "" | root CA certificate for communicating with the OIDC provider
 VerifyTLS | true | Whether to enforce strict TLS checking when communicating with Keycloak service.

--- a/examples/argocd-keycloak-openshift.yaml
+++ b/examples/argocd-keycloak-openshift.yaml
@@ -3,10 +3,14 @@ kind: ArgoCD
 metadata:
   name: example-argocd
 spec:
+  extraConfig:
+    oidc.tls.insecure.skip.verify: 'true' 
   sso:
     provider: keycloak
-    # uncomment the below line when running operator locally.
-    # verifyTLS: false 
+    keycloak:
+      rootCA: "---BEGIN---END---"
+      # Uncomment the below line when running operator locally.
+      # verifyTLS: false 
   server:
     route:
       enabled: true

--- a/tests/ocp/1-001_validate_rhsso/01-assert.yaml
+++ b/tests/ocp/1-001_validate_rhsso/01-assert.yaml
@@ -33,7 +33,7 @@ spec:
       name: keycloak
     spec:
       containers:
-      - image: registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3
+      - image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d
         resources:
           limits:
             cpu: "1"


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
RH-SSO 7.5 is deprecated, This PR upgrades the default RH-SSO version from 7.5 to 7.6. 

**Which issue(s) this PR fixes**:
Fixes #976 
Closes #976 

**How to test changes / Special notes to the reviewer**:
1. Run the operator locally using `make install run`.
2. Submit the below Argo CD CR, to create Argo CD instance and RH-SSO installation with configuration.
```
apiVersion: argoproj.io/v1alpha1
kind: ArgoCD
metadata:
  name: example-argocd
spec:
  extraConfig:
    oidc.tls.insecure.skip.verify: 'true'
  sso:
    provider: keycloak
    keycloak:
      rootCA: "---BEGIN---END---"
      # Uncomment the below line when running operator locally.
      # verifyTLS: false
  server:
    route:
      enabled: true
```
3. Login to the Argo CD via browser, Click on `Login via Keycloak`.
4. Click on `Login with OpenShift`.
5. Provide the required details.
6. Verify that you have logged in successfully. 
