### PR TITLE
fix: Allow override of default /tmp volume mount in repo server

### DIFF
--- a/tests/k8s/1-007_validate_volume_mounts/01-assert.yaml
+++ b/tests/k8s/1-007_validate_volume_mounts/01-assert.yaml
@@ -63,14 +63,14 @@ spec:
           name: gpg-keys
         - mountPath: /app/config/gpg/keys
           name: gpg-keyring
-        - mountPath: /tmp
-          name: tmp
         - mountPath: /app/config/reposerver/tls
           name: argocd-repo-server-tls
         - mountPath: /app/config/reposerver/tls/redis
           name: argocd-operator-redis-tls
         - mountPath: /home/argocd/cmp-server/plugins
           name: plugins
+        - mountPath: /tmp
+          name: tmp
       volumes:
       - configMap:
           defaultMode: 420
@@ -86,8 +86,6 @@ spec:
         name: gpg-keys
       - emptyDir: {}
         name: gpg-keyring
-      - emptyDir: {}
-        name: tmp
       - name: argocd-repo-server-tls
         secret:
           defaultMode: 420
@@ -102,6 +100,8 @@ spec:
         name: var-files
       - emptyDir: {}
         name: plugins
+      - emptyDir: {}
+        name: tmp
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

The ArgoCD HA guidelines [1] says:
> argocd-repo-server clones the repository into /tmp (or the path specified in the TMPDIR env variable). The Pod might run out of disk space if it has too many repositories or if the repositories have a lot of files. To avoid this problem mount a persistent volume.

However, with the current behaviour of argocd-operator, it is not possible to override the tmp path: when you attempt to do so, you will see this error in the operator logs:
```
2024-07-16T07:32:47Z ERROR Reconciler error {"controller": "argocd", "controllerGroup": "argoproj.io", "controllerKind": "ArgoCD", "ArgoCD": {"name":"argocd","namespace":"jgw"}, "namespace": "jgw", "name": "argocd", "reconcileID": "6979a388-fdae-453d-b999-b026aa1e260b", "error": "Deployment.apps \"argocd-repo-server\" is invalid: spec.template.spec.containers[0].volumeMounts[8].mountPath: Invalid value: \"/tmp\": must be unique"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
/remote-source/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:227
W0716 07:33:31.475998 1 warnings.go:70] apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
```

using an `ArgoCD` CR like this:
```yaml
kind: ArgoCD
# (...)
spec:
  # (...)
  repo:
    resources:
      limits:
        cpu: '1'
        memory: 1Gi
      requests:
        cpu: 250m
        memory: 256Mi
    volumeMounts:
      - mountPath: /tmp
        name: my-volume
    volumes:
      - emptyDir: {} # in practice, a user would likely use a persistent volume for increased storage capacity
        name: my-volume
```

This PR skips creation of the default /tmp mount path in the case where the user is already providing one via `.spec.repo.volumeMounts` in the `ArgoCD` CR.


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
N/A

**How to test changes / Special notes to the reviewer**:
