### PR TITLE
fix: Operator doesn't reflect deletion of SA from repo setting

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1190,6 +1190,7 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoproj.ArgoCD, useTLSFor
 
 		if deploy.Spec.Template.Spec.ServiceAccountName != existing.Spec.Template.Spec.ServiceAccountName {
 			existing.Spec.Template.Spec.ServiceAccountName = deploy.Spec.Template.Spec.ServiceAccountName
+			existing.Spec.Template.Spec.DeprecatedServiceAccount = deploy.Spec.Template.Spec.ServiceAccountName
 			changed = true
 		}
 

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -2005,3 +2005,87 @@ func TestArgoCDRepoServerDeploymentCommand(t *testing.T) {
 
 	assert.Equal(t, baseCommand, deployment.Spec.Template.Spec.Containers[0].Command)
 }
+
+func TestReconcileArgoCD_reconcileRepoDeployment_serviceAccount(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	tests := []struct {
+		testName                      string
+		serviceAccountName            string
+		expectedServiceAccountName    string
+		isServiceAccountNameChanged   bool
+		newServiceAccountName         string
+		newExpectedServiceAccountName string
+	}{
+		{
+			testName:                   "serviceAccountName field in the spec should reflect provided value",
+			serviceAccountName:         "deployer",
+			expectedServiceAccountName: "deployer",
+		}, {
+			testName:                      "serviceAccountName field in the spec should have updated value",
+			serviceAccountName:            "deployer",
+			expectedServiceAccountName:    "deployer",
+			isServiceAccountNameChanged:   true,
+			newServiceAccountName:         "builder",
+			newExpectedServiceAccountName: "builder",
+		}, {
+			testName:                      "Empty serviceAccountName field in the spec should have updated value",
+			serviceAccountName:            "",
+			expectedServiceAccountName:    "",
+			isServiceAccountNameChanged:   true,
+			newServiceAccountName:         "builder",
+			newExpectedServiceAccountName: "builder",
+		}, {
+			testName:                      "serviceAccountName field in the spec should be changed to empty",
+			serviceAccountName:            "builder",
+			expectedServiceAccountName:    "builder",
+			isServiceAccountNameChanged:   true,
+			newServiceAccountName:         "",
+			newExpectedServiceAccountName: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+				a.Spec.Repo.ServiceAccount = test.serviceAccountName
+			})
+
+			resObjs := []client.Object{a}
+			subresObjs := []client.Object{a}
+			runtimeObjs := []runtime.Object{}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+			r := makeTestReconciler(cl, sch)
+
+			err := r.reconcileRepoDeployment(a, false)
+			assert.NoError(t, err)
+
+			deployment := &appsv1.Deployment{}
+			key := types.NamespacedName{
+				Name:      "argocd-repo-server",
+				Namespace: testNamespace,
+			}
+
+			err = r.Client.Get(context.TODO(), key, deployment)
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
+
+			// check if SA name is changed
+			if test.isServiceAccountNameChanged {
+
+				a.Spec.Repo.ServiceAccount = test.newServiceAccountName
+
+				err = r.reconcileRepoDeployment(a, false)
+				assert.NoError(t, err)
+
+				err = r.Client.Get(context.TODO(), key, deployment)
+
+				assert.NoError(t, err)
+				assert.Equal(t, test.newExpectedServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What does this PR do / why we need it**:
This PR has fix for the issue where operator doesn't delete ServiceAccount from repo-server deployment configurations, if it is deleted from Argo CD CR.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1. Create Argo CD CR and add a service account in spec.repo.serviceaccount (other than default)
2. Observe repo-server deployment reflecting new service account in serviceAccountName and serviceAccount fields. 
3. Delete spec.repo.serviceaccount field in Argo CD CR.
4. repo-server deployment still has old value, it is supposed to be set to empty. 