### PR TITLE
feat: upgrade RH-SSO from 7.5 to 7.6

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -183,11 +183,11 @@ const (
 	ArgoCDKeycloakVersion = "sha256:64fb81886fde61dee55091e6033481fa5ccdac62ae30a4fd29b54eb5e97df6a9"
 
 	// ArgoCDKeycloakImageForOpenShift is the default Keycloak Image used for the OpenShift platform when not specified.
-	ArgoCDKeycloakImageForOpenShift = "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8"
+	ArgoCDKeycloakImageForOpenShift = "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8"
 
 	// ArgoCDKeycloakVersionForOpenShift is the default Keycloak version used for the OpenShift platform when not specified.
-	// Version: 7.5.1
-	ArgoCDKeycloakVersionForOpenShift = "sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3"
+	// Version: 7.6-25
+	ArgoCDKeycloakVersionForOpenShift = "sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d"
 
 	// ArgoCDDefaultOIDCConfig is the default OIDC configuration.
 	ArgoCDDefaultOIDCConfig = ""

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -186,8 +186,8 @@ const (
 	ArgoCDKeycloakImageForOpenShift = "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8"
 
 	// ArgoCDKeycloakVersionForOpenShift is the default Keycloak version used for the OpenShift platform when not specified.
-	// Version: 7.6-25
-	ArgoCDKeycloakVersionForOpenShift = "sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d"
+	// Version: 7.6-32
+	ArgoCDKeycloakVersionForOpenShift = "sha256:ec9f60018694dcc5d431ba47d5536b761b71cb3f66684978fe6bb74c157679ac"
 
 	// ArgoCDDefaultOIDCConfig is the default OIDC configuration.
 	ArgoCDDefaultOIDCConfig = ""

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -223,7 +223,7 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 		Image:           getKeycloakContainerImage(cr),
 		ImagePullPolicy: "Always",
 		LivenessProbe: &corev1.Probe{
-			FailureThreshold: 3,
+			TimeoutSeconds: 120,
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
@@ -243,7 +243,7 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 			{ContainerPort: 8888, Name: "ping", Protocol: "TCP"},
 		},
 		ReadinessProbe: &corev1.Probe{
-			FailureThreshold: 20,
+			TimeoutSeconds: 120,
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
@@ -253,7 +253,6 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 					},
 				},
 			},
-			InitialDelaySeconds: 60,
 		},
 		Resources: getKeycloakResources(cr),
 		VolumeMounts: []corev1.VolumeMount{
@@ -267,12 +266,18 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 				Name:      "service-ca",
 				ReadOnly:  true,
 			},
+			{
+				Name:      "sso-probe-netrc-volume",
+				MountPath: "/mnt/rh-sso",
+				ReadOnly:  false,
+			},
 		},
 	}
 }
 
 func getKeycloakDeploymentConfigTemplate(cr *argoprojv1a1.ArgoCD) *appsv1.DeploymentConfig {
 	ns := cr.Namespace
+	var medium corev1.StorageMedium = "Memory"
 	keycloakContainer := getKeycloakContainer(cr)
 
 	dc := &appsv1.DeploymentConfig{
@@ -339,6 +344,14 @@ func getKeycloakDeploymentConfigTemplate(cr *argoprojv1a1.ArgoCD) *appsv1.Deploy
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: "${APPLICATION_NAME}-service-ca",
 									},
+								},
+							},
+						},
+						{
+							Name: "sso-probe-netrc-volume",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									Medium: medium,
 								},
 							},
 						},

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -223,7 +223,7 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 		Image:           getKeycloakContainerImage(cr),
 		ImagePullPolicy: "Always",
 		LivenessProbe: &corev1.Probe{
-			TimeoutSeconds: 120,
+			TimeoutSeconds: 240,
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{
@@ -233,7 +233,7 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 					},
 				},
 			},
-			InitialDelaySeconds: 60,
+			InitialDelaySeconds: 120,
 		},
 		Name: "${APPLICATION_NAME}",
 		Ports: []corev1.ContainerPort{
@@ -243,7 +243,8 @@ func getKeycloakContainer(cr *argoprojv1a1.ArgoCD) corev1.Container {
 			{ContainerPort: 8888, Name: "ping", Protocol: "TCP"},
 		},
 		ReadinessProbe: &corev1.Probe{
-			TimeoutSeconds: 120,
+			TimeoutSeconds:      240,
+			InitialDelaySeconds: 120,
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
 					Command: []string{

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -59,6 +59,14 @@ var (
 				},
 			},
 		},
+		{
+			Name: "sso-probe-netrc-volume",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: "Memory",
+				},
+			},
+		},
 	}
 )
 
@@ -111,7 +119,7 @@ func TestKeycloakContainerImage(t *testing.T) {
 			}),
 			updateCrFunc:       nil,
 			templateAPIFound:   true,
-			wantContainerImage: "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3",
+			wantContainerImage: "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d",
 		},
 		{
 			name: "ArgoCDKeycloakImageEnvName env var set",
@@ -268,7 +276,7 @@ func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
 	}
 	kc := getKeycloakContainer(a)
 	assert.Equal(t,
-		"registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3", kc.Image)
+		"registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d", kc.Image)
 	assert.Equal(t, corev1.PullAlways, kc.ImagePullPolicy)
 	assert.Equal(t, "${APPLICATION_NAME}", kc.Name)
 }

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -119,7 +119,7 @@ func TestKeycloakContainerImage(t *testing.T) {
 			}),
 			updateCrFunc:       nil,
 			templateAPIFound:   true,
-			wantContainerImage: "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d",
+			wantContainerImage: "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:ec9f60018694dcc5d431ba47d5536b761b71cb3f66684978fe6bb74c157679ac",
 		},
 		{
 			name: "ArgoCDKeycloakImageEnvName env var set",
@@ -276,7 +276,7 @@ func TestNewKeycloakTemplate_testKeycloakContainer(t *testing.T) {
 	}
 	kc := getKeycloakContainer(a)
 	assert.Equal(t,
-		"registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d", kc.Image)
+		"registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:ec9f60018694dcc5d431ba47d5536b761b71cb3f66684978fe6bb74c157679ac", kc.Image)
 	assert.Equal(t, corev1.PullAlways, kc.ImagePullPolicy)
 	assert.Equal(t, "${APPLICATION_NAME}", kc.Name)
 }

--- a/examples/argocd-keycloak-openshift.yaml
+++ b/examples/argocd-keycloak-openshift.yaml
@@ -3,10 +3,14 @@ kind: ArgoCD
 metadata:
   name: example-argocd
 spec:
+  extraConfig:
+    oidc.tls.insecure.skip.verify: 'true' 
   sso:
     provider: keycloak
-    # uncomment the below line when running operator locally.
-    # verifyTLS: false 
+    keycloak:
+      rootCA: "---BEGIN---END---"
+      # Uncomment the below line when running operator locally.
+      # verifyTLS: false 
   server:
     route:
       enabled: true

--- a/tests/ocp/1-001_validate_rhsso/01-assert.yaml
+++ b/tests/ocp/1-001_validate_rhsso/01-assert.yaml
@@ -33,7 +33,7 @@ spec:
       name: keycloak
     spec:
       containers:
-      - image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d
+      - image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:ec9f60018694dcc5d431ba47d5536b761b71cb3f66684978fe6bb74c157679ac
         resources:
           limits:
             cpu: "1"

--- a/tests/ocp/1-001_validate_rhsso/01-assert.yaml
+++ b/tests/ocp/1-001_validate_rhsso/01-assert.yaml
@@ -33,7 +33,7 @@ spec:
       name: keycloak
     spec:
       containers:
-      - image: registry.redhat.io/rh-sso-7/sso75-openshift-rhel8@sha256:720a7e4c4926c41c1219a90daaea3b971a3d0da5a152a96fed4fb544d80f52e3
+      - image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:bb6dc12a49370ba6baa40cfa064238cddcfd1edb22c37dcdf53d331c0f7ee15d
         resources:
           limits:
             cpu: "1"


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What does this PR do / why we need it**:
Shipped version of RH-SSO in current release is obsolete and out of support. This PR updates the RH-SSO to the latest version and updates the required changes.

**Have you updated the necessary documentation?**
* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:
Run operator locally using `make install run`
Create an Argo CD instance and add Keycloak using the below spec:
```
.....
spec:
 sso:
  provider: keycloak
  keycloak:
   rootCA: "=== BEGIN END ==="
......
```
Verify the Keycloak pod is up and running. 
