### PR TITLE
 fix: Use image configured in spec as fallback before default image for repository server workload

### DIFF
--- a/common/keys.go
+++ b/common/keys.go
@@ -121,10 +121,6 @@ const (
 	// ArgoCDKeyResourceTrackingMethod is the configuration key for resource tracking method
 	ArgoCDKeyResourceTrackingMethod = "application.resourceTrackingMethod"
 
-	// ArgoCDRepoImageEnvName is the environment variable used to get the image
-	// to used for the Dex container.
-	ArgoCDRepoImageEnvName = "ARGOCD_REPOSERVER_IMAGE"
-
 	// ArgoCDKeyRepositories is the configuration key for repositories.
 	ArgoCDKeyRepositories = "repositories"
 

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -205,10 +205,10 @@ func getArgoContainerImage(cr *argoproj.ArgoCD) string {
 //
 // 1. from the Spec, the spec.repo field has an image and version to use for
 // generating an image reference.
-// 2. from the Environment, this looks for the `ARGOCD_IMAGE` field and uses
-// that if the spec is not configured.
-// 3. from the Spec, the spec.version field has an image and version to use for
+// 2. from the Spec, the spec.version field has an image and version to use for
 // generating an image reference
+// 3. from the Environment, this looks for the `ARGOCD_IMAGE` field and uses
+// that if the spec is not configured.
 // 4. the default is configured in common.ArgoCDDefaultArgoVersion and
 // common.ArgoCDDefaultArgoImage.
 func getRepoServerContainerImage(cr *argoproj.ArgoCD) string {

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -200,27 +200,35 @@ func getArgoContainerImage(cr *argoproj.ArgoCD) string {
 
 // getRepoServerContainerImage will return the container image for the Repo server.
 //
-// There are three possible options for configuring the image, and this is the
+// There are four possible options for configuring the image, and this is the
 // order of preference.
 //
 // 1. from the Spec, the spec.repo field has an image and version to use for
 // generating an image reference.
-// 2. from the Environment, this looks for the `ARGOCD_REPOSERVER_IMAGE` field and uses
+// 2. from the Environment, this looks for the `ARGOCD_IMAGE` field and uses
 // that if the spec is not configured.
-// 3. the default is configured in common.ArgoCDDefaultRepoServerVersion and
-// common.ArgoCDDefaultRepoServerImage.
+// 3. from the Spec, the spec.version field has an image and version to use for
+// generating an image reference
+// 4. the default is configured in common.ArgoCDDefaultArgoVersion and
+// common.ArgoCDDefaultArgoImage.
 func getRepoServerContainerImage(cr *argoproj.ArgoCD) string {
 	defaultImg, defaultTag := false, false
 	img := cr.Spec.Repo.Image
 	if img == "" {
-		img = common.ArgoCDDefaultArgoImage
-		defaultImg = true
+		img = cr.Spec.Image
+		if img == "" {
+			img = common.ArgoCDDefaultArgoImage
+			defaultImg = true
+		}
 	}
 
 	tag := cr.Spec.Repo.Version
 	if tag == "" {
-		tag = common.ArgoCDDefaultArgoVersion
-		defaultTag = true
+		tag = cr.Spec.Version
+		if tag == "" {
+			tag = common.ArgoCDDefaultArgoVersion
+			defaultTag = true
+		}
 	}
 	if e := os.Getenv(common.ArgoCDImageEnvName); e != "" && (defaultTag && defaultImg) {
 		return e

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -840,8 +840,8 @@ MountSAToken | false | Whether the ServiceAccount token should be mounted to the
 ServiceAccount | "" | The name of the ServiceAccount to use with the repo-server pod.
 VerifyTLS | false | Whether to enforce strict TLS checking on all components when communicating with repo server
 AutoTLS | "" | Provider to use for setting up TLS the repo-server's gRPC TLS certificate (one of: `openshift`). Currently only available for OpenShift.
-Image | `argoproj/argocd` | The container image for ArgoCD Repo Server. This overrides the `ARGOCD_REPOSERVER_IMAGE` environment variable.
-Version | same as `.spec.Version` | The tag to use with the ArgoCD Repo Server.
+Image | `argoproj/argocd` | The container image for ArgoCD Repo Server. This overrides the `ARGOCD_IMAGE` environment variable for the repo server.
+Version | same as `.spec.Version` | The tag to use with the ArgoCD Repo Server. Fallsback to `.spec.Version` and the default image version in that order if not specified. 
 LogLevel | info | The log level to be used by the ArgoCD Repo Server. Valid options are debug, info, error, and warn.
 LogFormat | text | The log format to be used by the ArgoCD Repo Server. Valid options are text or json.
 ExecTimeout | 180 | Execution timeout in seconds for rendering tools (e.g. Helm, Kustomize)

--- a/docs/usage/environment_variables.md
+++ b/docs/usage/environment_variables.md
@@ -32,7 +32,6 @@ The following default value of images could be overridden by setting the environ
 | Environment Variable | Default Value |
 | --- | --- |
 | `ARGOCD_IMAGE` | [quay.io/argoproj/argocd](quay.io/argoproj/argocd) |
-| `ARGOCD_REPOSERVER_IMAGE` | [quay.io/argoproj/argocd](quay.io/argoproj/argocd) |
 | `ARGOCD_DEX_IMAGE` | [ghcr.io/dexidp/dex](ghcr.io/dexidp/dex) |
 | `ARGOCD_KEYCLOAK_IMAGE` | [quay.io/keycloak/keycloak](quay.io/keycloak/keycloak) |
 | `ARGOCD_REDIS_IMAGE` | redis |


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

* The repo server container image version will now fallback to spec.version before falling back to the default version if spec.repo.version is not set. Otherwise users get in the confusing situation of all the argo pods other than repo running a newer version than the repo server.
* It also fixes some documentation and code comments which were inaccurate after a previous change (#373). Also cleans up the unused field ArgoCDRepoImageEnvName after that change.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #623 

**How to test changes / Special notes to the reviewer**:
Added tests for the repo server image and version
