### PR TITLE
fix: GITOPS-4133 Creating Job from CronJob using ArgoCD UI fails with - cannot set blockOwnerDeletion

### DIFF
--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -150,9 +150,12 @@ func policyRuleForServer() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"jobs",
+				"cronjobs",
+				"cronjobs/finalizers",
 			},
 			Verbs: []string{
 				"create",
+				"update",
 			},
 		},
 	}
@@ -246,9 +249,12 @@ func policyRuleForServerApplicationSourceNamespaces() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"jobs",
+				"cronjobs",
+				"cronjobs/finalizers",
 			},
 			Verbs: []string{
 				"create",
+				"update",
 			},
 		},
 	}
@@ -298,9 +304,12 @@ func policyRuleForServerClusterRole() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"jobs",
+				"cronjobs",
+				"cronjobs/finalizers",
 			},
 			Verbs: []string{
 				"create",
+				"update",
 			},
 		},
 	}


### PR DESCRIPTION
cherry-pick from #1277
Signed-off-by: Cheng Fang <cfang@redhat.com>

**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-4133
Creating Job from CronJob using ArgoCD UI fails with - cannot set blockOwnerDeletion

**How to test changes / Special notes to the reviewer**:
