### PR TITLE
Fix redirect uri

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -458,6 +458,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 			if err := r.reconcileDexConfiguration(existingCM, cr); err != nil {
 				return err
 			}
+			cm.Data[common.ArgoCDKeyDexConfig] = existingCM.Data[common.ArgoCDKeyDexConfig]
 		} else if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
 			// retain oidc.config during reconcilliation when keycloak is configured
 			cm.Data[common.ArgoCDKeyOIDCConfig] = existingCM.Data[common.ArgoCDKeyOIDCConfig]

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -125,6 +125,7 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 		}
 
 		deploy.Spec.Template.ObjectMeta.Labels["dex.config.changed"] = time.Now().UTC().Format("01022006-150406-MST")
+		deploy.Spec.Template.ObjectMeta.Labels["dex.redirectURI"] = r.getDexOAuthRedirectURI(cr)
 		return r.Client.Update(context.TODO(), deploy)
 	}
 	return nil

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -125,7 +125,6 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 		}
 
 		deploy.Spec.Template.ObjectMeta.Labels["dex.config.changed"] = time.Now().UTC().Format("01022006-150406-MST")
-		deploy.Spec.Template.ObjectMeta.Labels["dex.redirectURI"] = r.getDexOAuthRedirectURI(cr)
 		return r.Client.Update(context.TODO(), deploy)
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind bug

In the `reconcileArgoConfigMap` method, if dex is enabled, ConfigMap is updated twice - once in the `reconcileDexConfiguration` method and then outside. There is a chance that the redirect URI is different in both these updates, causing wrong values to be persisted in the configMap. To fix that, setting the same value of dex config in both the updates.

Reproduced the problem in a demo cluster and ensured that the problem is not reproducible with this fix.

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-4358 and https://issues.redhat.com/browse/GITOPS-3736

**How to test changes / Special notes to the reviewer**:
