### PR TITLE
fix: Reconcile serviceAccount fields in redis deployment

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -592,6 +592,15 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS b
 			changed = true
 		}
 
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.ServiceAccountName, existing.Spec.Template.Spec.ServiceAccountName) {
+			existing.Spec.Template.Spec.ServiceAccountName = deploy.Spec.Template.Spec.ServiceAccountName
+			if changed {
+				explanation += ", "
+			}
+			explanation += "serviceAccountName"
+			changed = true
+		}
+
 		if changed {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			return r.Client.Update(context.TODO(), existing)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

This PR aims at fixing reconciliation for redis deployment, any changes to serviceAccount and serviceAccountName fields will be reset to the original value of <instance name>-argocd-redis

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

Edit redis deployment to remove or modify serviceAccount & serviceAccountName, the changes should not take place and the values should be reset