### PR TITLE
feat: Add support for respectRBAC configuration.

### DIFF
--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -134,6 +134,9 @@ type ArgoCDApplicationControllerSpec struct {
 
 	// Custom labels to pods deployed by the operator
 	Labels map[string]string `json:"labels,omitempty"`
+
+	// RespectRBAC restricts controller from discovering/syncing specific resources, Defaults is empty if not configured. Valid options are strict and normal.
+	RespectRBAC string `json:"respectRBAC,omitempty"`
 }
 
 func (a *ArgoCDApplicationControllerSpec) IsEnabled() bool {

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-11-21T12:06:55Z"
+    createdAt: "2024-11-29T09:50:31Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -10897,6 +10897,11 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  respectRBAC:
+                    description: RespectRBAC restricts controller from discovering/syncing
+                      specific resources, Defaults is empty if not configured. Valid
+                      options are strict and normal.
+                    type: string
                   sharding:
                     description: Sharding contains the options for the Application
                       Controller sharding configuration.

--- a/common/keys.go
+++ b/common/keys.go
@@ -19,7 +19,17 @@ import (
 )
 
 const (
-	// ArgoCDKeyAdminEnabled is the configuration key for the admin enabled setting..
+
+	// ArgoCDKeyRespectRBAC is the configuration key for the respectRBAC setting.
+	ArgoCDKeyRespectRBAC = "resource.respectRBAC"
+
+	// ArgoCDValueRespectRBACStrict is the configuration value for the respectRBAC setting.
+	ArgoCDValueRespectRBACStrict = "strict"
+
+	// ArgoCDValueRespectRBACStrict is the configuration value for the respectRBAC setting.
+	ArgoCDValueRespectRBACNormal = "normal"
+
+	// ArgoCDKeyAdminEnabled is the configuration key for the admin enabled setting.
 	ArgoCDKeyAdminEnabled = "admin.enabled"
 
 	// ArgoCDKeyApplicationInstanceLabelKey is the configuration key for the application instance label.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -10886,6 +10886,11 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  respectRBAC:
+                    description: RespectRBAC restricts controller from discovering/syncing
+                      specific resources, Defaults is empty if not configured. Valid
+                      options are strict and normal.
+                    type: string
                   sharding:
                     description: Sharding contains the options for the Application
                       Controller sharding configuration.

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -54,6 +54,15 @@ func getApplicationInstanceLabelKey(cr *argoproj.ArgoCD) string {
 	return key
 }
 
+// setRespectRBAC configures RespectRBAC key and value for ConfigMap.
+func setRespectRBAC(cr *argoproj.ArgoCD, data map[string]string) map[string]string {
+	if cr.Spec.Controller.RespectRBAC != "" &&
+		(cr.Spec.Controller.RespectRBAC == common.ArgoCDValueRespectRBACStrict || cr.Spec.Controller.RespectRBAC == common.ArgoCDValueRespectRBACNormal) {
+		data[common.ArgoCDKeyRespectRBAC] = cr.Spec.Controller.RespectRBAC
+	}
+	return data
+}
+
 // getCAConfigMapName will return the CA ConfigMap name for the given ArgoCD.
 func getCAConfigMapName(cr *argoproj.ArgoCD) string {
 	if len(cr.Spec.TLS.CA.ConfigMapName) > 0 {
@@ -370,7 +379,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
 
 	cm.Data = make(map[string]string)
-
+	cm.Data = setRespectRBAC(cr, cm.Data)
 	cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = getApplicationInstanceLabelKey(cr)
 	cm.Data[common.ArgoCDKeyConfigManagementPlugins] = getConfigManagementPlugins(cr)
 	cm.Data[common.ArgoCDKeyAdminEnabled] = fmt.Sprintf("%t", !cr.Spec.DisableAdmin)

--- a/deploy/olm-catalog/argocd-operator/0.13.0/argocd-operator.v0.13.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.13.0/argocd-operator.v0.13.0.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2024-11-21T12:06:55Z"
+    createdAt: "2024-11-29T09:50:31Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/deploy/olm-catalog/argocd-operator/0.13.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.13.0/argoproj.io_argocds.yaml
@@ -10897,6 +10897,11 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  respectRBAC:
+                    description: RespectRBAC restricts controller from discovering/syncing
+                      specific resources, Defaults is empty if not configured. Valid
+                      options are strict and normal.
+                    type: string
                   sharding:
                     description: Sharding contains the options for the Application
                       Controller sharding configuration.

--- a/docs/usage/respect_rbac.md
+++ b/docs/usage/respect_rbac.md
@@ -1,0 +1,18 @@
+# Respect RBAC for controller
+
+See the [upstream documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#auto-respect-rbac-for-controller) for more information.
+
+This feature can be enabled by setting `respectRBAC` field in ArgoCD resource. To configure value in `argocd-cm` ConfigMap via ArgoCD resource, users need to configure `argocd.spec.controller.respectRBAC` field. Possible values for this field are `strict`, `normal` or empty (default).
+
+
+```yaml
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  controller:
+    respectRBAC: strict
+```
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
     - Notifications: usage/notifications.md
     - Resource Management: usage/resource_management.md
     - Routes: usage/routes.md
+    - Respect RBAC: usage/respect_rbac.md
     - Custom Roles: usage/custom_roles.md
     - Apps in Any Namespace: usage/apps-in-any-namespace.md
     - Appsets in Any Namespace: usage/appsets-in-any-namespace.md

--- a/tests/k8s/1-045_validate_controller_respect_rbac/01-assert.yaml
+++ b/tests/k8s/1-045_validate_controller_respect_rbac/01-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  resource.respectRBAC: normal

--- a/tests/k8s/1-045_validate_controller_respect_rbac/01-install.yaml
+++ b/tests/k8s/1-045_validate_controller_respect_rbac/01-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  controller:
+    respectRBAC: normal

--- a/tests/k8s/1-045_validate_controller_respect_rbac/02-assert.yaml
+++ b/tests/k8s/1-045_validate_controller_respect_rbac/02-assert.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+status:
+  phase: Available
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  resource.respectRBAC: strict

--- a/tests/k8s/1-045_validate_controller_respect_rbac/02-install.yaml
+++ b/tests/k8s/1-045_validate_controller_respect_rbac/02-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  controller:
+    respectRBAC: strict

--- a/tests/k8s/1-045_validate_controller_respect_rbac/03-errors.yaml
+++ b/tests/k8s/1-045_validate_controller_respect_rbac/03-errors.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  resource.respectRBAC: strict

--- a/tests/k8s/1-045_validate_controller_respect_rbac/03-install.yaml
+++ b/tests/k8s/1-045_validate_controller_respect_rbac/03-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  controller:
+    respectRBAC: somethibg

--- a/tests/k8s/1-045_validate_controller_respect_rbac/04-errors.yaml
+++ b/tests/k8s/1-045_validate_controller_respect_rbac/04-errors.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  resource.respectRBAC: ""

--- a/tests/k8s/1-045_validate_controller_respect_rbac/04-install.yaml
+++ b/tests/k8s/1-045_validate_controller_respect_rbac/04-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  controller:
+    respectRBAC: ""


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement

**What does this PR do / why we need it**:
This PR is to add logic to configure [RespectRBAC feature](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#auto-respect-rbac-for-controller) from Argo CD resource. Now users can configure value in `ConfigMap` via `argocd.spec.controller.respectRBAC` field.


**Which issue(s) this PR fixes**:
RH issue tracker :- https://issues.redhat.com/browse/GITOPS-5955
