### PR TITLE
fix: Add PostStart lifecycle hook to reset Redis sentinel

### DIFF
--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -278,6 +278,17 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoproj.ArgoCD) error {
 					Type: "RuntimeDefault",
 				},
 			},
+			Lifecycle: &corev1.Lifecycle{
+				PostStart: &corev1.LifecycleHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{
+							"/bin/sh",
+							"-c",
+							"sleep 30; redis-cli -p 26379 sentinel reset argocd",
+						},
+					},
+				},
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					MountPath: "/data",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

This pull request includes a change to the `reconcileRedisStatefulSet` function in the `statefulset.go` file to add a post-start lifecycle hook for the Redis StatefulSet. This hook ensures that the Redis Sentinel is reset after a short delay when the container starts.

Argo-cd:
Issue: https://github.com/argoproj/argo-cd/issues/16360
PR: https://github.com/argoproj/argo-cd/pull/20645

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #1664 

**How to test changes / Special notes to the reviewer**:
