### PR TITLE
fix: catalog source image

### DIFF
--- a/deploy/catalog_source.yaml
+++ b/deploy/catalog_source.yaml
@@ -4,6 +4,6 @@ metadata:
   name: argocd-catalog
 spec:
   sourceType: grpc
-  image: quay.io/argoprojlabs/argocd-operator-registry@sha256:3a9978fb88d0aa051de0bbeb87dd478de670729700be925d05a09bc7d339a7d2 # 0.12.0
+  image: quay.io/argoprojlabs/argocd-operator-registry@sha256:72a4c53d2baaddd7c770063735e8a62a3f56bb5c0a72b4277435773f305ac376 # 0.12.0
   displayName: Argo CD Operators
   publisher: Argo CD Community


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug 


**What does this PR do / why we need it**:
Fixes the incorrect catalog image that points to an invalid argocd-operator image

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

Didn't rebuild the bundle, as the current bundle is updated for 0.13 (next) release.
Checked manual installation and works well.
