### PR TITLE
Fix panic on SSO Keycloak conversion

### DIFF
--- a/api/v1alpha1/argocd_conversion.go
+++ b/api/v1alpha1/argocd_conversion.go
@@ -36,7 +36,7 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 			sso.Keycloak.Version = src.Spec.SSO.Version
 			sso.Keycloak.VerifyTLS = src.Spec.SSO.VerifyTLS
 			sso.Keycloak.Resources = src.Spec.SSO.Resources
-			sso.Keycloak.Host = src.Spec.SSO.Keycloak.Host
+
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What does this PR do / why we need it**:

Fix nil dereference in conversion of SSO.Keycloak field from v1alpha1 to v1beta1:
```
2024/05/27 23:31:07 http: panic serving 10.130.0.2:48878: runtime error: invalid memory address or nil pointer dereference
goroutine 900 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1868 +0xb9
panic({0x1a9be80?, 0x2eb0b90?})
	/usr/local/go/src/runtime/panic.go:920 +0x270
github.com/argoproj-labs/argocd-operator/api/v1alpha1.(*ArgoCD).ConvertTo(0xc002eb2900, {0x2031020?, 0xc00216b500})
	/go/pkg/mod/github.com/argoproj-labs/argocd-operator@v0.9.0-rc3.0.20240524133052-4047a69a7130/api/v1alpha1/argocd_conversion.go:39 +0x443
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*webhook).convertObject(0xc00041c650?, {0x202a1c0, 0xc002eb2900}, {0x202a210, 0xc00216b500})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/webhook/conversion/conversion.go:142 +0x3e3
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*webhook).handleConvertRequest(0xc00041c650, 0xc00353b400)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/webhook/conversion/conversion.go:105 +0x1c5
sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*webhook).ServeHTTP(0x20261e0?, {0x7f381bc561e8?, 0xc001a7afa0}, 0xc0037b7d00)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/webhook/conversion/conversion.go:72 +0xf6
sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1({0x7f381bc561e8, 0xc001a7afa0}, 0x2036e00?)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:60 +0xcb
net/http.HandlerFunc.ServeHTTP(0x2036ee0?, {0x7f381bc561e8?, 0xc001a7afa0?}, 0xc0006258a0?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1({0x2036ee0?, 0xc001df75e0?}, 0xc0037b7d00)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:147 +0xb6
net/http.HandlerFunc.ServeHTTP(0x70e946?, {0x2036ee0?, 0xc001df75e0?}, 0xc0030fd680?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2({0x2036ee0, 0xc001df75e0}, 0xc0037b7d00)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:109 +0xc2
net/http.HandlerFunc.ServeHTTP(0x10?, {0x2036ee0?, 0xc001df75e0?}, 0xc00353b3ec?)
	/usr/local/go/src/net/http/server.go:2136 +0x29
net/http.(*ServeMux).ServeHTTP(0x410945?, {0x2036ee0, 0xc001df75e0}, 0xc0037b7d00)
	/usr/local/go/src/net/http/server.go:2514 +0x142
net/http.serverHandler.ServeHTTP({0x202ce98?}, {0x2036ee0?, 0xc001df75e0?}, 0x6?)
	/usr/local/go/src/net/http/server.go:2938 +0x8e
net/http.(*conn).serve(0xc00102d560, {0x203f408, 0xc0004a5d40})
	/usr/local/go/src/net/http/server.go:2009 +0x5f4
created by net/http.(*Server).Serve in goroutine 47
	/usr/local/go/src/net/http/server.go:3086 +0x5cb
```

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
