### PR TITLE
chore: improve pull request template to include kind lines in comments instead of quote

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,15 @@
 **What type of PR is this?**
-> Uncomment only one ` /kind` line, and delete the rest.
-> For example, `> /kind bug` would simply become: `/kind bug`
 
-> /kind bug
-> /kind chore
-> /kind cleanup
-> /kind failing-test
-> /kind enhancement
-> /kind documentation
-> /kind code-refactoring
+[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
+[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )
+
+<!-- /kind bug -->
+<!-- /kind chore -->
+<!-- /kind cleanup -->
+<!-- /kind failing-test -->
+<!-- /kind enhancement -->
+<!-- /kind documentation -->
+<!-- /kind code-refactoring -->
 
 
 **What does this PR do / why we need it**:


### PR DESCRIPTION

**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:

Current PR template uses quote (>) to list all kind values, while it probably intend to use comments so submitters can choose the right PR kind by uncommenting a certain line.

I found the current template a bit confusing. I've seen some PR descriptions still contain all kind lines, or having the selecting kind line as quote.

With the fix in this PR, submitters just need to uncomment the right kind line, leave the rest as is, and the rendered description will only display the selected kind line, while keeping the other kind lines as hidden comments. Submitters can also choose to delete the 2 instruction lines and unused kind lines.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
