### PR TITLE
fix: Reconcile serviceAccount fields in redis deployment (#1635)

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -573,6 +573,15 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS b
 			changed = true
 		}
 
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.ServiceAccountName, existing.Spec.Template.Spec.ServiceAccountName) {
+			existing.Spec.Template.Spec.ServiceAccountName = deploy.Spec.Template.Spec.ServiceAccountName
+			if changed {
+				explanation += ", "
+			}
+			explanation += "serviceAccountName"
+			changed = true
+		}
+
 		if changed {
 			return r.Client.Update(context.TODO(), existing)
 		}

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -575,10 +575,6 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS b
 
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.ServiceAccountName, existing.Spec.Template.Spec.ServiceAccountName) {
 			existing.Spec.Template.Spec.ServiceAccountName = deploy.Spec.Template.Spec.ServiceAccountName
-			if changed {
-				explanation += ", "
-			}
-			explanation += "serviceAccountName"
 			changed = true
 		}
 

--- a/tests/k8s/1-038_validate_controller_extra_command_args/03-remove-extraCommandArgs.yaml
+++ b/tests/k8s/1-038_validate_controller_extra_command_args/03-remove-extraCommandArgs.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - script: |
-    oc patch -n test-1-38-controller-extra-command argocds/example-argocd --type=json --patch '[{"op": "remove", "path": "/spec/controller/extraCommandArgs"}]'
+    kubectl patch -n test-1-38-controller-extra-command argocds/example-argocd --type=json --patch '[{"op": "remove", "path": "/spec/controller/extraCommandArgs"}]'


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Cherry-pick https://github.com/argoproj-labs/argocd-operator/pull/1635

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:

Edit redis deployment to remove or modify serviceAccount & serviceAccountName, the changes should not take place and the values should be reset