### PR TITLE
fix: update logic to preserve k8s specific labels & annotations

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -252,7 +252,9 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoproj.ArgoCD,
 	}
 
 	if cr.Spec.ApplicationSet.Annotations != nil {
-		deploy.Spec.Template.Annotations = cr.Spec.ApplicationSet.Annotations
+		for key, value := range cr.Spec.ApplicationSet.Annotations {
+			deploy.Spec.Template.Annotations[key] = value
+		}
 	}
 
 	if cr.Spec.ApplicationSet.Labels != nil {
@@ -269,6 +271,10 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoproj.ArgoCD,
 	if exists {
 
 		existingSpec := existing.Spec.Template.Spec
+
+		// Add Kubernetes-specific labels/annotations from the live object in the source to preserve metadata.
+		deploy.Spec.Template.Labels = addKubernetesData(deploy.Spec.Template.Labels, existing.Spec.Template.Labels)
+		deploy.Spec.Template.Annotations = addKubernetesData(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations)
 
 		deploymentsDifferent := !reflect.DeepEqual(existingSpec.Containers[0], podSpec.Containers) ||
 			!reflect.DeepEqual(existingSpec.Volumes, podSpec.Volumes) ||

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -273,8 +273,8 @@ func (r *ReconcileArgoCD) reconcileApplicationSetDeployment(cr *argoproj.ArgoCD,
 		existingSpec := existing.Spec.Template.Spec
 
 		// Add Kubernetes-specific labels/annotations from the live object in the source to preserve metadata.
-		deploy.Spec.Template.Labels = addKubernetesData(deploy.Spec.Template.Labels, existing.Spec.Template.Labels)
-		deploy.Spec.Template.Annotations = addKubernetesData(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations)
+		addKubernetesData(deploy.Spec.Template.Labels, existing.Spec.Template.Labels)
+		addKubernetesData(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations)
 
 		deploymentsDifferent := !reflect.DeepEqual(existingSpec.Containers[0], podSpec.Containers) ||
 			!reflect.DeepEqual(existingSpec.Volumes, podSpec.Volumes) ||

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1201,8 +1201,8 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argoproj.ArgoCD, useTLSFor
 		}
 
 		// Add Kubernetes-specific labels/annotations from the live object in the source to preserve metadata.
-		deploy.Spec.Template.Labels = addKubernetesData(deploy.Spec.Template.Labels, existing.Spec.Template.Labels)
-		deploy.Spec.Template.Annotations = addKubernetesData(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations)
+		addKubernetesData(deploy.Spec.Template.Labels, existing.Spec.Template.Labels)
+		addKubernetesData(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations)
 
 		if !reflect.DeepEqual(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations) {
 			existing.Spec.Template.Annotations = deploy.Spec.Template.Annotations
@@ -1485,8 +1485,8 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		}
 
 		// Add Kubernetes-specific labels/annotations from the live object in the source to preserve metadata.
-		deploy.Spec.Template.Labels = addKubernetesData(deploy.Spec.Template.Labels, existing.Spec.Template.Labels)
-		deploy.Spec.Template.Annotations = addKubernetesData(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations)
+		addKubernetesData(deploy.Spec.Template.Labels, existing.Spec.Template.Labels)
+		addKubernetesData(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations)
 
 		if !reflect.DeepEqual(deploy.Spec.Template.Annotations, existing.Spec.Template.Annotations) {
 			existing.Spec.Template.Annotations = deploy.Spec.Template.Annotations

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -818,8 +818,8 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 		}
 
 		// Add Kubernetes-specific labels/annotations from the live object in the source to preserve metadata.
-		ss.Spec.Template.Labels = addKubernetesData(ss.Spec.Template.Labels, existing.Spec.Template.Labels)
-		ss.Spec.Template.Annotations = addKubernetesData(ss.Spec.Template.Annotations, existing.Spec.Template.Annotations)
+		addKubernetesData(ss.Spec.Template.Labels, existing.Spec.Template.Labels)
+		addKubernetesData(ss.Spec.Template.Annotations, existing.Spec.Template.Annotations)
 
 		if !reflect.DeepEqual(ss.Spec.Template.Annotations, existing.Spec.Template.Annotations) {
 			existing.Spec.Template.Annotations = ss.Spec.Template.Annotations

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1705,12 +1705,7 @@ func addKubernetesData(source map[string]string, live map[string]string) {
 	for key, value := range live {
 		found := glob.MatchStringInList(patterns, key, glob.GLOB)
 		if found {
-			// Don't override values already present in the source object.
-			// This ensures users have control over Kubernetes-managed data
-			// if they have intentionally set or modified these values in the source object.
-			if _, ok := source[key]; !ok {
-				source[key] = value
-			}
+			source[key] = value
 		}
 	}
 }

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1693,7 +1693,7 @@ func UseServer(name string, cr *argoproj.ArgoCD) bool {
 // in the live object and updates the source object to ensure critical metadata
 // (like scheduling, topology, or lifecycle information) is retained.
 // This helps avoid loss of important Kubernetes-managed metadata during updates.
-func addKubernetesData(source map[string]string, live map[string]string) map[string]string {
+func addKubernetesData(source map[string]string, live map[string]string) {
 
 	// List of Kubernetes-specific substrings (wildcard match)
 	patterns := []string{
@@ -1713,6 +1713,4 @@ func addKubernetesData(source map[string]string, live map[string]string) map[str
 			}
 		}
 	}
-
-	return source
 }

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1706,8 +1706,7 @@ func addKubernetesData(source map[string]string, live map[string]string) {
 		found := glob.MatchStringInList(patterns, key, glob.GLOB)
 		if found {
 			// Don't override values already present in the source object.
-			// This ensures users have control over Kubernetes-managed data
-			// if they have intentionally set or modified these values in the source object.
+			// This allows the operator to update Kubernetes specific data when needed.
 			if _, ok := source[key]; !ok {
 				source[key] = value
 			}

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1705,7 +1705,12 @@ func addKubernetesData(source map[string]string, live map[string]string) {
 	for key, value := range live {
 		found := glob.MatchStringInList(patterns, key, glob.GLOB)
 		if found {
-			source[key] = value
+			// Don't override values already present in the source object.
+			// This ensures users have control over Kubernetes-managed data
+			// if they have intentionally set or modified these values in the source object.
+			if _, ok := source[key]; !ok {
+				source[key] = value
+			}
 		}
 	}
 }

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1133,6 +1133,18 @@ func TestRetainKubernetesData(t *testing.T) {
 			},
 		},
 		{
+			name: "Do not override existing Kubernetes-specific keys in source",
+			source: map[string]string{
+				"node.kubernetes.io/pod": "source-true",
+			},
+			live: map[string]string{
+				"node.kubernetes.io/pod": "live-true", // should not override
+			},
+			expected: map[string]string{
+				"node.kubernetes.io/pod": "source-true", // source takes precedence
+			},
+		},
+		{
 			name: "Handles empty live map",
 			source: map[string]string{
 				"custom-label": "custom-value",

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1094,3 +1094,82 @@ func TestReconcileArgoCD_reconcileDexOAuthClientSecret(t *testing.T) {
 	}
 	assert.True(t, tokenExists, "Dex is enabled but unable to create oauth client secret")
 }
+
+func TestRetainKubernetesData(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   map[string]string
+		live     map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "Add Kubernetes-specific keys not in source",
+			source: map[string]string{
+				"custom-label": "custom-value",
+			},
+			live: map[string]string{
+				"node.kubernetes.io/pod":             "true",
+				"kubectl.kubernetes.io/restartedAt":  "2024-12-05T09:46:46+05:30",
+				"openshift.openshift.io/restartedAt": "2024-12-05T09:46:46+05:30",
+			},
+			expected: map[string]string{
+				"custom-label":                       "custom-value",              // unchanged
+				"node.kubernetes.io/pod":             "true",                      // added
+				"kubectl.kubernetes.io/restartedAt":  "2024-12-05T09:46:46+05:30", // added
+				"openshift.openshift.io/restartedAt": "2024-12-05T09:46:46+05:30", // added
+			},
+		},
+		{
+			name: "Ignores non-Kubernetes-specific keys",
+			source: map[string]string{
+				"custom-label": "custom-value",
+			},
+			live: map[string]string{
+				"non-k8s-key":  "non-k8s-value",
+				"custom-label": "live-value",
+			},
+			expected: map[string]string{
+				"custom-label": "custom-value", // unchanged
+			},
+		},
+		{
+			name: "Do not override existing Kubernetes-specific keys in source",
+			source: map[string]string{
+				"node.kubernetes.io/pod": "source-true",
+			},
+			live: map[string]string{
+				"node.kubernetes.io/pod": "live-true", // should not override
+			},
+			expected: map[string]string{
+				"node.kubernetes.io/pod": "source-true", // source takes precedence
+			},
+		},
+		{
+			name: "Handles empty live map",
+			source: map[string]string{
+				"custom-label": "custom-value",
+			},
+			live: map[string]string{},
+			expected: map[string]string{
+				"custom-label": "custom-value", // unchanged
+			},
+		},
+		{
+			name:   "Handles empty source map",
+			source: map[string]string{},
+			live: map[string]string{
+				"openshift.io/resource": "value",
+			},
+			expected: map[string]string{
+				"openshift.io/resource": "value", // added from live
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := addKubernetesData(tt.source, tt.live)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1133,18 +1133,6 @@ func TestRetainKubernetesData(t *testing.T) {
 			},
 		},
 		{
-			name: "Do not override existing Kubernetes-specific keys in source",
-			source: map[string]string{
-				"node.kubernetes.io/pod": "source-true",
-			},
-			live: map[string]string{
-				"node.kubernetes.io/pod": "live-true", // should not override
-			},
-			expected: map[string]string{
-				"node.kubernetes.io/pod": "source-true", // source takes precedence
-			},
-		},
-		{
 			name: "Handles empty live map",
 			source: map[string]string{
 				"custom-label": "custom-value",

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1168,8 +1168,8 @@ func TestRetainKubernetesData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := addKubernetesData(tt.source, tt.live)
-			assert.Equal(t, tt.expected, actual)
+			addKubernetesData(tt.source, tt.live)
+			assert.Equal(t, tt.expected, tt.source)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug 


**What does this PR do / why we need it**:

Operator overwrites k8s added labels or annotations. This sometimes results into unexpected behaviour. Eg. A kubectl rollout restart on deployment adds an annotation "kubectl.kubernetes.io/restartedAt" with timestamp. However operator detects this as a config drift and removes the annotations resulting into k8s terminating the rollout due to change in config. This commit fixes the issue by preserving such annotations & labels added onto live object during comparison.

**Special notes to the reviewer:**
This is a regression introduced by #1532
