### PR TITLE
fix: don't change the default policy to reencrypt if the TLS secret is already present

### DIFF
--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -231,13 +232,23 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoproj.ArgoCD) error {
 			Termination:                   routev1.TLSTerminationEdge,
 		}
 	} else {
-		// Server is using TLS configure reencrypt.
 		route.Spec.Port = &routev1.RoutePort{
 			TargetPort: intstr.FromString("https"),
 		}
-		route.Spec.TLS = &routev1.TLSConfig{
-			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-			Termination:                   routev1.TLSTerminationReencrypt,
+
+		isTLSSecretFound := argoutil.IsObjectFound(r.Client, cr.Namespace, common.ArgoCDServerTLSSecretName, &corev1.Secret{})
+		// Since Passthrough was the default policy in the previous versions of the operator, we don't want to
+		// break users who have already configured a TLS secret for Passthrough.
+		if cr.Spec.Server.Route.TLS == nil && isTLSSecretFound && route.Spec.TLS != nil && route.Spec.TLS.Termination == routev1.TLSTerminationPassthrough {
+			route.Spec.TLS = &routev1.TLSConfig{
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+				Termination:                   routev1.TLSTerminationPassthrough,
+			}
+		} else {
+			route.Spec.TLS = &routev1.TLSConfig{
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+				Termination:                   routev1.TLSTerminationReencrypt,
+			}
 		}
 	}
 

--- a/controllers/argocd/service_test.go
+++ b/controllers/argocd/service_test.go
@@ -1,28 +1,39 @@
 package argocd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 func TestEnsureAutoTLSAnnotation(t *testing.T) {
 	a := makeTestArgoCD()
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	fakeClient := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	t.Run("Ensure annotation will be set for OpenShift", func(t *testing.T) {
 		routeAPIFound = true
 		svc := newService(a)
 
 		// Annotation is inserted, update is required
-		needUpdate := ensureAutoTLSAnnotation(svc, "some-secret", true)
+		needUpdate := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
 		assert.Equal(t, needUpdate, true)
 		atls, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
 		assert.Equal(t, ok, true)
 		assert.Equal(t, atls, "some-secret")
 
 		// Annotation already set, doesn't need update
-		needUpdate = ensureAutoTLSAnnotation(svc, "some-secret", true)
+		needUpdate = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
 		assert.Equal(t, needUpdate, false)
 	})
 	t.Run("Ensure annotation will be unset for OpenShift", func(t *testing.T) {
@@ -32,21 +43,41 @@ func TestEnsureAutoTLSAnnotation(t *testing.T) {
 		svc.Annotations[common.AnnotationOpenShiftServiceCA] = "some-secret"
 
 		// Annotation getting removed, update required
-		needUpdate := ensureAutoTLSAnnotation(svc, "some-secret", false)
+		needUpdate := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
 		assert.Equal(t, needUpdate, true)
 		_, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
 		assert.Equal(t, ok, false)
 
 		// Annotation does not exist, no update required
-		needUpdate = ensureAutoTLSAnnotation(svc, "some-secret", false)
+		needUpdate = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
 		assert.Equal(t, needUpdate, false)
 	})
 	t.Run("Ensure annotation will not be set for non-OpenShift", func(t *testing.T) {
 		routeAPIFound = false
 		svc := newService(a)
-		needUpdate := ensureAutoTLSAnnotation(svc, "some-secret", true)
+		needUpdate := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
 		assert.Equal(t, needUpdate, false)
 		_, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
 		assert.Equal(t, ok, false)
+	})
+	t.Run("Ensure annotation will not be set if the TLS secret is already present", func(t *testing.T) {
+		routeAPIFound = true
+		svc := newService(a)
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-secret",
+				Namespace: svc.Namespace,
+			},
+		}
+		err := fakeClient.Create(context.Background(), secret)
+		assert.NoError(t, err)
+		needUpdate := ensureAutoTLSAnnotation(fakeClient, svc, secret.Name, true)
+		assert.Equal(t, needUpdate, false)
+		_, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
+		assert.Equal(t, ok, false)
+
+		// Annotation does not exist, no update required
+		needUpdate = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
+		assert.Equal(t, needUpdate, false)
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

https://github.com/argoproj-labs/argocd-operator/pull/1363 changed the default termination policy from passthrough to reencrypt. However, there could be some users who have configured the old passthrough Route with a custom certificate before the upgrade. We don't want to overwrite their configuration once they upgrade the operator.

This PR introduces logic to update the Route to renencrypt only if the "argocd-server-tls` secret is not present.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

1. Install/Run an older version of the operator that still has Passthrough as default.
2. Verify that the Route is using the Passthrough policy. Configure a custom TLS secret "argocd-server-tls" using OpenSSL.
3. Run the operator with the changes in this PR
4. The route shouldn't be updated to reenecrypt.
