### PR TITLE
fix: Standardize 'app.kubernetes.io/part-of' labels across all ArgoCD resources

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -891,7 +891,7 @@ func getApplicationSetResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements
 
 func setAppSetLabels(obj *metav1.ObjectMeta) {
 	obj.Labels["app.kubernetes.io/name"] = "argocd-applicationset-controller"
-	obj.Labels["app.kubernetes.io/part-of"] = "argocd-applicationset"
+	obj.Labels["app.kubernetes.io/part-of"] = "argocd"
 	obj.Labels["app.kubernetes.io/component"] = "controller"
 }
 

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -978,7 +978,7 @@ func TestReconcileApplicationSet_RoleBinding(t *testing.T) {
 
 func appsetAssertExpectedLabels(t *testing.T, meta *metav1.ObjectMeta) {
 	assert.Equal(t, meta.Labels["app.kubernetes.io/name"], "argocd-applicationset-controller")
-	assert.Equal(t, meta.Labels["app.kubernetes.io/part-of"], "argocd-applicationset")
+	assert.Equal(t, meta.Labels["app.kubernetes.io/part-of"], "argocd")
 	assert.Equal(t, meta.Labels["app.kubernetes.io/component"], "controller")
 }
 

--- a/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-assert.yaml
+++ b/tests/k8s/1-033_validate_applicationset_tls_scm_volume_mount/01-assert.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/managed-by: argocd
     app.kubernetes.io/name: argocd-applicationset-controller
-    app.kubernetes.io/part-of: argocd-applicationset
+    app.kubernetes.io/part-of: argocd
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Fixes: #1689 

**What type of PR is this?**
This fix Standardize ApplicationSet controller labels
- Update ApplicationSet controller resources to use consistent 'app.kubernetes.io/part-of: argocd' label
- Change from 'argocd-applicationset' to 'argocd' to ali

/kind enhancement

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
