### PR TITLE
docs: documentation notifications configuration example

### DIFF
--- a/docs/reference/notificationsconfiguration.md
+++ b/docs/reference/notificationsconfiguration.md
@@ -78,7 +78,7 @@ kind: NotificationsConfiguration
 metadata:
  name: default-notifications-configuration
 spec:
- Subscriptions: |
+ subscriptions:
   subscriptions: |
     # subscription for on-sync-status-unknown trigger notifications
     - recipients:


### PR DESCRIPTION
Subscription supposed to lowercase and no pipe is need at the end

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind documentation -->

**What does this PR do / why we need it**:
Notification configuration examples for subscriptions use uppercase letter and do not need to include a "|" at the end, which causes issues.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
