### PR TITLE
fix: ArgoCD SSO status is not updated

### DIFF
--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -762,6 +762,10 @@ type ArgoCDSSOSpec struct {
 	Keycloak *ArgoCDKeycloakSpec `json:"keycloak,omitempty"`
 }
 
+func (a *ArgoCDSSOSpec) IsEnabled() bool {
+	return a != nil && string(a.Provider) != ""
+}
+
 // KustomizeVersionSpec is used to specify information about a kustomize version to be used within ArgoCD.
 type KustomizeVersionSpec struct {
 	// Version is a configured kustomize version in the format of vX.Y.Z

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -34,15 +34,16 @@ import (
 
 // reconcileStatus will ensure that all of the Status properties are updated for the given ArgoCD.
 func (r *ReconcileArgoCD) reconcileStatus(cr *argoproj.ArgoCD) error {
+
+	if err := r.reconcileStatusPhase(cr); err != nil {
+		return err
+	}
+
 	if err := r.reconcileStatusApplicationController(cr); err != nil {
 		return err
 	}
 
 	if err := r.reconcileStatusSSO(cr); err != nil {
-		log.Info(err.Error())
-	}
-
-	if err := r.reconcileStatusPhase(cr); err != nil {
 		return err
 	}
 
@@ -245,7 +246,8 @@ func (r *ReconcileArgoCD) reconcileStatusPhase(cr *argoproj.ArgoCD) error {
 	if ((!cr.Spec.Controller.IsEnabled() && cr.Status.ApplicationController == "Unknown") || cr.Status.ApplicationController == "Running") &&
 		((!cr.Spec.Redis.IsEnabled() && cr.Status.Redis == "Unknown") || cr.Status.Redis == "Running" || (cr.Spec.Redis.IsEnabled() && cr.Spec.Redis.Remote != nil && *cr.Spec.Redis.Remote != "")) &&
 		((!cr.Spec.Repo.IsEnabled() && cr.Status.Repo == "Unknown") || cr.Status.Repo == "Running") &&
-		((!cr.Spec.Server.IsEnabled() && cr.Status.Server == "Unknown") || cr.Status.Server == "Running") {
+		((!cr.Spec.Server.IsEnabled() && cr.Status.Server == "Unknown") || cr.Status.Server == "Running") &&
+		((!cr.Spec.SSO.IsEnabled() && cr.Status.SSO == "Unknown") || cr.Status.SSO == "Running") {
 		phase = "Available"
 	} else {
 		phase = "Pending"

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -735,16 +735,15 @@ func (r *ReconcileArgoCD) redisShouldUseTLS(cr *argoproj.ArgoCD) bool {
 // reconcileResources will reconcile common ArgoCD resources.
 func (r *ReconcileArgoCD) reconcileResources(cr *argoproj.ArgoCD) error {
 
-	// we reconcile SSO first so that we can catch and throw errors for any illegal SSO configurations right away, and return control from here
-	// preventing dex resources from getting created anyway through the other function calls, effectively bypassing the SSO checks
-	log.Info("reconciling SSO")
-	if err := r.reconcileSSO(cr); err != nil {
-		log.Info(err.Error())
-	}
-
 	log.Info("reconciling status")
 	if err := r.reconcileStatus(cr); err != nil {
 		log.Info(err.Error())
+	}
+
+	log.Info("reconciling SSO")
+	if err := r.reconcileSSO(cr); err != nil {
+		log.Info(err.Error())
+		return err
 	}
 
 	log.Info("reconciling roles")

--- a/tests/k8s/1-015_validate_sso_status/05-assert.yaml
+++ b/tests/k8s/1-015_validate_sso_status/05-assert.yaml
@@ -3,5 +3,5 @@ kind: ArgoCD
 metadata:
   name: argocd
 status:
-  phase: Available
+  phase: Pending
   sso: Failed

--- a/tests/k8s/1-042_restricted_pss_compliant/01-install-argocd-in-restricted-pss-ns copy.yaml
+++ b/tests/k8s/1-042_restricted_pss_compliant/01-install-argocd-in-restricted-pss-ns copy.yaml
@@ -18,6 +18,9 @@ metadata:
   name: argocd
   namespace: test-1-042-restricted-pss-compliant
 spec:
+  server:
+    ingress:
+      enabled: true
   applicationSet:
     enabled: true
   notifications:

--- a/tests/k8s/1-042_restricted_pss_compliant/03-assert.yaml
+++ b/tests/k8s/1-042_restricted_pss_compliant/03-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 400
+---
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
@@ -9,7 +13,7 @@ status:
   redis: Running
   repo: Running
   server: Running
-  #sso: Running  # due to bug in keycloak service code, status remains as Pending
+  sso: Running
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/k8s/1-042_restricted_pss_compliant/03-enable-keycloak-sso.yaml
+++ b/tests/k8s/1-042_restricted_pss_compliant/03-enable-keycloak-sso.yaml
@@ -4,6 +4,9 @@ metadata:
   name: argocd
   namespace: test-1-042-restricted-pss-compliant
 spec:
+  server:
+    ingress:
+      enabled: true
   sso:
     provider: keycloak
     keycloak:

--- a/tests/k8s/1-042_restricted_pss_compliant/04-check-pod.yaml
+++ b/tests/k8s/1-042_restricted_pss_compliant/04-check-pod.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: sleep 10
+  - script: sleep 50
   - script: kubectl get pods -n test-1-042-restricted-pss-compliant | grep 'keycloak'

--- a/tests/k8s/1-042_restricted_pss_compliant/05-assert.yaml
+++ b/tests/k8s/1-042_restricted_pss_compliant/05-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:

--- a/tests/k8s/1-042_restricted_pss_compliant/05-enable-redis-ha.yaml
+++ b/tests/k8s/1-042_restricted_pss_compliant/05-enable-redis-ha.yaml
@@ -7,3 +7,9 @@ metadata:
 spec:
   ha:
     enabled: true
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    kubectl patch -n test-1-042-restricted-pss-compliant argocd/argocd --type='json' -p='[{"op": "remove", "path": "/spec/sso"}]'

--- a/tests/k8s/1-048_validate_status_conditions/01-assert.yaml
+++ b/tests/k8s/1-048_validate_status_conditions/01-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd
+status:
+  conditions:
+  - message: 'illegal SSO configuration: Unsupported SSO provider type. Supported providers are dex and keycloak'
+    reason: ErrorOccurred
+    status: "False"
+    type: Reconciled
+  phase: Pending
+  sso: Failed

--- a/tests/k8s/1-048_validate_status_conditions/01-install.yaml
+++ b/tests/k8s/1-048_validate_status_conditions/01-install.yaml
@@ -2,6 +2,5 @@ apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
   name: argocd
-status:
-  phase: Pending
-  sso: Failed
+spec:
+  sso: {}

--- a/tests/k8s/1-048_validate_status_conditions/02-assert.yaml
+++ b/tests/k8s/1-048_validate_status_conditions/02-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd
+status:
+  conditions:
+  - message: ""
+    reason: Success
+    status: "True"
+    type: Reconciled
+  phase: Available
+  sso: Running

--- a/tests/k8s/1-048_validate_status_conditions/02-install.yaml
+++ b/tests/k8s/1-048_validate_status_conditions/02-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd
+spec:
+  sso:
+    dex:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+      openShiftOAuth: true
+    provider: dex

--- a/tests/k8s/1-048_validate_status_conditions/03-assert.yaml
+++ b/tests/k8s/1-048_validate_status_conditions/03-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd
+status:
+  conditions:
+  - message: 'illegal SSO configuration: cannot supply dex configuration when requested SSO provider is keycloak'
+    reason: ErrorOccurred
+    status: "False"
+    type: Reconciled
+  phase: Pending
+  sso: Failed

--- a/tests/k8s/1-048_validate_status_conditions/03-install.yaml
+++ b/tests/k8s/1-048_validate_status_conditions/03-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd
+spec:
+  sso:
+    dex:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+      openShiftOAuth: true
+    provider: keycloak

--- a/tests/k8s/1-048_validate_status_conditions/04-assert.yaml
+++ b/tests/k8s/1-048_validate_status_conditions/04-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd
+status:
+  conditions:
+  - message: ""
+    reason: Success
+    status: "True"
+    type: Reconciled
+  phase: Available
+  sso: Running

--- a/tests/k8s/1-048_validate_status_conditions/04-install.yaml
+++ b/tests/k8s/1-048_validate_status_conditions/04-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: argocd
+spec:
+  sso:
+    dex:
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+      openShiftOAuth: true
+    provider: dex


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
This PR is to fix a bug where, ArgoCD `Status.Phase` is not updated properly when `SSO` fails.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/GITOPS-6667
