### PR TITLE
fix: Use correct repo-server address for notification controller

### DIFF
--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -531,6 +531,12 @@ func getNotificationsCommand(cr *argoproj.ArgoCD) []string {
 	cmd = append(cmd, "--loglevel")
 	cmd = append(cmd, getLogLevel(cr.Spec.Notifications.LogLevel))
 
+	if cr.Spec.Repo.IsEnabled() {
+		cmd = append(cmd, "--argocd-repo-server", getRepoServerAddress(cr))
+	} else {
+		log.Info("Repo Server is disabled. This would affect the functioning of Notification Controller.")
+	}
+
 	return cmd
 }
 

--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -166,7 +166,7 @@ func TestReconcileNotifications_CreateDeployments(t *testing.T) {
 	assert.Equal(t, deployment.Spec.Template.Spec.ServiceAccountName, sa.ObjectMeta.Name)
 
 	want := []corev1.Container{{
-		Command:         []string{"argocd-notifications", "--loglevel", "info"},
+		Command:         []string{"argocd-notifications", "--loglevel", "info", "--argocd-repo-server", "argocd-repo-server.argocd.svc.cluster.local:8081"},
 		Image:           argoutil.CombineImageTag(common.ArgoCDDefaultArgoImage, common.ArgoCDDefaultArgoVersion),
 		ImagePullPolicy: corev1.PullAlways,
 		Name:            "argocd-notifications-controller",
@@ -413,6 +413,8 @@ func TestReconcileNotifications_testLogLevel(t *testing.T) {
 		"argocd-notifications",
 		"--loglevel",
 		"debug",
+		"--argocd-repo-server",
+		"argocd-repo-server.argocd.svc.cluster.local:8081",
 	}
 
 	if diff := cmp.Diff(expectedCMD, deployment.Spec.Template.Spec.Containers[0].Command); diff != "" {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
This PR correctly initializes the repo-server address  using `--argocd-repo-server` flag to fix  #1124

```bash
$ argocd-notifications --help 
[...]
      --argocd-repo-server string       Argo CD repo server address (default "argocd-repo-server:8081")
```
**Which issue(s) this PR fixes**:
Fixes #1124

**How to test changes / Special notes to the reviewer**:
E2e tests are included in #1084. To manually verify the address,
1. create a ArgoCD CR with notifications enabled
   ```yaml
   apiVersion: argoproj.io/v1alpha1
   kind: ArgoCD
   metadata:
     name: example
   spec:
     notifications:
       enabled: true
   ```
2. check for `--argocd-repo-server`  flag under `command` in `example-notifications-controller` deployment spec.
3. verify that the service exists for the value of  `--argocd-repo-server`  flag.
