### PR TITLE
fix the logic for applicationset resources reconcilation when spec.applicationset.enabled is false

### DIFF
--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -555,6 +555,7 @@ func setProxyEnvVars(t *testing.T) {
 func TestReconcileApplicationSet_Service(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
 
 	resObjs := []client.Object{a}
 	subresObjs := []client.Object{a}

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1128,7 +1128,7 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoproj.ArgoCD, useTLSFor
 		if !cr.Spec.Repo.IsEnabled() {
 			log.Info("Existing ArgoCD Repo Server found but should be disabled. Deleting Repo Server")
 			// Delete existing deployment for ArgoCD Repo Server, if any ..
-			return nil
+			return r.Client.Delete(context.TODO(), existing)
 		}
 
 		changed := false
@@ -1328,7 +1328,7 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		if !cr.Spec.Server.IsEnabled() {
 			log.Info("Existing ArgoCD Server found but should be disabled. Deleting ArgoCD Server")
 			// Delete existing deployment for ArgoCD Server, if any ..
-			return nil
+			return r.Client.Delete(context.TODO(), existing)
 		}
 		actualImage := existing.Spec.Template.Spec.Containers[0].Image
 		desiredImage := getArgoContainerImage(cr)
@@ -1375,8 +1375,8 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		return nil // Deployment found with nothing to do, move along...
 	}
 
-	if !cr.Spec.Controller.IsEnabled() {
-		log.Info("ArgoCD Repo Server disabled. Skipping starting repo server.")
+	if !cr.Spec.Server.IsEnabled() {
+		log.Info("ArgoCD Server disabled. Skipping starting argocd server.")
 		return nil
 	}
 

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -207,7 +207,10 @@ func (r *ReconcileArgoCD) reconcileStatusSSO(cr *argoproj.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoproj.ArgoCD) error {
 	var phase string
 
-	if cr.Status.ApplicationController == "Running" && cr.Status.Redis == "Running" && cr.Status.Repo == "Running" && cr.Status.Server == "Running" {
+	if ((!cr.Spec.Controller.IsEnabled() && cr.Status.ApplicationController == "Unknown") || cr.Status.ApplicationController == "Running") &&
+		((!cr.Spec.Redis.IsEnabled() && cr.Status.Redis == "Unknown") || cr.Status.Redis == "Running") &&
+		((!cr.Spec.Repo.IsEnabled() && cr.Status.Repo == "Unknown") || cr.Status.Repo == "Running") &&
+		((!cr.Spec.Server.IsEnabled() && cr.Status.Server == "Unknown") || cr.Status.Server == "Running") {
 		phase = "Available"
 	} else {
 		phase = "Pending"

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/01-errors.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/01-errors.yaml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test
+

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/01-install.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/01-install.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: false
+  repo:
+    enabled: false
+  server:
+    enabled: false
+  applicationSet:
+    enabled: false

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/02-assert.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/02-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/02-errors.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/02-errors.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-repo-server
+  namespace: test

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/02-install.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/02-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: true
+  redis:
+    enabled: false
+  repo:
+    enabled: false
+  server:
+    enabled: false
+  applicationSet:
+    enabled: false

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/03-assert.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/03-assert.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/03-errors.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/03-errors.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+
+
+

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/03-install.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/03-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: true
+  redis:
+    enabled: true
+  repo:
+    enabled: false
+  server:
+    enabled: false
+  applicationSet:
+    enabled: false

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/04-assert.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/04-assert.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test
+

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/04-errors.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/04-errors.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-application-controller
+  namespace: test

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/04-install.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/04-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: true
+  redis:
+    enabled: true
+  repo:
+    enabled: true
+  server:
+    enabled: false
+  applicationSet:
+    enabled: false

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/05-assert.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/05-assert.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test
+

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/05-errors.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/05-errors.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-application-controller
+  namespace: test

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/05-install.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/05-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: true
+  redis:
+    enabled: true
+  repo:
+    enabled: true
+  server:
+    enabled: true
+  applicationSet:
+    enabled: false

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/06-assert.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/06-assert.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test
+

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/06-install.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/06-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: true
+  redis:
+    enabled: true
+  repo:
+    enabled: true
+  server:
+    enabled: true
+  applicationSet:
+    enabled: true

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/01-assert.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/01-assert.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test
+

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/01-install.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/01-install.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: true
+  redis:
+    enabled: true
+  repo:
+    enabled: true
+  server:
+    enabled: true
+  applicationSet:
+    enabled: true

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/02-assert.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/02-assert.yaml
@@ -1,0 +1,41 @@
+
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/02-errors.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/02-errors.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-repo-server
+  namespace: test

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/02-install.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/02-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: true
+  repo:
+    enabled: true
+  server:
+    enabled: true
+  applicationSet:
+    enabled: true

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/03-assert.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/03-assert.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+
+

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/03-errors.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/03-errors.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/03-install.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/03-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: false
+  repo:
+    enabled: true
+  server:
+    enabled: true
+  applicationSet:
+    enabled: true

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/04-assert.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/04-assert.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/04-errors.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/04-errors.yaml
@@ -1,0 +1,29 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+
+

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/04-install.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/04-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: false
+  repo:
+    enabled: false
+  server:
+    enabled: true
+  applicationSet:
+    enabled: true

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/05-assert.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/05-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+status:
+  phase: Available
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/05-errors.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/05-errors.yaml
@@ -1,0 +1,40 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+
+
+
+
+
+

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/05-install.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/05-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: false
+  repo:
+    enabled: false
+  server:
+    enabled: false
+  applicationSet:
+    enabled: true

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/06-errors.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/06-errors.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+
+---
+
+

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/06-install.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/06-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: false
+  repo:
+    enabled: false
+  server:
+    enabled: false
+  applicationSet:
+    enabled: false

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/07-errors.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/07-errors.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-redis
+  namespace: test
+  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-repo-server
+  namespace: test
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-server
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-application-controller
+  namespace: test
+
+---
+
+

--- a/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/07-install.yaml
+++ b/tests/k8s/1-035_validate_applicationset_reconcile_enabled_set_true/07-install.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: false
+  ha:
+    enabled: true
+  repo:
+    enabled: false
+  server:
+    enabled: false
+  applicationSet:
+    enabled: false


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Cherry-pick https://github.com/argoproj-labs/argocd-operator/pull/1089 
