### PR TITLE
fix:  `make bundle` on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,10 @@ bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metada
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
-	sed -i 's/control-plane: argocd-operator/control-plane: controller-manager/g' bundle/manifests/argocd-operator-webhook-service_v1_service.yaml bundle/manifests/argocd-operator-controller-manager-metrics-service_v1_service.yaml bundle/manifests/argocd-operator.clusterserviceversion.yaml
+	sed -i '' 's/control-plane: argocd-operator/control-plane: controller-manager/g' \
+	bundle/manifests/argocd-operator-webhook-service_v1_service.yaml \
+	bundle/manifests/argocd-operator-controller-manager-metrics-service_v1_service.yaml \
+	bundle/manifests/argocd-operator.clusterserviceversion.yaml
 	rm -fr deploy/olm-catalog/argocd-operator/$(VERSION)
 	mkdir -p deploy/olm-catalog/argocd-operator/$(VERSION)
 	cp -r bundle/manifests/* deploy/olm-catalog/argocd-operator/$(VERSION)/


### PR DESCRIPTION
What type of PR is this?

/kind bug

What does this PR do / why we need it:

Fix for make bundle command on MacOS for contributors on MacOS to generate the OLM bundle succesfully.

Have you updated the necessary documentation?

 Documentation update is required by this PR.
 Documentation has been updated.
Which issue(s) this PR fixes:

Fixes https://github.com/argoproj-labs/argocd-operator/issues/1564

How to test changes / Special notes to the reviewer: