### PR TITLE
Add SeccompProfile for PodSecurityStandards "restricted" to avoid Pod Security Violations on restricted namespaces

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -484,6 +484,9 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS b
 			},
 			RunAsNonRoot: boolPtr(true),
 			RunAsUser:    int64Ptr(999),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: "RuntimeDefault",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -629,6 +632,9 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) e
 				},
 			},
 			RunAsNonRoot: boolPtr(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: "RuntimeDefault",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -664,6 +670,10 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) e
 				Drop: []corev1.Capability{
 					"ALL",
 				},
+			},
+			RunAsNonRoot: boolPtr(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: "RuntimeDefault",
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
@@ -717,6 +727,9 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) e
 		RunAsNonRoot: boolPtr(true),
 		RunAsUser:    int64Ptr(1000),
 		FSGroup:      int64Ptr(1000),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: "RuntimeDefault",
+		},
 	}
 	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
 
@@ -812,6 +825,9 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoproj.ArgoCD, useTLSFor
 				},
 			},
 			RunAsNonRoot: boolPtr(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: "RuntimeDefault",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -906,6 +922,9 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoproj.ArgoCD, useTLSFor
 				},
 			},
 			RunAsNonRoot: boolPtr(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: "RuntimeDefault",
+			},
 		},
 		VolumeMounts: repoServerVolumeMounts,
 	}}
@@ -1136,6 +1155,9 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 				},
 			},
 			RunAsNonRoot: boolPtr(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: "RuntimeDefault",
+			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1110,7 +1110,7 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 					},
 					RunAsNonRoot: boolPtr(true),
 					SeccompProfile: &corev1.SeccompProfile{
-						Type: "runtime/default",
+						Type: "RuntimeDefault",
 					},
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),
@@ -1340,7 +1340,7 @@ func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 					},
 					RunAsNonRoot: boolPtr(true),
 					SeccompProfile: &corev1.SeccompProfile{
-						Type: "runtime/default",
+						Type: "RuntimeDefault",
 					},
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),
@@ -1435,7 +1435,7 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 					},
 					RunAsNonRoot: boolPtr(true),
 					SeccompProfile: &corev1.SeccompProfile{
-						Type: "runtime/default",
+						Type: "RuntimeDefault",
 					},
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1109,6 +1109,9 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 						},
 					},
 					RunAsNonRoot: boolPtr(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: "runtime/default",
+					},
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),
 			},
@@ -1336,6 +1339,9 @@ func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 						},
 					},
 					RunAsNonRoot: boolPtr(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: "runtime/default",
+					},
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),
 			},
@@ -1428,6 +1434,9 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 						},
 					},
 					RunAsNonRoot: boolPtr(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: "runtime/default",
+					},
 				},
 				VolumeMounts: serverDefaultVolumeMounts(),
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

It is necessary to set the seccompProfile to RuntimeDefault to meet the [PodSecurityStandards of restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted), which will be a common default in clusters.
Otherwise the workloads will be evaluated as baseline and rejected, if not set otherwise in the [namespace metadata](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces).

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

Wrt testing:

Ideally we would set the namespace `metadata.labels` values for argoCD to 

```
    pod-security.kubernetes.io/enforce: restricted
    pod-security.kubernetes.io/enforce-version: latest
    pod-security.kubernetes.io/audit: restricted
    pod-security.kubernetes.io/audit-version: latest
    pod-security.kubernetes.io/warn: restricted
    pod-security.kubernetes.io/warn-version: latest
```

and the workloads shouldn't fail.

Wrt special notes:
I hope I found all `SecurityContext`, it would be good if someone double checks this.