### PR TITLE
Ability to set annotations+labels on pods created by argocd

### DIFF
--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -560,6 +560,9 @@ type ArgoCDServerSpec struct {
 	// ExtraCommandArgs will not be added, if one of these commands is already part of the server command
 	// with same or different value.
 	ExtraCommandArgs []string `json:"extraCommandArgs,omitempty"`
+
+	// Pass extra pod annotations to the Argo CD server pod.
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 
 // ArgoCDServerServiceSpec defines the Service options for Argo CD Server component.

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -563,6 +563,9 @@ type ArgoCDServerSpec struct {
 
 	// Pass extra pod annotations to the Argo CD server pod.
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
+	// Pass extra pod labels to the Argo CD server pod.
+	PodLabels map[string]string `json:"podLabels,omitempty"`
 }
 
 // ArgoCDServerServiceSpec defines the Service options for Argo CD Server component.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -12448,6 +12448,11 @@ spec:
                     description: Pass extra pod annotations to the Argo CD server
                       pod.
                     type: object
+                  podLabels:
+                    additionalProperties:
+                      type: string
+                    description: Pass extra pod labels to the Argo CD server pod.
+                    type: object
                   replicas:
                     description: Replicas defines the number of replicas for argocd-server.
                       Default is nil. Value should be greater than or equal to 0.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -12442,6 +12442,12 @@ spec:
                       ArgoCD Server component. Defaults to ArgoCDDefaultLogLevel if
                       not set.  Valid options are debug, info, error, and warn.
                     type: string
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: Pass extra pod annotations to the Argo CD server
+                      pod.
+                    type: object
                   replicas:
                     description: Replicas defines the number of replicas for argocd-server.
                       Default is nil. Value should be greater than or equal to 0.

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1286,6 +1286,8 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		},
 	}
 
+	deploy.Spec.Template.Annotations = cr.Spec.Server.PodAnnotations
+
 	if replicas := getArgoCDServerReplicas(cr); replicas != nil {
 		deploy.Spec.Replicas = replicas
 	}
@@ -1330,6 +1332,10 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 				existing.Spec.Replicas = deploy.Spec.Replicas
 				changed = true
 			}
+		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations) {
+			existing.Spec.Template.Annotations = deploy.Spec.Template.Annotations
+			changed = true
 		}
 		if changed {
 			return r.Client.Update(context.TODO(), existing)

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1288,6 +1288,10 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 
 	deploy.Spec.Template.Annotations = cr.Spec.Server.PodAnnotations
 
+	for key, value := range cr.Spec.Server.PodLabels {
+		deploy.Spec.Template.Labels[key] = value
+	}
+
 	if replicas := getArgoCDServerReplicas(cr); replicas != nil {
 		deploy.Spec.Replicas = replicas
 	}
@@ -1335,6 +1339,10 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		}
 		if !reflect.DeepEqual(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations) {
 			existing.Spec.Template.Annotations = deploy.Spec.Template.Annotations
+			changed = true
+		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Labels, existing.Spec.Template.Labels) {
+			existing.Spec.Template.Labels = deploy.Spec.Template.Labels
 			changed = true
 		}
 		if changed {


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:

Allows adding additional annotations and labels to pods that are created by argocd.

Specifially need it to intigrate argocd and istio in an openshift environment.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #637

**How to test changes / Special notes to the reviewer**:

Gonna push the updated go code as an image to https://hub.docker.com/repository/docker/athallerde/argocd-operator/general

I have never updated a CRD so comments if I'm using the right types/format would be appreciated.