### PR TITLE
Fix: Add Server Ingress checks to apply the changes in case it  exists

### DIFF
--- a/controllers/argocd/ingress_test.go
+++ b/controllers/argocd/ingress_test.go
@@ -63,7 +63,67 @@ func TestReconcileArgoCD_reconcile_ServerIngress_ingressClassName(t *testing.T) 
 		})
 	}
 }
+func TestReconcileArgoCD_reconcile_ServerIngress_serverHost(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
 
+	nginx := "nginx"
+
+	tests := []struct {
+		name             string
+		ingressClassName *string
+		host             string
+	}{
+		{
+			name:             "New Server host specified",
+			ingressClassName: &nginx,
+			host:             "foo.bar",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+				a.Spec.Server.Ingress.Enabled = true
+				a.Spec.Server.Ingress.IngressClassName = test.ingressClassName
+			})
+
+			resObjs := []client.Object{a}
+			subresObjs := []client.Object{a}
+			runtimeObjs := []runtime.Object{}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+			r := makeTestReconciler(cl, sch)
+			err := r.reconcileArgoServerIngress(a)
+			assert.NoError(t, err)
+
+			ingress := &networkingv1.Ingress{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      "argocd-server",
+				Namespace: testNamespace,
+			}, ingress)
+			assert.NoError(t, err)
+			assert.Equal(t, test.ingressClassName, ingress.Spec.IngressClassName)
+			assert.Equal(t, "argocd", ingress.Spec.TLS[0].Hosts[0])
+			a = makeTestArgoCD(func(a *argoproj.ArgoCD) {
+				a.Spec.Server.Ingress.Enabled = true
+				a.Spec.Server.Ingress.IngressClassName = test.ingressClassName
+				a.Spec.Server.Host = test.host
+			})
+
+			err = r.reconcileArgoServerIngress(a)
+			assert.NoError(t, err)
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      "argocd-server",
+				Namespace: testNamespace,
+			}, ingress)
+			assert.NoError(t, err)
+			assert.Equal(t, test.host, ingress.Spec.TLS[0].Hosts[0])
+			assert.Equal(t, test.host, ingress.Spec.Rules[0].Host)
+			assert.Equal(t, test.ingressClassName, ingress.Spec.IngressClassName)
+		})
+	}
+}
 func TestReconcileArgoCD_reconcile_ServerIngress_ingressClassName_update(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
@@ -102,7 +162,7 @@ func TestReconcileArgoCD_reconcile_ServerIngress_ingressClassName_update(t *test
 		Namespace: testNamespace,
 	}, updatedIngress)
 	assert.NoError(t, err)
-	assert.Equal(t, a.Spec.Server.Ingress.IngressClassName, updatedIngress.Spec.IngressClassName)
+	assert.Equal(t, *a.Spec.Server.Ingress.IngressClassName, *updatedIngress.Spec.IngressClassName)
 
 }
 


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug 


**What does this PR do / why we need it**:
This PR adds logic to reconcile Server Ingress related changes in case it exists previously.

**Which issue(s) this PR fixes**:

Fixes #558
Fixes: https://issues.redhat.com/browse/GITOPS-5386

**How to test changes / Special notes to the reviewer**:
I performed an upgrade test as follows:

1. Ran make run
2. Created an ArgoCD CR.
3. Check the Server Service Type is ClusterIP (by default)
4. Do a kubectl apply on something like:

> ```yaml
> apiVersion: argoproj.io/v1alpha1
> kind: ArgoCD
> metadata:
>   name: argocd
> spec:
>   server:
>     ingress:
>       enabled: true

5. Followed by a kubectl apply on something like:

> ```yaml
> apiVersion: argoproj.io/v1alpha1
> kind: ArgoCD
> metadata:
>   name: argocd
> spec:
>   server:
>     host: foo.bar
>     ingress:
>       enabled: true


6. Check the ingress have been updated with the new host value when describing the ingress

