### PR TITLE
Copying argocd-cmp-server binary instead of argocd which can be dynamically linked for FIPS

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -276,7 +276,7 @@ func getArgoCmpServerInitCommand() []string {
 	cmd := make([]string, 0)
 	cmd = append(cmd, "cp")
 	cmd = append(cmd, "-n")
-	cmd = append(cmd, "/usr/local/bin/argocd")
+	cmd = append(cmd, "/usr/local/bin/argocd-cmp-server")
 	cmd = append(cmd, "/var/run/argocd/argocd-cmp-server")
 	return cmd
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
Fix for issue [GITOPS-6495](https://issues.redhat.com/browse/GITOPS-6495)

**What does this PR do / why we need it**:
Error message when starting cmp server with busybox image and a FIPS compliant Argo CD binary.
```
/var/run/argocd/argocd-cmp-server: error while loading shared libraries: libdl.so.2: cannot open shared object file: No such file or directory
```
####Root Cause:
For FIPS compliance, `argocd` binary must be compiled with `CGO_ENABLED=1`, and this mandates it to run with the same OS version in which it was complied so that the libraries linked during compilation are available at runtime as well. So if the binary was compiled in RHEL 8, it may not run on a RHEL 9/10. Since the `argocd-cmp-server` is designed to be run on different images, we need to have a separate binary for `argocd-cmp-server` which is compiled with `CGO_ENABLED=0` so that the binary is statically compiled and can work across different flavours of Linux images.

#### Note:
If the same FIPS compliant image is used, then the `argocd-cmp-server` would work without any issues. Only if you copy the binary image to a volume and run it from a different container image, this issue would occur.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-6495](https://issues.redhat.com/browse/GITOPS-6495)

**How to test changes / Special notes to the reviewer**:
Run cmp server using a FIPS compliant Argo CD base image and binary.