### PR TITLE
chore: Update golang to 1.22

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Restore go build cache
         uses: actions/cache@v4
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: GH actions workaround - Kill XSP4 process
         run: |
           sudo pkill mono || true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     - name: Build
       run: make build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.2
+          version: v1.61.0
           args: --timeout 5m --exclude SA5011
           only-new-issues: true
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Restore go build cache
         uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/argoproj-labs/argocd-operator
 
-go 1.21.0
-
-toolchain go1.21.9
+go 1.22.0
 
 require (
 	github.com/argoproj/argo-cd/v2 v2.12.3


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:

Argo CD 2.13 shipped with latest version of operator is built with golang 1.22

