### PR TITLE
feat: Add support for Aggregated ClusterRole for cluster scoped instances

### DIFF
--- a/api/v1alpha1/argocd_conversion.go
+++ b/api/v1alpha1/argocd_conversion.go
@@ -94,6 +94,7 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Version = src.Spec.Version
 	dst.Spec.Banner = (*v1beta1.Banner)(src.Spec.Banner)
 	dst.Spec.DefaultClusterScopedRoleDisabled = src.Spec.DefaultClusterScopedRoleDisabled
+	dst.Spec.AggregatedClusterRoles = src.Spec.AggregatedClusterRoles
 
 	// Status conversion
 	dst.Status = v1beta1.ArgoCDStatus(src.Status)
@@ -162,6 +163,7 @@ func (dst *ArgoCD) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.Version = src.Spec.Version
 	dst.Spec.Banner = (*Banner)(src.Spec.Banner)
 	dst.Spec.DefaultClusterScopedRoleDisabled = src.Spec.DefaultClusterScopedRoleDisabled
+	dst.Spec.AggregatedClusterRoles = src.Spec.AggregatedClusterRoles
 
 	// Status conversion
 	dst.Status = ArgoCDStatus(src.Status)

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -829,6 +829,9 @@ type ArgoCDSpec struct {
 
 	// DefaultClusterScopedRoleDisabled will disable creation of default ClusterRoles for a cluster scoped instance.
 	DefaultClusterScopedRoleDisabled bool `json:"defaultClusterScopedRoleDisabled,omitempty"`
+
+	// AggregatedClusterRoles will allow users to have aggregated ClusterRoles for a cluster scoped instance.
+	AggregatedClusterRoles bool `json:"aggregatedClusterRoles,omitempty"`
 }
 
 // ArgoCDStatus defines the observed state of ArgoCD

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -860,6 +860,9 @@ type ArgoCDSpec struct {
 
 	// DefaultClusterScopedRoleDisabled will disable creation of default ClusterRoles for a cluster scoped instance.
 	DefaultClusterScopedRoleDisabled bool `json:"defaultClusterScopedRoleDisabled,omitempty"`
+
+	// AggregatedClusterRoles will allow users to have aggregated ClusterRoles for a cluster scoped instance.
+	AggregatedClusterRoles bool `json:"aggregatedClusterRoles,omitempty"`
 }
 
 // ArgoCDStatus defines the observed state of ArgoCD

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-07-16T05:45:52Z"
+    createdAt: "2024-07-19T13:00:16Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -54,6 +54,10 @@ spec:
           spec:
             description: ArgoCDSpec defines the desired state of ArgoCD
             properties:
+              aggregatedClusterRoles:
+                description: AggregatedClusterRoles will allow users to have aggregated
+                  ClusterRoles for a cluster scoped instance.
+                type: boolean
               applicationInstanceLabelKey:
                 description: ApplicationInstanceLabelKey is the key name where Argo
                   CD injects the app name as a tracking label.
@@ -7089,6 +7093,10 @@ spec:
           spec:
             description: ArgoCDSpec defines the desired state of ArgoCD
             properties:
+              aggregatedClusterRoles:
+                description: AggregatedClusterRoles will allow users to have aggregated
+                  ClusterRoles for a cluster scoped instance.
+                type: boolean
               applicationInstanceLabelKey:
                 description: ApplicationInstanceLabelKey is the key name where Argo
                   CD injects the app name as a tracking label.

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -18,6 +18,12 @@ const (
 	// ArgoCDApplicationControllerComponent is the name of the application controller control plane component
 	ArgoCDApplicationControllerComponent = "argocd-application-controller"
 
+	// ArgoCDApplicationControllerComponentView is the name of aggregated ClusterRole to configure view permissions for the application controller control plane component
+	ArgoCDApplicationControllerComponentView = "argocd-application-controller-view"
+
+	// ArgoCDApplicationControllerComponentAdmin is the name of aggregated ClusterRole to configure admin permissions for the application controller control plane component
+	ArgoCDApplicationControllerComponentAdmin = "argocd-application-controller-admin"
+
 	// ArgoCDApplicationControllerDefaultShardReplicas is the default number of replicas that the ArgoCD Application Controller Should Use
 	ArgocdApplicationControllerDefaultReplicas = 1
 

--- a/common/values.go
+++ b/common/values.go
@@ -85,4 +85,13 @@ const (
 
 	//ApplicationSetServiceNameSuffix is the suffix for Apllication Set Controller Service
 	ApplicationSetServiceNameSuffix = "applicationset-controller"
+
+	// ArgoCDAggregateToControllerLabelKey is label to configure base aggregated ClusterRole for Argo CD Application Controller.
+	ArgoCDAggregateToControllerLabelKey = "argocd/aggregate-to-controller"
+
+	// ArgoCDAggregateToControllerLabelKey is label for aggregated ClusterRole to configure Admin permissions for Argo CD Application Controller.
+	ArgoCDAggregateToAdminLabelKey = "argocd/aggregate-to-admin"
+
+	// AutoUpdateAnnotationKey is the name of an annotation which prevents reconciliation if set to "false"
+	AutoUpdateAnnotationKey = "rbac.authorization.kubernetes.io/autoupdate"
 )

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -43,6 +43,10 @@ spec:
           spec:
             description: ArgoCDSpec defines the desired state of ArgoCD
             properties:
+              aggregatedClusterRoles:
+                description: AggregatedClusterRoles will allow users to have aggregated
+                  ClusterRoles for a cluster scoped instance.
+                type: boolean
               applicationInstanceLabelKey:
                 description: ApplicationInstanceLabelKey is the key name where Argo
                   CD injects the app name as a tracking label.
@@ -7078,6 +7082,10 @@ spec:
           spec:
             description: ArgoCDSpec defines the desired state of ArgoCD
             properties:
+              aggregatedClusterRoles:
+                description: AggregatedClusterRoles will allow users to have aggregated
+                  ClusterRoles for a cluster scoped instance.
+                type: boolean
               applicationInstanceLabelKey:
                 description: ApplicationInstanceLabelKey is the key name where Argo
                   CD injects the app name as a tracking label.

--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -28,6 +28,37 @@ func policyRuleForApplicationController() []v1.PolicyRule {
 	}
 }
 
+func policyRuleForApplicationControllerView() []v1.PolicyRule {
+
+	return []v1.PolicyRule{
+		{
+			APIGroups: []string{
+				"*",
+			},
+			Resources: []string{
+				"*",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+				"watch",
+			},
+		}, {
+			NonResourceURLs: []string{
+				"*",
+			},
+			Verbs: []string{
+				"get",
+				"list",
+			},
+		},
+	}
+}
+
+func policyRuleForApplicationControllerAdmin() []v1.PolicyRule {
+	return []v1.PolicyRule{}
+}
+
 func policyRuleForRedis(client client.Client) []v1.PolicyRule {
 	rules := []v1.PolicyRule{
 		{
@@ -384,6 +415,12 @@ func getPolicyRuleClusterRoleList() []struct {
 		}, {
 			name:       common.ArgoCDServerComponent,
 			policyRule: policyRuleForServerClusterRole(),
+		}, {
+			name:       common.ArgoCDApplicationControllerComponentView,
+			policyRule: policyRuleForApplicationControllerView(),
+		}, {
+			name:       common.ArgoCDApplicationControllerComponentAdmin,
+			policyRule: policyRuleForApplicationControllerAdmin(),
 		},
 	}
 }

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,7 +122,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 		}
 		// only skip creation of dex and redisHa roles for namespaces that no argocd instance is deployed in
 		if len(list.Items) < 1 {
-			// namespace doesn't contain argocd instance, so skipe all the ArgoCD internal roles
+			// namespace doesn't contain argocd instance, so skip all the ArgoCD internal roles
 			if cr.ObjectMeta.Namespace != namespace.Name && (name != common.ArgoCDApplicationControllerComponent && name != common.ArgoCDServerComponent) {
 				continue
 			}
@@ -279,59 +280,96 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 	return nil
 }
 
-func (r *ReconcileArgoCD) reconcileClusterRole(name string, policyRules []v1.PolicyRule, cr *argoproj.ArgoCD) (*v1.ClusterRole, error) {
+func (r *ReconcileArgoCD) reconcileClusterRole(componentName string, policyRules []v1.PolicyRule, cr *argoproj.ArgoCD) (*v1.ClusterRole, error) {
 
 	allowed := false
 	if allowedNamespace(cr.Namespace, os.Getenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES")) {
+		// namespace is allowed to host cluster-scoped Argo CD instance
 		allowed = true
 	}
 
-	// Check if it is cluster-scoped instance namespace and user doesn't want to use default ClusterRole
-	if allowed && cr.Spec.DefaultClusterScopedRoleDisabled {
-
-		// In case DefaultClusterScopedRoleDisabled was false earlier and default ClusterRole was created, then delete it.
-		existingClusterRole := &v1.ClusterRole{}
-		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: GenerateUniqueResourceName(name, cr)}, existingClusterRole); err == nil {
-
-			// Default ClusterRole exists, now delete it
-			if err := r.Client.Delete(context.TODO(), existingClusterRole); err != nil {
-				return nil, fmt.Errorf("failed to delete existing cluster role for the service account associated with %s : %s", name, err)
-			}
-		}
-
-		// Don't create a default ClusterRole
+	if err := verifyInstallationMode(cr, allowed); err != nil {
+		log.Error(err, "error occurred in reconcileClusterRole")
 		return nil, nil
 	}
 
-	clusterRole := newClusterRole(name, policyRules, cr)
-	if err := applyReconcilerHook(cr, clusterRole, ""); err != nil {
+	// if custom ClusterRole mode is enabled then do nothing and return
+	useCustomClusterRole, err := checkCustomClusterRoleMode(r, cr, componentName, allowed)
+	if useCustomClusterRole {
+		if err == nil {
+			// Do nothing as user wants to have custom ClusterRole
+			return nil, nil
+		}
+	}
+	if err != nil {
 		return nil, err
 	}
 
-	existingClusterRole := &v1.ClusterRole{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRole.Name}, existingClusterRole)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to reconcile the cluster role for the service account associated with %s : %s", name, err)
-		}
-		if !allowed {
-			// Do Nothing
+	expectedClusterRole := newClusterRole(componentName, policyRules, cr)
+
+	if allowed && cr.Spec.AggregatedClusterRoles {
+		// if aggregated ClusterRole mode is enabled, then add required fields in ClusterRole
+		configureAggregatedClusterRole(cr, expectedClusterRole, componentName)
+	} else {
+		// if current mode is default mode, but last one was aggregated mode, then delete ClusterRoles for View and Admin permissions
+		if componentName == common.ArgoCDApplicationControllerComponentView || componentName == common.ArgoCDApplicationControllerComponentAdmin {
+			if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRole.Name}, expectedClusterRole); err == nil {
+				if err := r.Client.Delete(context.TODO(), expectedClusterRole); err != nil {
+					return nil, fmt.Errorf("failed to delete aggregated ClusterRoles: %s", expectedClusterRole.Name)
+				}
+			} else {
+				// if it is "Not Found" error then ignore it else return the error
+				if !apierrors.IsNotFound(err) {
+					return nil, err
+				}
+			}
+
+			// Do Nothing and return, as ClusterRoles for View and Admin permissions are not required in default mode
 			return nil, nil
 		}
-		return clusterRole, r.Client.Create(context.TODO(), clusterRole)
+
+		// default ClusterRole mode is enabled and permissions can be update using a Hook if needed
+		if err := applyReconcilerHook(cr, expectedClusterRole, ""); err != nil {
+			return nil, err
+		}
+	}
+
+	// if ClusterRole does not exist then create new, if it does then match required fields
+	existingClusterRole := &v1.ClusterRole{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRole.Name}, existingClusterRole)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to reconcile the cluster role for the service account associated with %s : %s", componentName, err)
+		}
+
+		if !allowed {
+			// no need to create ClusterRole as namespace can not host cluster-scoped Argo CD instance
+			return nil, nil
+		}
+
+		return expectedClusterRole, r.Client.Create(context.TODO(), expectedClusterRole)
 	}
 
 	if !allowed {
+		// delete existing ClusterRole as namespace can not host cluster-scoped Argo CD instance
 		return nil, r.Client.Delete(context.TODO(), existingClusterRole)
 	}
 
-	// if the Rules differ, update the Role
-	if !reflect.DeepEqual(existingClusterRole.Rules, clusterRole.Rules) {
-		existingClusterRole.Rules = clusterRole.Rules
+	changed := false
+
+	// if existing ClusterRole field values differ from expected values then update them
+	if cr.Spec.AggregatedClusterRoles {
+		changed = matchAggregatedClusterRoleFields(expectedClusterRole, existingClusterRole, componentName)
+	} else {
+		changed = matchDefaultClusterRoleFields(expectedClusterRole, existingClusterRole, componentName)
+	}
+
+	if changed {
 		if err := r.Client.Update(context.TODO(), existingClusterRole); err != nil {
 			return nil, err
 		}
 	}
+
 	return existingClusterRole, nil
 }
 
@@ -340,6 +378,155 @@ func deleteClusterRoles(c client.Client, clusterRoleList *v1.ClusterRoleList) er
 		if err := c.Delete(context.TODO(), &clusterRole); err != nil {
 			return fmt.Errorf("failed to delete ClusterRole %q during cleanup: %w", clusterRole.Name, err)
 		}
+	}
+	return nil
+}
+
+// checkCustomClusterRoleMode checks if custom ClusterRole mode is enabled and deletes default ClusterRoles if they exist
+func checkCustomClusterRoleMode(r *ReconcileArgoCD, cr *argoproj.ArgoCD, componentName string, allowed bool) (bool, error) {
+	// check if it is cluster-scoped instance namespace and user doesn't want to use default ClusterRole
+	if allowed && cr.Spec.DefaultClusterScopedRoleDisabled {
+
+		// in case DefaultClusterScopedRoleDisabled was false earlier and default ClusterRole was created, then delete it.
+		existingClusterRole := &v1.ClusterRole{}
+		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: GenerateUniqueResourceName(componentName, cr)}, existingClusterRole); err == nil {
+			// default ClusterRole exists, now delete it
+			if err := r.Client.Delete(context.TODO(), existingClusterRole); err != nil {
+				return true, fmt.Errorf("failed to delete existing cluster role for the service account associated with %s : %s", componentName, err)
+			}
+		} else {
+			// if it is "Not Found" error then ignore it else return the error
+			if !apierrors.IsNotFound(err) {
+				return true, err
+			}
+		}
+
+		// don't create a default ClusterRole and return
+		return true, nil
+	}
+
+	// custom ClusterRole is not enabled, continue process
+	return false, nil
+}
+
+// configureAggregatedClusterRole updates the ClusterRole and adds required fields for aggregated ClusterRole mode
+func configureAggregatedClusterRole(cr *argoproj.ArgoCD, clusterRole *v1.ClusterRole, componentName string) {
+
+	// if it is base ClusterRole then add AggregationRule, Annotations fields and remove default Rules
+	if componentName == common.ArgoCDApplicationControllerComponent {
+		clusterRole.AggregationRule = &v1.AggregationRule{
+			ClusterRoleSelectors: []metav1.LabelSelector{
+				{
+					MatchLabels: map[string]string{
+						common.ArgoCDAggregateToControllerLabelKey: "true",
+						common.ArgoCDKeyManagedBy:                  cr.Name,
+					},
+				},
+			},
+		}
+		clusterRole.Annotations[common.AutoUpdateAnnotationKey] = "true"
+		clusterRole.Rules = []v1.PolicyRule{}
+	}
+
+	// if ClusterRole is for Admin permissions then add AggregationRule and Labels
+	if componentName == common.ArgoCDApplicationControllerComponentAdmin {
+		clusterRole.AggregationRule = &v1.AggregationRule{
+			ClusterRoleSelectors: []metav1.LabelSelector{
+				{
+					MatchLabels: map[string]string{
+						common.ArgoCDAggregateToAdminLabelKey: "true",
+						common.ArgoCDKeyManagedBy:             cr.Name,
+					},
+				},
+			},
+		}
+		clusterRole.Labels[common.ArgoCDAggregateToControllerLabelKey] = "true"
+	}
+
+	// if ClusterRole is for View permissions then add Labels
+	if componentName == common.ArgoCDApplicationControllerComponentView {
+		clusterRole.Labels[common.ArgoCDAggregateToControllerLabelKey] = "true"
+	}
+}
+
+// matchAggregatedClusterRoleFields compares field values of expected and existing ClusterRoles for aggregated ClusterRole
+func matchAggregatedClusterRoleFields(expectedClusterRole *v1.ClusterRole, existingClusterRole *v1.ClusterRole, name string) bool {
+	changed := false
+	aggregatedClusterRoleExists := true
+
+	// if it is base ClusterRole then compare AggregationRule, Annotations and Rules
+	if name == common.ArgoCDApplicationControllerComponent {
+
+		if !reflect.DeepEqual(existingClusterRole.AggregationRule, expectedClusterRole.AggregationRule) {
+			aggregatedClusterRoleExists = false
+			existingClusterRole.AggregationRule = expectedClusterRole.AggregationRule
+			changed = true
+		}
+
+		if !reflect.DeepEqual(existingClusterRole.Annotations, expectedClusterRole.Annotations) {
+			existingClusterRole.Annotations = expectedClusterRole.Annotations
+			changed = true
+		}
+
+		// if existing ClusterRole is not Aggregated ClusterRole then only make Rules empty
+		if !aggregatedClusterRoleExists {
+			existingClusterRole.Rules = []v1.PolicyRule{}
+		}
+	}
+
+	// if ClusterRole is for View permissions then compare Labels
+	if name == common.ArgoCDApplicationControllerComponentView {
+		if !reflect.DeepEqual(existingClusterRole.Labels, expectedClusterRole.Labels) {
+			existingClusterRole.Labels = expectedClusterRole.Labels
+			changed = true
+		}
+	}
+
+	// if ClusterRole is for Admin permissions then compare AggregationRule and Labels
+	if name == common.ArgoCDApplicationControllerComponentAdmin {
+		if !reflect.DeepEqual(existingClusterRole.AggregationRule, expectedClusterRole.AggregationRule) {
+			existingClusterRole.AggregationRule = expectedClusterRole.AggregationRule
+			changed = true
+		}
+
+		if !reflect.DeepEqual(existingClusterRole.Labels, expectedClusterRole.Labels) {
+			existingClusterRole.Labels = expectedClusterRole.Labels
+			changed = true
+		}
+	}
+
+	return changed
+}
+
+// matchDefaultClusterRoleFields compares field values of expected and existing ClusterRoles for default ClusterRole
+func matchDefaultClusterRoleFields(expectedClusterRole *v1.ClusterRole, existingClusterRole *v1.ClusterRole, name string) bool {
+	changed := false
+
+	// if it is base ClusterRole then compare AggregationRule and Annotations
+	if name == common.ArgoCDApplicationControllerComponent {
+		if !reflect.DeepEqual(existingClusterRole.AggregationRule, expectedClusterRole.AggregationRule) {
+			existingClusterRole.AggregationRule = expectedClusterRole.AggregationRule
+			changed = true
+		}
+
+		if !reflect.DeepEqual(existingClusterRole.Annotations, expectedClusterRole.Annotations) {
+			existingClusterRole.Annotations = expectedClusterRole.Annotations
+			changed = true
+		}
+	}
+
+	// for all default ClusterRoles compare Rules
+	if !reflect.DeepEqual(existingClusterRole.Rules, expectedClusterRole.Rules) {
+		existingClusterRole.Rules = expectedClusterRole.Rules
+		changed = true
+	}
+
+	return changed
+}
+
+func verifyInstallationMode(cr *argoproj.ArgoCD, allowed bool) error {
+	if allowed && cr.Spec.DefaultClusterScopedRoleDisabled && cr.Spec.AggregatedClusterRoles {
+		return fmt.Errorf("Custom Cluster Roles and Aggregated Cluster Roles can not be used together.")
 	}
 	return nil
 }

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -151,65 +151,46 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole).Error(), "not found")
 }
 
-func TestReconcileArgoCD_reconcileClusterRole_disabled(t *testing.T) {
-	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD()
-
-	resObjs := []client.Object{a}
-	subresObjs := []client.Object{a}
-	runtimeObjs := []runtime.Object{}
-	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
-	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
-	r := makeTestReconciler(cl, sch)
-
+func TestReconcileArgoCD_reconcileClusterRole_custom_cluster_role(t *testing.T) {
+	ctx, r, a, cl := setup(t)
 	workloadIdentifier := common.ArgoCDApplicationControllerComponent
 	clusterRoleName := GenerateUniqueResourceName(workloadIdentifier, a)
 	expectedRules := policyRuleForApplicationController()
-
-	// Set the namespace to be cluster-scoped
-	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
-
-	// Disable creation of default ClusterRole
-	a.Spec.DefaultClusterScopedRoleDisabled = true
-
-	err := cl.Update(context.Background(), a)
-	assert.NoError(t, err)
-
-	// Reconcile ClusterRole
-	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
-	assert.NoError(t, err)
-
-	// Ensure default ClusterRole is not created
 	reconciledClusterRole := &v1.ClusterRole{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "not found")
 
-	// Now enable creation of default ClusterRole
-	a.Spec.DefaultClusterScopedRoleDisabled = false
-	err = cl.Update(context.Background(), a)
+	t.Log("Mode 1: Enable custom ClusterRole")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole")
+	_, err := r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
-	// Again reconcile ClusterRole
+	t.Log("Mode 1: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 1: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	t.Log("Mode 2: Enable default ClusterRole")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole")
 	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
-	// Ensure default ClusterRole is created now
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	t.Log("Mode 2: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
 
-	// Once again disable creation of default ClusterRole
-	a.Spec.DefaultClusterScopedRoleDisabled = true
-	err = cl.Update(context.Background(), a)
-	assert.NoError(t, err)
+	t.Log("Mode 1: Enable custom ClusterRole")
+	enableCustomClusterRoles(t, ctx, a, cl)
 
-	// Once again reconcile ClusterRole
+	t.Log("Mode 1: Reconcile ClusterRole")
 	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
-	// Ensure default ClusterRole is deleted again
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "not found")
+	t.Log("Mode 1: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
 }
 
 func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.T) {
@@ -420,4 +401,783 @@ func TestReconcileRoles_ManagedTerminatingNamespace(t *testing.T) {
 
 	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
+}
+
+// This test is to verify that Custom and Aggregated ClusterRoles are not allowed together.
+func TestReconcileArgoCD_reconcileClusterRole_aggregated_error(t *testing.T) {
+	ctx, _, a, cl := setup(t)
+
+	t.Log("Enable both Aggregated and Custom ClusterRoles.")
+	a.Spec.AggregatedClusterRoles = true
+	a.Spec.DefaultClusterScopedRoleDisabled = true
+	assert.NoError(t, cl.Update(ctx, a))
+
+	t.Log("Call function to check.")
+	err := verifyInstallationMode(a, true)
+
+	t.Log("Verify response.")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "Custom Cluster Roles and Aggregated Cluster Roles can not be used together.")
+}
+
+// This test is to verify that base aggregated ClusterRole is created.
+func TestReconcileArgoCD_reconcileClusterRole_aggregated_controller(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	t.Log("Enable aggregated ClusterRole")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRuleForApplicationController(), a)
+
+	t.Log("Verify response.")
+	assert.NoError(t, err)
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, GenerateUniqueResourceName(componentName, a))
+}
+
+// This test is to verify that aggregated ClusterRole for view permission is created.
+func TestReconcileArgoCD_reconcileClusterRole_aggregated_view(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponentView
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	t.Log("Enable aggregated ClusterRole")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRuleForApplicationControllerView(), a)
+
+	t.Log("Verify response.")
+	assert.NoError(t, err)
+	validateAggregatedViewClusterRole(t, ctx, r, clusterRoleName)
+
+	t.Log("Change ClusterRole fields.")
+	reconciledClusterRole := &v1.ClusterRole{}
+	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	reconciledClusterRole.Labels = map[string]string{"test": "test"}
+	assert.NoError(t, r.Client.Update(ctx, reconciledClusterRole))
+
+	t.Log("Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRuleForApplicationControllerView(), a)
+
+	t.Log("Verify changes are reverted.")
+	assert.NoError(t, err)
+	validateAggregatedViewClusterRole(t, ctx, r, clusterRoleName)
+}
+
+// This test is to verify that aggregated ClusterRole for admin permission is created.
+func TestReconcileArgoCD_reconcileClusterRole_aggregated_admin(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponentAdmin
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	t.Log("Enable aggregated ClusterRole")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRuleForApplicationControllerAdmin(), a)
+
+	t.Log("Verify response.")
+	assert.NoError(t, err)
+	validateAggregatedAdminClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+
+	t.Log("Change ClusterRole fields.")
+	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	reconciledClusterRole.Labels = map[string]string{"test": "test"}
+	reconciledClusterRole.AggregationRule = &v1.AggregationRule{}
+	assert.NoError(t, r.Client.Update(ctx, reconciledClusterRole))
+
+	t.Log("Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRuleForApplicationControllerAdmin(), a)
+
+	t.Log("Verify changes are reverted.")
+	assert.NoError(t, err)
+	validateAggregatedAdminClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+}
+
+// This test is to verify the scenario for View permission when user is switching between aggregated and default ClusterRoles.
+func TestReconcileArgoCD_reconcileClusterRole_view_aggregated_and_default(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponentView
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationControllerView()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Enable aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole for View permission is created.")
+	validateAggregatedViewClusterRole(t, ctx, r, clusterRoleName)
+
+	//------- Default Mode -------
+	t.Log("Mode 2: Switch to default ClusterRole.")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify aggregated ClusterRole for View permission is deleted now.")
+	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Switch back to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole for View permission is created.")
+	validateAggregatedViewClusterRole(t, ctx, r, clusterRoleName)
+}
+
+// This test is to verify the scenario for Admin permission when user is switching between aggregated and default ClusterRoles.
+func TestReconcileArgoCD_reconcileClusterRole_admin_aggregated_and_default(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponentAdmin
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationControllerAdmin()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Enable aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole for Admin permission is created.")
+	validateAggregatedAdminClusterRole(t, ctx, r, a, reconciledClusterRole, GenerateUniqueResourceName(componentName, a))
+
+	//------- Default Mode -------
+	t.Log("Mode 2: Switch to default ClusterRole.")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify aggregated ClusterRole for Admin permission is deleted now.")
+	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Switch back to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole for View permission is created.")
+	validateAggregatedAdminClusterRole(t, ctx, r, a, reconciledClusterRole, GenerateUniqueResourceName(componentName, a))
+}
+
+// This test is to verify the scenario for View permission when user is switching between aggregated and custom ClusterRoles.
+func TestReconcileArgoCD_reconcileClusterRole_view_aggregated_and_custom(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponentView
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationControllerView()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Enable aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole for View permission is created.")
+	validateAggregatedViewClusterRole(t, ctx, r, clusterRoleName)
+
+	//------- Custom Mode -------
+	t.Log("Mode 2: Switch to custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 2: Verify aggregated ClusterRole for View permission is deleted now.")
+	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+
+	t.Log("Mode 2: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Switch back to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole is created.")
+	validateAggregatedViewClusterRole(t, ctx, r, clusterRoleName)
+}
+
+// This test is to verify the scenario for Admin permission when user is switching between aggregated and custom ClusterRoles.
+func TestReconcileArgoCD_reconcileClusterRole_admin_aggregated_and_custom(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponentAdmin
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationControllerAdmin()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Enable aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole for Admin permission is created.")
+	validateAggregatedAdminClusterRole(t, ctx, r, a, reconciledClusterRole, GenerateUniqueResourceName(componentName, a))
+
+	//------- Custom Mode -------
+	t.Log("Mode 2: Switch to custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 2: Verify aggregated ClusterRole for Admin permission is deleted now.")
+	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+
+	t.Log("Mode 2: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Switch back to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole for Admin permission is created.")
+	validateAggregatedAdminClusterRole(t, ctx, r, a, reconciledClusterRole, GenerateUniqueResourceName(componentName, a))
+}
+
+// This test is to verify the scenario when user is switching between default and aggregated ClusterRoles.
+func TestReconcileArgoCD_reconcileClusterRole_default_and_aggregated(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//----- Default Mode -----
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+
+	//----- Aggregated Mode -----
+	t.Log("Mode 2: Switch to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify aggregated ClusterRole is created.")
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+
+	//----- Default Mode -----
+	t.Log("Mode 1: Switch back to default ClusterRole.")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+}
+
+// This test is to verify the scenario when user is switching between default and custom ClusterRoles.
+func TestReconcileArgoCD_reconcileClusterRole_default_and_custom(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//----- Default Mode -----
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+
+	//----- Custom Mode -----
+	t.Log("Mode 2: Switch to custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 2: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	//----- Default Mode -----
+	t.Log("Mode 1: Switch back to default ClusterRole.")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+}
+
+// This test is to verify the scenario when user is switching between custom and aggregated ClusterRoles.
+func TestReconcileArgoCD_reconcileClusterRole_custom_and_aggregated(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//----- Custom Mode -----
+	t.Log("Mode 1: Enable custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 1: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	//----- Aggregated Mode -----
+	t.Log("Mode 2: Switch to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify aggregated ClusterRole is created.")
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+
+	//----- Custom Mode -----
+	t.Log("Mode 1: Switch back to custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+}
+
+// This test is to verify the scenario when user is switching from default to custom ClusterRole and then to aggregated ClusterRole.
+func TestReconcileArgoCD_reconcileClusterRole_default_to_custom_to_aggregated(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Default Mode -------
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+
+	//------- Custom Mode -------
+	t.Log("Mode 2: Switch to custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 2: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 3: Switch to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 3: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 3: Verify aggregated ClusterRole is created.")
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+}
+
+// This test is to verify the scenario when user is switching from default to aggregated ClusterRole and then to custom ClusterRole.
+func TestReconcileArgoCD_reconcileClusterRole_default_to_aggregated_to_custom(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Default Mode -------
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 2: Switch to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify aggregated ClusterRole is created.")
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+
+	//------- Custom Mode -------
+	t.Log("Mode 3: Switch to custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 3: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 3: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 3: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+}
+
+// This test is to verify the scenario when user is switching from custom to default ClusterRole and then to aggregated ClusterRole.
+func TestReconcileArgoCD_reconcileClusterRole_custom_to_default_to_aggregated(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Custom Mode -------
+	t.Log("Mode 1: Enable custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 1: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	//------- Default Mode -------
+	t.Log("Mode 2: Switch to default ClusterRole.")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 3: Switch to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 3: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 3: Verify aggregated ClusterRole is created.")
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+}
+
+// This test is to verify the scenario when user is switching from custom to aggregated ClusterRole and then to default ClusterRole.
+func TestReconcileArgoCD_reconcileClusterRole_custom_to_aggregated_to_default(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Custom Mode -------
+	t.Log("Mode 1: Enable custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 1: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 2: Switch to aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify aggregated ClusterRole is created.")
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+
+	//------- Default Mode -------
+	t.Log("Mode 3: Switch to default ClusterRole.")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 3: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 3: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+}
+
+// This test is to verify the scenario when user is switching from aggregated to default ClusterRole and then to custom ClusterRole.
+func TestReconcileArgoCD_reconcileClusterRole_aggregated_to_default_to_custom(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Enable aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole is created.")
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+
+	//------- Default Mode -------
+	t.Log("Mode 2: Switch to default ClusterRole.")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+
+	//------- Custom Mode -------
+	t.Log("Mode 3: Switch to custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 3: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 3: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 3: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+}
+
+// This test is to verify the scenario when user is switching from aggregated to custom ClusterRole and then to default ClusterRole.
+func TestReconcileArgoCD_reconcileClusterRole_aggregated_to_custom_to_default(t *testing.T) {
+	ctx, r, a, cl := setup(t)
+	componentName := common.ArgoCDApplicationControllerComponent
+	clusterRoleName := GenerateUniqueResourceName(componentName, a)
+	policyRules := policyRuleForApplicationController()
+	reconciledClusterRole := &v1.ClusterRole{}
+
+	//------- Aggregated Mode -------
+	t.Log("Mode 1: Enable aggregated ClusterRole.")
+	enableAggregatedClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 1: Reconcile ClusterRole.")
+	_, err := r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 1: Verify aggregated ClusterRole is created.")
+	validateAggregatedControllerClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
+
+	//------- Custom Mode -------
+	t.Log("Mode 2: Switch to custom ClusterRole.")
+	enableCustomClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 2: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 2: Verify custom ClusterRole is allowed.")
+	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
+
+	t.Log("Mode 2: Create a custom ClusterRole.")
+	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
+	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+
+	//------- Default Mode -------
+	t.Log("Mode 3: Switch to default ClusterRole.")
+	enableDefaultClusterRoles(t, ctx, a, cl)
+
+	t.Log("Mode 3: Reconcile ClusterRole.")
+	_, err = r.reconcileClusterRole(componentName, policyRules, a)
+	assert.NoError(t, err)
+
+	t.Log("Mode 3: Verify default ClusterRole is created.")
+	validateDefaultClusterRole(t, ctx, r, reconciledClusterRole, clusterRoleName)
+}
+
+func setup(t *testing.T) (context.Context, *ReconcileArgoCD, *argoproj.ArgoCD, client.Client) {
+	logf.SetLogger(ZapLogger(true))
+	ctx := context.Background()
+	a := makeTestArgoCD()
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch)
+	// Set the namespace to be cluster-scoped
+	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
+	return ctx, r, a, cl
+}
+
+// validateAggregatedAdminClusterRole checks that ClusterRole for View permissions has field values configured in aggregated mode
+func validateAggregatedViewClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, clusterRoleName string) {
+	// Ensure aggregated ClusterRole for view permission is created
+	reconciledClusterRole := &v1.ClusterRole{}
+	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+
+	// Ensure ClusterRole has expected Labels
+	assert.EqualValues(t, reconciledClusterRole.Labels[common.ArgoCDAggregateToControllerLabelKey], "true")
+	// Ensure ClusterRole has no pre defined Rules
+	assert.EqualValues(t, reconciledClusterRole.Rules, policyRuleForApplicationControllerView())
+}
+
+// validateAggregatedAdminClusterRole checks that ClusterRole for Admin permissions has field values configured in aggregated mode
+func validateAggregatedAdminClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, a *argoproj.ArgoCD, reconciledClusterRole *v1.ClusterRole, clusterRoleName string) {
+
+	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+
+	// Ensure ClusterRole has expected AggregationRule
+	expectedAggregationRule := &v1.AggregationRule{ClusterRoleSelectors: []metav1.LabelSelector{{
+		MatchLabels: map[string]string{common.ArgoCDAggregateToAdminLabelKey: "true", common.ArgoCDKeyManagedBy: a.Name}}}}
+	assert.Equal(t, reconciledClusterRole.AggregationRule, expectedAggregationRule)
+
+	// Ensure ClusterRole has expected Labels
+	assert.EqualValues(t, reconciledClusterRole.Labels[common.ArgoCDAggregateToControllerLabelKey], "true")
+	// Ensure ClusterRole has no pre defined Rules
+	assert.EqualValues(t, reconciledClusterRole.Rules, policyRuleForApplicationControllerAdmin())
+}
+
+// validateAggregatedControllerClusterRole checks that ClusterRole has field values configured in aggregated mode
+func validateAggregatedControllerClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, a *argoproj.ArgoCD, reconciledClusterRole *v1.ClusterRole, clusterRoleName string) {
+
+	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+
+	// Ensure ClusterRole has expected AggregationRule
+	expectedAggregationRule := &v1.AggregationRule{ClusterRoleSelectors: []metav1.LabelSelector{{
+		MatchLabels: map[string]string{common.ArgoCDAggregateToControllerLabelKey: "true", common.ArgoCDKeyManagedBy: a.Name}}}}
+	assert.Equal(t, reconciledClusterRole.AggregationRule, expectedAggregationRule)
+
+	// Ensure expected Annotation is added in ClusterRole
+	assert.EqualValues(t, reconciledClusterRole.Annotations[common.AutoUpdateAnnotationKey], "true")
+	// Ensure now ClusterRole has no pre defined Rules
+	assert.Empty(t, reconciledClusterRole.Rules)
+}
+
+// validateDefaultClusterRole checks that ClusterRole has field values configured in default mode
+func validateDefaultClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, reconciledClusterRole *v1.ClusterRole, clusterRoleName string) {
+
+	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+
+	// Ensure ClusterRole does not have AggregationRule
+	assert.Empty(t, reconciledClusterRole.AggregationRule)
+	// Ensure ClusterRole does not have Annotations
+	assert.NotContains(t, reconciledClusterRole.Annotations, common.AutoUpdateAnnotationKey)
+	// Ensure ClusterRole has pre defined Rules
+	assert.Equal(t, reconciledClusterRole.Rules, policyRuleForApplicationController())
+}
+
+// validateCustomClusterRole checks that default ClusterRole is deleted
+func validateCustomClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, clusterRoleName string, reconciledClusterRole *v1.ClusterRole) {
+	err := r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "not found")
+}
+
+// enableAggregatedClusterRoles will set fields to create aggregated ClusterRoles
+func enableAggregatedClusterRoles(t *testing.T, ctx context.Context, a *argoproj.ArgoCD, cl client.Client) {
+	a.Spec.AggregatedClusterRoles = true
+	a.Spec.DefaultClusterScopedRoleDisabled = false
+	assert.NoError(t, cl.Update(ctx, a))
+}
+
+// enableCustomClusterRoles will set fields to create custom ClusterRoles
+func enableCustomClusterRoles(t *testing.T, ctx context.Context, a *argoproj.ArgoCD, cl client.Client) {
+	a.Spec.DefaultClusterScopedRoleDisabled = true
+	a.Spec.AggregatedClusterRoles = false
+	assert.NoError(t, cl.Update(ctx, a))
+}
+
+// enableDefaultClusterRoles will set fields to create default ClusterRoles
+func enableDefaultClusterRoles(t *testing.T, ctx context.Context, a *argoproj.ArgoCD, cl client.Client) {
+	a.Spec.DefaultClusterScopedRoleDisabled = false
+	a.Spec.AggregatedClusterRoles = false
+	assert.NoError(t, cl.Update(ctx, a))
 }

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -339,6 +339,15 @@ func newRoleBindingWithNameForApplicationSourceNamespaces(namespace string, cr *
 }
 
 func (r *ReconcileArgoCD) reconcileClusterRoleBinding(name string, role *v1.ClusterRole, cr *argoproj.ArgoCD) error {
+	if name == common.ArgoCDApplicationControllerComponentAdmin || name == common.ArgoCDApplicationControllerComponentView {
+		// Don't create ClusterRoleBinding
+		return nil
+	}
+
+	if err := verifyInstallationMode(cr, true); err != nil {
+		log.Error(err, "error occurred in reconcileClusterRoleBinding")
+		return nil
+	}
 
 	// Check if user doesn't want to use default ClusterRole, hence default ClusterRoleBinding is also not required
 	if cr.Spec.DefaultClusterScopedRoleDisabled {

--- a/deploy/olm-catalog/argocd-operator/0.10.1/argocd-operator.v0.10.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.10.1/argocd-operator.v0.10.1.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-07-16T05:45:52Z"
+    createdAt: "2024-07-19T13:00:16Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/deploy/olm-catalog/argocd-operator/0.10.1/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.10.1/argoproj.io_argocds.yaml
@@ -54,6 +54,10 @@ spec:
           spec:
             description: ArgoCDSpec defines the desired state of ArgoCD
             properties:
+              aggregatedClusterRoles:
+                description: AggregatedClusterRoles will allow users to have aggregated
+                  ClusterRoles for a cluster scoped instance.
+                type: boolean
               applicationInstanceLabelKey:
                 description: ApplicationInstanceLabelKey is the key name where Argo
                   CD injects the app name as a tracking label.
@@ -7089,6 +7093,10 @@ spec:
           spec:
             description: ArgoCDSpec defines the desired state of ArgoCD
             properties:
+              aggregatedClusterRoles:
+                description: AggregatedClusterRoles will allow users to have aggregated
+                  ClusterRoles for a cluster scoped instance.
+                type: boolean
               applicationInstanceLabelKey:
                 description: ApplicationInstanceLabelKey is the key name where Argo
                   CD injects the app name as a tracking label.

--- a/docs/usage/aggregated_roles.md
+++ b/docs/usage/aggregated_roles.md
@@ -1,0 +1,124 @@
+# Aggregated Roles
+
+Using an aggregated cluster role enables users to easily add their own permissions without having to define a completely new cluster role from scratch. The current default cluster role for application controller is hard-coded with a specific set of permissions. This cluster role is operator managed and cannot be modified by the user. In this case administrative user can opt for custom cluster roles and define permissions by creating cluster roles from scratch or go for aggregated cluster role. 
+
+A user can enable creation of aggregated ClusterRole by setting `argocd.spec.aggregatedClusterRoles` field to `true`.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  aggregatedClusterRoles: true
+```
+
+When `aggregatedClusterRoles` is `true`, the default cluster role for the Argo CD application controller will be created having `aggregationRule` field. This is the base cluster role and a cluster role binding pointing to it will be created and managed by operator.
+
+Example: Configure permissions using aggregated cluster role model for application controller:
+
+1. Base cluster role
+
+```yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-argocd-argocd-application-controller
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: 'true'
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        app.kubernetes.io/managed-by: argocd
+        argocd/aggregate-to-controller: 'true'
+rules: []
+```
+
+Initially there are no permissions defined in base cluster role, here it has `aggregationRule`, that means if there are other cluster roles with these two labels, then base cluster role can inherit permission from those.
+
+2. Operator creates one cluster role to configure view permissions to base cluster role.
+
+```yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-argocd-argocd-application-controller-view
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    argocd/aggregate-to-controller: 'true'
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - '*'
+    resources:
+      - '*'
+  - verbs:
+      - get
+      - list
+    nonResourceURLs:
+      - '*'
+```
+It has predefined view permissions.
+
+3. Operator creates one cluster role to configure admin permissions to base cluster role.
+
+```yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-argocd-argocd-application-controller-admin
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    argocd/aggregate-to-controller: 'true'
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        app.kubernetes.io/managed-by: argocd
+        argocd/aggregate-to-admin: 'true'
+rules: []
+```
+
+Here there are no predefined rules and user can configure self-defined permissions by creating a self-defined cluster role. 
+
+4. Now user need to create a new self-defined cluster role, but it must have matching labels given in `aggregationRule` of cluster role created for admin permissions i.e. `argocd-argocd-argocd-application-controller-admin`
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: 
+  name: my-cluster-role
+  labels:
+    app.kubernetes.io/managed-by: argocd
+    argocd/aggregate-to-admin: 'true'
+rules:
+  - verbs:
+      - '*'
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - configmaps
+  - verbs:
+      - '*'
+    apiGroups:
+      - machine.openshift.io
+    resources:
+      - '*'
+  - verbs:
+      - '*'
+    apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - '*'
+```
+
+Let's summarize this example. The `argocd-argocd-argocd-application-controller` cluster role inherits permissions from two cluster role which are `argocd-argocd-argocd-application-controller-view` for view permissions and `argocd-argocd-argocd-application-controller-admin` for admin permission. These three are operator managed. Now `argocd-argocd-argocd-application-controller-admin` inherits permissions from `my-cluster-role` which is a user defined cluster role.  
+
+For more details on aggregated cluster role, check the [documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles).


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
This PR enables user to use aggregated cluster roles for application controller in a cluster scoped instances of Argo CD. 
This will create a base cluster role (argocd-argocd-application-controlle) which can inherit permissions from these two other cluster roles.
- argocd-application-controller-view = It configures View permissions.
- gitops-application-controller-admin = It is also an  aggregated cluster role to configures Admin permissions. This can inherit permissions from cluster role that is created by users and add those into base cluster role. 

**Which issue(s) this PR fixes**:

Fixes #?
This is tracked in Red Hat's issue database here: https://issues.redhat.com/browse/GITOPS-2615

**How to test changes / Special notes to the reviewer**:
- Create a cluster-scoped Argo CD instance
- Create Argo CD CR in namespace and set `Spec.aggregatedClusterRolesEnabled` to true.
- Create a user-defined cluster role having these two labels  `argocd/aggregate-to-admin: 'true'` and `app.kubernetes.io/managed-by: argocd` and configure permission you want to add for application controller component.