### PR TITLE
[ operator Redesign ] fix: argocdexport job using incorrect Service Account

### DIFF
--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -188,7 +188,7 @@ func newExportPodSpec(cr *argoprojv1alpha1.ArgoCDExport, argocdName string, clie
 	}}
 
 	pod.RestartPolicy = corev1.RestartPolicyOnFailure
-	pod.ServiceAccountName = fmt.Sprintf("%s-%s", argocdName, "argocd-application-controller")
+	pod.ServiceAccountName = fmt.Sprintf("%s-%s", argocdName, "application-controller")
 	pod.Volumes = []corev1.Volume{
 		getArgoStorageVolume("backup-storage", cr),
 		getArgoSecretVolume("secret-storage", cr),


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug
**What does this PR do / why we need it**:
argocdexport job was still using service account name same as master branch. As the naming Scheme is updated, this PR updates the SA name for argocdexport jobs.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
