### PR TITLE
fix: update --enable-scm-providers cmd in appset deployment

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -83,10 +83,11 @@ func (r *ReconcileArgoCD) getArgoApplicationSetCommand(cr *argoproj.ArgoCD) []st
 		cmd = append(cmd, "--allowed-scm-providers", fmt.Sprint(strings.Join(cr.Spec.ApplicationSet.SCMProviders, ",")))
 	}
 
-	// appset in any ns doesn't support default SCM providers list.
-	// The list needs to be explicitly defined by admins when the feature is enabled.
+	// appset in any ns is enabled and no scmProviders allow list is specified,
+	// disables scm & PR generators to prevent potential security issues
+	// https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Appset-Any-Namespace/#scm-providers-secrets-consideration
 	if len(appsetsSourceNamespaces) > 0 && !(len(cr.Spec.ApplicationSet.SCMProviders) > 0) {
-		cmd = append(cmd, "--enable-scm-providers", "false")
+		cmd = append(cmd, "--enable-scm-providers=false")
 	}
 
 	// ApplicationSet command arguments provided by the user

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -450,7 +450,7 @@ func TestReconcileApplicationSet_Deployments_Command(t *testing.T) {
 				},
 				SourceNamespaces: []string{"foo", "bar"},
 			},
-			expectedCmd: []string{"--applicationset-namespaces", "foo,bar", "--enable-scm-providers", "false"},
+			expectedCmd: []string{"--applicationset-namespaces", "foo,bar", "--enable-scm-providers=false"},
 		},
 		{
 			name: "with SCM provider list",


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What does this PR do / why we need it**:
The appset controller doesn't consider the `--enable-scm-providers` flag value when set as below in deployment
```yaml
args:
- --enable-scm-providers
- "false"
```
This changes updates the flag to be in following format which is recognized by the controller
```yaml
args:
- --enable-scm-providers=false
```
