### PR TITLE
fix(Redis): Custom Endpoint without Deploying Redis

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -553,6 +553,11 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS b
 		return nil // Deployment found with nothing to do, move along...
 	}
 
+	if cr.Spec.Redis.IsEnabled() && cr.Spec.Redis.Remote != nil && *cr.Spec.Redis.Remote != "" {
+		log.Info("Custom Redis Endpoint. Skipping starting redis.")
+		return nil
+	}
+
 	if !cr.Spec.Redis.IsEnabled() {
 		log.Info("Redis disabled. Skipping starting redis.")
 		return nil

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -424,6 +424,11 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoproj.ArgoCD) error {
 		return nil // StatefulSet found, do nothing
 	}
 
+	if cr.Spec.Redis.IsEnabled() && cr.Spec.Redis.Remote != nil && *cr.Spec.Redis.Remote != "" {
+		log.Info("Custom Redis Endpoint. Skipping starting redis.")
+		return nil
+	}
+
 	if !cr.Spec.Redis.IsEnabled() {
 		log.Info("Redis disabled. Skipping starting Redis.") // Redis not enabled, do nothing.
 		return nil

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -243,7 +243,7 @@ func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoproj.ArgoCD) error {
 	var phase string
 
 	if ((!cr.Spec.Controller.IsEnabled() && cr.Status.ApplicationController == "Unknown") || cr.Status.ApplicationController == "Running") &&
-		((!cr.Spec.Redis.IsEnabled() && cr.Status.Redis == "Unknown") || cr.Status.Redis == "Running") &&
+		((!cr.Spec.Redis.IsEnabled() && cr.Status.Redis == "Unknown") || cr.Status.Redis == "Running" || (cr.Spec.Redis.IsEnabled() && cr.Spec.Redis.Remote != nil && *cr.Spec.Redis.Remote != "")) &&
 		((!cr.Spec.Repo.IsEnabled() && cr.Status.Repo == "Unknown") || cr.Status.Repo == "Running") &&
 		((!cr.Spec.Server.IsEnabled() && cr.Status.Server == "Unknown") || cr.Status.Server == "Running") {
 		phase = "Available"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

When Redis is set to false, the remote field is not being set, and the argocd controller/repo server fall back to the default value of  ```argocd-redis```

```yaml
  redis:
    enabled: false
    remote: 'argocd-dragonfly:6379'
```

When Redis is set to true, the custom remote field is being set, but the redis deployment is also being deployed
```yaml
  redis:
    enabled: true
    remote: 'argocd-dragonfly:6379'
 ```
 
 Looking at the code,  it seemed simpler to update the condition to be ```enabled + remote``` for a custom endpoint instead of rewriting for ```disabled + remote```.
    
**Have you updated the necessary documentation?**

N/A?

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
Should I open a Separate Issue?

**How to test changes / Special notes to the reviewer**:
