### PR TITLE
fix: broken check for context in notificationController

### DIFF
--- a/controllers/notificationsconfiguration/configmap.go
+++ b/controllers/notificationsconfiguration/configmap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -65,7 +66,16 @@ func (r *NotificationsConfigurationReconciler) reconcileNotificationsConfigmap(c
 		expectedConfiguration["context"] = mapToString(cr.Spec.Context)
 	}
 
-	if !reflect.DeepEqual(expectedConfiguration, NotificationsConfigMap.Data) {
+	// check context separately as converting context map to string produce different string due to random serialization of map value
+	changed := checkIfContextEquals(cr, NotificationsConfigMap)
+
+	for k, _ := range expectedConfiguration {
+		if !reflect.DeepEqual(expectedConfiguration[k], NotificationsConfigMap.Data[k]) && k != "context" {
+			changed = true
+		}
+	}
+
+	if changed {
 		NotificationsConfigMap.Data = expectedConfiguration
 		err := r.Client.Update(context.TODO(), NotificationsConfigMap)
 		if err != nil {
@@ -76,10 +86,34 @@ func (r *NotificationsConfigurationReconciler) reconcileNotificationsConfigmap(c
 	// Do nothing
 	return nil
 }
+
 func mapToString(m map[string]string) string {
 	result := ""
 	for key, value := range m {
 		result += fmt.Sprintf("%s: %s\n", key, value)
 	}
 	return result
+}
+
+// checkIfContextEquals checks if context value in NotificationConfiguration and notificationConfigMap context have same value
+// return true if there is difference, and false if no changes observed
+func checkIfContextEquals(cr *v1alpha1.NotificationsConfiguration, notificationConfigMap *corev1.ConfigMap) bool {
+	cmContext := strings.Split(strings.TrimSuffix(notificationConfigMap.Data["context"], "\n"), "\n")
+	if len(cmContext) == len(cr.Spec.Context) {
+		// Create a map for quick lookups
+		stringMap := make(map[string]bool)
+		for _, item := range cmContext {
+			stringMap[item] = true
+		}
+
+		// Check for each item in array1
+		for key, value := range cr.Spec.Context {
+			if !stringMap[fmt.Sprintf("%s: %s", key, value)] {
+				return true
+			}
+		}
+	} else {
+		return true
+	}
+	return false
 }

--- a/controllers/notificationsconfiguration/configmap.go
+++ b/controllers/notificationsconfiguration/configmap.go
@@ -67,7 +67,7 @@ func (r *NotificationsConfigurationReconciler) reconcileNotificationsConfigmap(c
 	}
 
 	// check context separately as converting context map to string produce different string due to random serialization of map value
-	changed := checkIfContextEquals(cr, NotificationsConfigMap)
+	changed := checkIfContextChanged(cr, NotificationsConfigMap)
 
 	for k, _ := range expectedConfiguration {
 		if !reflect.DeepEqual(expectedConfiguration[k], NotificationsConfigMap.Data[k]) && k != "context" {
@@ -95,9 +95,9 @@ func mapToString(m map[string]string) string {
 	return result
 }
 
-// checkIfContextEquals checks if context value in NotificationConfiguration and notificationConfigMap context have same value
+// checkIfContextChanged checks if context value in NotificationConfiguration and notificationConfigMap context have same value
 // return true if there is difference, and false if no changes observed
-func checkIfContextEquals(cr *v1alpha1.NotificationsConfiguration, notificationConfigMap *corev1.ConfigMap) bool {
+func checkIfContextChanged(cr *v1alpha1.NotificationsConfiguration, notificationConfigMap *corev1.ConfigMap) bool {
 	cmContext := strings.Split(strings.TrimSuffix(notificationConfigMap.Data["context"], "\n"), "\n")
 	if len(cmContext) == len(cr.Spec.Context) {
 		// Create a map for quick lookups

--- a/controllers/notificationsconfiguration/configmap_test.go
+++ b/controllers/notificationsconfiguration/configmap_test.go
@@ -243,7 +243,7 @@ func Test_checkIfContextEquals(t *testing.T) {
 		result   bool
 	}{
 		{"equal context",
-			corev1.ConfigMap{Data: map[string]string{"context": "key1: value1\nkey2: value2\nkey4: value4\nkey3: value3\nkey6: value6\n"}},
+			corev1.ConfigMap{Data: map[string]string{"context": "key4: value4\nkey2: value2\nkey6: value6\nkey1: value1\nkey3: value3\n"}},
 			false,
 		},
 		{"context is not equal",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
This PR fix the broken check for context fields in notification configmap and notificationConfiguration CR.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-5970](https://issues.redhat.com/browse/GITOPS-5970)

**How to test changes / Special notes to the reviewer**:
- run controller on local using `make install run`
- create an argo-cd instance with notification controller enabled
- create a notificationConfiguraion with single context and check for notification-controller pod logs
- update the context field in the notificationConfiguration with more context and check for notification-controller pod logs, there should not be indefinitely repeated logs similar to `time="2024-11-21T09:40:54Z" level=info msg="invalidated cache for resource in namespace: argocd-debug with the name: argocd-notifications-cm"` .