### PR TITLE
 GITOPS-6759: fix- Redis HA Server StatefulSet SecurityContext Not Updated During Upgrade

### DIFF
--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -495,6 +495,14 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoproj.ArgoCD) error {
 				changed = true
 			}
 		}
+		if !reflect.DeepEqual(ss.Spec.Template.Spec.SecurityContext, existing.Spec.Template.Spec.SecurityContext) {
+			existing.Spec.Template.Spec.SecurityContext = ss.Spec.Template.Spec.SecurityContext
+			if changed {
+				explanation += ", "
+			}
+			explanation += "security context"
+			changed = true
+		}
 		if !reflect.DeepEqual(ss.Spec.Template.Spec.Volumes, existing.Spec.Template.Spec.Volumes) {
 			existing.Spec.Template.Spec.Volumes = ss.Spec.Template.Spec.Volumes
 			if changed {
@@ -895,6 +903,14 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 				explanation += ", "
 			}
 			explanation += "replicas"
+			changed = true
+		}
+		if !reflect.DeepEqual(ss.Spec.Template.Spec.SecurityContext, existing.Spec.Template.Spec.SecurityContext) {
+			existing.Spec.Template.Spec.SecurityContext = ss.Spec.Template.Spec.SecurityContext
+			if changed {
+				explanation += ", "
+			}
+			explanation += "security context"
 			changed = true
 		}
 

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -889,6 +890,20 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_ModifyContainerSpec(t *testin
 		}
 	}
 	assert.False(t, envVarFound, "NEW_ENV_VAR should not be present")
+
+	// Modify the SecurityContext
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	expectedSecurityContext := s.Spec.Template.Spec.SecurityContext
+	fsGroup := int64(2000)
+	newSecurityContext := &corev1.PodSecurityContext{
+		FSGroup: &fsGroup,
+	}
+	s.Spec.Template.Spec.SecurityContext = newSecurityContext
+	assert.NoError(t, r.Client.Update(context.TODO(), s))
+	// Reconcile again and check if the SecurityContext is reverted
+	assert.NoError(t, r.reconcileRedisStatefulSet(a))
+	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.Equal(t, true, reflect.DeepEqual(expectedSecurityContext, s.Spec.Template.Spec.SecurityContext))
 
 	// Modify the initcontainer environment variable
 	s.Spec.Template.Spec.Containers[0].Env = append(s.Spec.Template.Spec.InitContainers[0].Env, corev1.EnvVar{


### PR DESCRIPTION
**Description**

After upgrading from GitOps 1.15 to 1.16, the redis service account in GitOps 1.16 is assigned lower SecurityContextConstraints (SCC) and the operator fails to update the securityContext of the redis-ha-server StatefulSet. As a result, the container's user is hardcoded instead of being randomly assigned as required by the restricted-v2 SCC. This prevents the new configuration of the StatefulSet from being applied correctly.
**What type of PR is this?**

**Impact**

The redis-ha-server StatefulSet pods will not be updated with the new settings, causing them to retain old configurations.

**Fixes:**

Ensure the operator updates the securityContext of redis-ha-server/argocd-application-controller StatefulSet after an upgrade.
