### PR TITLE
refactor: Remove dead code

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"time"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -186,7 +186,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 	return roles, nil
 }
 
-func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) (error) {
+func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) error {
 	var roles []*v1.Role
 
 	// create policy rules for each source namespace for ArgoCD Server

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -31,7 +31,7 @@ func newRole(name string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.Ro
 	}
 }
 
-func newRoleForApplicationSourceNamespaces(name, namespace string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.Role {
+func newRoleForApplicationSourceNamespaces(namespace string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.Role {
 	return &v1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getRoleNameForApplicationSourceNamespaces(namespace, cr),
@@ -83,7 +83,7 @@ func (r *ReconcileArgoCD) reconcileRoles(cr *argoprojv1a1.ArgoCD) error {
 	log.Info("reconciling roles for source namespaces")
 	policyRuleForApplicationSourceNamespaces := policyRuleForServerApplicationSourceNamespaces()
 	// reconcile roles is source namespaces for ArgoCD Server
-	if _, err := r.reconcileRoleForApplicationSourceNamespaces(common.ArgoCDServerComponent, policyRuleForApplicationSourceNamespaces, cr); err != nil {
+	if err := r.reconcileRoleForApplicationSourceNamespaces(common.ArgoCDServerComponent, policyRuleForApplicationSourceNamespaces, cr); err != nil {
 		return err
 	}
 
@@ -186,7 +186,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 	return roles, nil
 }
 
-func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) ([]*v1.Role, error) {
+func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) (error) {
 	var roles []*v1.Role
 
 	// create policy rules for each source namespace for ArgoCD Server
@@ -194,7 +194,7 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 
 		namespace := &corev1.Namespace{}
 		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: sourceNamespace}, namespace); err != nil {
-			return nil, err
+			return err
 		}
 
 		// do not reconcile roles for namespaces already containing managed-by label
@@ -214,16 +214,16 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 
 		log.Info(fmt.Sprintf("Reconciling role for %s", namespace.Name))
 
-		role := newRoleForApplicationSourceNamespaces(name, namespace.Name, policyRules, cr)
+		role := newRoleForApplicationSourceNamespaces(namespace.Name, policyRules, cr)
 		if err := applyReconcilerHook(cr, role, ""); err != nil {
-			return nil, err
+			return err
 		}
 		role.Namespace = namespace.Name
 		existingRole := v1.Role{}
 		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: namespace.Name}, &existingRole)
 		if err != nil {
 			if !errors.IsNotFound(err) {
-				return nil, fmt.Errorf("failed to reconcile the role for the service account associated with %s : %s", name, err)
+				return fmt.Errorf("failed to reconcile the role for the service account associated with %s : %s", name, err)
 			}
 		}
 
@@ -234,7 +234,7 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 			if reflect.DeepEqual(existingRole, v1.Role{}) {
 				log.Info(fmt.Sprintf("creating role %s for Argo CD instance %s in namespace %s", role.Name, cr.Name, namespace))
 				if err := r.Client.Create(context.TODO(), role); err != nil {
-					return nil, err
+					return err
 				}
 			}
 			continue
@@ -248,7 +248,7 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 
 		// Get the latest value of namespace before updating it
 		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: namespace.Name}, namespace); err != nil {
-			return nil, err
+			return err
 		}
 		// Update namespace with managed-by-cluster-argocd label
 		namespace.Labels[common.ArgoCDManagedByClusterArgoCDLabel] = cr.Namespace
@@ -259,7 +259,7 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 		if !reflect.DeepEqual(existingRole.Rules, role.Rules) {
 			existingRole.Rules = role.Rules
 			if err := r.Client.Update(context.TODO(), &existingRole); err != nil {
-				return nil, err
+				return err
 			}
 		}
 		roles = append(roles, &existingRole)
@@ -269,7 +269,7 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 		}
 
 	}
-	return roles, nil
+	return nil
 }
 
 func (r *ReconcileArgoCD) reconcileClusterRole(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) (*v1.ClusterRole, error) {

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -151,7 +151,7 @@ func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.
 
 	workloadIdentifier := common.ArgoCDServerComponent
 	expectedRules := policyRuleForServerApplicationSourceNamespaces()
-	_, err := r.reconcileRoleForApplicationSourceNamespaces(workloadIdentifier, expectedRules, a)
+	err := r.reconcileRoleForApplicationSourceNamespaces(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
 	expectedName := getRoleNameForApplicationSourceNamespaces(sourceNamespace, a)

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -243,7 +243,7 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 			}
 
 			// get expected name
-			roleBinding := newRoleBindingWithNameForApplicationSourceNamespaces(name, namespace.Name, cr)
+			roleBinding := newRoleBindingWithNameForApplicationSourceNamespaces(namespace.Name, cr)
 			roleBinding.Namespace = namespace.Name
 
 			roleBinding.RoleRef = v1.RoleRef{
@@ -324,7 +324,7 @@ func getRoleNameForApplicationSourceNamespaces(targetNamespace string, cr *argop
 }
 
 // newRoleBindingWithNameForApplicationSourceNamespaces creates a new RoleBinding with the given name for the source namespaces of ArgoCD Server.
-func newRoleBindingWithNameForApplicationSourceNamespaces(name, namespace string, cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
+func newRoleBindingWithNameForApplicationSourceNamespaces(namespace string, cr *argoprojv1a1.ArgoCD) *v1.RoleBinding {
 	roleBinding := newRoleBindingForSupportNamespaces(cr, namespace)
 
 	labels := roleBinding.ObjectMeta.Labels

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -31,7 +31,6 @@ const (
 	ssoLegalSuccess          string = "Success"
 	ssoLegalFailed           string = "Failed"
 	illegalSSOConfiguration  string = "illegal SSO configuration: "
-	multipleSSOConfiguration string = "multiple SSO configuration: "
 )
 
 var (

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	ssoLegalUnknown          string = "Unknown"
-	ssoLegalSuccess          string = "Success"
-	ssoLegalFailed           string = "Failed"
-	illegalSSOConfiguration  string = "illegal SSO configuration: "
+	ssoLegalUnknown         string = "Unknown"
+	ssoLegalSuccess         string = "Success"
+	ssoLegalFailed          string = "Failed"
+	illegalSSOConfiguration string = "illegal SSO configuration: "
 )
 
 var (

--- a/controllers/argocd/testing.go
+++ b/controllers/argocd/testing.go
@@ -94,32 +94,6 @@ func makeTestArgoCDForKeycloak() *argoprojv1alpha1.ArgoCD {
 	}
 	return a
 }
-func makeTestArgoCDForKeycloakWithDex(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
-	a := &argoprojv1alpha1.ArgoCD{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testArgoCDName,
-			Namespace: testNamespace,
-		},
-		Spec: argoprojv1alpha1.ArgoCDSpec{
-			SSO: &argoprojv1alpha1.ArgoCDSSOSpec{
-				Provider: "keycloak",
-				Dex: &argoprojv1alpha1.ArgoCDDexSpec{
-					OpenShiftOAuth: true,
-					Resources:      makeTestDexResources(),
-				},
-			},
-			Server: argoprojv1alpha1.ArgoCDServerSpec{
-				Route: argoprojv1alpha1.ArgoCDRouteSpec{
-					Enabled: true,
-				},
-			},
-		},
-	}
-	for _, o := range opts {
-		o(a)
-	}
-	return a
-}
 
 func makeTestArgoCDWithResources(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
 	a := &argoprojv1alpha1.ArgoCD{


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring

**What does this PR do / why we need it**:

This PR removes dead code and unused parms which is causing lint failure in #975.
Fixes following linter errors
```
controllers/argocd/sso.go:34:2: `multipleSSOConfiguration` is unused (deadcode)
        multipleSSOConfiguration string = "multiple SSO configuration: "
        ^
controllers/argocd/testing.go:97:6: `makeTestArgoCDForKeycloakWithDex` is unused (deadcode)
func makeTestArgoCDForKeycloakWithDex(opts ...argoCDOpt) *argoprojv1alpha1.ArgoCD {
     ^
controllers/argocd/argocd_controller.go:24: File is not `goimports`-ed with -local github.com/argoproj-labs/argocd-operator (goimports)
        argoproj "github.com/argoproj-labs/argocd-operator/api/v1alpha1"

controllers/argocd/role.go:34:44: `newRoleForApplicationSourceNamespaces` - `name` is unused (unparam)
func newRoleForApplicationSourceNamespaces(name, namespace string, rules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) *v1.Role {
                                           ^
controllers/argocd/role.go:189:139: (*ReconcileArgoCD).reconcileRoleForApplicationSourceNamespaces - result 0 ([]*k8s.io/api/rbac/v1.Role) is never used (unparam)
func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name string, policyRules []v1.PolicyRule, cr *argoprojv1a1.ArgoCD) ([]*v1.Role, error) {
                      
```