### PR TITLE
Use unique namespaces in kuttl test 1-036, to avoid conflicts with other tests

### DIFF
--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/01-assert.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/01-assert.yaml
@@ -6,8 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: test
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: test-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -16,22 +16,22 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_test
-  namespace: test
+  name: example-argocd_test-thirtysix
+  namespace: test-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_test
-  namespace: test
+  name: example-argocd_test-thirtysix
+  namespace: test-thirtysix
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_test
+  name: example-argocd_test-thirtysix
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/01-sourcenamespace_without_wildcard.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/01-sourcenamespace_without_wildcard.yaml
@@ -1,13 +1,20 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test
+  name: test-thirtysix
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: default-thirtysix
 ---
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd
-  namespace: default
+  namespace: default-thirtysix
 spec:
   sourceNamespaces:
-  - test
+  - test-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/02-assert.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/02-assert.yaml
@@ -6,8 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: test-1
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: test-thirtysix-1
 ---  
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -16,25 +16,25 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_test
-  namespace: test
+  name: example-argocd_test-thirtysix
+  namespace: test-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_test
-  namespace: test
+  name: example-argocd_test-thirtysix
+  namespace: test-thirtysix
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_test
+  name: example-argocd_test-thirtysix
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -43,22 +43,22 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_test-1
-  namespace: test-1
+  name: example-argocd_test-thirtysix-1
+  namespace: test-thirtysix-1
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_test-1
-  namespace: test-1
+  name: example-argocd_test-thirtysix-1
+  namespace: test-thirtysix-1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_test-1
+  name: example-argocd_test-thirtysix-1
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/02-errors.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/02-errors.yaml
@@ -6,13 +6,13 @@ metadata:
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
   name: example-argocd_dev
-  namespace: dev
+  namespace: dev-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: example-argocd_dev
-  namespace: dev
+  namespace: dev-thirtysix
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -20,7 +20,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/02-sourceNamespace_with_wildcard_pattern.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/02-sourceNamespace_with_wildcard_pattern.yaml
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-1
+  name: test-thirtysix-1
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: dev
+  name: dev-thirtysix
 ---   
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd
-  namespace: default
+  namespace: default-thirtysix
 spec:
   sourceNamespaces:
-  - test*
+  - test-thirtysix*

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/03-assert.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/03-assert.yaml
@@ -6,8 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: test-2
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: test-thirtysix-2
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -16,22 +16,22 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_test-2
-  namespace: test-2
+  name: example-argocd_test-thirtysix-2
+  namespace: test-thirtysix-2
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_test-2
-  namespace: test-2
+  name: example-argocd_test-thirtysix-2
+  namespace: test-thirtysix-2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_test-2
+  name: example-argocd_test-thirtysix-2
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/03-new_namespace_with_match_pattern.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/03-new_namespace_with_match_pattern.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-2
+  name: test-thirtysix-2

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/04-assert.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/04-assert.yaml
@@ -6,29 +6,29 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: test
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: test-thirtysix
 --- 
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: test-1
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: test-thirtysix-1
 --- 
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: test-2
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: test-thirtysix-2
 --- 
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: dev
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: dev-thirtysix
 --- 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -37,26 +37,25 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_test
-  namespace: test
+  name: example-argocd_test-thirtysix
+  namespace: test-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_test
-  namespace: test
+  name: example-argocd_test-thirtysix
+  namespace: test-thirtysix
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_test
+  name: example-argocd_test-thirtysix
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
----
+  namespace: default-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -65,25 +64,25 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_test-1
-  namespace: test-1
+  name: example-argocd_test-thirtysix-1
+  namespace: test-thirtysix-1
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_test-1
-  namespace: test-1
+  name: example-argocd_test-thirtysix-1
+  namespace: test-thirtysix-1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_test-1
+  name: example-argocd_test-thirtysix-1
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -92,25 +91,25 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_test-2
-  namespace: test-2
+  name: example-argocd_test-thirtysix-2
+  namespace: test-thirtysix-2
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_test-2
-  namespace: test-2
+  name: example-argocd_test-thirtysix-2
+  namespace: test-thirtysix-2
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_test-2
+  name: example-argocd_test-thirtysix-2
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix
 --- 
 apiVersion: rbac.authorization.k8s.io/v1 
 kind: Role
@@ -119,22 +118,22 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_dev
-  namespace: dev
+  name: example-argocd_dev-thirtysix
+  namespace: dev-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_dev
-  namespace: dev
+  name: example-argocd_dev-thirtysix
+  namespace: dev-thirtysix
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_dev
+  name: example-argocd_dev-thirtysix
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/04-sourceNamespace_with_wildcard.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/04-sourceNamespace_with_wildcard.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-3
+  name: test-thirtysix-3
 ---  
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd
-  namespace: default
+  namespace: default-thirtysix
 spec:
   sourceNamespaces:
   - '*'

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/05-assert.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/05-assert.yaml
@@ -6,15 +6,15 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: test-ns-1
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: test-ns-thirtysix-1
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: default
-  name: dev-ns-1
+    argocd.argoproj.io/managed-by-cluster-argocd: default-thirtysix
+  name: dev-ns-thirtysix-1
 ---  
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -23,25 +23,25 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_test-ns-1
-  namespace: test-ns-1
+  name: example-argocd_test-ns-thirtysix-1
+  namespace: test-ns-thirtysix-1
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_test-ns-1
-  namespace: test-ns-1
+  name: example-argocd_test-ns-thirtysix-1
+  namespace: test-ns-thirtysix-1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_test-ns-1
+  name: example-argocd_test-ns-thirtysix-1
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix
 ---  
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -50,22 +50,22 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_dev-ns-1
-  namespace: dev-ns-1
+  name: example-argocd_dev-ns-thirtysix-1
+  namespace: dev-ns-thirtysix-1
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_dev-ns-1
-  namespace: dev-ns-1
+  name: example-argocd_dev-ns-thirtysix-1
+  namespace: dev-ns-thirtysix-1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_dev-ns-1
+  name: example-argocd_dev-ns-thirtysix-1
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/05-errors.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/05-errors.yaml
@@ -5,22 +5,22 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_ other-ns
-  namespace:  other-ns
+  name: example-argocd_other-ns-thirtysix
+  namespace: other-ns-thirtysix
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: example-argocd_ other-ns
-  namespace: other-ns
+  namespace: other-ns-thirtysix
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_ other-ns
+  name: example-argocd_other-ns-thirtysix
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/05-multiple_sourcenamespace.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/05-multiple_sourcenamespace.yaml
@@ -1,24 +1,24 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-ns-1
+  name: test-ns-thirtysix-1
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: dev-ns-1
+  name: dev-ns-thirtysix-1
 ---  
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: other-ns
+  name: other-ns-thirtysix
 ---  
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd
-  namespace: default
+  namespace: default-thirtysix
 spec:
   sourceNamespaces:
-  - test-ns*
-  - dev-ns*
+  - test-ns-thirtysix*
+  - dev-ns-thirtysix*

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/06-assert.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/06-assert.yaml
@@ -5,4 +5,4 @@ timeout: 60
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: dev-ns-1
+  name: dev-ns-thirtysix-1

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/06-errors.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/06-errors.yaml
@@ -5,22 +5,22 @@ metadata:
     app.kubernetes.io/managed-by: example-argocd
     app.kubernetes.io/name: example-argocd
     app.kubernetes.io/part-of: argocd
-  name: example-argocd_dev-ns-1
-  namespace: dev-ns-1
+  name: example-argocd_dev-ns-thirtysix-1
+  namespace: dev-ns-thirtysix-1
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: example-argocd_dev-ns-1
-  namespace: dev-ns-1
+  name: example-argocd_dev-ns-thirtysix-1
+  namespace: dev-ns-thirtysix-1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: example-argocd_dev-ns-1
+  name: example-argocd_dev-ns-thirtysix-1
 subjects:
 - kind: ServiceAccount
   name: example-argocd-argocd-server
-  namespace: default
+  namespace: default-thirtysix
 - kind: ServiceAccount
   name: example-argocd-argocd-application-controller
-  namespace: default
+  namespace: default-thirtysix

--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/06-validate_labels_role_rolebinding_after_removing_namespace_from_sourcenamespace.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/06-validate_labels_role_rolebinding_after_removing_namespace_from_sourcenamespace.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd
-  namespace: default
+  namespace: default-thirtysix
 spec:
   sourceNamespaces:
-  - test-ns*
+  - test-ns-thirtysix*


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What does this PR do / why we need it**:
- Add `-thirtysix` prefix to namespaces (and associated resources), to prevent conflicts with other tests that use these namespace names (`default`, `test`, `dev`, etc)
- This should fix/improve intermittent failures of this test seen in other PRs.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

N/A