### PR TITLE
Adds podman compatibility in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CONTAINER_RUNTIME := $(shell command -v docker 2> /dev/null || command -v podman
 
 # If neither Docker nor Podman is found, print an error message and exit
 ifeq ($(CONTAINER_RUNTIME),)
-$(error "No container runtime (Docker or Podman) found in PATH. Please install one of them.")
+$(warning "No container runtime (Docker or Podman) found in PATH. Please install one of them.")
 endif
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.9.0
 
+# Try to detect Docker or Podman
+CONTAINER_RUNTIME := $(shell command -v docker 2> /dev/null || command -v podman 2> /dev/null)
+
+# If neither Docker nor Podman is found, print an error message and exit
+ifeq ($(CONTAINER_RUNTIME),)
+$(error "No container runtime (Docker or Podman) found in PATH. Please install one of them.")
+endif
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -99,10 +107,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	REDIS_CONFIG_PATH="build/redis" go run -ldflags=$(LD_FLAGS) ./main.go
 
 docker-build: test ## Build docker image with the manager.
-	docker build --build-arg LD_FLAGS=$(LD_FLAGS) -t ${IMG} .
+	$(CONTAINER_RUNTIME) build --build-arg LD_FLAGS=$(LD_FLAGS) -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	$(CONTAINER_RUNTIME) push ${IMG}
 
 ##@ Deployment
 
@@ -169,7 +177,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_RUNTIME) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
@@ -181,7 +189,7 @@ UTIL_IMG ?= $(IMAGE_TAG_BASE)-util:v$(VERSION)
 
 .PHONY: util-build
 util-build: ## Build the util container image (for backup)
-	docker build --no-cache -t $(UTIL_IMG) build/util
+	$(CONTAINER_RUNTIME) build --no-cache -t $(UTIL_IMG) build/util
 
 .PHONY: util-push
 util-push: ## Push the util container image
@@ -198,7 +206,7 @@ registry-build: ## Build the registry container image
 	cp -r deploy/registry/* build/_output/registry/
 	mkdir -p build/_output/registry/manifests
 	cp -r deploy/olm-catalog/argocd-operator build/_output/registry/manifests/
-	docker build -t $(REGISTRY_IMG) build/_output/registry
+	$(CONTAINER_RUNTIME) build -t $(REGISTRY_IMG) build/_output/registry
 
 .PHONY: registry-push
 registry-push: ## Push the util container image
@@ -238,7 +246,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(CONTAINER_RUNTIME) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

Adds Podman compatibility to Makefile

**Have you updated the necessary documentation?**

I think no doc update is needed for this

**Which issue(s) this PR fixes**:

Fixes #1298

**How to test changes / Special notes to the reviewer**:

```bash
make docker-build docker-push
make bundle-build bundle-push
make catalog-build catalog-push
```

with podman or docker installed, both will work