### PR TITLE
Copying argocd-cmp-server binary instead of argocd which can be dynamically linked for FIPS (#1692)

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -266,7 +266,7 @@ func getArgoCmpServerInitCommand() []string {
 	cmd := make([]string, 0)
 	cmd = append(cmd, "cp")
 	cmd = append(cmd, "-n")
-	cmd = append(cmd, "/usr/local/bin/argocd")
+	cmd = append(cmd, "/usr/local/bin/argocd-cmp-server")
 	cmd = append(cmd, "/var/run/argocd/argocd-cmp-server")
 	return cmd
 }


### PR DESCRIPTION


**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Copy the `argocd-cmp-server` instead of the `argocd` binary which can be compiled dynamically for FIPS compliance and may not run with other container images.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
