### PR TITLE
Add support for custom ClusterRoles (controller,server) for cluster scoped instances

### DIFF
--- a/common/keys.go
+++ b/common/keys.go
@@ -213,6 +213,12 @@ const (
 	// ArgoCDControllerClusterRoleEnvName is an environment variable to specify a custom cluster role for Argo CD application controller
 	ArgoCDControllerClusterRoleEnvName = "CONTROLLER_CLUSTER_ROLE"
 
+	// ArgoCDControllerClusterScopeRoleEnvName is an environment variable to specify a custom controller cluster role to replace the default cluster role used when Argo CD is deployed in cluster scoped mode.
+	ArgoCDControllerClusterScopeRoleEnvName = "CONTROLLER_CLUSTER_SCOPE_ROLE"
+
+	// ArgoCDServerClusterScopeRoleEnvName is an environment variable to specify a custom server cluster role to replace the default cluster role used when Argo CD is deployed in cluster scoped mode.
+	ArgoCDServerClusterScopeRoleEnvName = "SERVER_CLUSTER_SCOPE_ROLE"
+
 	// ArgoCDServerClusterRoleEnvName is an environment variable to specify a custom cluster role for Argo CD server
 	ArgoCDServerClusterRoleEnvName = "SERVER_CLUSTER_ROLE"
 

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -151,6 +151,57 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole).Error(), "not found")
 }
 
+func TestReconcileArgoCD_reconcileClusterRole_custom_role(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch)
+
+	workloadIdentifier := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(workloadIdentifier, a)
+	expectedRules := policyRuleForApplicationController()
+	_, err := r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
+	assert.NoError(t, err)
+
+	// set the namespace to be cluster scoped
+	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
+	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
+	assert.NoError(t, err)
+
+	// Confirm default cluster role is created
+	reconciledClusterRole := &v1.ClusterRole{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.Equal(t, expectedRules, reconciledClusterRole.Rules)
+
+	// Check if specified role doesn't exist error is raised
+	t.Setenv(common.ArgoCDControllerClusterScopeRoleEnvName, "custom-cluster-scope-role")
+	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
+	// Confirm error since custom role doesn't exist
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	//Create custom-cluster-scope-role
+	customClusterRole := &v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "custom-cluster-scope-role",
+		},
+	}
+	assert.NoError(t, r.Client.Create(context.TODO(), customClusterRole))
+
+	// Confirm reconcilliation works
+	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
+	assert.NoError(t, err)
+
+	// Confirm default role has been deleted
+	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole).Error(), "not found")
+}
+
 func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	sourceNamespace := "newNamespaceTest"

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -312,6 +312,16 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 	return nil
 }
 
+func getCustomClusterRoleName(name string) string {
+	if name == common.ArgoCDApplicationControllerComponent {
+		return os.Getenv(common.ArgoCDControllerClusterScopeRoleEnvName)
+	}
+	if name == common.ArgoCDServerComponent {
+		return os.Getenv(common.ArgoCDServerClusterScopeRoleEnvName)
+	}
+	return ""
+}
+
 func getCustomRoleName(name string) string {
 	if name == common.ArgoCDApplicationControllerComponent {
 		return os.Getenv(common.ArgoCDControllerClusterRoleEnvName)
@@ -362,17 +372,29 @@ func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.Clus
 		return nil
 	}
 
-	roleBinding.Subjects = []v1.Subject{
+	var subjects []v1.Subject
+	subjects = []v1.Subject{
 		{
 			Kind:      v1.ServiceAccountKind,
 			Name:      generateResourceName(name, cr),
 			Namespace: cr.Namespace,
 		},
 	}
-	roleBinding.RoleRef = v1.RoleRef{
-		APIGroup: v1.GroupName,
-		Kind:     "ClusterRole",
-		Name:     GenerateUniqueResourceName(name, cr),
+
+	var roleRef v1.RoleRef
+	customClusterRoleName := getCustomClusterRoleName(name)
+	if customClusterRoleName != "" {
+		roleRef = v1.RoleRef{
+			APIGroup: v1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     customClusterRoleName,
+		}
+	} else {
+		roleRef = v1.RoleRef{
+			APIGroup: v1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     GenerateUniqueResourceName(name, cr),
+		}
 	}
 
 	if cr.Namespace == roleBinding.Namespace {
@@ -380,6 +402,21 @@ func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.Clus
 			return fmt.Errorf("failed to set ArgoCD CR \"%s\" as owner for roleBinding \"%s\": %s", cr.Name, roleBinding.Name, err)
 		}
 	}
+
+	// if the rolebinding exists but the roleRef changed we need to delete it and recreate it since we cannot
+	// a role with a different roleRef
+	if roleBindingExists {
+		// if the RoleRef changes, delete the existing role binding and create a new one
+		if !reflect.DeepEqual(roleBinding.RoleRef, roleRef) {
+			if err = r.Client.Delete(context.TODO(), roleBinding); err != nil {
+				return err
+			}
+			roleBindingExists = false
+			roleBinding = newClusterRoleBindingWithname(name, cr)
+		}
+	}
+	roleBinding.Subjects = subjects
+	roleBinding.RoleRef = roleRef
 
 	if roleBindingExists {
 		return r.Client.Update(context.TODO(), roleBinding)

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -163,7 +163,8 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding(t *testing.T) {
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch)
 
-	workloadIdentifier := "x"
+	//workloadIdentifier := "x"
+	workloadIdentifier := common.ArgoCDApplicationControllerComponent
 	expectedClusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: workloadIdentifier}}
 
 	assert.NoError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, a))
@@ -182,6 +183,21 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding(t *testing.T) {
 
 	clusterRoleBinding = &rbacv1.ClusterRoleBinding{}
 	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding))
+
+	// set custom role
+	customClusterRoleName := "custom-argocd-controller"
+	t.Setenv(common.ArgoCDControllerClusterScopeRoleEnvName, customClusterRoleName)
+
+	// Test that RoleBinding is updated for custom role
+	assert.NoError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, a))
+	clusterRoleBinding = &rbacv1.ClusterRoleBinding{}
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding))
+	expectedRoleRef := rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "ClusterRole",
+		Name:     customClusterRoleName,
+	}
+	assert.Equal(t, clusterRoleBinding.RoleRef, expectedRoleRef)
 }
 
 func TestReconcileArgoCD_reconcileRoleBinding_custom_role(t *testing.T) {

--- a/docs/usage/custom_roles.md
+++ b/docs/usage/custom_roles.md
@@ -1,5 +1,10 @@
 # Custom Roles
 
+The operator supports specifying alternate roles to the ones that are created by default. This
+enables administrative users to tailor the permissions used by the operator deployed Argo CD instance as needed.
+
+## Namespace Scoped Roles
+
 As an administrative user, when you give Argo CD access to a namespace by using the `argocd.argoproj.io/managed-by` label, it assumes namespace-admin privileges. These privileges are an issue for administrators who provide namespaces to non-administrators, such as development teams, because the privileges enable non-administrators to modify objects such as network policies. With this update, administrators can configure a common cluster role for all the managed namespaces. In role bindings for the Argo CD application controller, the Operator refers to the CONTROLLER_CLUSTER_ROLE environment variable. In role bindings for the Argo CD server, the Operator refers to the SERVER_CLUSTER_ROLE environment variable. If these environment variables contain custom roles, the Operator doesn't create the default admin role. Instead, it uses the existing custom role for all managed namespaces.
 
 Example: Custom role environment variables in operator Subscription:
@@ -37,4 +42,52 @@ spec:
             value: custom-controller-role
           - name: SERVER_CLUSTER_ROLE
             value: custom-server-role
+```
+
+## Cluster Scoped Roles
+
+When the administrative user deploys Argo CD as a cluster scoped instance, the operator creates additional ClusterRoles and ClusterRoleBindings for the
+application-controller and server components. These provide the additional permissions that Argo CD requires to operate at the cluster level.
+
+Specifying alternate ClusterRoles enables the administrative user to add or remove permissions
+as needed and have them applied across all cluster scoped instances. For example, features such as the [Auto Respect RBAC For Controller](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#auto-respect-rbac-for-controller) enables specifying more granular permissions for the application-controller service account.
+
+These cluster roles can be customized via the `CONTROLLER_CLUSTER_SCOPE_ROLE` and `SERVER_CLUSTER_SCOPE_ROLE` environment variables. If these variables are set the operator will
+use the specified ClusterRole instead of creating a new ClusterRole with the default permissions.
+
+Example: Custom cluster scoped role environment variables in operator Subscription:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: argocd-operator
+  namespace: argocd
+spec:
+  config:
+    env:
+    - name: CONTROLLER_CLUSTER_SCOPE_ROLE
+      value: custom-cluster-scope-controller-role
+    - name: SERVER_CLUSTER_SCOPE_ROLE
+      value: custom-cluster-scope-server-role
+```
+
+Example: Custom cluster scoped role environment variables in operator Deployment:
+
+```yaml
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: argocd-operator-controller-manager
+  namespace: argocd
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+          env:
+          - name: CONTROLLER_CLUSTER_SCOPE_ROLE
+            value: custom-cluster-scope-controller-role
+          - name: SERVER_CLUSTER_SCOPE_ROLE
+            value: custom-cluster-scope-server-role
 ```


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

This WIP PR enables users to define custom roles for cluster scoped instances of Argo CD. This is becoming increasingly important with the addition of the auto-respect RBAC feature added in Argo CD 2.10.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #1275

Note this also tracked in Red Hat's issue database here: https://issues.redhat.com/browse/GITOPS-2614

**How to test changes / Special notes to the reviewer**:

Ready for review, note I am a novice Go developer so would recommend close scrunity in case I;m not complying with  Go ideoms anywhere.

