### PR TITLE
[ Operator Redesign ] fix: Reconciler skip's env reconciliation for reposerver and server deployment

### DIFF
--- a/controllers/argocd/applicationset/deployment.go
+++ b/controllers/argocd/applicationset/deployment.go
@@ -30,6 +30,7 @@ func (asr *ApplicationSetReconciler) reconcileDeployment() error {
 				},
 			},
 			{Existing: &existing.Spec.Template.Spec.Containers[0].Command, Desired: &desired.Spec.Template.Spec.Containers[0].Command, ExtraAction: nil},
+			{Existing: &existing.Spec.Template.Spec.Containers[0].Env, Desired: &desired.Spec.Template.Spec.Containers[0].Env, ExtraAction: nil},
 			{Existing: &existing.Spec.Template.Spec.Volumes, Desired: &desired.Spec.Template.Spec.Volumes, ExtraAction: nil},
 			{Existing: &existing.Spec.Template.Spec.NodeSelector, Desired: &desired.Spec.Template.Spec.NodeSelector, ExtraAction: nil},
 			{Existing: &existing.Spec.Template.Spec.Tolerations, Desired: &desired.Spec.Template.Spec.Tolerations, ExtraAction: nil},

--- a/controllers/argocd/reposerver/deployment.go
+++ b/controllers/argocd/reposerver/deployment.go
@@ -68,6 +68,7 @@ func (rsr *RepoServerReconciler) reconcileDeployment() error {
 		{Existing: &existing.Spec.Template.Spec.Tolerations, Desired: &desired.Spec.Template.Spec.Tolerations, ExtraAction: nil},
 		{Existing: &existing.Spec.Template.Spec.Containers[0].Command, Desired: &desired.Spec.Template.Spec.Containers[0].Command, ExtraAction: nil},
 		{Existing: &existing.Spec.Template.Spec.Containers[0].Resources, Desired: &desired.Spec.Template.Spec.Containers[0].Resources, ExtraAction: nil},
+		{Existing: &existing.Spec.Template.Spec.Containers[0].Env, Desired: &desired.Spec.Template.Spec.Containers[0].Env, ExtraAction: nil},
 		{Existing: &existing.Spec.Template.Spec.Containers[0].VolumeMounts, Desired: &desired.Spec.Template.Spec.Containers[0].VolumeMounts, ExtraAction: nil},
 		{Existing: &existing.Spec.Template.Spec.AutomountServiceAccountToken, Desired: &desired.Spec.Template.Spec.AutomountServiceAccountToken, ExtraAction: nil},
 		{Existing: &existing.Spec.Template.Spec.ServiceAccountName, Desired: &desired.Spec.Template.Spec.ServiceAccountName, ExtraAction: func() {

--- a/controllers/argocd/server/deployment.go
+++ b/controllers/argocd/server/deployment.go
@@ -38,6 +38,7 @@ func (sr *ServerReconciler) reconcileDeployment() error {
 			},
 			{Existing: &existing.Spec.Template.Spec.Containers[0].Command, Desired: &desired.Spec.Template.Spec.Containers[0].Command, ExtraAction: nil},
 			{Existing: &existing.Spec.Template.Spec.Containers[0].Resources, Desired: &desired.Spec.Template.Spec.Containers[0].Resources, ExtraAction: nil},
+			{Existing: &existing.Spec.Template.Spec.Containers[0].Env, Desired: &desired.Spec.Template.Spec.Containers[0].Env, ExtraAction: nil},
 			{Existing: &existing.Spec.Template.Spec.Containers[0].VolumeMounts, Desired: &desired.Spec.Template.Spec.Containers[0].VolumeMounts, ExtraAction: nil},
 			{Existing: &existing.Spec.Template.Spec.NodeSelector, Desired: &desired.Spec.Template.Spec.NodeSelector, ExtraAction: nil},
 			{Existing: &existing.Spec.Template.Spec.Tolerations, Desired: &desired.Spec.Template.Spec.Tolerations, ExtraAction: nil},
@@ -141,6 +142,7 @@ func (sr *ServerReconciler) getDeploymentReq() workloads.DeploymentRequest {
 	}
 
 	podSpec := corev1.PodSpec{
+		NodeSelector:       common.DefaultNodeSelector(),
 		ServiceAccountName: resourceName,
 		Volumes: []corev1.Volume{
 			{


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug


**What does this PR do / why we need it**:
With this PR, the Reconciler will update the `env` for deployment of reposerver and server.

This PR also adds the missing default node selector from server deployment.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
