### PR TITLE
fix: Create Job from Cronjob feature failing with error cannot create…

### DIFF
--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -143,6 +143,17 @@ func policyRuleForServer() []v1.PolicyRule {
 				"list",
 			},
 		},
+		{
+			APIGroups: []string{
+				"batch",
+			},
+			Resources: []string{
+				"jobs",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
 	}
 }
 
@@ -228,6 +239,17 @@ func policyRuleForServerApplicationSourceNamespaces() []v1.PolicyRule {
 				"delete",
 			},
 		},
+		{
+			APIGroups: []string{
+				"batch",
+			},
+			Resources: []string{
+				"jobs",
+			},
+			Verbs: []string{
+				"create",
+			},
+		},
 	}
 }
 
@@ -267,6 +289,17 @@ func policyRuleForServerClusterRole() []v1.PolicyRule {
 			},
 			Verbs: []string{
 				"list",
+			},
+		},
+		{
+			APIGroups: []string{
+				"batch",
+			},
+			Resources: []string{
+				"jobs",
+			},
+			Verbs: []string{
+				"create",
 			},
 		},
 	}


### PR DESCRIPTION
This is a cherry-pick of the fix in https://github.com/argoproj-labs/argocd-operator/pull/1219 to release-0.9 branch, to fix issue [GITOPS-3617](https://issues.redhat.com/browse/GITOPS-3617) Create Job from Cronjob feature failing with error cannot create resource "jobs"