### PR TITLE
fix: Add Server Service check to apply the changes in case the service exists

### DIFF
--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -17,6 +17,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -422,20 +423,6 @@ func (r *ReconcileArgoCD) reconcileServerMetricsService(cr *argoproj.ArgoCD) err
 // reconcileServerService will ensure that the Service is present for the Argo CD server component.
 func (r *ReconcileArgoCD) reconcileServerService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("server", "server", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
-		if !cr.Spec.Server.IsEnabled() {
-			return r.Client.Delete(context.TODO(), svc)
-		}
-		if ensureAutoTLSAnnotation(r.Client, svc, common.ArgoCDServerTLSSecretName, cr.Spec.Server.WantsAutoTLS()) {
-			return r.Client.Update(context.TODO(), svc)
-		}
-		return nil // Service found, do nothing
-	}
-
-	if !cr.Spec.Repo.IsEnabled() {
-		return nil
-	}
-
 	ensureAutoTLSAnnotation(r.Client, svc, common.ArgoCDServerTLSSecretName, cr.Spec.Server.WantsAutoTLS())
 
 	svc.Spec.Ports = []corev1.ServicePort{
@@ -460,6 +447,27 @@ func (r *ReconcileArgoCD) reconcileServerService(cr *argoproj.ArgoCD) error {
 
 	if err := controllerutil.SetControllerReference(cr, svc, r.Scheme); err != nil {
 		return err
+	}
+
+	existingSVC := &corev1.Service{}
+	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, existingSVC) {
+		if !cr.Spec.Server.IsEnabled() {
+			return r.Client.Delete(context.TODO(), svc)
+		}
+		if ensureAutoTLSAnnotation(r.Client, svc, common.ArgoCDServerTLSSecretName, cr.Spec.Server.WantsAutoTLS()) {
+			return r.Client.Update(context.TODO(), svc)
+		}
+		if !cr.Spec.Repo.IsEnabled() {
+			return nil
+		}
+		changed := false
+		if !reflect.DeepEqual(svc.Spec.Type, existingSVC.Spec.Type) {
+			changed = true
+		}
+		if changed {
+			return r.Client.Update(context.TODO(), svc)
+		}
+		return nil
 	}
 	return r.Client.Create(context.TODO(), svc)
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug 

**What does this PR do / why we need it**:
This PR adds logic to reconcile any manual changes on Server Service properties.

**Which issue(s) this PR fixes**:

Fixes #1390

**How to test changes / Special notes to the reviewer**:
I performed an upgrade test as follows:

1. Ran make run
2. Created an ArgoCD CR.
3. Check the Server Service Type is ClusterIP (by default)
4. Apply 
```yaml
apiVersion: argoproj.io/v1beta1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: basic
spec:
  server:
    service:
      type: NodePort
```
6.Check the Server Service Type is NodePort
