### PR TITLE
fix:  nil pointer err in appset & add missing notification crd in kustomize

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - bases/argoproj.io_applications.yaml
 - bases/argoproj.io_applicationsets.yaml
 - bases/argoproj.io_appprojects.yaml
-
+- bases/argoproj.io_notificationsconfigurations.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/controllers/argocd/applicationset/status.go
+++ b/controllers/argocd/applicationset/status.go
@@ -14,7 +14,7 @@ import (
 func (asr *ApplicationSetReconciler) ReconcileStatus() error {
 	status := common.ArgoCDStatusUnknown
 
-	if asr.Instance.Spec.ApplicationSet.IsEnabled() {
+	if asr.Instance.Spec.ApplicationSet != nil && asr.Instance.Spec.ApplicationSet.IsEnabled() {
 		d, err := workloads.GetDeployment(resourceName, asr.Instance.Namespace, asr.Client)
 		if err != nil {
 			return errors.Wrapf(err, "failed to retrieve deployment %s", resourceName)


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
This PR fix missing notificaionConfiguration.yaml to `crd/kustomation.yaml` and fixes a nil pointer error caused by directly checking if applicationSet is enabled.
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
