### PR TITLE
feat: Update the default TLS termination policy to reencrypt 

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -960,10 +960,12 @@ func (argocd *ArgoCD) IsDeletionFinalizerPresent() bool {
 	return false
 }
 
-// WantsAutoTLS returns true if user configured a route with reencryption
-// termination policy.
+// WantsAutoTLS returns true if:
+// 1. user has configured a route with reencrypt.
+// 2. user has not configured TLS and we default to reencrypt.
 func (s *ArgoCDServerSpec) WantsAutoTLS() bool {
-	return s.Route.TLS != nil && s.Route.TLS.Termination == routev1.TLSTerminationReencrypt
+	return s.Route.TLS == nil ||
+		(s.Route.TLS != nil && s.Route.TLS.Termination == routev1.TLSTerminationReencrypt)
 }
 
 // WantsAutoTLS returns true if the repository server configuration has set

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -964,8 +964,7 @@ func (argocd *ArgoCD) IsDeletionFinalizerPresent() bool {
 // 1. user has configured a route with reencrypt.
 // 2. user has not configured TLS and we default to reencrypt.
 func (s *ArgoCDServerSpec) WantsAutoTLS() bool {
-	return s.Route.TLS == nil ||
-		(s.Route.TLS != nil && s.Route.TLS.Termination == routev1.TLSTerminationReencrypt)
+	return s.Route.TLS == nil || s.Route.TLS.Termination == routev1.TLSTerminationReencrypt
 }
 
 // WantsAutoTLS returns true if the repository server configuration has set

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -991,7 +991,9 @@ func (argocd *ArgoCD) IsDeletionFinalizerPresent() bool {
 	return false
 }
 
-// WantsAutoTLS returns true if the user has configured a route with reencrypt or we default to reencrypt.
+// WantsAutoTLS returns true if:
+// 1. user has configured a route with reencrypt.
+// 2. user has not configured TLS and we default to reencrypt.
 func (s *ArgoCDServerSpec) WantsAutoTLS() bool {
 	return s.Route.TLS == nil ||
 		(s.Route.TLS != nil && s.Route.TLS.Termination == routev1.TLSTerminationReencrypt)

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -991,10 +991,10 @@ func (argocd *ArgoCD) IsDeletionFinalizerPresent() bool {
 	return false
 }
 
-// WantsAutoTLS returns true if user configured a route with reencryption
-// termination policy.
+// WantsAutoTLS returns true if the user has configured a route with reencrypt or we default to reencrypt.
 func (s *ArgoCDServerSpec) WantsAutoTLS() bool {
-	return s.Route.TLS != nil && s.Route.TLS.Termination == routev1.TLSTerminationReencrypt
+	return s.Route.TLS == nil ||
+		(s.Route.TLS != nil && s.Route.TLS.Termination == routev1.TLSTerminationReencrypt)
 }
 
 // WantsAutoTLS returns true if the repository server configuration has set

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -995,8 +995,7 @@ func (argocd *ArgoCD) IsDeletionFinalizerPresent() bool {
 // 1. user has configured a route with reencrypt.
 // 2. user has not configured TLS and we default to reencrypt.
 func (s *ArgoCDServerSpec) WantsAutoTLS() bool {
-	return s.Route.TLS == nil ||
-		(s.Route.TLS != nil && s.Route.TLS.Termination == routev1.TLSTerminationReencrypt)
+	return s.Route.TLS == nil || s.Route.TLS.Termination == routev1.TLSTerminationReencrypt
 }
 
 // WantsAutoTLS returns true if the repository server configuration has set

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -231,13 +231,13 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoproj.ArgoCD) error {
 			Termination:                   routev1.TLSTerminationEdge,
 		}
 	} else {
-		// Server is using TLS configure passthrough.
+		// Server is using TLS configure reencrypt.
 		route.Spec.Port = &routev1.RoutePort{
 			TargetPort: intstr.FromString("https"),
 		}
 		route.Spec.TLS = &routev1.TLSConfig{
-			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-			Termination:                   routev1.TLSTerminationPassthrough,
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+			Termination:                   routev1.TLSTerminationReencrypt,
 		}
 	}
 

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -236,7 +236,7 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoproj.ArgoCD) error {
 			TargetPort: intstr.FromString("https"),
 		}
 		route.Spec.TLS = &routev1.TLSConfig{
-			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 			Termination:                   routev1.TLSTerminationReencrypt,
 		}
 	}

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -97,8 +97,8 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
-		Termination:                   routev1.TLSTerminationPassthrough,
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		Termination:                   routev1.TLSTerminationReencrypt,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 	}
 	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
 		t.Fatalf("failed to reconcile route:\n%s", diff)
@@ -202,8 +202,8 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig = &routev1.TLSConfig{
-		Termination:                   routev1.TLSTerminationPassthrough,
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		Termination:                   routev1.TLSTerminationReencrypt,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 	}
 	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
 		t.Fatalf("failed to reconcile route:\n%s", diff)
@@ -280,7 +280,8 @@ func TestReconcileRouteApplicationSetTlsTermination(t *testing.T) {
 				Route: argoproj.ArgoCDRouteSpec{
 					Enabled: true,
 					TLS: &routev1.TLSConfig{
-						Termination: "passthrough",
+						Termination:                   routev1.TLSTerminationPassthrough,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 					},
 				},
 			},
@@ -311,7 +312,7 @@ func TestReconcileRouteApplicationSetTlsTermination(t *testing.T) {
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 		Termination:                   routev1.TLSTerminationPassthrough,
 	}
 	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -98,7 +98,7 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 
 	wantTLSConfig := &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationReencrypt,
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
 	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
 		t.Fatalf("failed to reconcile route:\n%s", diff)
@@ -203,7 +203,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 
 	wantTLSConfig = &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationReencrypt,
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
 	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
 		t.Fatalf("failed to reconcile route:\n%s", diff)
@@ -281,7 +281,7 @@ func TestReconcileRouteApplicationSetTlsTermination(t *testing.T) {
 					Enabled: true,
 					TLS: &routev1.TLSConfig{
 						Termination:                   routev1.TLSTerminationPassthrough,
-						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 					},
 				},
 			},
@@ -312,7 +312,7 @@ func TestReconcileRouteApplicationSetTlsTermination(t *testing.T) {
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
-		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		Termination:                   routev1.TLSTerminationPassthrough,
 	}
 	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {

--- a/docs/usage/routes.md
+++ b/docs/usage/routes.md
@@ -48,7 +48,7 @@ $ kubectl get secret argocd-cluster -n argocd -ojsonpath='{.data.admin\.password
 
 ## Setting TLS modes for routes
 
-You can parameterize the route's TLS configuration by setting appropriate values in the `.spec.server.route.tls` field of the `ArgoCD` CR.
+By default, the operator creates the Argo CD server route with `reencrypt` termination policy. You can parameterize the route's TLS configuration by setting appropriate values in the `.spec.server.route.tls` field of the `ArgoCD` CR.
 
 ### TLS edge termination mode
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind enhancement


**What does this PR do / why we need it**:

- This PR updates the default TLS termination policy of OpenShift Route from passthrough to reencrypt. With this change, OpenShift users could use the default ingress certificates for the argocd server without any explicit modification.
- The user/browser/CLI and the Router will communicate using the ingress certificate. The operator relies on OpenShift Service's CA to generate a self-signed certificate in the argocd-server-tls secret which will be used between the Router and the Argo CD server.


**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Create an Argo CD CR without specifying the server's TLS termination policy.
2. Verify if the server Route is using the Reencrypt policy.
3. Open the server route in a browser and ensure that it is using the ingress operator certificate.
 
