### PR TITLE
Automatically download correct operator-sdk version to bin dir, if not found

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -6,13 +6,6 @@ on:
   pull_request:
     branches:
       - 'master'
-env:
-  # Golang version to use
-  GOLANG_VERSION: '1.21'
-  # Version of operator-sdk binary
-  SDK_VERSION: 1.11.0
-  # Checksum of operator-sdk binary
-  SDK_CHECKSUM: 'b1f6fb02c619cfcdb46edf41cbeb4d66f627fd8bba122edaeeb06718965299eb'
 
 jobs:
   check-go-modules:
@@ -24,7 +17,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GOLANG_VERSION }}
+          go-version-file: 'go.mod'
       - name: Download all Go modules
         run: |
           go mod download
@@ -42,22 +35,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GOLANG_VERSION }}
-      - name: Download and install Operator SDK
-        run: |
-          set -ue
-          set -o pipefail
-          curl -sLf --retry 3 \
-            -o /tmp/operator-sdk_linux_amd64 \
-            https://github.com/operator-framework/operator-sdk/releases/download/v1.11.0/operator-sdk_linux_amd64
-          calculated=$(sha256sum /tmp/operator-sdk_linux_amd64 | awk '{print $1}')
-          if test "${calculated}" != "${SDK_CHECKSUM}"; then
-            echo "FAILED TO VALIDATE CHECKSUM" >&2
-            echo "Download is: ${calculated}"
-            echo "Should: ${SDK_CHECKSUM}"
-            exit 1
-          fi
-          sudo install -m 0755 /tmp/operator-sdk_linux_amd64 /usr/local/bin/operator-sdk
+          go-version-file: 'go.mod'        
       - name: Run make bundle
         run: |
           make bundle

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ $(LOCALBIN):
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 operator-sdk: ## Download operator-sdk locally if necessary.
 ifeq (,$(wildcard $(OPERATOR_SDK)))
-ifeq (,$(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
@@ -129,9 +128,6 @@ ifeq (,$(shell which operator-sdk 2>/dev/null))
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
-else
-OPERATOR_SDK = $(shell which operator-sdk)
-endif
 endif
 
 


### PR DESCRIPTION

**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
- Update `Makefile` to automatically downloaded the specific version of operator-sdk into `(repo root)/bin`
- Update `codegen.yaml` to automatically use the Go version defined in `go.mod`

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.
