### PR TITLE
Add tls cert mount appset controller

### DIFF
--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -160,7 +160,8 @@ type ArgoCDApplicationSet struct {
 
 	WebhookServer WebhookServerSpec `json:"webhookServer,omitempty"`
 
-	SCMRootCaPath string `json:"scmRootCaPath,omitempty"`
+	// SCMRootCAPath is the path where the Gitlab SCM Provider's TLS certificate is mounted on the ApplicationSet Controller.
+	SCMRootCAPath string `json:"scmRootCaPath,omitempty"`
 }
 
 // ArgoCDCASpec defines the CA options for ArgCD.

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -159,6 +159,8 @@ type ArgoCDApplicationSet struct {
 	LogLevel string `json:"logLevel,omitempty"`
 
 	WebhookServer WebhookServerSpec `json:"webhookServer,omitempty"`
+
+	ScmRootCaPath string `json:"scmRootCaPath,omitempty"`
 }
 
 // ArgoCDCASpec defines the CA options for ArgCD.

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -160,7 +160,7 @@ type ArgoCDApplicationSet struct {
 
 	WebhookServer WebhookServerSpec `json:"webhookServer,omitempty"`
 
-	ScmRootCaPath string `json:"scmRootCaPath,omitempty"`
+	SCMRootCaPath string `json:"scmRootCaPath,omitempty"`
 }
 
 // ArgoCDCASpec defines the CA options for ArgCD.

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -160,8 +160,8 @@ type ArgoCDApplicationSet struct {
 
 	WebhookServer WebhookServerSpec `json:"webhookServer,omitempty"`
 
-	// SCMRootCAPath is the path where the Gitlab SCM Provider's TLS certificate is mounted on the ApplicationSet Controller.
-	SCMRootCAPath string `json:"scmRootCaPath,omitempty"`
+	// SCMRootCAConfigMap is the name of the config map that stores the Gitlab SCM Provider's TLS certificate which will be mounted on the ApplicationSet Controller (optional).
+	SCMRootCAConfigMap string `json:"scmRootCAConfigMap,omitempty"`
 }
 
 // ArgoCDCASpec defines the CA options for ArgCD.

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -6653,9 +6653,10 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  scmRootCaPath:
-                    description: SCMRootCAPath is the path where the Gitlab SCM Provider's
-                      TLS certificate is mounted on the ApplicationSet Controller.
+                  scmRootCAConfigMap:
+                    description: SCMRootCAConfigMap is the name of the config map
+                      that stores the Gitlab SCM Provider's TLS certificate which
+                      will be mounted on the ApplicationSet Controller (optional).
                     type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -6654,6 +6654,8 @@ spec:
                         type: object
                     type: object
                   scmRootCaPath:
+                    description: SCMRootCAPath is the path where the Gitlab SCM Provider's
+                      TLS certificate is mounted on the ApplicationSet Controller.
                     type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -6653,6 +6653,8 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  scmRootCaPath:
+                    type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.
                       (optional)

--- a/common/values.go
+++ b/common/values.go
@@ -77,6 +77,9 @@ const (
 	// ArgoCDTLSCertsConfigMapName is the upstream hard-coded TLS certificate data ConfigMap name.
 	ArgoCDTLSCertsConfigMapName = "argocd-tls-certs-cm"
 
+	// ArgoCDAppSetGitlabSCMTLSCertsConfigMapName is the hard-coded ApplicationSet Gitlab SCM TLS certificate data ConfigMap name.
+	ArgoCDAppSetGitlabSCMTLSCertsConfigMapName = "argocd-appset-gitlab-scm-tls-certs-cm"
+
 	// ArgoCDRedisServerTLSSecretName is the name of the TLS secret for the redis-server
 	ArgoCDRedisServerTLSSecretName = "argocd-operator-redis-tls"
 

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -6645,6 +6645,8 @@ spec:
                         type: object
                     type: object
                   scmRootCaPath:
+                    description: SCMRootCAPath is the path where the Gitlab SCM Provider's
+                      TLS certificate is mounted on the ApplicationSet Controller.
                     type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -6644,6 +6644,8 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  scmRootCaPath:
+                    type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.
                       (optional)

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -6644,9 +6644,10 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  scmRootCaPath:
-                    description: SCMRootCAPath is the path where the Gitlab SCM Provider's
-                      TLS certificate is mounted on the ApplicationSet Controller.
+                  scmRootCAConfigMap:
+                    description: SCMRootCAConfigMap is the name of the config map
+                      that stores the Gitlab SCM Provider's TLS certificate which
+                      will be mounted on the ApplicationSet Controller (optional).
                     type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -46,9 +46,9 @@ func getArgoApplicationSetCommand(cr *argoproj.ArgoCD) []string {
 	cmd = append(cmd, "--loglevel")
 	cmd = append(cmd, getLogLevel(cr.Spec.ApplicationSet.LogLevel))
 
-	if cr.Spec.ApplicationSet.ScmRootCaPath != "" {
+	if cr.Spec.ApplicationSet.SCMRootCaPath != "" {
 		cmd = append(cmd, "--scm-root-ca-path")
-		cmd = append(cmd, cr.Spec.ApplicationSet.ScmRootCaPath)
+		cmd = append(cmd, cr.Spec.ApplicationSet.SCMRootCaPath)
 	}
 
 	// ApplicationSet command arguments provided by the user
@@ -150,7 +150,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoproj.ArgoCD,
 		},
 	}
 	addSCMGitlabVolumeMount := false
-	if cr.Spec.ApplicationSet.ScmRootCaPath != "" {
+	if cr.Spec.ApplicationSet.SCMRootCaPath != "" {
 		cm := newConfigMapWithName(getCAConfigMapName(cr), cr)
 		if argoutil.IsObjectFound(r.Client, cr.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, cm) {
 			addSCMGitlabVolumeMount = true
@@ -277,7 +277,7 @@ func applicationSetContainer(cr *argoproj.ArgoCD, addSCMGitlabVolumeMount bool) 
 	if addSCMGitlabVolumeMount {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      "appset-gitlab-scm-tls-cert",
-			MountPath: cr.Spec.ApplicationSet.ScmRootCaPath,
+			MountPath: cr.Spec.ApplicationSet.SCMRootCaPath,
 		})
 	}
 	return container

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -46,8 +46,10 @@ func getArgoApplicationSetCommand(cr *argoproj.ArgoCD) []string {
 	cmd = append(cmd, "--loglevel")
 	cmd = append(cmd, getLogLevel(cr.Spec.ApplicationSet.LogLevel))
 
-	cmd = append(cmd, "--scm-root-ca-path")
-	cmd = append(cmd, cr.Spec.ApplicationSet.ScmRootCaPath)
+	if cr.Spec.ApplicationSet.ScmRootCaPath != "" {
+		cmd = append(cmd, "--scm-root-ca-path")
+		cmd = append(cmd, cr.Spec.ApplicationSet.ScmRootCaPath)
+	}
 
 	// ApplicationSet command arguments provided by the user
 	extraArgs := cr.Spec.ApplicationSet.ExtraCommandArgs

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -46,9 +46,9 @@ func getArgoApplicationSetCommand(cr *argoproj.ArgoCD) []string {
 	cmd = append(cmd, "--loglevel")
 	cmd = append(cmd, getLogLevel(cr.Spec.ApplicationSet.LogLevel))
 
-	if cr.Spec.ApplicationSet.SCMRootCaPath != "" {
+	if cr.Spec.ApplicationSet.SCMRootCAPath != "" {
 		cmd = append(cmd, "--scm-root-ca-path")
-		cmd = append(cmd, cr.Spec.ApplicationSet.SCMRootCaPath)
+		cmd = append(cmd, cr.Spec.ApplicationSet.SCMRootCAPath)
 	}
 
 	// ApplicationSet command arguments provided by the user
@@ -150,7 +150,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoproj.ArgoCD,
 		},
 	}
 	addSCMGitlabVolumeMount := false
-	if cr.Spec.ApplicationSet.SCMRootCaPath != "" {
+	if cr.Spec.ApplicationSet.SCMRootCAPath != "" {
 		cm := newConfigMapWithName(getCAConfigMapName(cr), cr)
 		if argoutil.IsObjectFound(r.Client, cr.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, cm) {
 			addSCMGitlabVolumeMount = true
@@ -277,7 +277,7 @@ func applicationSetContainer(cr *argoproj.ArgoCD, addSCMGitlabVolumeMount bool) 
 	if addSCMGitlabVolumeMount {
 		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 			Name:      "appset-gitlab-scm-tls-cert",
-			MountPath: cr.Spec.ApplicationSet.SCMRootCaPath,
+			MountPath: cr.Spec.ApplicationSet.SCMRootCAPath,
 		})
 	}
 	return container

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -151,7 +151,7 @@ func checkExpectedDeploymentValues(t *testing.T, r *ReconcileArgoCD, deployment 
 		},
 	}
 
-	if a.Spec.ApplicationSet.SCMRootCAPath != "" && argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a) {
+	if a.Spec.ApplicationSet.SCMRootCAConfigMap != "" && argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a) {
 		volumes = append(volumes, corev1.Volume{
 			Name: "appset-gitlab-scm-tls-cert",
 			VolumeSource: corev1.VolumeSource{
@@ -363,7 +363,7 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 		{
 			name: "ensure scm tls cert mount is present",
 			appSetField: &argoproj.ArgoCDApplicationSet{
-				SCMRootCAPath: "testPath",
+				SCMRootCAConfigMap: "test-scm-tls-mount",
 			},
 			envVars:                map[string]string{common.ArgoCDImageEnvName: "custom-env-image"},
 			expectedContainerImage: "custom-env-image",

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -151,7 +151,7 @@ func checkExpectedDeploymentValues(t *testing.T, r *ReconcileArgoCD, deployment 
 		},
 	}
 
-	if a.Spec.ApplicationSet.SCMRootCaPath != "" && argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a) {
+	if a.Spec.ApplicationSet.SCMRootCAPath != "" && argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a) {
 		volumes = append(volumes, corev1.Volume{
 			Name: "appset-gitlab-scm-tls-cert",
 			VolumeSource: corev1.VolumeSource{
@@ -363,7 +363,7 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 		{
 			name: "ensure scm tls cert mount is present",
 			appSetField: &argoproj.ArgoCDApplicationSet{
-				SCMRootCaPath: "testPath",
+				SCMRootCAPath: "testPath",
 			},
 			envVars:                map[string]string{common.ArgoCDImageEnvName: "custom-env-image"},
 			expectedContainerImage: "custom-env-image",

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
@@ -92,10 +93,10 @@ func TestReconcileApplicationSet_CreateDeployments(t *testing.T) {
 		deployment))
 
 	// Ensure the created Deployment has the expected properties
-	checkExpectedDeploymentValues(t, deployment, &sa, a)
+	checkExpectedDeploymentValues(t, r, deployment, &sa, a)
 }
 
-func checkExpectedDeploymentValues(t *testing.T, deployment *appsv1.Deployment, sa *corev1.ServiceAccount, a *argoproj.ArgoCD) {
+func checkExpectedDeploymentValues(t *testing.T, r *ReconcileArgoCD, deployment *appsv1.Deployment, sa *corev1.ServiceAccount, a *argoproj.ArgoCD) {
 	assert.Equal(t, deployment.Spec.Template.Spec.ServiceAccountName, sa.ObjectMeta.Name)
 	appsetAssertExpectedLabels(t, &deployment.ObjectMeta)
 
@@ -148,6 +149,19 @@ func checkExpectedDeploymentValues(t *testing.T, deployment *appsv1.Deployment, 
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+	}
+
+	if a.Spec.ApplicationSet.ScmRootCaPath != "" && argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a) {
+		volumes = append(volumes, corev1.Volume{
+			Name: "appset-gitlab-scm-tls-cert",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName,
+					},
+				},
+			},
+		})
 	}
 
 	if diff := cmp.Diff(volumes, deployment.Spec.Template.Spec.Volumes); diff != "" {
@@ -261,7 +275,7 @@ func TestReconcileApplicationSet_UpdateExistingDeployments(t *testing.T) {
 		deployment))
 
 	// Ensure the updated Deployment has the expected properties
-	checkExpectedDeploymentValues(t, deployment, &sa, a)
+	checkExpectedDeploymentValues(t, r, deployment, &sa, a)
 
 }
 
@@ -346,6 +360,14 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 			envVars:                map[string]string{common.ArgoCDImageEnvName: "custom-env-image"},
 			expectedContainerImage: "custom-image:custom-version",
 		},
+		{
+			name: "ensure scm tls cert mount is present",
+			appSetField: &argoproj.ArgoCDApplicationSet{
+				ScmRootCaPath: "testPath",
+			},
+			envVars:                map[string]string{common.ArgoCDImageEnvName: "custom-env-image"},
+			expectedContainerImage: "custom-env-image",
+		},
 	}
 
 	for _, test := range tests {
@@ -357,6 +379,8 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 
 			a := makeTestArgoCD()
 			r := makeTestReconciler(t, a)
+			cm := newConfigMapWithName(getCAConfigMapName(a), a)
+			r.Client.Create(context.Background(), cm, &client.CreateOptions{})
 
 			a.Spec.ApplicationSet = test.appSetField
 
@@ -374,7 +398,7 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 
 			specImage := deployment.Spec.Template.Spec.Containers[0].Image
 			assert.Equal(t, test.expectedContainerImage, specImage)
-
+			checkExpectedDeploymentValues(t, r, deployment, &sa, a)
 		})
 	}
 

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -151,7 +151,7 @@ func checkExpectedDeploymentValues(t *testing.T, r *ReconcileArgoCD, deployment 
 		},
 	}
 
-	if a.Spec.ApplicationSet.ScmRootCaPath != "" && argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a) {
+	if a.Spec.ApplicationSet.SCMRootCaPath != "" && argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a) {
 		volumes = append(volumes, corev1.Volume{
 			Name: "appset-gitlab-scm-tls-cert",
 			VolumeSource: corev1.VolumeSource{
@@ -363,7 +363,7 @@ func TestReconcileApplicationSet_Deployments_SpecOverride(t *testing.T) {
 		{
 			name: "ensure scm tls cert mount is present",
 			appSetField: &argoproj.ArgoCDApplicationSet{
-				ScmRootCaPath: "testPath",
+				SCMRootCaPath: "testPath",
 			},
 			envVars:                map[string]string{common.ArgoCDImageEnvName: "custom-env-image"},
 			expectedContainerImage: "custom-env-image",

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -99,7 +99,7 @@ func checkExpectedDeploymentValues(t *testing.T, deployment *appsv1.Deployment, 
 	assert.Equal(t, deployment.Spec.Template.Spec.ServiceAccountName, sa.ObjectMeta.Name)
 	appsetAssertExpectedLabels(t, &deployment.ObjectMeta)
 
-	want := []corev1.Container{applicationSetContainer(a)}
+	want := []corev1.Container{applicationSetContainer(a, false)}
 
 	if diff := cmp.Diff(want, deployment.Spec.Template.Spec.Containers); diff != "" {
 		t.Fatalf("failed to reconcile applicationset-controller deployment containers:\n%s", diff)
@@ -287,7 +287,7 @@ func TestReconcileApplicationSet_Deployments_resourceRequirements(t *testing.T) 
 	assert.Equal(t, deployment.Spec.Template.Spec.ServiceAccountName, sa.ObjectMeta.Name)
 	appsetAssertExpectedLabels(t, &deployment.ObjectMeta)
 
-	containerWant := []corev1.Container{applicationSetContainer(a)}
+	containerWant := []corev1.Container{applicationSetContainer(a, false)}
 
 	if diff := cmp.Diff(containerWant, deployment.Spec.Template.Spec.Containers); diff != "" {
 		t.Fatalf("failed to reconcile argocd-server deployment:\n%s", diff)

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -198,6 +198,6 @@ func (r *ReconcileArgoCD) Reconcile(ctx context.Context, request ctrl.Request) (
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReconcileArgoCD) SetupWithManager(mgr ctrl.Manager) error {
 	bldr := ctrl.NewControllerManagedBy(mgr)
-	r.setResourceWatches(bldr, r.clusterResourceMapper, r.tlsSecretMapper, r.namespaceResourceMapper, r.clusterSecretResourceMapper)
+	r.setResourceWatches(bldr, r.clusterResourceMapper, r.tlsSecretMapper, r.namespaceResourceMapper, r.clusterSecretResourceMapper, r.applicationSetSCMTLSConfigMapMapper)
 	return bldr.Complete(r)
 }

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -63,6 +63,14 @@ func getCAConfigMapName(cr *argoproj.ArgoCD) string {
 	return nameWithSuffix(common.ArgoCDCASuffix, cr)
 }
 
+// getSCMRootCAConfigMapName will return the SCMRootCA ConfigMap name for the given ArgoCD ApplicationSet Controller.
+func getSCMRootCAConfigMapName(cr *argoproj.ArgoCD) string {
+	if cr.Spec.ApplicationSet.SCMRootCAConfigMap != "" && len(cr.Spec.ApplicationSet.SCMRootCAConfigMap) > 0 {
+		return cr.Spec.ApplicationSet.SCMRootCAConfigMap
+	}
+	return ""
+}
+
 // getConfigManagementPlugins will return the config management plugins for the given ArgoCD.
 func getConfigManagementPlugins(cr *argoproj.ArgoCD) string {
 	plugins := common.ArgoCDDefaultConfigManagementPlugins

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -182,3 +182,31 @@ func (r *ReconcileArgoCD) clusterSecretResourceMapper(o client.Object) []reconci
 
 	return result
 }
+
+// applicationSetSCMTLSConfigMapMapper maps a watch event on a configmap with name "argocd-appset-gitlab-scm-tls-certs-cm",
+// back to the ArgoCD object that we want to reconcile.
+func (r *ReconcileArgoCD) applicationSetSCMTLSConfigMapMapper(o client.Object) []reconcile.Request {
+	var result = []reconcile.Request{}
+
+	if o.GetName() == common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName {
+		argocds := &argoproj.ArgoCDList{}
+		if err := r.Client.List(context.TODO(), argocds, &client.ListOptions{Namespace: o.GetNamespace()}); err != nil {
+			return result
+		}
+
+		if len(argocds.Items) != 1 {
+			return result
+		}
+
+		argocd := argocds.Items[0]
+		namespacedName := client.ObjectKey{
+			Name:      argocd.Name,
+			Namespace: argocd.Namespace,
+		}
+		result = []reconcile.Request{
+			{NamespacedName: namespacedName},
+		}
+	}
+
+	return result
+}

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -931,7 +931,7 @@ func removeString(slice []string, s string) []string {
 }
 
 // setResourceWatches will register Watches for each of the supported Resources.
-func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResourceMapper, tlsSecretMapper, namespaceResourceMapper, clusterSecretResourceMapper handler.MapFunc) *builder.Builder {
+func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResourceMapper, tlsSecretMapper, namespaceResourceMapper, clusterSecretResourceMapper, applicationSetGitlabSCMTLSConfigMapMapper handler.MapFunc) *builder.Builder {
 
 	deploymentConfigPred := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -1046,11 +1046,17 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 
 	clusterSecretResourceHandler := handler.EnqueueRequestsFromMapFunc(clusterSecretResourceMapper)
 
+	appSetGitlabSCMTLSConfigMapHandler := handler.EnqueueRequestsFromMapFunc(applicationSetGitlabSCMTLSConfigMapMapper)
+
 	tlsSecretHandler := handler.EnqueueRequestsFromMapFunc(tlsSecretMapper)
 
 	bldr.Watches(&source.Kind{Type: &v1.ClusterRoleBinding{}}, clusterResourceHandler)
 
 	bldr.Watches(&source.Kind{Type: &v1.ClusterRole{}}, clusterResourceHandler)
+
+	bldr.Watches(&source.Kind{Type: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName,
+	}}}, appSetGitlabSCMTLSConfigMapHandler)
 
 	// Watch for secrets of type TLS that might be created by external processes
 	bldr.Watches(&source.Kind{Type: &corev1.Secret{Type: corev1.SecretTypeTLS}}, tlsSecretHandler)

--- a/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
@@ -6653,9 +6653,10 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
-                  scmRootCaPath:
-                    description: SCMRootCAPath is the path where the Gitlab SCM Provider's
-                      TLS certificate is mounted on the ApplicationSet Controller.
+                  scmRootCAConfigMap:
+                    description: SCMRootCAConfigMap is the name of the config map
+                      that stores the Gitlab SCM Provider's TLS certificate which
+                      will be mounted on the ApplicationSet Controller (optional).
                     type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.

--- a/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
@@ -6654,6 +6654,8 @@ spec:
                         type: object
                     type: object
                   scmRootCaPath:
+                    description: SCMRootCAPath is the path where the Gitlab SCM Provider's
+                      TLS certificate is mounted on the ApplicationSet Controller.
                     type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.

--- a/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.8.0/argoproj.io_argocds.yaml
@@ -6653,6 +6653,8 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  scmRootCaPath:
+                    type: string
                   version:
                     description: Version is the Argo CD ApplicationSet image tag.
                       (optional)

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -85,6 +85,7 @@ Resources | [Empty] | The container compute resources.
 LogLevel | info | The log level to be used by the ArgoCD Application Controller component. Valid options are debug, info, error, and warn.
 LogFormat | text | The log format to be used by the ArgoCD Application Controller component. Valid options are text or json.
 ParallelismLimit | 10 | The kubectl parallelism limit to set for the controller (`--kubectl-parallelism-limit` flag)
+SCMRootCaPath (#add-tls-certificate-for-gitlab-scm-provider-to-applicationsets-controller) | [Empty] | The path where the Gitlab SCM Provider's TLS certificate is mounted on the ApplicationSet Controller. The TLS certificate is picked from a configMap `"argocd-appset-gitlab-scm-tls-certs-cm"` and mounted on the applicationset-controller as a volume mount.
 
 ### ApplicationSet Controller Example
 
@@ -118,6 +119,24 @@ spec:
       - --foo
       - bar
 ```
+
+### Add Self signed TLS Certificate for Gitlab SCM Provider to ApplicationSets Controller
+
+ApplicationSetController added a new option `--scm-root-ca-path` and expects the self-signed TLS certificate to be mounted on the path specified and to be used for Gitlab SCM Provider and Gitlab Pull Request Provider. To set this option, you can set `spec.applicationSet.scmRootCaPath` in ArgoCD CR. The operator expects the TLS certificate to be stored in a ConfigMap named `argocd-appset-gitlab-scm-tls-certs-cm`. When the parameter `spec.applicationSet.scmRootCaPath` is set in ArgoCD CR, the operator checks for ConfigMap named `argocd-appset-gitlab-scm-tls-certs-cm` in the same namespace as the ArgoCD instance and mounts the Certificate stored in ConfigMap to ApplicationSet Controller pods at the path specified by `spec.applicationSet.scmRootCaPath`.
+
+Below example shows how a user can add scmRootCaPath to the ApplicationSet controller.
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: applicationset
+spec:
+  applicationSet:
+    scmRootCaPath: /path/for/tls/certificate/mount
+```
+
 
 ## Config Management Plugins
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -85,7 +85,7 @@ Resources | [Empty] | The container compute resources.
 LogLevel | info | The log level to be used by the ArgoCD Application Controller component. Valid options are debug, info, error, and warn.
 LogFormat | text | The log format to be used by the ArgoCD Application Controller component. Valid options are text or json.
 ParallelismLimit | 10 | The kubectl parallelism limit to set for the controller (`--kubectl-parallelism-limit` flag)
-SCMRootCaPath (#add-tls-certificate-for-gitlab-scm-provider-to-applicationsets-controller) | [Empty] | The path where the Gitlab SCM Provider's TLS certificate is mounted on the ApplicationSet Controller. The TLS certificate is picked from a configMap `"argocd-appset-gitlab-scm-tls-certs-cm"` and mounted on the applicationset-controller as a volume mount.
+SCMRootCAConfigMap (#add-tls-certificate-for-gitlab-scm-provider-to-applicationsets-controller) | [Empty] | The name of the config map that stores the Gitlab SCM Provider's TLS certificate which will be mounted on the ApplicationSet Controller at `"/app/tls/scm/cert"` path.
 
 ### ApplicationSet Controller Example
 
@@ -122,7 +122,7 @@ spec:
 
 ### Add Self signed TLS Certificate for Gitlab SCM Provider to ApplicationSets Controller
 
-ApplicationSetController added a new option `--scm-root-ca-path` and expects the self-signed TLS certificate to be mounted on the path specified and to be used for Gitlab SCM Provider and Gitlab Pull Request Provider. To set this option, you can set `spec.applicationSet.scmRootCaPath` in ArgoCD CR. The operator expects the TLS certificate to be stored in a ConfigMap named `argocd-appset-gitlab-scm-tls-certs-cm`. When the parameter `spec.applicationSet.scmRootCaPath` is set in ArgoCD CR, the operator checks for ConfigMap named `argocd-appset-gitlab-scm-tls-certs-cm` in the same namespace as the ArgoCD instance and mounts the Certificate stored in ConfigMap to ApplicationSet Controller pods at the path specified by `spec.applicationSet.scmRootCaPath`.
+ApplicationSetController added a new option `--scm-root-ca-path` and expects the self-signed TLS certificate to be mounted on the path specified and to be used for Gitlab SCM Provider and Gitlab Pull Request Provider. To set this option, you can store the certificate in the config map and specify the config map name using `spec.applicationSet.SCMRootCAConfigMap` in ArgoCD CR. When the parameter `spec.applicationSet.SCMRootCAConfigMap` is set in ArgoCD CR, the operator checks for ConfigMap in the same namespace as the ArgoCD instance and mounts the Certificate stored in ConfigMap to ApplicationSet Controller pods at the path `/app/tls/scm/cert`.
 
 Below example shows how a user can add scmRootCaPath to the ApplicationSet controller.
 ```yaml
@@ -134,7 +134,7 @@ metadata:
     example: applicationset
 spec:
   applicationSet:
-    scmRootCaPath: /path/for/tls/certificate/mount
+    SCMRootCAConfigMap: example-gitlab-scm-tls-cert
 ```
 
 

--- a/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-assert.yaml
+++ b/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-assert.yaml
@@ -1,0 +1,75 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd
+  namespace: test-1-32-appsets-scm-tls-mount
+spec:
+  applicationSet:
+    scmRootCaPath: /app/tls/cert
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-applicationset-controller
+  namespace: test-1-32-appsets-scm-tls-mount
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/managed-by: argocd
+    app.kubernetes.io/name: argocd-applicationset-controller
+    app.kubernetes.io/part-of: argocd-applicationset
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-applicationset-controller
+  template:
+    spec:
+      containers:
+        - command:
+          - entrypoint.sh
+          - argocd-applicationset-controller
+          - --argocd-repo-server
+          - argocd-repo-server.test-1-32-appsets-scm-tls-mount.svc.cluster.local:8081
+          - --loglevel
+          - info
+          - --scm-root-ca-path
+          - /app/tls/cert
+          volumeMounts:
+          - mountPath: /app/config/ssh
+            name: ssh-known-hosts
+          - mountPath: /app/config/tls
+            name: tls-certs
+          - mountPath: /app/config/gpg/source
+            name: gpg-keys
+          - mountPath: /app/config/gpg/keys
+            name: gpg-keyring
+          - mountPath: /tmp
+            name: tmp
+          - mountPath: /app/tls/cert
+            name: appset-gitlab-scm-tls-cert
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: argocd-ssh-known-hosts-cm
+        name: ssh-known-hosts
+      - configMap:
+          defaultMode: 420
+          name: argocd-tls-certs-cm
+        name: tls-certs
+      - configMap:
+          defaultMode: 420
+          name: argocd-gpg-keys-cm
+        name: gpg-keys
+      - emptyDir: {}
+        name: gpg-keyring
+      - emptyDir: {}
+        name: tmp
+      - configMap:
+          defaultMode: 420
+          name: argocd-appset-gitlab-scm-tls-certs-cm
+        name: appset-gitlab-scm-tls-cert

--- a/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-assert.yaml
+++ b/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-assert.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: test-1-32-appsets-scm-tls-mount
 spec:
   applicationSet:
-    scmRootCaPath: /app/tls/cert
+    scmRootCAConfigMap: test-1-32-appsets-scm-tls-cm
 status:
   phase: Available
 ---
@@ -38,7 +38,7 @@ spec:
           - --loglevel
           - info
           - --scm-root-ca-path
-          - /app/tls/cert
+          - /app/tls/scm/cert
           volumeMounts:
           - mountPath: /app/config/ssh
             name: ssh-known-hosts
@@ -50,7 +50,7 @@ spec:
             name: gpg-keyring
           - mountPath: /tmp
             name: tmp
-          - mountPath: /app/tls/cert
+          - mountPath: /app/tls/scm/cert
             name: appset-gitlab-scm-tls-cert
       volumes:
       - configMap:

--- a/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-install.yaml
+++ b/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-install.yaml
@@ -6,7 +6,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: argocd-appset-gitlab-scm-tls-certs-cm
+  name: test-1-32-appsets-scm-tls-cm
   namespace: test-1-32-appsets-scm-tls-mount
 data:
   cert: |
@@ -53,4 +53,4 @@ metadata:
   namespace: test-1-32-appsets-scm-tls-mount
 spec:
   applicationSet:
-    scmRootCaPath: /app/tls/cert
+    scmRootCAConfigMap: test-1-32-appsets-scm-tls-cm

--- a/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-install.yaml
+++ b/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-install.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-1-32-appsets-scm-tls-mount
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-appset-gitlab-scm-tls-certs-cm
+  namespace: test-1-32-appsets-scm-tls-mount
+data:
+  cert: |
+    -----BEGIN CERTIFICATE-----
+    AIIEBCCA7+gAwIBAgIUQdTcSHY2Sxd3Tq/v1eIEZPCNbOowDQYJKoZIhvcNAQEL
+    BQAwezELMAkGA1UEBhMCREUxFTATBgNVBAgMDExvd2VyIFNheG9ueTEQMA4GA1UE
+    BwwHSGFub3ZlcjEVMBMGA1UECgwMVGVzdGluZyBDb3JwMRIwEAYDVQQLDAlUZXN0
+    c3VpdGUxGDAWBrNVBAMMD2Jhci5leGFtcGxlLmNvbTAeFw0xOTA3MDgxMzU2MTda
+    Fw0yMDA3MDcxMzU2MTdaMHsxCzAJBgNVBAYTAkRFMRUwEwYDVQQIDAxMb3dlciBT
+    YXhvbnkxEDAOBgNVBAcMB0hhbm92ZXIxFTATBgNVBAoMDFRlc3RpbmcgQ29ycDES
+    MBAGA1UECwwJVGVzdHN1aXRlMRgwFgYDVQQDDA9iYXIuZXhhbXBsZS5jb20wggIi
+    MA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCv4mHMdVUcafmaSHVpUM0zZWp5
+    NFXfboxA4inuOkE8kZlbGSe7wiG9WqLirdr39Ts+WSAFA6oANvbzlu3JrEQ2CHPc
+    CNQm6diPREFwcDPFCe/eMawbwkQAPVSHPts0UoRxnpZox5pn69ghncBR+jtvx+/u
+    P6HdwW0qqTvfJnfAF1hBJ4oIk2AXiip5kkIznsAh9W6WRy6nTVCeetmIepDOGe0G
+    ZJIRn/OfSz7NzKylfDCat2z3EAutyeT/5oXZoWOmGg/8T7pn/pR588GoYYKRQnp+
+    YilqCPFX+az09EqqK/iHXnkdZ/Z2fCuU+9M/Zhrnlwlygl3RuVBI6xhm/ZsXtL2E
+    Gxa61lNy6pyx5+hSxHEFEJshXLtioRd702VdLKxEOuYSXKeJDs1x9o6cJ75S6hko
+    Ml1L4zCU+xEsMcvb1iQ2n7PZdacqhkFRUVVVmJ56th8aYyX7KNX6M9CD+kMpNm6J
+    kKC1li/Iy+RI138bAvaFplajMF551kt44dSvIoJIbTr1LigudzWPqk31QaZXV/4u
+    kD1n4p/XMc9HYU/was/CmQBFqmIZedTLTtK7clkuFN6wbwzdo1wmUNgnySQuMacO
+    gxhHxxzRWxd24uLyk9Px+9U3BfVPaRLiOPaPoC58lyVOykjSgfpgbus7JS69fCq7
+    bEH4Jatp/10zkco+UQIDAQABo1MwUTAdBgNVHQ4EFgQUjXH6PHi92y4C4hQpey86
+    r6+x1ewwHwYDVR0jBBgwFoAUjXH6PHi92y4C4hQpey86r6+x1ewwDwYDVR0TAQH/
+    BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEAFE4SdKsX9UsLy+Z0xuHSxhTd0jfn
+    Iih5mtzb8CDNO5oTw4z0aMeAvpsUvjJ/XjgxnkiRACXh7K9hsG2r+ageRWGevyvx
+    CaRXFbherV1kTnZw4Y9/pgZTYVWs9jlqFOppz5sStkfjsDQ5lmPJGDii/StENAz2
+    XmtiPOgfG9Upb0GAJBCuKnrU9bIcT4L20gd2F4Y14ccyjlf8UiUi192IX6yM9OjT
+    +TuXwZgqnTOq6piVgr+FTSa24qSvaXb5z/mJDLlk23npecTouLg83TNSn3R6fYQr
+    d/Y9eXuUJ8U7/qTh2Ulz071AO9KzPOmleYPTx4Xty4xAtWi1QE5NHW9/Ajlv5OtO
+    OnMNWIs7ssDJBsB7VFC8hcwf79jz7kC0xmQqDfw51Xhhk04kla+v+HZcFW2AO9so
+    6ZdVHHQnIbJa7yQJKZ+hK49IOoBR6JgdB5kymoplLLiuqZSYTcwSBZ72FYTm3iAr
+    jzvt1hxpxVDmXvRnkhRrIRhK4QgJL0jRmirBjDY+PYYd7bdRIjN7WNZLFsgplnS8
+    9w6CwG32pRlm0c8kkiQ7FXA6BYCqOsDI8f1VGQv331OpR2Ck+FTv+L7DAmg6l37W
+    AIIEBCCA7+gAwIBAgIUQdTcSHY2Sxd3Tq/v1eIEZPCNbOowDQYJKoZIhvcNAQEL
+    XWyb96wrUlv+E8I=
+    -----END CERTIFICATE-----
+
+---
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd
+  namespace: test-1-32-appsets-scm-tls-mount
+spec:
+  applicationSet:
+    scmRootCaPath: /app/tls/cert


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
ArgoCD recently added support for custom TLS certificates for ApplicationSet Gitlab SCM Providers. ApplicationSetController added a new option `--scm-root-ca-path` and expects the certificate to be mounted on the path specified. As part of this PR, we added a new parameter to `spec.applicationSet.scmRootCaPath` to ArgoCD spec which takes the data from a hard-coded configMap named `argocd-appset-gitlab-scm-tls-certs-cm` containing the certificate and volume mounts it on the applicationset-controller pods on the path specified in `spec.applicationSet.scmRootCaPath`. The PR also adds a watcher on the the configMap to reconcile ArgoCD for any changes to the ConfigMap.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-3107](https://issues.redhat.com/browse/GITOPS-3107)

**How to test changes / Special notes to the reviewer**:
1. Start the argocd-operator using `make install run`
2. Create a configMap named `argocd-appset-gitlab-scm-tls-certs-cm` with TLS cert details.
3. Create the ArgoCD instance with below configuration in the same namespace as the configMap.
```
apiVersion: argoproj.io/v1beta1
kind: ArgoCD
metadata:
  name: argocd
  namespace: test-1-32-appsets-scm-tls-mount
spec:
  applicationSet:
    scmRootCaPath: <path_of_the_cert_for_volume_mount>
```
4. Describe the applicationset controller pod to see if the volume and volume mount is present or not.