### PR TITLE
feat: Add support for custom ClusterRoles (controller,server) for cluster scoped instances

### DIFF
--- a/api/v1alpha1/argocd_conversion.go
+++ b/api/v1alpha1/argocd_conversion.go
@@ -92,6 +92,7 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.UsersAnonymousEnabled = src.Spec.UsersAnonymousEnabled
 	dst.Spec.Version = src.Spec.Version
 	dst.Spec.Banner = (*v1beta1.Banner)(src.Spec.Banner)
+	dst.Spec.DefaultClusterScopedRoleDisabled = src.Spec.DefaultClusterScopedRoleDisabled
 
 	// Status conversion
 	dst.Status = v1beta1.ArgoCDStatus(src.Status)
@@ -159,6 +160,7 @@ func (dst *ArgoCD) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.UsersAnonymousEnabled = src.Spec.UsersAnonymousEnabled
 	dst.Spec.Version = src.Spec.Version
 	dst.Spec.Banner = (*Banner)(src.Spec.Banner)
+	dst.Spec.DefaultClusterScopedRoleDisabled = src.Spec.DefaultClusterScopedRoleDisabled
 
 	// Status conversion
 	dst.Status = ArgoCDStatus(src.Status)

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -821,6 +821,9 @@ type ArgoCDSpec struct {
 	// Deprecated field. Support dropped in v1beta1 version.
 	// Dex defines the Dex server options for ArgoCD.
 	Dex *ArgoCDDexSpec `json:"dex,omitempty"`
+
+	// DefaultClusterScopedRoleDisabled will disable creation of default ClusterRoles for a cluster scoped instance.
+	DefaultClusterScopedRoleDisabled bool `json:"defaultClusterScopedRoleDisabled,omitempty"`
 }
 
 // ArgoCDStatus defines the observed state of ArgoCD

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -852,6 +852,9 @@ type ArgoCDSpec struct {
 
 	// Banner defines an additional banner to be displayed in Argo CD UI
 	Banner *Banner `json:"banner,omitempty"`
+
+	// DefaultClusterScopedRoleDisabled will disable creation of default ClusterRoles for a cluster scoped instance.
+	DefaultClusterScopedRoleDisabled bool `json:"defaultClusterScopedRoleDisabled,omitempty"`
 }
 
 // ArgoCDStatus defines the observed state of ArgoCD

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -630,6 +630,10 @@ spec:
                         type: integer
                     type: object
                 type: object
+              defaultClusterScopedRoleDisabled:
+                description: DefaultClusterScopedRoleDisabled will disable creation
+                  of default ClusterRoles for a cluster scoped instance.
+                type: boolean
               dex:
                 description: Deprecated field. Support dropped in v1beta1 version.
                   Dex defines the Dex server options for ArgoCD.
@@ -7589,6 +7593,10 @@ spec:
                         type: integer
                     type: object
                 type: object
+              defaultClusterScopedRoleDisabled:
+                description: DefaultClusterScopedRoleDisabled will disable creation
+                  of default ClusterRoles for a cluster scoped instance.
+                type: boolean
               disableAdmin:
                 description: DisableAdmin will disable the admin user.
                 type: boolean

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -621,6 +621,10 @@ spec:
                         type: integer
                     type: object
                 type: object
+              defaultClusterScopedRoleDisabled:
+                description: DefaultClusterScopedRoleDisabled will disable creation
+                  of default ClusterRoles for a cluster scoped instance.
+                type: boolean
               dex:
                 description: Deprecated field. Support dropped in v1beta1 version.
                   Dex defines the Dex server options for ArgoCD.
@@ -7580,6 +7584,10 @@ spec:
                         type: integer
                     type: object
                 type: object
+              defaultClusterScopedRoleDisabled:
+                description: DefaultClusterScopedRoleDisabled will disable creation
+                  of default ClusterRoles for a cluster scoped instance.
+                type: boolean
               disableAdmin:
                 description: DisableAdmin will disable the admin user.
                 type: boolean

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -94,7 +94,7 @@ func TestReconcileArgoCD_reconcileTLSCerts_configMapUpdate(t *testing.T) {
 	}
 
 	// update a new cert in argocd-tls-certs-cm
-	testPEM := generateEncodedPEM(t, "example.com")
+	testPEM := generateEncodedPEM(t)
 
 	configMap.Data["example.com"] = string(testPEM)
 	assert.NoError(t, r.Client.Update(context.TODO(), configMap))

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -172,8 +172,11 @@ func TestReconcileArgoCD_reconcileClusterRole_disabled(t *testing.T) {
 	// Disable creation of default ClusterRole
 	a.Spec.DefaultClusterScopedRoleDisabled = true
 
+	err := cl.Update(context.Background(), a)
+	assert.NoError(t, err)
+
 	// Reconcile ClusterRole
-	_, err := r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
+	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
 	// Ensure default ClusterRole is not created
@@ -184,6 +187,8 @@ func TestReconcileArgoCD_reconcileClusterRole_disabled(t *testing.T) {
 
 	// Now enable creation of default ClusterRole
 	a.Spec.DefaultClusterScopedRoleDisabled = false
+	err = cl.Update(context.Background(), a)
+	assert.NoError(t, err)
 
 	// Again reconcile ClusterRole
 	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
@@ -194,6 +199,8 @@ func TestReconcileArgoCD_reconcileClusterRole_disabled(t *testing.T) {
 
 	// Once again disable creation of default ClusterRole
 	a.Spec.DefaultClusterScopedRoleDisabled = true
+	err = cl.Update(context.Background(), a)
+	assert.NoError(t, err)
 
 	// Once again reconcile ClusterRole
 	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -184,6 +184,52 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding(t *testing.T) {
 	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding))
 }
 
+func TestReconcileArgoCD_reconcileClusterRoleBinding_disabled(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch)
+	workloadIdentifier := "x"
+	expectedClusterRole := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: workloadIdentifier}}
+
+	// Disable creation of default ClusterRole, hence RoleBinding won't be created either.
+	a.Spec.DefaultClusterScopedRoleDisabled = true
+
+	// Reconcile ClusterRoleBinding
+	assert.NoError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, a))
+
+	// Ensure default ClusterRoleBinding is not created
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	expectedName := fmt.Sprintf("%s-%s-%s", a.Name, a.Namespace, workloadIdentifier)
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+
+	// Now enable creation of default ClusterRole, hence RoleBinding should be created aw well.
+	a.Spec.DefaultClusterScopedRoleDisabled = false
+
+	// Again reconcile ClusterRoleBinding
+	assert.NoError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, a))
+
+	// Ensure default ClusterRoleBinding is created now
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding))
+
+	// Once again disable creation of default ClusterRole
+	a.Spec.DefaultClusterScopedRoleDisabled = true
+
+	// Once again reconcile ClusterRoleBinding
+	assert.NoError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, a))
+
+	// Ensure default ClusterRoleBinding is deleted again
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+}
+
 func TestReconcileArgoCD_reconcileRoleBinding_custom_role(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -198,6 +198,8 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding_disabled(t *testing.T) {
 
 	// Disable creation of default ClusterRole, hence RoleBinding won't be created either.
 	a.Spec.DefaultClusterScopedRoleDisabled = true
+	err := cl.Update(context.Background(), a)
+	assert.NoError(t, err)
 
 	// Reconcile ClusterRoleBinding
 	assert.NoError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, a))
@@ -205,12 +207,14 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding_disabled(t *testing.T) {
 	// Ensure default ClusterRoleBinding is not created
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 	expectedName := fmt.Sprintf("%s-%s-%s", a.Name, a.Namespace, workloadIdentifier)
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding)
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName}, clusterRoleBinding)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "not found")
 
 	// Now enable creation of default ClusterRole, hence RoleBinding should be created aw well.
 	a.Spec.DefaultClusterScopedRoleDisabled = false
+	err = cl.Update(context.Background(), a)
+	assert.NoError(t, err)
 
 	// Again reconcile ClusterRoleBinding
 	assert.NoError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, a))
@@ -220,6 +224,8 @@ func TestReconcileArgoCD_reconcileClusterRoleBinding_disabled(t *testing.T) {
 
 	// Once again disable creation of default ClusterRole
 	a.Spec.DefaultClusterScopedRoleDisabled = true
+	err = cl.Update(context.Background(), a)
+	assert.NoError(t, err)
 
 	// Once again reconcile ClusterRoleBinding
 	assert.NoError(t, r.reconcileClusterRoleBinding(workloadIdentifier, expectedClusterRole, a))

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -33,7 +33,7 @@ import (
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
-func getRedisHAReplicas(cr *argoproj.ArgoCD) *int32 {
+func getRedisHAReplicas() *int32 {
 	replicas := common.ArgoCDDefaultRedisHAReplicas
 	// TODO: Allow override of this value through CR?
 	return &replicas
@@ -107,7 +107,7 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoproj.ArgoCD) error {
 	})
 
 	ss.Spec.PodManagementPolicy = appsv1.OrderedReadyPodManagement
-	ss.Spec.Replicas = getRedisHAReplicas(cr)
+	ss.Spec.Replicas = getRedisHAReplicas()
 	ss.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			common.ArgoCDKeyName: nameWithSuffix("redis-ha", cr),

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -549,8 +549,8 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 func TestGetArgoApplicationContainerEnv(t *testing.T) {
 
 	sync60s := []v1.EnvVar{
-		v1.EnvVar{Name: "HOME", Value: "/home/argocd", ValueFrom: (*v1.EnvVarSource)(nil)},
-		v1.EnvVar{Name: "REDIS_PASSWORD", Value: "",
+		{Name: "HOME", Value: "/home/argocd", ValueFrom: (*v1.EnvVarSource)(nil)},
+		{Name: "REDIS_PASSWORD", Value: "",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -559,7 +559,7 @@ func TestGetArgoApplicationContainerEnv(t *testing.T) {
 					Key: "admin.password",
 				},
 			}},
-		v1.EnvVar{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "60s", ValueFrom: (*v1.EnvVarSource)(nil)}}
+		{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "60s", ValueFrom: (*v1.EnvVarSource)(nil)}}
 
 	cmdTests := []struct {
 		name string
@@ -994,7 +994,7 @@ func TestGenerateRandomString(t *testing.T) {
 	assert.Len(t, b, 20)
 }
 
-func generateEncodedPEM(t *testing.T, host string) []byte {
+func generateEncodedPEM(t *testing.T) []byte {
 	key, err := argoutil.NewPrivateKey()
 	assert.NoError(t, err)
 

--- a/deploy/olm-catalog/argocd-operator/0.9.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.9.0/argoproj.io_argocds.yaml
@@ -630,6 +630,10 @@ spec:
                         type: integer
                     type: object
                 type: object
+              defaultClusterScopedRoleDisabled:
+                description: DefaultClusterScopedRoleDisabled will disable creation
+                  of default ClusterRoles for a cluster scoped instance.
+                type: boolean
               dex:
                 description: Deprecated field. Support dropped in v1beta1 version.
                   Dex defines the Dex server options for ArgoCD.
@@ -7589,6 +7593,10 @@ spec:
                         type: integer
                     type: object
                 type: object
+              defaultClusterScopedRoleDisabled:
+                description: DefaultClusterScopedRoleDisabled will disable creation
+                  of default ClusterRoles for a cluster scoped instance.
+                type: boolean
               disableAdmin:
                 description: DisableAdmin will disable the admin user.
                 type: boolean

--- a/docs/usage/custom_roles.md
+++ b/docs/usage/custom_roles.md
@@ -38,3 +38,24 @@ spec:
           - name: SERVER_CLUSTER_ROLE
             value: custom-server-role
 ```
+
+## Cluster Scoped Roles
+
+When the administrative user deploys Argo CD as a cluster scoped instance, the operator creates additional ClusterRoles and ClusterRoleBindings for the
+application-controller and server components. These provide the additional permissions that Argo CD requires to operate at the cluster level.
+
+Specifying alternate ClusterRoles enables the administrative user to add or remove permissions
+as needed and have them applied across all cluster scoped instances. For example, features such as the [Auto Respect RBAC For Controller](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#auto-respect-rbac-for-controller) enables specifying more granular permissions for the application-controller service account.
+
+These customized ClusterRoles need to be created and referred in ClusterRoleBinding by admin. A user can disable creation of default ClusterRoles by setting `ArgoCD.Spec.DefaultClusterScopedRoleDisabled` field to `true`.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  defaultClusterScopedRoleDisabled: true
+```

--- a/docs/usage/custom_roles.md
+++ b/docs/usage/custom_roles.md
@@ -59,3 +59,5 @@ metadata:
 spec:
   defaultClusterScopedRoleDisabled: true
 ```
+
+When `defaultClusterScopedRoleDisabled` is `true`, the default ClusterRole/ClusterRoleBindings for the Argo CD instance will not be created, and the administrative user is free to create and customize these independent of the operator. The field can later be set to `false`, to recreate these resources, if needed.


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

This PR enables user to define custom roles for cluster scoped instances of Argo CD. This is becoming increasingly important with the addition of the auto-respect RBAC feature added in Argo CD 2.10.

**Have you updated the necessary documentation?**

- [x]  Documentation update is required by this PR.
- [x]  Documentation has been updated.

**Which issue(s) this PR fixes:**

Fixes https://github.com/argoproj-labs/argocd-operator/issues/1275
Note this also tracked in Red Hat's issue database here: https://issues.redhat.com/browse/GITOPS-2614

**How to test changes / Special notes to the reviewer:**
- Create a namespace and to make it cluster scoped namespace update `ARGOCD_CLUSTER_CONFIG_NAMESPACES` environment variable of Subscription resource. 
- Create ClusterRoles and ClusterRoleBindings for Application controller and server.
- Create Argo CD CR in namespace and set  `Spec.DefaultClusterScopedRoleCreationDisabled` to `true`. 
- All Argo CD components should be healthy.