### PR TITLE
deploy/operator_group.yaml: remove targetNamespaces 

### DIFF
--- a/deploy/operator_group.yaml
+++ b/deploy/operator_group.yaml
@@ -2,6 +2,3 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: argocd-operator
-spec:
-  targetNamespaces:
-  - argocd


### PR DESCRIPTION
remove `targetNamespaces` in `deploy/operator_group.yaml`, as this is no longer supported in 0.8.0

fix #1106

**What type of PR is this?**

(Not sure if bug or documentation?)

/kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

fixes #1106

**How to test changes / Special notes to the reviewer**:
