### PR TITLE
fix: operator shouldn't overwrite dex config 

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -428,8 +428,8 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 	if UseDex(cr) {
 		dexConfig := getDexConfig(cr)
 
-		// Append the default OpenShift dex config if the dex config is not provided or the openShiftOAuth is requested through `.spec.sso.dex`.
-		if dexConfig == "" || (cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth) {
+		// Append the default OpenShift dex config if the openShiftOAuth is requested through `.spec.sso.dex`.
+		if cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth {
 			cfg, err := r.getOpenShiftDexConfig(cr)
 			if err != nil {
 				return err

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -428,9 +428,8 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 	if UseDex(cr) {
 		dexConfig := getDexConfig(cr)
 
-		// If no dexConfig expressed but openShiftOAuth is requested through `.spec.sso.dex`, use default
-		// openshift dex config
-		if dexConfig == "" && (cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth) {
+		// Append the default OpenShift dex config if the dex config is not provided or the openShiftOAuth is requested through `.spec.sso.dex`.
+		if dexConfig == "" || (cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth) {
 			cfg, err := r.getOpenShiftDexConfig(cr)
 			if err != nil {
 				return err

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -359,28 +359,6 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 		},
 	}
 
-	getDexConfig := func(t *testing.T, k8sClient client.Client) map[string]interface{} {
-		t.Helper()
-
-		cm := &corev1.ConfigMap{}
-		err := k8sClient.Get(context.TODO(), types.NamespacedName{
-			Name:      common.ArgoCDConfigMapName,
-			Namespace: testNamespace,
-		}, cm)
-		assert.NoError(t, err)
-
-		dex, ok := cm.Data["dex.config"]
-		if !ok {
-			t.Fatal("reconcileArgoConfigMap with dex failed")
-		}
-
-		m := make(map[string]interface{})
-		err = yaml.Unmarshal([]byte(dex), &m)
-		assert.NoError(t, err, fmt.Sprintf("failed to unmarshal %s", dex))
-
-		return m
-	}
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			sa := &corev1.ServiceAccount{
@@ -415,15 +393,40 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 			err := r.reconcileArgoConfigMap(a)
 			assert.NoError(t, err)
 
-			m := getDexConfig(t, r.Client)
-			connectors, ok := m["connectors"]
-			if !ok {
-				t.Fatal("no connectors found in dex.config")
-			}
-			dexConnector := connectors.([]interface{})[0].(map[interface{}]interface{})
-			config := dexConnector["config"]
-			assert.Equal(t, config.(map[interface{}]interface{})["clientID"], "system:serviceaccount:argocd:argocd-argocd-dex-server")
+			getDexConfig := func(t *testing.T, k8sClient client.Client) map[string]interface{} {
+				cm := &corev1.ConfigMap{}
+				err := k8sClient.Get(context.TODO(), types.NamespacedName{
+					Name:      common.ArgoCDConfigMapName,
+					Namespace: testNamespace,
+				}, cm)
+				assert.NoError(t, err)
 
+				dex, ok := cm.Data["dex.config"]
+				if !ok {
+					t.Fatal("reconcileArgoConfigMap with dex failed")
+				}
+
+				m := make(map[string]interface{})
+				err = yaml.Unmarshal([]byte(dex), &m)
+				assert.NoError(t, err, fmt.Sprintf("failed to unmarshal %s", dex))
+
+				return m
+			}
+
+			m := getDexConfig(t, r.Client)
+
+			verifyDexConnector := func(dexCfg map[string]interface{}) {
+				connectors, ok := dexCfg["connectors"]
+				if !ok {
+					t.Fatal("no connectors found in dex.config")
+				}
+				dexConnector := connectors.([]interface{})[0].(map[interface{}]interface{})
+				config := dexConnector["config"]
+				assert.Equal(t, config.(map[interface{}]interface{})["clientID"], "system:serviceaccount:argocd:argocd-argocd-dex-server")
+			}
+			verifyDexConnector(m)
+
+			// update .dex.config and verify that the dex connector is not overwritten
 			type expiry struct {
 				IdTokens    string `yaml:"idTokens"`
 				SigningKeys string `yaml:"signingKeys"`
@@ -445,10 +448,10 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 			assert.NoError(t, err)
 
 			m = getDexConfig(t, r.Client)
-			_, ok = m["expiry"]
-			if !ok {
-				t.Fatal("default dex config not found")
-			}
+			_, ok := m["expiry"]
+			assert.True(t, ok)
+
+			verifyDexConnector(m)
 		})
 	}
 

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -101,8 +101,8 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 	actual := cm.Data[common.ArgoCDKeyDexConfig]
 	desired := getDexConfig(cr)
 
-	// Append the default OpenShift dex config if the dex config is not provided or the openShiftOAuth is requested through `.spec.sso.dex`.
-	if len(desired) <= 0 || (cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth) {
+	// Append the default OpenShift dex config if the openShiftOAuth is requested through `.spec.sso.dex`.
+	if cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth {
 		cfg, err := r.getOpenShiftDexConfig(cr)
 		if err != nil {
 			return err

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -159,7 +159,8 @@ func (r *ReconcileArgoCD) getOpenShiftDexConfig(cr *argoproj.ArgoCD) (string, er
 	dex := make(map[string]interface{})
 	dex["connectors"] = connectors
 
-	if err := updateDexConfig(cr, dex); err != nil {
+	// add dex config from the Argo CD CR.
+	if err := addDexConfigFromCR(cr, dex); err != nil {
 		return "", err
 	}
 
@@ -167,7 +168,7 @@ func (r *ReconcileArgoCD) getOpenShiftDexConfig(cr *argoproj.ArgoCD) (string, er
 	return string(bytes), err
 }
 
-func updateDexConfig(cr *argoproj.ArgoCD, dex map[string]interface{}) error {
+func addDexConfigFromCR(cr *argoproj.ArgoCD, dex map[string]interface{}) error {
 	dexCfgStr := getDexConfig(cr)
 	if dexCfgStr == "" {
 		return nil

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -101,9 +101,8 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 	actual := cm.Data[common.ArgoCDKeyDexConfig]
 	desired := getDexConfig(cr)
 
-	// If no dexConfig expressed but openShiftOAuth is requested through `.spec.sso.dex`, use default
-	// openshift dex config
-	if len(desired) <= 0 && (cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth) {
+	// Append the default OpenShift dex config if the dex config is not provided or the openShiftOAuth is requested through `.spec.sso.dex`.
+	if len(desired) <= 0 || (cr.Spec.SSO != nil && cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth) {
 		cfg, err := r.getOpenShiftDexConfig(cr)
 		if err != nil {
 			return err
@@ -160,8 +159,30 @@ func (r *ReconcileArgoCD) getOpenShiftDexConfig(cr *argoproj.ArgoCD) (string, er
 	dex := make(map[string]interface{})
 	dex["connectors"] = connectors
 
+	if err := updateDexConfig(cr, dex); err != nil {
+		return "", err
+	}
+
 	bytes, err := yaml.Marshal(dex)
 	return string(bytes), err
+}
+
+func updateDexConfig(cr *argoproj.ArgoCD, dex map[string]interface{}) error {
+	dexCfgStr := getDexConfig(cr)
+	if dexCfgStr == "" {
+		return nil
+	}
+
+	dexCfg := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(dexCfgStr), dexCfg); err != nil {
+		return err
+	}
+
+	for k, v := range dexCfg {
+		dex[k] = v
+	}
+
+	return nil
 }
 
 // reconcileDexServiceAccount will ensure that the Dex ServiceAccount is configured properly for OpenShift OAuth.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What does this PR do / why we need it**:
The operator overrides dex connector configuration in argocd-cm upon setting .spec.sso.dex.config in ArgoCD CR. This PR includes the user provided dex config along with the dex connectors. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1. Create an Argo CD CR with the dex provider and OpenShiftAuth enabled. Or use the default Argo CD instance in the openshift-gitops namespace.
2. Update the dex config in the CR.
```yaml
    provider: dex
    dex:
      config: |
        expiry:
          idTokens: "1h"
          signingKeys: "12h"
```
3. Ensure that both the connector and the config are present in the argocd-cm.

