### PR TITLE
[ Operator Redesign ] fix: Argocd sso status resets to Unknow if spec.sso is set to nil

### DIFF
--- a/controllers/argocd/sso/status.go
+++ b/controllers/argocd/sso/status.go
@@ -2,6 +2,7 @@ package sso
 
 import (
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/pkg/resource"
 )
 
@@ -19,6 +20,8 @@ func (sr *SSOReconciler) ReconcileStatus() error {
 			// TO DO: get status from keycloak
 		case argoproj.SSOProviderTypeDex:
 			status = sr.DexController.ReconcileStatus()
+		default:
+			status = common.ArgoCDStatusUnknown
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What does this PR do / why we need it**:
SSO status didn't revert to unknown status if argocd spec.sso is set empty, with this PR if no provider is set for SSO, the default status is set to unknown

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
