### PR TITLE
fix: GITOPS-4133 Creating Job from CronJob using ArgoCD UI fails with - cannot set blockOwnerDeletion

### DIFF
--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -149,9 +149,12 @@ func policyRuleForServer() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"jobs",
+				"cronjobs",
+				"cronjobs/finalizers",
 			},
 			Verbs: []string{
 				"create",
+				"update",
 			},
 		},
 	}
@@ -245,9 +248,12 @@ func policyRuleForServerApplicationSourceNamespaces() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"jobs",
+				"cronjobs",
+				"cronjobs/finalizers",
 			},
 			Verbs: []string{
 				"create",
+				"update",
 			},
 		},
 	}
@@ -297,9 +303,12 @@ func policyRuleForServerClusterRole() []v1.PolicyRule {
 			},
 			Resources: []string{
 				"jobs",
+				"cronjobs",
+				"cronjobs/finalizers",
 			},
 			Verbs: []string{
 				"create",
+				"update",
 			},
 		},
 	}


### PR DESCRIPTION
cherry-pick from #1277
Signed-off-by: Cheng Fang <cfang@redhat.com>

**What type of PR is this?**

 /kind bug

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-4133
Creating Job from CronJob using ArgoCD UI fails with - cannot set blockOwnerDeletion

**How to test changes / Special notes to the reviewer**:
