### PR TITLE
fix: Stabilize on-deployed notification trigger

### DIFF
--- a/controllers/argocd/notifications_util.go
+++ b/controllers/argocd/notifications_util.go
@@ -526,8 +526,8 @@ func getDefaultNotificationsTriggers() map[string]string {
   oncePer: app.status.operationState.syncResult.revision
   send:
   - app-deployed
-  when: app.status.operationState.phase in ['Succeeded'] and app.status.health.status
-      == 'Healthy'`
+  when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded'] and app.status.health.status
+      == 'Healthy' and !time.Parse(app.status.health.lastTransitionTime).Before(time.Parse(app.status.operationState.finishedAt))`
 
 	notificationsTriggers["trigger.on-health-degraded"] = `- description: Application has degraded
   send:


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Fix false positives for on-deployed notifications trigger. Refer https://github.com/argoproj/argo-cd/pull/21333 for more details. 

**How to test changes / Special notes to the reviewer**:
The fix cannot be backported as it depends on a new upstream feature.
