### PR TITLE
feat: make specifying config-management sidecar plugin image optional

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -468,7 +468,9 @@ type ArgoCDRepoSpec struct {
 	// InitContainers defines the list of initialization containers for the repo server deployment
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
-	// SidecarContainers defines the list of sidecar containers for the repo server deployment
+	// SidecarContainers defines the list of sidecar containers for the repo
+	// server deployment. If the image field is omitted from a SidecarContainer,
+	// the image for the repo server will be used.
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
 }
 

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -546,7 +546,9 @@ type ArgoCDRepoSpec struct {
 	// InitContainers defines the list of initialization containers for the repo server deployment
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
-	// SidecarContainers defines the list of sidecar containers for the repo server deployment
+	// SidecarContainers defines the list of sidecar containers for the repo
+	// server deployment. If the image field is omitted from a SidecarContainer,
+	// the image for the repo server will be used.
 	SidecarContainers []corev1.Container `json:"sidecarContainers,omitempty"`
 
 	// Enabled is the flag to enable Repo Server during ArgoCD installation. (optional, default `true`)

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-12-05T15:45:35Z"
+    createdAt: "2024-12-05T16:51:54Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-11-29T09:50:31Z"
+    createdAt: "2024-12-05T15:45:35Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -16441,8 +16441,10 @@ spec:
                       you would like the Repo server to use
                     type: string
                   sidecarContainers:
-                    description: SidecarContainers defines the list of sidecar containers
-                      for the repo server deployment
+                    description: |-
+                      SidecarContainers defines the list of sidecar containers for the repo
+                      server deployment. If the image field is omitted from a SidecarContainer,
+                      the image for the repo server will be used.
                     items:
                       description: A single application container that you want to
                         run within a pod.

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -3280,8 +3280,10 @@ spec:
                       you would like the Repo server to use
                     type: string
                   sidecarContainers:
-                    description: SidecarContainers defines the list of sidecar containers
-                      for the repo server deployment
+                    description: |-
+                      SidecarContainers defines the list of sidecar containers for the repo
+                      server deployment. If the image field is omitted from a SidecarContainer,
+                      the image for the repo server will be used.
                     items:
                       description: A single application container that you want to
                         run within a pod.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -3269,8 +3269,10 @@ spec:
                       you would like the Repo server to use
                     type: string
                   sidecarContainers:
-                    description: SidecarContainers defines the list of sidecar containers
-                      for the repo server deployment
+                    description: |-
+                      SidecarContainers defines the list of sidecar containers for the repo
+                      server deployment. If the image field is omitted from a SidecarContainer,
+                      the image for the repo server will be used.
                     items:
                       description: A single application container that you want to
                         run within a pod.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -16430,8 +16430,10 @@ spec:
                       you would like the Repo server to use
                     type: string
                   sidecarContainers:
-                    description: SidecarContainers defines the list of sidecar containers
-                      for the repo server deployment
+                    description: |-
+                      SidecarContainers defines the list of sidecar containers for the repo
+                      server deployment. If the image field is omitted from a SidecarContainer,
+                      the image for the repo server will be used.
                     items:
                       description: A single application container that you want to
                         run within a pod.

--- a/deploy/olm-catalog/argocd-operator/0.13.0/argocd-operator.v0.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.13.0/argocd-operator.v0.13.0.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-12-05T15:45:35Z"
+    createdAt: "2024-12-05T16:51:54Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/deploy/olm-catalog/argocd-operator/0.13.0/argocd-operator.v0.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.13.0/argocd-operator.v0.13.0.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-11-29T09:50:31Z"
+    createdAt: "2024-12-05T15:45:35Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/deploy/olm-catalog/argocd-operator/0.13.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.13.0/argoproj.io_argocds.yaml
@@ -16441,8 +16441,10 @@ spec:
                       you would like the Repo server to use
                     type: string
                   sidecarContainers:
-                    description: SidecarContainers defines the list of sidecar containers
-                      for the repo server deployment
+                    description: |-
+                      SidecarContainers defines the list of sidecar containers for the repo
+                      server deployment. If the image field is omitted from a SidecarContainer,
+                      the image for the repo server will be used.
                     items:
                       description: A single application container that you want to
                         run within a pod.

--- a/deploy/olm-catalog/argocd-operator/0.13.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.13.0/argoproj.io_argocds.yaml
@@ -3280,8 +3280,10 @@ spec:
                       you would like the Repo server to use
                     type: string
                   sidecarContainers:
-                    description: SidecarContainers defines the list of sidecar containers
-                      for the repo server deployment
+                    description: |-
+                      SidecarContainers defines the list of sidecar containers for the repo
+                      server deployment. If the image field is omitted from a SidecarContainer,
+                      the image for the repo server will be used.
                     items:
                       description: A single application container that you want to
                         run within a pod.

--- a/docs/usage/config_management_2.0.md
+++ b/docs/usage/config_management_2.0.md
@@ -2,7 +2,8 @@
 
 See the [upstream documentation](https://argo-cd.readthedocs.io/en/stable/user-guide/config-management-plugins/#configure-plugin-via-sidecar) for more information.
 
-Plugin sidecare containers can be added to the repo server using the `ArgoCD` custom resource.
+Plugin sidecar containers can be added to the repo server using the `ArgoCD` custom resource. If the image field for a sidecar container is omitted, the image for the repo server will be used.
+
 If you want to specify the ConfigManagementPlugin manifest by specifying a config map,
 the config map should be specified separately.
 

--- a/tests/k8s/1-0017_validate_cmp/02-assert.yaml
+++ b/tests/k8s/1-0017_validate_cmp/02-assert.yaml
@@ -1,0 +1,30 @@
+# Increase the timeout for the first test because it needs to download
+# a number of container images
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 720
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  namespace: test-2-17-custom
+status:
+  phase: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-argocd-repo-server
+  namespace: test-2-17-custom
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: guestbook
+  namespace: test-2-17-custom
+  annotations:
+    Bar: baz
+    Foo: myfoo

--- a/tests/k8s/1-0017_validate_cmp/02-cmp2-default-image.yaml
+++ b/tests/k8s/1-0017_validate_cmp/02-cmp2-default-image.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-2-17-custom
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cmp-plugin
+  namespace: test-2-17-custom
+data:
+  plugin.yaml: |
+    apiVersion: argoproj.io/v1alpha1
+    kind: ConfigManagementPlugin
+    metadata:
+      name: cmp-plugin
+    spec:
+      version: v1.0
+      generate:
+        command: [sh, -c, 'echo "{\"kind\": \"ConfigMap\", \"apiVersion\": \"v1\", \"metadata\": { \"name\": \"$ARGOCD_APP_NAME\", \"namespace\": \"$ARGOCD_APP_NAMESPACE\", \"annotations\": {\"Foo\": \"$ARGOCD_ENV_FOO\", \"Bar\": \"baz\"}}}"']
+      discover:
+        find:
+          command: [sh, -c, 'echo "FOUND"; exit 0']
+      allowConcurrency: true
+      lockRepo: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  namespace: test-2-17-custom
+spec:
+  server:
+    route:
+      enabled: true
+  repo:
+    sidecarContainers:
+      - name: cmp
+        command: [/var/run/argocd/argocd-cmp-server]
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 999
+        volumeMounts:
+          - mountPath: /var/run/argocd
+            name: var-files
+          - mountPath: /home/argocd/cmp-server/plugins
+            name: plugins
+          - mountPath: /tmp
+            name: tmp
+          - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+            subPath: plugin.yaml
+            name: cmp-plugin
+    volumes:
+      - configMap:
+          name: cmp-plugin
+        name: cmp-plugin
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: guestbook
+  namespace: test-2-17-custom
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/argoproj/argocd-example-apps.git'
+    path: guestbook
+    targetRevision: HEAD
+    plugin:
+      env:
+        - name: FOO
+          value: myfoo
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: test-2-17-custom
+  syncPolicy:
+    automated: {}

--- a/tests/k8s/1-0017_validate_cmp/99-delete.yaml
+++ b/tests/k8s/1-0017_validate_cmp/99-delete.yaml
@@ -5,3 +5,6 @@ delete:
 - apiVersion: v1
   kind: Namespace
   name: test-1-17-custom
+- apiVersion: v1
+  kind: Namespace
+  name: test-2-17-custom


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

Make specifying the sidecar image for a config-management plugin optional. When the image is not specified the operator will use the product image being used for the repo server.