### PR TITLE
Add warning and send events if key and certificate used for route TLS configuration

### DIFF
--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -479,7 +479,7 @@ func (r *ReconcileArgoCD) overrideRouteTLS(tls *routev1.TLSConfig, route *routev
 	if tls.Key != "" || tls.Certificate != "" {
 		// Emit event for each instance providing users with deprecation notice for `.spec.SSO` subfields if not emitted already
 		if currentInstanceEventEmissionStatus, ok := DeprecationEventEmissionTracker[cr.Namespace]; !ok || !currentInstanceEventEmissionStatus.TLSInsecureWarningEmitted {
-			err := argoutil.CreateEvent(r.Client, "Warning", "Insecure field Used", "WARNING: .tls.key and .tls.certificate are insecure in ArgoCD CR and not recommended. Use .tls.externalCertificate to reference a TLS secret instead.", "InsecureFields", cr.ObjectMeta, cr.TypeMeta)
+			err := argoutil.CreateEvent(r.Client, "Warning", "Insecure field Used", "Warning: .tls.key and .tls.certificate are insecure in ArgoCD CR and not recommended. Use .tls.externalCertificate to reference a TLS secret instead.", "InsecureFields", cr.ObjectMeta, cr.TypeMeta)
 			if err != nil {
 				return err
 			}

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -477,9 +477,9 @@ func (r *ReconcileArgoCD) overrideRouteTLS(tls *routev1.TLSConfig, route *routev
 
 	// Send an event when deprecated field key and certificate is used
 	if tls.Key != "" || tls.Certificate != "" {
-		// Emit event for each instance providing users with deprecation notice for `.spec.SSO` subfields if not emitted already
+		// Emit event for each instance providing users with warning message for `.tls.key` & `tls.certificate` subfields if not emitted already
 		if currentInstanceEventEmissionStatus, ok := DeprecationEventEmissionTracker[cr.Namespace]; !ok || !currentInstanceEventEmissionStatus.TLSInsecureWarningEmitted {
-			err := argoutil.CreateEvent(r.Client, "Warning", "Insecure field Used", "Warning: .tls.key and .tls.certificate are insecure in ArgoCD CR and not recommended. Use .tls.externalCertificate to reference a TLS secret instead.", "InsecureFields", cr.ObjectMeta, cr.TypeMeta)
+			err := argoutil.CreateEvent(r.Client, "Warning", "Insecure field Used", ".tls.key and .tls.certificate are insecure in ArgoCD CR and not recommended. Use .tls.externalCertificate to reference a TLS secret instead.", "InsecureFields", cr.ObjectMeta, cr.TypeMeta)
 			if err != nil {
 				return err
 			}

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -476,10 +476,10 @@ func (r *ReconcileArgoCD) overrideRouteTLS(tls *routev1.TLSConfig, route *routev
 	route.Spec.TLS = tls.DeepCopy()
 	if tls.Key != "" || tls.Certificate != "" {
 		// Send an event when deprecated field key and certificate is used
-		argoutil.CreateEvent(r.Client, "Warning", "Deprecated Field Used", "key and certificate fields are deprecated", "Deprecated Field", cr.ObjectMeta, cr.TypeMeta)
+		argoutil.CreateEvent(r.Client, "Warning", "Insecure field Used", "Using key and certificate fields are not recommended", "InsecureFields", cr.ObjectMeta, cr.TypeMeta)
 
 		// These fields are deprecated in favor of using `.tls.externalCertificate` to reference a Kubernetes TLS secret.
-		log.Info("Warning: Using `.tls.key` and `.tls.certificate` in ArgoCD CR is not recommended. Use `.tls.externalCertificate` to reference a TLS secret instead.")
+		log.Info("WARNING: Using `.tls.key` and `.tls.certificate` are insecure fields in ArgoCD CR and is not recommended. Use `.tls.externalCertificate` to reference a TLS secret instead.")
 	}
 
 	// Populate the Route's `tls.key` and `tls.certificate` fields with data from the specified Kubernetes TLS secret.

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -819,7 +819,7 @@ func TestOverrideRouteTLSData(t *testing.T) {
 				},
 			}
 
-			err := r.overrideRouteTLS(test.newTLSConfig, &route, nil)
+			err := r.overrideRouteTLS(test.newTLSConfig, &route, argoCD)
 
 			if test.expectErr {
 				assert.Error(t, err)

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -819,7 +819,7 @@ func TestOverrideRouteTLSData(t *testing.T) {
 				},
 			}
 
-			err := r.overrideRouteTLS(test.newTLSConfig, &route)
+			err := r.overrideRouteTLS(test.newTLSConfig, &route, nil)
 
 			if test.expectErr {
 				assert.Error(t, err)

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1204,6 +1204,7 @@ type DeprecationEventEmissionStatus struct {
 	SSOSpecDeprecationWarningEmitted    bool
 	DexSpecDeprecationWarningEmitted    bool
 	DisableDexDeprecationWarningEmitted bool
+	TLSInsecureWarningEmitted           bool
 }
 
 // DeprecationEventEmissionTracker map stores the namespace containing ArgoCD instance as key and DeprecationEventEmissionStatus as value,


### PR DESCRIPTION
**What type of PR is this?**

/kind chore 
**What does this PR do / why we need it**:
This PR sends event if insecure fields key and certificates are used for route TLS configuration also adds warning in logs for the same.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-5517](https://issues.redhat.com/browse/GITOPS-5517)

**How to test changes / Special notes to the reviewer**:
- run `make install run` on an OpenShift cluster 
- apply the below 
```
apiVersion: argoproj.io/v1beta1
kind: ArgoCD
metadata:
  name: example-argocd
  labels:
    example: repo
spec:
  server:
    route: 
      enabled: true
      tls: 
        certificate: "Y2VydGlmY2F0ZQ=="
        key: "cHJpdmF0ZS1rZXk="
        insecureEdgeTerminationPolicy: Redirect
        termination: reencrypt
```
- check for event created and logs