### PR TITLE
Fix intermittent failure on 'step 4' of 1-036_validate_role_rolebinding_for_source_namespace

### DIFF
--- a/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/04-sourceNamespace_with_wildcard.yaml
+++ b/tests/k8s/1-036_validate_role_rolebinding_for_source_namespace/04-sourceNamespace_with_wildcard.yaml
@@ -10,4 +10,5 @@ metadata:
   namespace: default-thirtysix
 spec:
   sourceNamespaces:
-  - '*'
+  - '*thirtysix*'
+  # Previously this test used '*', however, this will cause intermittent failures in this test: when this test is run, other namespaces on the cluster may still be in the process of being deleted (e.g. they have non-nil '.metadata.deletionTimestamp'), and the operator code will fail on those namespaces if we use '*'.


### PR DESCRIPTION
**What type of PR is this?**

Test fix

**What does this PR do / why we need it**:

'1-036_validate_role_rolebinding_for_source_namespace' will fail on step 4 if another namespace on the cluster is in the process of being deleted (e.g. it has a non-nil deletiontimestamp). 

Unfortunately this can occur often in E2E tests, because after each test, that test's namespace is deleted.

The fix is to update the `sourceNamespaces` field to use a pattern that will only match the namespaces created by this test.


When this problem occurs, this is the operator output:
```
2025-01-08T07:46:26Z	INFO	controller_argocd	Creating Role 'kuttl-test-ultimate-ocelot/example-argocd_kuttl-test-ultimate-ocelot'
2025-01-08T07:46:26Z	INFO	controller_argocd	roles.rbac.authorization.k8s.io "example-argocd_kuttl-test-ultimate-ocelot" is forbidden: unable to create new content in namespace kuttl-test-ultimate-ocelot because it is being terminated
2025-01-08T07:46:26Z	ERROR	Reconciler error	{"controller": "argocd", "controllerGroup": "argoproj.io", "controllerKind": "ArgoCD", "ArgoCD": {"name":"example-argocd","namespace":"default-thirtysix"}, "namespace": "default-thirtysix", "name": "example-argocd", "reconcileID": "9a1acee3-3103-4c61-95e0-e94f09884562", "error": "roles.rbac.authorization.k8s.io \"example-argocd_kuttl-test-ultimate-ocelot\" is forbidden: unable to create new content in namespace kuttl-test-ultimate-ocelot because it is being terminated"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:329
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:227
```

And this is the test failure:
```
2025-01-08T07:46:22.4950540Z === CONT  kuttl/harness/1-036_validate_role_rolebinding_for_source_namespace
2025-01-08T07:46:22.5054738Z     logger.go:42: 07:46:22 | 1-036_validate_role_rolebinding_for_source_namespace | Creating namespace: kuttl-test-comic-adder
2025-01-08T07:46:22.5114779Z     logger.go:42: 07:46:22 | 1-036_validate_role_rolebinding_for_source_namespace/1-sourcenamespace_without_wildcard | starting test step 1-sourcenamespace_without_wildcard
2025-01-08T07:46:22.5430472Z     logger.go:42: 07:46:22 | 1-036_validate_role_rolebinding_for_source_namespace/1-sourcenamespace_without_wildcard | Namespace:/test-thirtysix created
2025-01-08T07:46:22.5591533Z     logger.go:42: 07:46:22 | 1-036_validate_role_rolebinding_for_source_namespace/1-sourcenamespace_without_wildcard | Namespace:/default-thirtysix created
2025-01-08T07:46:22.5693789Z     logger.go:42: 07:46:22 | 1-036_validate_role_rolebinding_for_source_namespace/1-sourcenamespace_without_wildcard | ArgoCD:default-thirtysix/example-argocd created
2025-01-08T07:46:23.6039428Z     logger.go:42: 07:46:23 | 1-036_validate_role_rolebinding_for_source_namespace/1-sourcenamespace_without_wildcard | test step completed 1-sourcenamespace_without_wildcard
2025-01-08T07:46:23.6051745Z     logger.go:42: 07:46:23 | 1-036_validate_role_rolebinding_for_source_namespace/2-sourceNamespace_with_wildcard_pattern | starting test step 2-sourceNamespace_with_wildcard_pattern
2025-01-08T07:46:23.6253026Z     logger.go:42: 07:46:23 | 1-036_validate_role_rolebinding_for_source_namespace/2-sourceNamespace_with_wildcard_pattern | Namespace:/test-thirtysix-1 created
2025-01-08T07:46:23.6512869Z     logger.go:42: 07:46:23 | 1-036_validate_role_rolebinding_for_source_namespace/2-sourceNamespace_with_wildcard_pattern | Namespace:/dev-thirtysix created
2025-01-08T07:46:23.6855770Z     logger.go:42: 07:46:23 | 1-036_validate_role_rolebinding_for_source_namespace/2-sourceNamespace_with_wildcard_pattern | ArgoCD:default-thirtysix/example-argocd updated
2025-01-08T07:46:24.7458339Z     logger.go:42: 07:46:24 | 1-036_validate_role_rolebinding_for_source_namespace/2-sourceNamespace_with_wildcard_pattern | test step completed 2-sourceNamespace_with_wildcard_pattern
2025-01-08T07:46:24.7460043Z     logger.go:42: 07:46:24 | 1-036_validate_role_rolebinding_for_source_namespace/3-new_namespace_with_match_pattern | starting test step 3-new_namespace_with_match_pattern
2025-01-08T07:46:24.7658166Z     logger.go:42: 07:46:24 | 1-036_validate_role_rolebinding_for_source_namespace/3-new_namespace_with_match_pattern | Namespace:/test-thirtysix-2 created
2025-01-08T07:46:25.7972125Z     logger.go:42: 07:46:25 | 1-036_validate_role_rolebinding_for_source_namespace/3-new_namespace_with_match_pattern | test step completed 3-new_namespace_with_match_pattern
2025-01-08T07:46:25.7974335Z     logger.go:42: 07:46:25 | 1-036_validate_role_rolebinding_for_source_namespace/4-sourceNamespace_with_wildcard | starting test step 4-sourceNamespace_with_wildcard
2025-01-08T07:46:25.8240677Z     logger.go:42: 07:46:25 | 1-036_validate_role_rolebinding_for_source_namespace/4-sourceNamespace_with_wildcard | Namespace:/test-thirtysix-3 created
2025-01-08T07:46:25.8463195Z     logger.go:42: 07:46:25 | 1-036_validate_role_rolebinding_for_source_namespace/4-sourceNamespace_with_wildcard | ArgoCD:default-thirtysix/example-argocd updated
2025-01-08T07:47:26.4668024Z     logger.go:42: 07:47:26 | 1-036_validate_role_rolebinding_for_source_namespace/4-sourceNamespace_with_wildcard | test step failed 4-sourceNamespace_with_wildcard
2025-01-08T07:47:26.4669332Z     case.go:254: failed in step 4-sourceNamespace_with_wildcard
2025-01-08T07:47:26.4670042Z     case.go:256: rolebindings.rbac.authorization.k8s.io "example-argocd_dev-thirtysix" not found
2025-01-08T07:47:26.4670992Z     logger.go:42: 07:47:26 | 1-036_validate_role_rolebinding_for_source_namespace | skipping kubernetes event logging
2025-01-08T07:47:26.5317521Z     logger.go:42: 07:47:26 | 1-036_validate_role_rolebinding_for_source_namespace | Deleting namespace: kuttl-test-comic-adder
```