### PR TITLE
fix: doc table for Environment Variables

### DIFF
--- a/docs/usage/environment_variables.md
+++ b/docs/usage/environment_variables.md
@@ -29,6 +29,7 @@ spec:
 ```
 
 The following default value of images could be overridden by setting the environment variables:
+
 | Environment Variable | Default Value |
 | --- | --- |
 | `ARGOCD_IMAGE` | [quay.io/argoproj/argocd](quay.io/argoproj/argocd) |


### PR DESCRIPTION
**What type of PR is this?**

 /kind documentation

**What does this PR do / why we need it**:
This PR fixes the distorted table for "Environment Variables" [page](https://argocd-operator.readthedocs.io/en/stable/usage/environment_variables/).
![image](https://github.com/user-attachments/assets/ccfafb89-7418-4881-bb14-1aea1d55cae6)

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
