### PR TITLE
revert: "fix: Add PostStart lifecycle hook to reset Redis sentinel"

### DIFF
--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -278,17 +278,6 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoproj.ArgoCD) error {
 					Type: "RuntimeDefault",
 				},
 			},
-			Lifecycle: &corev1.Lifecycle{
-				PostStart: &corev1.LifecycleHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{
-							"/bin/sh",
-							"-c",
-							"sleep 30; redis-cli -p 26379 sentinel reset argocd",
-						},
-					},
-				},
-			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					MountPath: "/data",


### PR DESCRIPTION
Reverts argoproj-labs/argocd-operator#1674

The PostStart hook results into a crashLoopBackOff for state redis when custom certificates are used with redis. Reverting the change for now to unblock the release. 