### PR TITLE
code-refactoring: Fixed nil pointer runtime panic error

### DIFF
--- a/controllers/argocd/applicationset/deployment.go
+++ b/controllers/argocd/applicationset/deployment.go
@@ -47,7 +47,7 @@ func (asr *ApplicationSetReconciler) reconcileDeployment() error {
 	existingDeployment, err := workloads.GetDeployment(desiredDeployment.Name, desiredDeployment.Namespace, asr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			asr.Logger.Error(err, "reconcileDeployment: failed to retrieve deployment", "name", existingDeployment.Name, "namespace", existingDeployment.Namespace)
+			asr.Logger.Error(err, "reconcileDeployment: failed to retrieve deployment", "name", desiredDeployment.Name, "namespace", desiredDeployment.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/applicationset/role.go
+++ b/controllers/argocd/applicationset/role.go
@@ -51,7 +51,7 @@ func (asr *ApplicationSetReconciler) reconcileRole() error {
 	existingRole, err := permissions.GetRole(desiredRole.Name, desiredRole.Namespace, asr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			asr.Logger.Error(err, "reconcileRole: failed to retrieve role", "name", existingRole.Name, "namespace", existingRole.Namespace)
+			asr.Logger.Error(err, "reconcileRole: failed to retrieve role", "name", desiredRole.Name, "namespace", desiredRole.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/applicationset/rolebinding.go
+++ b/controllers/argocd/applicationset/rolebinding.go
@@ -61,7 +61,7 @@ func (asr *ApplicationSetReconciler) reconcileRoleBinding() error {
 	existingRoleBinding, err := permissions.GetRoleBinding(desiredRoleBinding.Name, desiredRoleBinding.Namespace, asr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			asr.Logger.Error(err, "reconcileRoleBinding: failed to retrieve roleBinding", "name", existingRoleBinding.Name, "namespace", existingRoleBinding.Namespace)
+			asr.Logger.Error(err, "reconcileRoleBinding: failed to retrieve roleBinding", "name", desiredRoleBinding.Name, "namespace", desiredRoleBinding.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/applicationset/service.go
+++ b/controllers/argocd/applicationset/service.go
@@ -48,10 +48,10 @@ func (asr *ApplicationSetReconciler) reconcileService() error {
 		return err
 	}
 
-	existingService, err := networking.GetService(desiredService.Name, desiredService.Namespace, asr.Client)
+	_, err = networking.GetService(desiredService.Name, desiredService.Namespace, asr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			asr.Logger.Error(err, "reconcileService: failed to retrieve service", "name", existingService.Name, "namespace", existingService.Namespace)
+			asr.Logger.Error(err, "reconcileService: failed to retrieve service", "name", desiredService.Name, "namespace", desiredService.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/applicationset/serviceaccount.go
+++ b/controllers/argocd/applicationset/serviceaccount.go
@@ -36,10 +36,10 @@ func (asr *ApplicationSetReconciler) reconcileServiceAccount() error {
 		return err
 	}
 
-	existingServiceAccount, err := permissions.GetServiceAccount(desiredServiceAccount.Name, desiredServiceAccount.Namespace, asr.Client)
+	_, err = permissions.GetServiceAccount(desiredServiceAccount.Name, desiredServiceAccount.Namespace, asr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			asr.Logger.Error(err, "reconcileServiceAccount: failed to retrieve serviceAccount", "name", existingServiceAccount.Name, "namespace", existingServiceAccount.Namespace)
+			asr.Logger.Error(err, "reconcileServiceAccount: failed to retrieve serviceAccount", "name", desiredServiceAccount.Name, "namespace", desiredServiceAccount.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/notifications/configmap.go
+++ b/controllers/argocd/notifications/configmap.go
@@ -43,10 +43,10 @@ func (nr *NotificationsReconciler) reconcileConfigMap() error {
 		return err
 	}
 
-	existingConfigMap, err := workloads.GetConfigMap(desiredConfigMap.Name, desiredConfigMap.Namespace, nr.Client)
+	_, err = workloads.GetConfigMap(desiredConfigMap.Name, desiredConfigMap.Namespace, nr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			nr.Logger.Error(err, "reconcileConfigMap: failed to retrieve configMap", "name", existingConfigMap.Name, "namespace", existingConfigMap.Namespace)
+			nr.Logger.Error(err, "reconcileConfigMap: failed to retrieve configMap", "name", desiredConfigMap.Name, "namespace", desiredConfigMap.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/notifications/deployment.go
+++ b/controllers/argocd/notifications/deployment.go
@@ -47,7 +47,7 @@ func (nr *NotificationsReconciler) reconcileDeployment() error {
 	existingDeployment, err := workloads.GetDeployment(desiredDeployment.Name, desiredDeployment.Namespace, nr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			nr.Logger.Error(err, "reconcileDeployment: failed to retrieve deployment", "name", existingDeployment.Name, "namespace", existingDeployment.Namespace)
+			nr.Logger.Error(err, "reconcileDeployment: failed to retrieve deployment", "name", desiredDeployment.Name, "namespace", desiredDeployment.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/notifications/role.go
+++ b/controllers/argocd/notifications/role.go
@@ -51,7 +51,7 @@ func (nr *NotificationsReconciler) reconcileRole() error {
 	existingRole, err := permissions.GetRole(desiredRole.Name, desiredRole.Namespace, nr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			nr.Logger.Error(err, "reconcileRole: failed to retrieve role", "name", existingRole.Name, "namespace", existingRole.Namespace)
+			nr.Logger.Error(err, "reconcileRole: failed to retrieve role", "name", desiredRole.Name, "namespace", desiredRole.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/notifications/rolebinding.go
+++ b/controllers/argocd/notifications/rolebinding.go
@@ -61,7 +61,7 @@ func (nr *NotificationsReconciler) reconcileRoleBinding() error {
 	existingRoleBinding, err := permissions.GetRoleBinding(desiredRoleBinding.Name, desiredRoleBinding.Namespace, nr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			nr.Logger.Error(err, "reconcileRoleBinding: failed to retrieve roleBinding", "name", existingRoleBinding.Name, "namespace", existingRoleBinding.Namespace)
+			nr.Logger.Error(err, "reconcileRoleBinding: failed to retrieve roleBinding", "name", desiredRoleBinding.Name, "namespace", desiredRoleBinding.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/notifications/secret.go
+++ b/controllers/argocd/notifications/secret.go
@@ -44,10 +44,10 @@ func (nr *NotificationsReconciler) reconcileSecret() error {
 		return err
 	}
 
-	existingSecret, err := workloads.GetSecret(desiredSecret.Name, desiredSecret.Namespace, nr.Client)
+	_, err = workloads.GetSecret(desiredSecret.Name, desiredSecret.Namespace, nr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			nr.Logger.Error(err, "reconcileSecret: failed to retrieve secret", "name", existingSecret.Name, "namespace", existingSecret.Namespace)
+			nr.Logger.Error(err, "reconcileSecret: failed to retrieve secret", "name", desiredSecret.Name, "namespace", desiredSecret.Namespace)
 			return err
 		}
 

--- a/controllers/argocd/notifications/serviceaccount.go
+++ b/controllers/argocd/notifications/serviceaccount.go
@@ -36,10 +36,10 @@ func (nr *NotificationsReconciler) reconcileServiceAccount() error {
 		return err
 	}
 
-	existingServiceAccount, err := permissions.GetServiceAccount(desiredServiceAccount.Name, desiredServiceAccount.Namespace, nr.Client)
+	_, err = permissions.GetServiceAccount(desiredServiceAccount.Name, desiredServiceAccount.Namespace, nr.Client)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			nr.Logger.Error(err, "reconcileServiceAccount: failed to retrieve serviceAccount", "name", existingServiceAccount.Name, "namespace", existingServiceAccount.Namespace)
+			nr.Logger.Error(err, "reconcileServiceAccount: failed to retrieve serviceAccount", "name", desiredServiceAccount.Name, "namespace", desiredServiceAccount.Namespace)
 			return err
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind code-refactoring

**What does this PR do / why we need it**:
Fixed nil pointer runtime panic error. When there is a get resource error, the `existingResource` would be nil, and there would be a nil point error on `existingResource.Name` and `existingResourceNamespace`. So it has to be `desiredResource.Name` and `desiredResource.Namespace` instead.

NOTE: this PR just adds the package files and tests, this code is not invoked at any point yet
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
Notifications controller and ApplicationSet controller.

**How to test changes / Special notes to the reviewer**:
Peer review.