### PR TITLE
Expand argocd-server permissions to manage applicationsets

### DIFF
--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -119,6 +119,7 @@ func policyRuleForServer() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"applications",
+				"applicationsets",
 				"appprojects",
 			},
 			Verbs: []string{


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

   /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
> /kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

 Expand argocd-server permissions/rbac to manage applicationsets

 JIRA Link: https://issues.redhat.com/browse/GITOPS-3762

**How to test changes / Special notes to the reviewer**:

Fixed a bug in the RBAC rules within the controllers/argocd/policyrule.go file, particularly within the policyRuleForServer() function. This correction ensures the accurate assignment of permissions for the argocd-server pod's service account to manage the ApplicationSet resource.
