### PR TITLE
fix flaky e2e test 1-034_validate_applicationset_reconcile_enabled_se…

### DIFF
--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/01-assert.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/01-assert.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-test
+  namespace: test
+spec:
+  controller:
+    enabled: false
+  redis:
+    enabled: false
+  repo:
+    enabled: false
+  server:
+    enabled: false
+  applicationSet:
+    enabled: false
+status:
+  phase: Available
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-test-argocd-application-controller
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-server
+  namespace: test
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-test-argocd-redis-ha
+  namespace: test

--- a/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/01-errors.yaml
+++ b/tests/k8s/1-034_validate_applicationset_reconcile_enabled_set_false/01-errors.yaml
@@ -1,10 +1,3 @@
-apiVersion: argoproj.io/v1beta1
-kind: ArgoCD
-metadata:
-  name: argocd-test
-  namespace: test
-status:
-  phase: Available
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -26,38 +19,4 @@ metadata:
   name: argocd-test-server
   namespace: test
 
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: argocd-test-server
-  namespace: test
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: argocd-test-application-controller
-  namespace: test
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: argocd-test-argocd-application-controller
-  namespace: test
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: argocd-test-argocd-server
-  namespace: test
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: argocd-test-argocd-redis-ha
-  namespace: test
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Currently the e2e test `1-034_validate_applicationset_reconcile_enabled_set_false` seems to be working when argocd-controller is running locally, but failing when the test is executed against the cluster. The PR fixes the test flakiness.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:
* To execute locally:
  * Execute `make install run` in argocd-operator.
  * In a new tab, execute `kubectl kuttl test ./tests/k8s --config ./tests/kuttl-tests.yaml --test 1-034_validate_applicationset_reconcile_enabled_set_false`
* To run against a cluster:
  * Deploy the operator in the cluster. Update your kube context to point to the cluster.
  * Execute the test using command `kubectl kuttl test ./tests/k8s --config ./tests/kuttl-tests.yaml --test 1-034_validate_applicationset_reconcile_enabled_set_false`