### PR TITLE
fix: Update Argo CD to v2.9.10 to patch multiple Argo CD CVEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,11 @@ KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
+# Pin setup env due to go version incompatibility between setup-envtest and controller-runtime.
+# More info: https://github.com/kubernetes-sigs/controller-runtime/issues/2744
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@bf15e44028f908c790721fc8fe67c7bf2d06a611)
 	$(ENVTEST) use 1.26
 
 # go-install-tool will 'go install' any package $2 and install it to $1.

--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,5 +1,5 @@
-# Argo CD v2.9.5
-FROM quay.io/argoproj/argocd@sha256:b0df6dc907f85a54ffb320264c6ab642b778eacea6f92ceae203322ba4cf149e as argocd
+# Argo CD v2.9.10
+FROM quay.io/argoproj/argocd@sha256:5d3e4347349041b6ac5c93082bdacbb7f4e00ffe0d0cb5ff54e1c2a575544927 as argocd
 
 # Final Image
 FROM docker.io/library/ubuntu:22.04

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -61,7 +61,7 @@ const (
 	ArgoCDDefaultArgoImage = "quay.io/argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:b0df6dc907f85a54ffb320264c6ab642b778eacea6f92ceae203322ba4cf149e" // v2.9.5
+	ArgoCDDefaultArgoVersion = "sha256:5d3e4347349041b6ac5c93082bdacbb7f4e00ffe0d0cb5ff54e1c2a575544927" // v2.9.10
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -499,7 +499,7 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 				InitContainers: []corev1.Container{
 					{
 						Name:  "copyutil",
-						Image: "quay.io/argoproj/argocd@sha256:b0df6dc907f85a54ffb320264c6ab642b778eacea6f92ceae203322ba4cf149e",
+						Image: "quay.io/argoproj/argocd@" + common.ArgoCDDefaultArgoVersion,
 						Command: []string{
 							"cp",
 							"-n",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-operator
 go 1.20
 
 require (
-	github.com/argoproj/argo-cd/v2 v2.9.5
+	github.com/argoproj/argo-cd/v2 v2.9.10
 	github.com/coreos/prometheus-operator v0.40.0
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -649,8 +649,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/argoproj/argo-cd/v2 v2.9.5 h1:PdR23x9HVuh4phv+WO/2vvYSMf60BDtbDZNz6+md5Pw=
-github.com/argoproj/argo-cd/v2 v2.9.5/go.mod h1:3DQwsQvXosH/lpa7NYI9xBdDl5pdXQijO99ltKuSxQA=
+github.com/argoproj/argo-cd/v2 v2.9.10 h1:4TxlKafJ9WRbO14zMPwoV5PBqK90FA8X8Z7m5Traa14=
+github.com/argoproj/argo-cd/v2 v2.9.10/go.mod h1:y24WY8Phm7hz9X7AlnkB5oq9swpoUiRlcT86wcTSRRI=
 github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1 h1:qsHwwOJ21K2Ao0xPju1sNuqphyMnMYkyB3ZLoLtxWpo=
 github.com/argoproj/pkg v0.13.7-0.20230626144333-d56162821bd1/go.mod h1:CZHlkyAD1/+FbEn6cB2DQTj48IoLGvEYsWEvtzP3238=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

This PR patches below Argo CD CVEs

https://github.com/advisories/GHSA-6v85-wr92-q4p7 - Denial of Service Due to Unsafe Array Modification in Multi-threaded Environment
https://github.com/advisories/GHSA-g623-jcgg-mhmm - Users with create but not override privileges can perform local sync
https://github.com/advisories/GHSA-x32m-mvfj-52xv - Bypassing Brute Force Protection via Application Crash and In-Memory Data Loss
https://github.com/advisories/GHSA-jhwx-mhww-rgc3 - uncontrolled resource consumption vulnerability
https://github.com/advisories/GHSA-2vgg-9h6w-m454 - Bypassing Rate Limit and Brute Force Protection Using Cache Overflow

**How to test changes / Special notes to the reviewer**:
Argo CD version: v2.9.10
Argo CD image: https://quay.io/repository/argoproj/argocd?tab=tags