### PR TITLE
GITOPS-3617 Create Job from Cronjob feature failing with error cannot create resource "jobs"

### DIFF
--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -144,6 +144,17 @@ func policyRuleForServer() []v1.PolicyRule {
 				"list",
 			},
 		},
+		{
+			APIGroups: []string{
+				"batch",
+			},
+			Resources: []string{
+				"jobs",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
 	}
 }
 
@@ -229,6 +240,17 @@ func policyRuleForServerApplicationSourceNamespaces() []v1.PolicyRule {
 				"delete",
 			},
 		},
+		{
+			APIGroups: []string{
+				"batch",
+			},
+			Resources: []string{
+				"jobs",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
 	}
 }
 
@@ -268,6 +290,17 @@ func policyRuleForServerClusterRole() []v1.PolicyRule {
 			},
 			Verbs: []string{
 				"list",
+			},
+		},
+		{
+			APIGroups: []string{
+				"batch",
+			},
+			Resources: []string{
+				"jobs",
+			},
+			Verbs: []string{
+				"create",
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
Add the necessary batch permissions to the policy rules for argocd server to support creating batch job

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-3617

**How to test changes / Special notes to the reviewer**:
Successfully tested through manual verification in Argo CD UI:
* build the argocd-operator images with the changes in this PR, and push to quay.io/username/argocd-operator
* configure a new CustomCatalog in OpenShift, pointing to the above quay.io images
* in OpenShift OperatorHub, search the modified custom argocd-operator, and install it
* create an Argo CD instance under the installed custom argocd-operator
* navigate to Argo CD UI, and create an Argo CD application that contains a batch job. For instance, https://github.com/chengfang/argocd-example-apps/tree/master/batch
* in the application details page of the above application, try to create a batch job, and it should succeed. See the attached screenshot in [GITOPS-3617](https://issues.redhat.com/browse/GITOPS-3617)
* See the [test result screenshot](https://issues.redhat.com/secure/attachment/13133097/create%20batch%20job%20in%20argocd%20ui.png) attached to the jira.