### PR TITLE
code-refactoring: Replace ArgoCD v1alpha1 references with v1beta1

### DIFF
--- a/controllers/argocd/custommapper_test.go
+++ b/controllers/argocd/custommapper_test.go
@@ -119,7 +119,7 @@ func TestArgoCDReconciler_tlsSecretMapperRepoServer(t *testing.T) {
 				Namespace: "argocd-operator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "argoproj.io/v1alpha1",
+						APIVersion: "argoproj.io/v1beta1",
 						Kind:       "ArgoCD",
 						Name:       "argocd",
 						UID:        argocd.GetUID(),
@@ -174,7 +174,7 @@ func TestArgoCDReconciler_tlsSecretMapperRepoServer(t *testing.T) {
 				Namespace: "argocd-operator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "argoproj.io/v1alpha1",
+						APIVersion: "argoproj.io/v1beta1",
 						Kind:       "ArgoCD",
 						Name:       "argocd",
 						UID:        argocd.GetUID(),
@@ -221,7 +221,7 @@ func TestArgoCDReconciler_tlsSecretMapperRepoServer(t *testing.T) {
 				Namespace: "argocd-operator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "argoproj.io/v1alpha1",
+						APIVersion: "argoproj.io/v1beta1",
 						Kind:       "ArgoCD",
 						Name:       "argocd",
 						UID:        argocd.GetUID(),
@@ -336,7 +336,7 @@ func TestArgoCDReconciler_tlsSecretMapperRedis(t *testing.T) {
 				Namespace: "argocd-operator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "argoproj.io/v1alpha1",
+						APIVersion: "argoproj.io/v1beta1",
 						Kind:       "ArgoCD",
 						Name:       "argocd",
 						UID:        argocd.GetUID(),
@@ -391,7 +391,7 @@ func TestArgoCDReconciler_tlsSecretMapperRedis(t *testing.T) {
 				Namespace: "argocd-operator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "argoproj.io/v1alpha1",
+						APIVersion: "argoproj.io/v1beta1",
 						Kind:       "ArgoCD",
 						Name:       "argocd",
 						UID:        argocd.GetUID(),
@@ -438,7 +438,7 @@ func TestArgoCDReconciler_tlsSecretMapperRedis(t *testing.T) {
 				Namespace: "argocd-operator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "argoproj.io/v1alpha1",
+						APIVersion: "argoproj.io/v1beta1",
 						Kind:       "ArgoCD",
 						Name:       "argocd",
 						UID:        argocd.GetUID(),

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -352,7 +352,7 @@ func getKeycloakDeploymentConfigTemplate(cr *argoproj.ArgoCD) *appsv1.Deployment
 			Namespace: ns,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: "argoproj.io/v1alpha1",
+					APIVersion: "argoproj.io/v1beta1",
 					UID:        cr.UID,
 					Name:       cr.Name,
 					Controller: &controllerRef,

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -70,7 +70,7 @@ func Test_ArgoCDReconciler_ReconcileRepoTLSSecret(t *testing.T) {
 				Namespace: "argocd-operator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "argoproj.io/v1alpha1",
+						APIVersion: "argoproj.io/v1beta1",
 						Kind:       "ArgoCD",
 						Name:       "argocd",
 						UID:        argocd.GetUID(),
@@ -264,7 +264,7 @@ func Test_ArgoCDReconciler_ReconcileRedisTLSSecret(t *testing.T) {
 				Namespace: "argocd-operator",
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion: "argoproj.io/v1alpha1",
+						APIVersion: "argoproj.io/v1beta1",
 						Kind:       "ArgoCD",
 						Name:       "argocd",
 						UID:        argocd.GetUID(),

--- a/controllers/argocd/testing.go
+++ b/controllers/argocd/testing.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	argoprojv1alpha1 "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
@@ -67,7 +68,7 @@ func makeTestNs(opts ...namespaceOpt) *corev1.Namespace {
 func makeTestReconciler(t *testing.T, objs ...runtime.Object) *ArgoCDReconciler {
 	s := scheme.Scheme
 	assert.NoError(t, argoproj.AddToScheme(s))
-	assert.NoError(t, argoproj.AddToScheme(s))
+	assert.NoError(t, argoprojv1alpha1.AddToScheme(s))
 
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 	logger := ctrl.Log.WithName("test-logger")


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring

**What does this PR do / why we need it**:
Follow up PR for https://github.com/argoproj-labs/argocd-operator/pull/999 to replace v1alpha1 references of ArgoCD to v1beta1 in operator-redesign branch.

Change:
Update the ArgoCD API import path & references to use 
- `argoproj` for v1beta1
- `argoprojv1alpha1` for v1alpha1
