### PR TITLE
chore: Add gcp cherry-pick bot

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,0 +1,2 @@
+enabled: true
+preservePullRequestTitle: true


### PR DESCRIPTION
**What type of PR is this?**
This PR adds configuration for GCP cherry pick bot to streamline the process of back-porting PRs to release branches. This bot is already used in upstream argocd for cherry picking changes.

**Bot Usage:**
Any PR which needs to be back-ported can be automated by commenting on the PR with
```
/cherry-pick target-branch-name
```
More details regarding bot can be found [here](https://github.com/googleapis/repo-automation-bots/tree/main/packages/cherry-pick-bot)

**How to test changes / Special notes to the reviewer**:
[GCP cherry pick bot ](https://github.com/apps/gcp-cherry-pick-bot) is already installed on this repo by argocd org admins. 