### PR TITLE
Only update Argo CD Cluster secret if the values have changed

### DIFF
--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -722,7 +722,7 @@ func TestRemoveManagedNamespaceFromClusterSecretAfterDeletion(t *testing.T) {
 	// secret should still exists with updated list of namespaces
 	s, err := testClient.CoreV1().Secrets(a.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
-	assert.Equal(t, string(s.Data["namespaces"]), "testNamespace2")
+	assert.Equal(t, "testNamespace2", string(s.Data["namespaces"]))
 
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Currently, the Argo CD operator will update the default cluster Secret after every reconcile, regardless of whether or not the `.data.namespaces` field has actually changed.

This PR updates the logic to only update `.data.namespaces` if the field has changed.
