### PR TITLE
Add Failed status field for all ArgoCD Controllers

### DIFF
--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -28,6 +28,7 @@ import (
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 // reconcileStatus will ensure that all of the Status properties are updated for the given ArgoCD.
@@ -168,6 +169,14 @@ func (r *ReconcileArgoCD) reconcileStatusApplicationSetController(cr *argoproj.A
 		if deploy.Spec.Replicas != nil {
 			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
 				status = "Running"
+			} else if deploy.Status.Conditions != nil {
+				for _, condition := range deploy.Status.Conditions {
+					if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+						// Deployment has failed
+						status = "Failed"
+						break
+					}
+				}
 			}
 		}
 	}

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -26,9 +26,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
-	appsv1 "k8s.io/api/apps/v1"
 )
 
 // reconcileStatus will ensure that all of the Status properties are updated for the given ArgoCD.
@@ -105,6 +106,14 @@ func (r *ReconcileArgoCD) reconcileStatusDex(cr *argoproj.ArgoCD) error {
 		if deploy.Spec.Replicas != nil {
 			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
 				status = "Running"
+			} else if deploy.Status.Conditions != nil {
+				for _, condition := range deploy.Status.Conditions {
+					if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+						// Deployment has failed
+						status = "Failed"
+						break
+					}
+				}
 			}
 		}
 	}
@@ -134,6 +143,14 @@ func (r *ReconcileArgoCD) reconcileStatusKeycloak(cr *argoproj.ArgoCD) error {
 
 			if dc.Status.ReadyReplicas == dc.Spec.Replicas {
 				status = "Running"
+			} else if dc.Status.Conditions != nil {
+				for _, condition := range dc.Status.Conditions {
+					if condition.Type == oappsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+						// Deployment has failed
+						status = "Failed"
+						break
+					}
+				}
 			}
 		}
 
@@ -145,7 +162,16 @@ func (r *ReconcileArgoCD) reconcileStatusKeycloak(cr *argoproj.ArgoCD) error {
 			if d.Spec.Replicas != nil {
 				if d.Status.ReadyReplicas == *d.Spec.Replicas {
 					status = "Running"
+				} else if d.Status.Conditions != nil {
+					for _, condition := range d.Status.Conditions {
+						if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+							// Deployment has failed
+							status = "Failed"
+							break
+						}
+					}
 				}
+
 			}
 		}
 	}
@@ -244,6 +270,14 @@ func (r *ReconcileArgoCD) reconcileStatusRedis(cr *argoproj.ArgoCD) error {
 			if deploy.Spec.Replicas != nil {
 				if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
 					status = "Running"
+				} else if deploy.Status.Conditions != nil {
+					for _, condition := range deploy.Status.Conditions {
+						if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+							// Deployment has failed
+							status = "Failed"
+							break
+						}
+					}
 				}
 			}
 		}
@@ -277,6 +311,14 @@ func (r *ReconcileArgoCD) reconcileStatusRepo(cr *argoproj.ArgoCD) error {
 		if deploy.Spec.Replicas != nil {
 			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
 				status = "Running"
+			} else if deploy.Status.Conditions != nil {
+				for _, condition := range deploy.Status.Conditions {
+					if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+						// Deployment has failed
+						status = "Failed"
+						break
+					}
+				}
 			}
 		}
 	}
@@ -300,6 +342,14 @@ func (r *ReconcileArgoCD) reconcileStatusServer(cr *argoproj.ArgoCD) error {
 		if deploy.Spec.Replicas != nil {
 			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
 				status = "Running"
+			} else if deploy.Status.Conditions != nil {
+				for _, condition := range deploy.Status.Conditions {
+					if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+						// Deployment has failed
+						status = "Failed"
+						break
+					}
+				}
 			}
 		}
 	}
@@ -322,6 +372,14 @@ func (r *ReconcileArgoCD) reconcileStatusNotifications(cr *argoproj.ArgoCD) erro
 		if deploy.Spec.Replicas != nil {
 			if deploy.Status.ReadyReplicas == *deploy.Spec.Replicas {
 				status = "Running"
+			} else if deploy.Status.Conditions != nil {
+				for _, condition := range deploy.Status.Conditions {
+					if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+						// Deployment has failed
+						status = "Failed"
+						break
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
>  ApplicationSet controller status is Pending even if its Failed which will be misleading for the user

**What does this PR do / why we need it**:
>  Fixed it by adding Failed status field

JIRA LINK - https://issues.redhat.com/browse/GITOPS-2472

