### PR TITLE
fix: stop argo-cd secret reseting admin password when updated using cli/dashboard

### DIFF
--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -313,9 +313,10 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoproj.ArgoCD, secre
 		secret.Data[common.ArgoCDKeyServerSecretKey] = sessionKey
 	}
 
+	// reset the value to default only when secret.data field is nil
 	if hasArgoAdminPasswordChanged(secret, clusterSecret) {
 		pwBytes, ok := clusterSecret.Data[common.ArgoCDKeyAdminPassword]
-		if ok {
+		if ok && secret.Data[common.ArgoCDKeyAdminPassword] == nil {
 			hashedPassword, err := argopass.HashPassword(strings.TrimRight(string(pwBytes), "\n"))
 			if err != nil {
 				return err


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
This PR fixes the reset of Argo-cd admin password when updated using cli/dashboard. Argo-cd will reset the password when the data field for admin.password is nil.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-3581](https://issues.redhat.com/browse/GITOPS-3581)

**How to test changes / Special notes to the reviewer**:

To check it locally, running k8s cluster
1. Run below command
```
make install run
```
2. On different terminal run 
```
kubectl port-forward service/example-argocd-server 8443:443
```
3. Get login password and perform login 
```
kubectl -n argocd get secret <secret-name> -o jsonpath="{.data.password}" | base64 -d; echo
argocd login --username admin --password <password>  127.0.0.1:8080
```
4. Update password
```
$ argocd account update-password
*** Enter password of currently logged in user (admin):
*** Enter new password for user admin:
*** Confirm new password for user admin:
```
5. Login using new password
```argocd login --username admin --password <NewPassword>  127.0.0.1:8080```