### PR TITLE
Add containerenv unittest for appsync

### DIFF
--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1625,24 +1625,6 @@ func Test_UpdateNodePlacement(t *testing.T) {
 	}
 }
 
-func parallelismLimit(n int32) argoCDOpt {
-	return func(a *argoproj.ArgoCD) {
-		a.Spec.Controller.ParallelismLimit = n
-	}
-}
-
-func logFormat(f string) argoCDOpt {
-	return func(a *argoproj.ArgoCD) {
-		a.Spec.Controller.LogFormat = f
-	}
-}
-
-func logLevel(l string) argoCDOpt {
-	return func(a *argoproj.ArgoCD) {
-		a.Spec.Controller.LogLevel = l
-	}
-}
-
 func assertDeploymentHasProxyVars(t *testing.T, c client.Client, name string) {
 	t.Helper()
 	deployment := &appsv1.Deployment{}

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,6 +30,30 @@ const (
 	redisHATestImage      = "testing/redis:latest-ha"
 	redisHAProxyTestImage = "testing/redis-ha-haproxy:latest-ha"
 )
+
+func parallelismLimit(n int32) argoCDOpt {
+	return func(a *argoproj.ArgoCD) {
+		a.Spec.Controller.ParallelismLimit = n
+	}
+}
+
+func logFormat(f string) argoCDOpt {
+	return func(a *argoproj.ArgoCD) {
+		a.Spec.Controller.LogFormat = f
+	}
+}
+
+func logLevel(l string) argoCDOpt {
+	return func(a *argoproj.ArgoCD) {
+		a.Spec.Controller.LogLevel = l
+	}
+}
+
+func appSync(s int) argoCDOpt {
+	return func(a *argoproj.ArgoCD) {
+		a.Spec.Controller.AppSync = &metav1.Duration{Duration: time.Second * time.Duration(s)}
+	}
+}
 
 var imageTests = []struct {
 	name      string
@@ -507,7 +532,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 		},
 		{
 			"configured invalid loglevel",
-			[]argoCDOpt{logFormat("arbitrary")},
+			[]argoCDOpt{logLevel("arbitrary")},
 			defaultResult,
 		},
 		{
@@ -538,6 +563,34 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 
 		if !reflect.DeepEqual(cmd, tt.want) {
 			t.Fatalf("got %#v, want %#v", cmd, tt.want)
+		}
+	}
+}
+
+func TestGetArgoApplicationContainerEnv(t *testing.T) {
+
+	sync60s := []v1.EnvVar{
+		v1.EnvVar{Name: "HOME", Value: "/home/argocd", ValueFrom: (*v1.EnvVarSource)(nil)},
+		v1.EnvVar{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "60s", ValueFrom: (*v1.EnvVarSource)(nil)}}
+
+	cmdTests := []struct {
+		name string
+		opts []argoCDOpt
+		want []v1.EnvVar
+	}{
+		{
+			"configured apsync to 60s",
+			[]argoCDOpt{appSync(60)},
+			sync60s,
+		},
+	}
+
+	for _, tt := range cmdTests {
+		cr := makeTestArgoCD(tt.opts...)
+		env := getArgoControllerContainerEnv(cr)
+
+		if !reflect.DeepEqual(env, tt.want) {
+			t.Fatalf("got %#v, want %#v", env, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind code-refactoring


**What does this PR do / why we need it**:

We want to improve coverage of our unit-tests. This adds a new test for getArgoControllerContainerEnv in simmilar fashion to existing tests of getArgoApplicationControllerCommand.
