### PR TITLE
[ Operator Redesign ] fix: container ResourceRequirements reconciliation 

### DIFF
--- a/controllers/argocd/appcontroller/helper.go
+++ b/controllers/argocd/appcontroller/helper.go
@@ -54,7 +54,10 @@ func (acr *AppControllerReconciler) getParallelismLimit() int32 {
 
 func (acr *AppControllerReconciler) getResources() corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{}
-	return argocdcommon.GetValueOrDefault(acr.Instance.Spec.Controller.Resources, resources).(corev1.ResourceRequirements)
+	if acr.Instance.Spec.Controller.Resources != nil {
+		resources = *acr.Instance.Spec.Controller.Resources
+	}
+	return resources
 }
 
 func (acr *AppControllerReconciler) getCmd() []string {


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What does this PR do / why we need it**:
Before this PR, container resource didn't reconcile due to the type mismatch for func GetValueOrDefault, This change returns the resource requirement if it's not nil, And return empty/default resource requirement if nil.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
- run 
   `make install run` 

- Run test kuttl k8s test `1-010`
   `kubectl kuttl test ./tests/k8s --config ./tests/kuttl-tests.yaml --test 1-010_validate_resource_limit_changes`