### PR TITLE
fix: allow argocd spec.image to override default image for appset controller

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -758,28 +758,24 @@ func (r *ReconcileArgoCD) reconcileApplicationSetRoleBinding(cr *argoproj.ArgoCD
 }
 
 func getApplicationSetContainerImage(cr *argoproj.ArgoCD) string {
+
 	defaultImg, defaultTag := false, false
-
-	img := ""
-	tag := ""
-
-	// First pull from spec, if it exists
-	if cr.Spec.ApplicationSet.Image != "" && cr.Spec.ApplicationSet.Version != "" {
-		img = cr.Spec.ApplicationSet.Image
-		tag = cr.Spec.ApplicationSet.Version
-	} else if cr.Spec.Image != "" && cr.Spec.Version != "" && cr.Spec.ApplicationSet.Image == "" && cr.Spec.ApplicationSet.Version == "" {
-		img = cr.Spec.Image
-		tag = cr.Spec.Version
-	}
-
-	// If spec is empty, use the defaults
+	img := cr.Spec.ApplicationSet.Image
 	if img == "" {
-		img = common.ArgoCDDefaultArgoImage
-		defaultImg = true
+		img = cr.Spec.Image
+		if img == "" {
+			img = common.ArgoCDDefaultArgoImage
+			defaultImg = true
+		}
 	}
+
+	tag := cr.Spec.ApplicationSet.Version
 	if tag == "" {
-		tag = common.ArgoCDDefaultArgoVersion
-		defaultTag = true
+		tag = cr.Spec.Version
+		if tag == "" {
+			tag = common.ArgoCDDefaultArgoVersion
+			defaultTag = true
+		}
 	}
 
 	// If an env var is specified then use that, but don't override the spec values (if they are present)

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -764,9 +764,12 @@ func getApplicationSetContainerImage(cr *argoproj.ArgoCD) string {
 	tag := ""
 
 	// First pull from spec, if it exists
-	if cr.Spec.ApplicationSet != nil {
+	if cr.Spec.ApplicationSet.Image != "" && cr.Spec.ApplicationSet.Version != "" {
 		img = cr.Spec.ApplicationSet.Image
 		tag = cr.Spec.ApplicationSet.Version
+	} else if cr.Spec.Image != "" && cr.Spec.Version != "" && cr.Spec.ApplicationSet.Image == "" && cr.Spec.ApplicationSet.Version == "" {
+		img = cr.Spec.Image
+		tag = cr.Spec.Version
 	}
 
 	// If spec is empty, use the defaults


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
Current behaviour doesnt allow image to be overriden by `argocdSpec.image` for applicationset-controller pod, with this PR update application-set  controller image can be overide with priority set `default value < .spec.image < .spec.applicationSet.image`

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-operator/issues/1517

**How to test changes / Special notes to the reviewer**:
