### PR TITLE
fix logic to allow processor operation to be less than default value

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -309,10 +309,11 @@ func (r *ReconcileArgoCD) getArgoServerURI(cr *argoproj.ArgoCD) string {
 // getArgoServerOperationProcessors will return the numeric Operation Processors value for the ArgoCD Server.
 func getArgoServerOperationProcessors(cr *argoproj.ArgoCD) int32 {
 	op := common.ArgoCDDefaultServerOperationProcessors
-	if cr.Spec.Controller.Processors.Operation > op {
-		op = cr.Spec.Controller.Processors.Operation
+	if cr.Spec.Controller.Processors.Operation > 0 {
+		return cr.Spec.Controller.Processors.Operation
+	} else {
+		return op
 	}
-	return op
 }
 
 // getArgoServerStatusProcessors will return the numeric Status Processors value for the ArgoCD Server.

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -310,10 +310,9 @@ func (r *ReconcileArgoCD) getArgoServerURI(cr *argoproj.ArgoCD) string {
 func getArgoServerOperationProcessors(cr *argoproj.ArgoCD) int32 {
 	op := common.ArgoCDDefaultServerOperationProcessors
 	if cr.Spec.Controller.Processors.Operation > 0 {
-		return cr.Spec.Controller.Processors.Operation
-	} else {
-		return op
+		op = cr.Spec.Controller.Processors.Operation
 	}
+	return op
 }
 
 // getArgoServerStatusProcessors will return the numeric Status Processors value for the ArgoCD Server.

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -390,6 +390,27 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 			},
 		},
 		{
+			"configured operation processors to zero",
+			[]argoCDOpt{operationProcessors(0)},
+			[]string{
+				"argocd-application-controller",
+				"--operation-processors",
+				"10",
+				"--redis",
+				"argocd-redis.argocd.svc.cluster.local:6379",
+				"--repo-server",
+				"argocd-repo-server.argocd.svc.cluster.local:8081",
+				"--status-processors",
+				"20",
+				"--kubectl-parallelism-limit",
+				"10",
+				"--loglevel",
+				"info",
+				"--logformat",
+				"text",
+			},
+		},
+		{
 			"configured parallelism limit",
 			[]argoCDOpt{parallelismLimit(30)},
 			[]string{

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -411,6 +411,27 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 			},
 		},
 		{
+			"configured operation processors to be between zero and ten",
+			[]argoCDOpt{operationProcessors(5)},
+			[]string{
+				"argocd-application-controller",
+				"--operation-processors",
+				"5",
+				"--redis",
+				"argocd-redis.argocd.svc.cluster.local:6379",
+				"--repo-server",
+				"argocd-repo-server.argocd.svc.cluster.local:8081",
+				"--status-processors",
+				"20",
+				"--kubectl-parallelism-limit",
+				"10",
+				"--loglevel",
+				"info",
+				"--logformat",
+				"text",
+			},
+		},
+		{
 			"configured parallelism limit",
 			[]argoCDOpt{parallelismLimit(30)},
 			[]string{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Currently, when we set application-controller 'status/operation processor' values below 10, it set it to default value of 10.
This PR allows the value to be less than the default value, but is the value is less or equals to 0 it sets it back to the default value.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-3770](https://issues.redhat.com/browse/GITOPS-3770)

**How to test changes / Special notes to the reviewer**:
