### PR TITLE
Allow policyrule.go to handle applicationsets

### DIFF
--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -120,6 +120,7 @@ func policyRuleForServer() []v1.PolicyRule {
 			Resources: []string{
 				"applications",
 				"appprojects",
+				"applicationsets",
 			},
 			Verbs: []string{
 				"create",
@@ -156,6 +157,7 @@ func policyRuleForNotificationsController() []v1.PolicyRule {
 			Resources: []string{
 				"applications",
 				"appprojects",
+				"applicationsets",
 			},
 			Verbs: []string{
 				"get",
@@ -217,6 +219,7 @@ func policyRuleForServerApplicationSourceNamespaces() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"applications",
+				"applicationsets",
 			},
 			Verbs: []string{
 				"create",
@@ -252,6 +255,7 @@ func policyRuleForServerClusterRole() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"applications",
+				"applicationsets",
 			},
 			Verbs: []string{
 				"list",


### PR DESCRIPTION
The serviceRole for the argocd instance now is unable to handle applicationsets. 
For example, newly provisioned cluster-wide instance will get this error

```
FATA[0000] rpc error: code = PermissionDenied desc = error listing
ApplicationSets with selectors: applicationsets.argoproj.io is
forbidden: User "system:serviceaccount:argocd:dr3-argocd-server"
cannot list resource "applicationsets" in API group "argoproj.io" in
the namespace "argocd" 
```

This change aims to give more privilege to the argocd instance to address this permission error.

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug
> /kind chore
> /kind cleanup
> /kind failing-test
/kind enhancement
> /kind documentation
> /kind code-refactoring


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

To reviewer: I have added multiple `applicatonsets` to different places, as I am not very sure the exact place. We may need some clean up as there may be some reason to have only `applications` at some place that I don't know.  Thanks a lot.
