### PR TITLE
Update olm.md

### DIFF
--- a/docs/install/olm.md
+++ b/docs/install/olm.md
@@ -21,7 +21,7 @@ Install the OLM components manually. If you already have OLM installed, skip to 
 
 Either
 
-- install OLM from here: https://github.com/operator-framework/operator-lifecycle-manager/releases
+- install OLM from [here](https://github.com/operator-framework/operator-lifecycle-manager/releases)
 
 or
 


### PR DESCRIPTION
Fix the link as plain link was not highlighted in the doc like clickable URL.


https://argocd-operator.readthedocs.io/en/latest/install/olm/

proof:
<img width="810" alt="Screenshot 2024-12-05 at 16 38 47" src="https://github.com/user-attachments/assets/290fa107-5a03-4018-aa3e-dc2706242223">
