### PR TITLE
fix: Add update logic to handle addition of PSS to deployments

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -262,7 +262,8 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoproj.ArgoCD,
 			!reflect.DeepEqual(existing.Spec.Template.Labels, deploy.Spec.Template.Labels) ||
 			!reflect.DeepEqual(existing.Spec.Selector, deploy.Spec.Selector) ||
 			!reflect.DeepEqual(existing.Spec.Template.Spec.NodeSelector, deploy.Spec.Template.Spec.NodeSelector) ||
-			!reflect.DeepEqual(existing.Spec.Template.Spec.Tolerations, deploy.Spec.Template.Spec.Tolerations)
+			!reflect.DeepEqual(existing.Spec.Template.Spec.Tolerations, deploy.Spec.Template.Spec.Tolerations) ||
+			!reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].SecurityContext, deploy.Spec.Template.Spec.Containers[0].SecurityContext)
 
 		// If the Deployment already exists, make sure the values we care about are up-to-date
 		if deploymentsDifferent {
@@ -274,6 +275,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoproj.ArgoCD,
 			existing.Spec.Selector = deploy.Spec.Selector
 			existing.Spec.Template.Spec.NodeSelector = deploy.Spec.Template.Spec.NodeSelector
 			existing.Spec.Template.Spec.Tolerations = deploy.Spec.Template.Spec.Tolerations
+			existing.Spec.Template.Spec.Containers[0].SecurityContext = deploy.Spec.Template.Spec.Containers[0].SecurityContext
 			return r.Client.Update(context.TODO(), existing)
 		}
 		return nil // Deployment found with nothing to do, move along...

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -563,6 +563,11 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS b
 			changed = true
 		}
 
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].SecurityContext, existing.Spec.Template.Spec.Containers[0].SecurityContext) {
+			existing.Spec.Template.Spec.Containers[0].SecurityContext = deploy.Spec.Template.Spec.Containers[0].SecurityContext
+			changed = true
+		}
+
 		if changed {
 			return r.Client.Update(context.TODO(), existing)
 		}
@@ -808,8 +813,18 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) e
 			changed = true
 		}
 
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].SecurityContext, existing.Spec.Template.Spec.Containers[0].SecurityContext) {
+			existing.Spec.Template.Spec.Containers[0].SecurityContext = deploy.Spec.Template.Spec.Containers[0].SecurityContext
+			changed = true
+		}
+
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].Resources, existing.Spec.Template.Spec.InitContainers[0].Resources) {
 			existing.Spec.Template.Spec.InitContainers[0].Resources = deploy.Spec.Template.Spec.InitContainers[0].Resources
+			changed = true
+		}
+
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].SecurityContext, existing.Spec.Template.Spec.InitContainers[0].SecurityContext) {
+			existing.Spec.Template.Spec.InitContainers[0].SecurityContext = deploy.Spec.Template.Spec.InitContainers[0].SecurityContext
 			changed = true
 		}
 
@@ -1135,6 +1150,10 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoproj.ArgoCD, useTLSFor
 			existing.Spec.Template.Spec.Containers[0].Command = deploy.Spec.Template.Spec.Containers[0].Command
 			changed = true
 		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].SecurityContext, existing.Spec.Template.Spec.Containers[0].SecurityContext) {
+			existing.Spec.Template.Spec.Containers[0].SecurityContext = deploy.Spec.Template.Spec.Containers[0].SecurityContext
+			changed = true
+		}
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[1:],
 			existing.Spec.Template.Spec.Containers[1:]) {
 			existing.Spec.Template.Spec.Containers = append(existing.Spec.Template.Spec.Containers[0:1],
@@ -1369,6 +1388,11 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].Resources,
 			existing.Spec.Template.Spec.Containers[0].Resources) {
 			existing.Spec.Template.Spec.Containers[0].Resources = deploy.Spec.Template.Spec.Containers[0].Resources
+			changed = true
+		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].SecurityContext,
+			existing.Spec.Template.Spec.Containers[0].SecurityContext) {
+			existing.Spec.Template.Spec.Containers[0].SecurityContext = deploy.Spec.Template.Spec.Containers[0].SecurityContext
 			changed = true
 		}
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[1:],

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -356,9 +356,19 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoproj.ArgoCD) error {
 			existing.Spec.Template.Spec.InitContainers[0].Env = deploy.Spec.Template.Spec.InitContainers[0].Env
 			changed = true
 		}
+		if !reflect.DeepEqual(existing.Spec.Template.Spec.InitContainers[0].SecurityContext,
+			deploy.Spec.Template.Spec.InitContainers[0].SecurityContext) {
+			existing.Spec.Template.Spec.InitContainers[0].SecurityContext = deploy.Spec.Template.Spec.InitContainers[0].SecurityContext
+			changed = true
+		}
 
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].Resources, existing.Spec.Template.Spec.Containers[0].Resources) {
 			existing.Spec.Template.Spec.Containers[0].Resources = deploy.Spec.Template.Spec.Containers[0].Resources
+			changed = true
+		}
+
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Containers[0].SecurityContext, existing.Spec.Template.Spec.Containers[0].SecurityContext) {
+			existing.Spec.Template.Spec.Containers[0].SecurityContext = deploy.Spec.Template.Spec.Containers[0].SecurityContext
 			changed = true
 		}
 

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -21,6 +21,7 @@ import (
 	json "encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
@@ -236,18 +237,7 @@ func getKeycloakContainer(cr *argoproj.ArgoCD) corev1.Container {
 			{ContainerPort: 8443, Name: "https", Protocol: "TCP"},
 			{ContainerPort: 8888, Name: "ping", Protocol: "TCP"},
 		},
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{
-					"ALL",
-				},
-			},
-			AllowPrivilegeEscalation: boolPtr(false),
-			RunAsNonRoot:             boolPtr(true),
-			SeccompProfile: &corev1.SeccompProfile{
-				Type: "RuntimeDefault",
-			},
-		},
+		SecurityContext: restrictedContainerSecurityContext(),
 		ReadinessProbe: &corev1.Probe{
 			TimeoutSeconds:      240,
 			InitialDelaySeconds: 120,
@@ -639,18 +629,7 @@ func newKeycloakDeployment(cr *argoproj.ArgoCD) *k8sappsv1.Deployment {
 								{Name: "http", ContainerPort: httpPort},
 								{Name: "https", ContainerPort: portTLS},
 							},
-							SecurityContext: &corev1.SecurityContext{
-								Capabilities: &corev1.Capabilities{
-									Drop: []corev1.Capability{
-										"ALL",
-									},
-								},
-								AllowPrivilegeEscalation: boolPtr(false),
-								RunAsNonRoot:             boolPtr(true),
-								SeccompProfile: &corev1.SeccompProfile{
-									Type: "RuntimeDefault",
-								},
-							},
+							SecurityContext: restrictedContainerSecurityContext(),
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -1352,11 +1331,21 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoproj.ArgoCD) err
 		log.Error(err, fmt.Sprintf("Keycloak Deployment not found or being created for ArgoCD %s in namespace %s",
 			cr.Name, cr.Namespace))
 	} else {
+		changed := false
 		// Handle Image upgrades
 		desiredImage := getKeycloakContainerImage(cr)
 		if existingDC.Spec.Template.Spec.Containers[0].Image != desiredImage {
 			existingDC.Spec.Template.Spec.Containers[0].Image = desiredImage
+			changed = true
+		}
 
+		desiredSecurityContext := restrictedContainerSecurityContext()
+		if !reflect.DeepEqual(existingDC.Spec.Template.Spec.Containers[0].SecurityContext, desiredSecurityContext) {
+			existingDC.Spec.Template.Spec.Containers[0].SecurityContext = desiredSecurityContext
+			changed = true
+		}
+
+		if changed {
 			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				return r.Client.Update(context.TODO(), existingDC)
 			})
@@ -1455,11 +1444,21 @@ func (r *ReconcileArgoCD) reconcileKeycloak(cr *argoproj.ArgoCD) error {
 		log.Error(err, fmt.Sprintf("Keycloak Deployment not found or being created for ArgoCD %s in namespace %s",
 			cr.Name, cr.Namespace))
 	} else {
+		changed := false
 		// Handle Image upgrades
 		desiredImage := getKeycloakContainerImage(cr)
 		if existingDeployment.Spec.Template.Spec.Containers[0].Image != desiredImage {
 			existingDeployment.Spec.Template.Spec.Containers[0].Image = desiredImage
+			changed = true
+		}
 
+		desiredSecurityContext := restrictedContainerSecurityContext()
+		if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].SecurityContext, desiredSecurityContext) {
+			existingDeployment.Spec.Template.Spec.Containers[0].SecurityContext = desiredSecurityContext
+			changed = true
+		}
+
+		if changed {
 			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				return r.Client.Update(context.TODO(), existingDeployment)
 			})
@@ -1514,4 +1513,19 @@ func (r *ReconcileArgoCD) reconcileKeycloak(cr *argoproj.ArgoCD) error {
 	}
 
 	return nil
+}
+
+func restrictedContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+		AllowPrivilegeEscalation: boolPtr(false),
+		RunAsNonRoot:             boolPtr(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: "RuntimeDefault",
+		},
+	}
 }

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -478,6 +478,11 @@ func (r *ReconcileArgoCD) reconcileNotificationsDeployment(cr *argoproj.ArgoCD, 
 		deploymentChanged = true
 	}
 
+	if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.Containers[0].SecurityContext, desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext) {
+		existingDeployment.Spec.Template.Spec.Containers[0].SecurityContext = desiredDeployment.Spec.Template.Spec.Containers[0].SecurityContext
+		deploymentChanged = true
+	}
+
 	if !reflect.DeepEqual(existingDeployment.Spec.Template.Spec.ServiceAccountName, desiredDeployment.Spec.Template.Spec.ServiceAccountName) {
 		existingDeployment.Spec.Template.Spec.ServiceAccountName = desiredDeployment.Spec.Template.Spec.ServiceAccountName
 		deploymentChanged = true

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -444,10 +444,20 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoproj.ArgoCD) error {
 				existing.Spec.Template.Spec.Containers[i].Resources = ss.Spec.Template.Spec.Containers[i].Resources
 				changed = true
 			}
+
+			if !reflect.DeepEqual(ss.Spec.Template.Spec.Containers[i].SecurityContext, existing.Spec.Template.Spec.Containers[i].SecurityContext) {
+				existing.Spec.Template.Spec.Containers[i].SecurityContext = ss.Spec.Template.Spec.Containers[i].SecurityContext
+				changed = true
+			}
 		}
 
 		if !reflect.DeepEqual(ss.Spec.Template.Spec.InitContainers[0].Resources, existing.Spec.Template.Spec.InitContainers[0].Resources) {
 			existing.Spec.Template.Spec.InitContainers[0].Resources = ss.Spec.Template.Spec.InitContainers[0].Resources
+			changed = true
+		}
+
+		if !reflect.DeepEqual(ss.Spec.Template.Spec.InitContainers[0].SecurityContext, existing.Spec.Template.Spec.InitContainers[0].SecurityContext) {
+			existing.Spec.Template.Spec.InitContainers[0].SecurityContext = ss.Spec.Template.Spec.InitContainers[0].SecurityContext
 			changed = true
 		}
 
@@ -776,6 +786,10 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 		}
 		if !reflect.DeepEqual(ss.Spec.Template.Spec.Containers[0].Resources, existing.Spec.Template.Spec.Containers[0].Resources) {
 			existing.Spec.Template.Spec.Containers[0].Resources = ss.Spec.Template.Spec.Containers[0].Resources
+			changed = true
+		}
+		if !reflect.DeepEqual(ss.Spec.Template.Spec.Containers[0].SecurityContext, existing.Spec.Template.Spec.Containers[0].SecurityContext) {
+			existing.Spec.Template.Spec.Containers[0].SecurityContext = ss.Spec.Template.Spec.Containers[0].SecurityContext
 			changed = true
 		}
 		if !reflect.DeepEqual(ss.Spec.Replicas, existing.Spec.Replicas) {


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:

[#1288](https://github.com/argoproj-labs/argocd-operator/pull/1288) and [#1493](https://github.com/argoproj-labs/argocd-operator/pull/1493) introduced Pod Security Standards (PSS) to ensure all Argo CD component pods comply with the restricted security policy. However, these changes only apply to new installations.

This PR addresses the gap by adding logic to update existing installations. It ensures that the necessary `securityContext` is applied to existing pods and automatically reconciles any manual changes back to the intended configuration.

**Which issue(s) this PR fixes**:

Closes #1492 

**How to test changes / Special notes to the reviewer**:

I performed an upgrade test as follows:
1. Ran `make run` with the `v0.11.0` tag.
2. Created an `ArgoCD` CR.
3. Stopped `make run` and switched to this `PR branch`.
4. Ran `make run` again.

The following command should return no warnings:
```bash
# Example of a non-compliant namespace
$ kubectl label --overwrite --dry-run=server ns test pod-security.kubernetes.io/enforce=restricted
Warning: existing pods in namespace "test" violate the new PodSecurity enforce level "restricted:latest"
namespace/test labeled (server dry run)

# Example of a compliant namespace
$ kubectl label --overwrite --dry-run=server ns test pod-security.kubernetes.io/enforce=restricted
namespace/test labeled (server dry run)
```
