### PR TITLE
doc: Proper reference to where to find default admin password

### DIFF
--- a/docs/usage/basics.md
+++ b/docs/usage/basics.md
@@ -71,7 +71,7 @@ The operator will create these ConfigMaps for the cluster and set the initial va
 ### Secrets
 
 There is a Secret that is used by Argo CD named `argocd-secret`. The `argocd-server` component reads this secret to
-obtain the admin password for authentication.
+obtain the admin password for authentication. NOTE: Upon initial deployment, the initial password for the `admin` user is stored in the `argocd-cluster` secret instead.
 
 This Secret is managed by the operator and should not be changed directly.
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind code-refactoring

/kind documentation

**What does this PR do / why we need it**:
This adds a reference for where to find the initial password for the `admin` user when first creating a new `ArgoCD` resource. The `admin.password` in `argocd-secret`, is incorrect and you can't log in as the `admin` user. I found the fix in [this issue](https://github.com/argoproj/argo-cd/issues/3543) and figured the docs should be updated accordingly.

**Have you updated the necessary documentation?**


* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #78
This was `Closed` but still wrong in the docs. [This issue](https://github.com/argoproj/argo-cd/issues/3543) is also related

**How to test changes / Special notes to the reviewer**:
Deploy a new `ArgoCD` resource and attempt to log in with the `admin.password` stored in the `argocd-secret` `secret`. This will fail.

Now instead grab the secret from `argocd-cluster`, and the login will succeed
