### PR TITLE
[ Operator Redesign ] fix:  add custom node placement

### DIFF
--- a/common/keys.go
+++ b/common/keys.go
@@ -116,7 +116,7 @@ const (
 	ArgoCDDexSecretKey = "oidc.dex.clientSecret"
 
 	ArgoCDKeyKustomizeVersion       = "kustomize.version."
-	ArgoCDKeyResourceCustomizations = "resource.customizations."
+	ArgoCDKeyResourceCustomizations = "resource.customizations"
 )
 
 // openshift.io keys

--- a/controllers/argocd/redis/deployment.go
+++ b/controllers/argocd/redis/deployment.go
@@ -201,6 +201,11 @@ func (rr *RedisReconciler) getDeploymentRequest() workloads.DeploymentRequest {
 		Client:    rr.Client,
 	}
 
+	if rr.Instance.Spec.NodePlacement != nil {
+		req.Spec.Template.Spec.NodeSelector = argoutil.AppendStringMap(req.Spec.Template.Spec.NodeSelector, rr.Instance.Spec.NodePlacement.NodeSelector)
+		req.Spec.Template.Spec.Tolerations = rr.Instance.Spec.NodePlacement.Tolerations
+	}
+
 	return req
 }
 

--- a/controllers/argocd/server/deployment.go
+++ b/controllers/argocd/server/deployment.go
@@ -141,6 +141,7 @@ func (sr *ServerReconciler) getDeploymentReq() workloads.DeploymentRequest {
 	}
 
 	podSpec := corev1.PodSpec{
+		NodeSelector:       common.DefaultNodeSelector(),
 		ServiceAccountName: resourceName,
 		Volumes: []corev1.Volume{
 			{
@@ -263,6 +264,11 @@ func (sr *ServerReconciler) getDeploymentReq() workloads.DeploymentRequest {
 			},
 		},
 		Replicas: replicas,
+	}
+
+	if sr.Instance.Spec.NodePlacement != nil {
+		req.Spec.Template.Spec.NodeSelector = argoutil.AppendStringMap(req.Spec.Template.Spec.NodeSelector, sr.Instance.Spec.NodePlacement.NodeSelector)
+		req.Spec.Template.Spec.Tolerations = sr.Instance.Spec.NodePlacement.Tolerations
 	}
 
 	return req

--- a/controllers/argocd/sso/dex/deployment.go
+++ b/controllers/argocd/sso/dex/deployment.go
@@ -133,6 +133,7 @@ func (dr *DexReconciler) getDeploymentReq() workloads.DeploymentRequest {
 	}
 
 	podSpec := corev1.PodSpec{
+		NodeSelector:       common.DefaultNodeSelector(),
 		ServiceAccountName: resourceName,
 		Volumes: []corev1.Volume{{
 			Name: "static-files",
@@ -230,6 +231,11 @@ func (dr *DexReconciler) getDeploymentReq() workloads.DeploymentRequest {
 				common.AppK8sKeyName: resourceName,
 			},
 		},
+	}
+
+	if dr.Instance.Spec.NodePlacement != nil {
+		req.Spec.Template.Spec.NodeSelector = argoutil.AppendStringMap(req.Spec.Template.Spec.NodeSelector, dr.Instance.Spec.NodePlacement.NodeSelector)
+		req.Spec.Template.Spec.Tolerations = dr.Instance.Spec.NodePlacement.Tolerations
 	}
 
 	return req


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
This PR adds custom node placement to the deployment of dex, server and Redis 
This PR also updates removes trailing dot from ArgoCDKeyResourceCustomizations variable, as it's used with [dotSep](https://github.com/argoproj-labs/argocd-operator/blob/c8f011d11ef81d8dfba4ec2960aae993e2c6ff6f/controllers/argocd/instance.go#L182)

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
