### PR TITLE
Preserve RBAC scope conf in RBAC CM in when updating to SSO keycloak

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -579,12 +579,16 @@ func (r *ReconcileArgoCD) reconcileRBACConfigMap(cm *corev1.ConfigMap, cr *argop
 
 	// Scopes
 	if cr.Spec.RBAC.Scopes != nil && cm.Data[common.ArgoCDKeyRBACScopes] != *cr.Spec.RBAC.Scopes {
-		cm.Data[common.ArgoCDKeyRBACScopes] = *cr.Spec.RBAC.Scopes
-		if changed {
-			explanation += ", "
+		if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
+			log.Info("cr.Spec.RBAC.Scopes value could be out of sync with the RBACConfigMap, since keycloak sso is enabled and scopes are fixed to [groups,mails]")
+		} else {
+			cm.Data[common.ArgoCDKeyRBACScopes] = *cr.Spec.RBAC.Scopes
+			if changed {
+				explanation += ", "
+			}
+			explanation += "rbac scopes"
+			changed = true
 		}
-		explanation += "rbac scopes"
-		changed = true
 	}
 
 	if changed {

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -1159,6 +1159,47 @@ func Test_reconcileRBAC(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, cm.Data["policy.matchMode"], matcherMode)
+
+	// Verify when SSO different from keycloak it sync
+	rbacScopes := "[groups,email]"
+	cmRbacScopes := ""
+	a.Spec.RBAC.Scopes = &rbacScopes
+	cm.Data["scopes"] = cmRbacScopes
+	a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+		Provider: argoproj.SSOProviderTypeDex,
+	}
+	err = r.reconcileRBAC(a)
+	assert.NoError(t, err)
+
+	cm = &corev1.ConfigMap{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      common.ArgoCDRBACConfigMapName,
+		Namespace: testNamespace,
+	}, cm)
+
+	assert.NoError(t, err)
+	assert.Equal(t, rbacScopes, cm.Data["scopes"])
+	assert.Equal(t, rbacScopes, *a.Spec.RBAC.Scopes)
+
+	rbacScopes = "[groups]"
+	cmRbacScopes = cm.Data["scopes"]
+	a.Spec.RBAC.Scopes = &rbacScopes
+	a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+		Provider: argoproj.SSOProviderTypeKeycloak,
+	}
+	err = r.reconcileRBAC(a)
+	assert.NoError(t, err)
+
+	cm = &corev1.ConfigMap{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      common.ArgoCDRBACConfigMapName,
+		Namespace: testNamespace,
+	}, cm)
+
+	assert.NoError(t, err)
+	assert.Equal(t, cmRbacScopes, cm.Data["scopes"])
+	assert.Equal(t, rbacScopes, *a.Spec.RBAC.Scopes)
+
 }
 
 func Test_validateOwnerReferences(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug 


**What does this PR do / why we need it**:
This PR adds logic to preserve the RBAC scope configuration in the RBAC ConfigMap when updating to SSO Keycloak. Previously, it was set to '[groups,email]' in the RBAC ConfigMap without updating the Spec.RBAC.Scopes, which caused a conflict during the ConfigMap sync when switching to Keycloak SSO and updating the ArgoCDConfiguration.

**Which issue(s) this PR fixes**:
Fixes: https://issues.redhat.com/browse/GITOPS-5977

**How to test changes / Special notes to the reviewer**:
Steps to reproduce:

1. Ran make run
2. Created an ArgoCD CR.
3. Set the RBAC scope
4. Do a kubectl apply on something like:

> ```yaml
> apiVersion: argoproj.io/v1beta1
> kind: ArgoCD
> metadata:
>   name: argocd
> spec:
>   rbac:
>    scopes: '[groups]'

5. Followed by a kubectl apply on something like:

> ```yaml
> apiVersion: argoproj.io/v1beta1
> kind: ArgoCD
> metadata:
>  name: openshift-gitops
>  namespace: openshift-gitops
> spec:
>  extraConfig:
>    oidc.tls.insecure.skip.verify: "true"
>  sso:
>    provider: keycloak
>    keycloak:
>      rootCA : ---BEGIN---END---

6. After the keycloak container is created, Previously this change, logs keep showing "RBAC ConfigMap 'argocd-rbac-cm' updated"