### PR TITLE
docs: Document how to use persistent storage for repo server

### DIFF
--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -848,10 +848,10 @@ LogFormat | text | The log format to be used by the ArgoCD Repo Server. Valid op
 ExecTimeout | 180 | Execution timeout in seconds for rendering tools (e.g. Helm, Kustomize)
 Env | [Empty] | Environment to set for the repository server workloads
 Replicas | [Empty] | The number of replicas for the ArgoCD Repo Server. Must be greater than or equal to 0.
-Volumes | [Empty] | Add addition volumes to the repo server deployment.
-VolumeMounts | [Empty] | Add addition volume mounts to the repo server deployment.
-InitContainers | [Empty] | List of initialization containers for the repo server deployment.
-SidecarContainers | [Empty] | List of sidecar containers for the repo server deployment.
+Volumes | [Empty] | Configure addition volumes to the repo server deployment. This field is optional.
+VolumeMounts | [Empty] | Configure addition volume mounts to the repo server deployment. This field is optional.
+InitContainers | [Empty] | List of init containers for the repo server deployment. This field is optional.
+SidecarContainers | [Empty] | List of sidecar containers for the repo server deployment. This field is optional.
 Enabled | true | Flag to enable repo server during ArgoCD installation.
 Remote | [Empty] | Specifies the remote URL of the repo server container. By default, it points to a local instance managed by the operator. This field is optional.
 

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -848,8 +848,8 @@ LogFormat | text | The log format to be used by the ArgoCD Repo Server. Valid op
 ExecTimeout | 180 | Execution timeout in seconds for rendering tools (e.g. Helm, Kustomize)
 Env | [Empty] | Environment to set for the repository server workloads
 Replicas | [Empty] | The number of replicas for the ArgoCD Repo Server. Must be greater than or equal to 0.
-Volumes | [Empty] | Configure addition volumes to the repo server deployment. This field is optional.
-VolumeMounts | [Empty] | Configure addition volume mounts to the repo server deployment. This field is optional.
+Volumes | [Empty] | Configure addition volumes for the repo server deployment. This field is optional.
+VolumeMounts | [Empty] | Configure addition volume mounts for the repo server deployment. This field is optional.
 InitContainers | [Empty] | List of init containers for the repo server deployment. This field is optional.
 SidecarContainers | [Empty] | List of sidecar containers for the repo server deployment. This field is optional.
 Enabled | true | Flag to enable repo server during ArgoCD installation.

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -35,6 +35,7 @@ Name | Default | Description
 [**Prometheus**](#prometheus-options) | [Object] | Prometheus configuration options.
 [**RBAC**](#rbac-options) | [Object] | RBAC configuration options.
 [**Redis**](#redis-options) | [Object] | Redis configuration options.
+[**Repo**](#repo-options) | [Object] | Repo Server configuration options.
 [**ResourceHealthChecks**](#resource-customizations) | [Empty] | Customizes resource health check behavior.
 [**ResourceIgnoreDifferences**](#resource-customizations) | [Empty] | Customizes resource ignore difference behavior.
 [**ResourceActions**](#resource-customizations) | [Empty] | Customizes resource action behavior.
@@ -847,6 +848,12 @@ LogFormat | text | The log format to be used by the ArgoCD Repo Server. Valid op
 ExecTimeout | 180 | Execution timeout in seconds for rendering tools (e.g. Helm, Kustomize)
 Env | [Empty] | Environment to set for the repository server workloads
 Replicas | [Empty] | The number of replicas for the ArgoCD Repo Server. Must be greater than or equal to 0.
+Volumes | [Empty] | Add addition volumes to the repo server deployment.
+VolumeMounts | [Empty] | Add addition volume mounts to the repo server deployment.
+InitContainers | [Empty] | List of initialization containers for the repo server deployment.
+SidecarContainers | [Empty] | List of sidecar containers for the repo server deployment.
+Enabled | true | Flag to enable repo server during ArgoCD installation.
+Remote | [Empty] | Specifies the remote URL of the repo server container. By default, it points to a local instance managed by the operator. This field is optional.
 
 ### Pass Command Arguments To Repo Server
 

--- a/docs/usage/ha/redis.md
+++ b/docs/usage/ha/redis.md
@@ -1,4 +1,4 @@
-# High Availability
+# High Availability for Redis
 
 The Argo CD operator supports high availability through the mechanism described in the Argo CD [documentation][argocd_ha].
 

--- a/docs/usage/ha/repo-server.md
+++ b/docs/usage/ha/repo-server.md
@@ -27,6 +27,9 @@ spec:
     volumeMounts:
     - mountPath: /tmp
       name: repo-storage
+    env:
+    - name: TMPDIR
+      value: "/tmp"
 ```
 
 [argocd_repo_scaling]:https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#scaling-up

--- a/docs/usage/ha/repo-server.md
+++ b/docs/usage/ha/repo-server.md
@@ -1,0 +1,32 @@
+# High Availability for Repo Server
+
+The Argo CD operator supports scaling up the repo server to ensure high availability. This can be achieved using the mechanism described in the Argo CD [documentation][argocd_repo_scaling].
+
+### Persistent Volumes for Repo Server Storage
+
+> `argocd-repo-server` clones the repository into `/tmp` (or the path specified in the `TMPDIR` env variable). The Pod might run out of disk space if it has too many repositories or if the repositories have a lot of files. To avoid this problem mount a persistent volume.
+
+To mount a Persistent Volume to the Repo Server, add the volume details in the `volumes` and `volumeMounts` fields under `.spec.repo` in the `ArgoCD` custom resource (CR).
+
+!!! important
+      The Argo CD operator does not create persistent volumes automatically. It is the user's responsibility to create and manage the required Persistent Volume (PV) and Persistent Volume Claim (PVC) resources. Make sure to provision these resources according to your storage needs and environment.
+
+Example: 
+
+```yaml
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-sample
+spec:
+  repo:
+    volumes:
+    - name: repo-storage
+      persistentVolumeClaim:
+        claimName: <persistent-volume-claim>
+    volumeMounts:
+    - mountPath: /tmp
+      name: repo-storage
+```
+
+[argocd_repo_scaling]:https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#scaling-up

--- a/docs/usage/ha/repo-server.md
+++ b/docs/usage/ha/repo-server.md
@@ -11,8 +11,9 @@ To mount a Persistent Volume to the Repo Server, add the volume details in the `
 !!! important
       The Argo CD operator does not create persistent volumes automatically. It is the user's responsibility to create and manage the required Persistent Volume (PV) and Persistent Volume Claim (PVC) resources. Make sure to provision these resources according to your storage needs and environment.
 
-Example: 
+**Examples:**  
 
+1) Mount the persistent volume to the default repository storage location, i.e. `/tmp`.
 ```yaml
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
@@ -27,9 +28,26 @@ spec:
     volumeMounts:
     - mountPath: /tmp
       name: repo-storage
+```
+
+2) Mount the persistent volume to a custom repository storage location, e.g. `/manifests`.
+```yaml
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-sample
+spec:
+  repo:
+    volumes:
+    - name: repo-storage
+      persistentVolumeClaim:
+        claimName: <persistent-volume-claim>
+    volumeMounts:
+    - mountPath: /manifests
+      name: repo-storage
     env:
     - name: TMPDIR
-      value: "/tmp"
+      value: "/manifests"
 ```
 
 [argocd_repo_scaling]:https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#scaling-up

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,9 @@ nav:
     - Deploy Resources to Different Namespaces: usage/deploy-to-different-namespaces.md
     - Export: usage/export.md
     - ExtraConfig: usage/extra-config.md
-    - High Availability: usage/ha.md
+    - High Availability: 
+      - Redis: usage/ha/redis.md
+      - Repo Server: usage/ha/repo-server.md
     - Ingress: usage/ingress.md
     - Insights: usage/insights.md
     - Dex: usage/dex.md


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What does this PR do / why we need it**:
This PR adds documentation on how to use persistent volumes to increase repo-server storage. It also adds the missing CR fields for `.spec.repo` in documentation.