### PR TITLE
fix: replace deprecated syntax in kustomization.yaml

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,17 +10,17 @@ resources:
 
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_argocds.yaml
-#- patches/webhook_in_argocdexports.yaml
+- path: patches/webhook_in_argocds.yaml
+#- path: patches/webhook_in_argocdexports.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_argocds.yaml
-#- patches/cainjection_in_argocdexports.yaml
+- path: patches/cainjection_in_argocds.yaml
+#- path: patches/cainjection_in_argocdexports.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: argocd-operator-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -24,24 +24,24 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 # - ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-# - manager_auth_proxy_patch.yaml
+#- path: manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+#- path: manager_config_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#- path: webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -50,9 +50,9 @@ metadata:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ```
 
-Enable `../certmanager` directory under the `bases` section in `config/default/kustomization.yaml` file.
+Enable `../certmanager` directory under the `resources` section in `config/default/kustomization.yaml` file.
 ```yaml
-bases:
+resources:
 .....
 - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

Deprecation warning from kustomize build:

```shell
$ kustomize build ./config/default
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```
The `bases` field was deprecated in [v2.1.0](https://github.com/kubernetes-sigs/kustomize/blob/v2.1.0/docs/v_2.1.0.md#resources-expanded-bases-deprecated), and `patchesStrategicMerge` in [v5.0.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0).

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

Run `kustomize build config/default` to generate manifests, there is nothing changed.