### PR TITLE
Add support in appendUniqueArgs to allow flag with multiple values

### DIFF
--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -1035,12 +1035,12 @@ func TestArgoCDApplicationSetCommand(t *testing.T) {
 	wantCmd := []string{
 		"entrypoint.sh",
 		"argocd-applicationset-controller",
-		"--argocd-repo-server",
-		"foo.scv.cluster.local:6379",
 		"--loglevel",
 		"info",
 		"--logformat",
 		"text",
+		"--argocd-repo-server",
+		"foo.scv.cluster.local:6379",
 	}
 
 	deployment := &appsv1.Deployment{}
@@ -1120,6 +1120,10 @@ func TestArgoCDApplicationSetCommand(t *testing.T) {
 		"newvalue",
 		"--newarg", // Duplicate argument passing at once
 		"newvalue",
+		"--arg1", // flag with 2 different vales
+		"value1",
+		"--arg1",
+		"value2",
 	}
 
 	assert.NoError(t, r.reconcileApplicationSetController(a))
@@ -1132,7 +1136,7 @@ func TestArgoCDApplicationSetCommand(t *testing.T) {
 		deployment))
 
 	// Non-duplicate argument "--newarg" should be added, duplicate "--newarg" which is added twice is ignored
-	cmd = append(cmd, "--newarg", "newvalue")
+	cmd = append(cmd, "--newarg", "newvalue", "--arg1", "value1", "--arg1", "value2")
 	assert.Equal(t, cmd, deployment.Spec.Template.Spec.Containers[0].Command)
 }
 

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1427,12 +1427,12 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 		"https://argocd-dex-server.argocd.svc.cluster.local:5556",
 		"--repo-server",
 		"argocd-repo-server.argocd.svc.cluster.local:8081",
-		"--redis",
-		"foo.scv.cluster.local:6379",
 		"--loglevel",
 		"info",
 		"--logformat",
 		"text",
+		"--redis",
+		"foo.scv.cluster.local:6379",
 	}
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
@@ -2515,12 +2515,12 @@ func TestArgoCDRepoServerDeploymentCommand(t *testing.T) {
 	wantCmd := []string{
 		"uid_entrypoint.sh",
 		"argocd-repo-server",
-		"--redis",
-		"foo.scv.cluster.local:6379",
 		"--loglevel",
 		"info",
 		"--logformat",
 		"text",
+		"--redis",
+		"foo.scv.cluster.local:6379",
 	}
 
 	assert.NoError(t, r.reconcileRepoDeployment(a, false))

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -418,6 +418,26 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 		}
 	}
 
+	operationProcesorsChangedResult2 := func(n string) []string {
+		return []string{
+			"argocd-application-controller",
+			"--redis",
+			"argocd-redis.argocd.svc.cluster.local:6379",
+			"--repo-server",
+			"argocd-repo-server.argocd.svc.cluster.local:8081",
+			"--status-processors",
+			"20",
+			"--kubectl-parallelism-limit",
+			"10",
+			"--loglevel",
+			"info",
+			"--logformat",
+			"text",
+			"--operation-processors",
+			n,
+		}
+	}
+
 	parallelismLimitChangedResult := func(n string) []string {
 		return []string{
 			"argocd-application-controller",
@@ -574,13 +594,13 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 		},
 		{
 			"configured extraCommandArgs",
-			[]argoCDOpt{extraCommandArgs([]string{"--app-hard-resync", "--app-resync"})},
-			extraCommandArgsChangedResult([]string{"--app-hard-resync", "--app-resync"}),
+			[]argoCDOpt{extraCommandArgs([]string{"--hydrator-enabled"})},
+			extraCommandArgsChangedResult([]string{"--hydrator-enabled"}),
 		},
 		{
 			"overriding default argument using extraCommandArgs",
 			[]argoCDOpt{extraCommandArgs([]string{"--operation-processors", "15"})},
-			operationProcesorsChangedResult("15"),
+			operationProcesorsChangedResult2("15"),
 		},
 		{
 			"configured empty extraCommandArgs",
@@ -1372,6 +1392,12 @@ func TestAppendUniqueArgs(t *testing.T) {
 			cmd:       []string{"arg1", "arg2"},
 			extraArgs: []string{"arg2", "arg3"},
 			want:      []string{"arg1", "arg2", "arg2", "arg3"},
+		},
+		{
+			name:      "add flag with two different values",
+			cmd:       []string{"arg1", "arg2"},
+			extraArgs: []string{"flag1", "value1", "flag1", "value2"},
+			want:      []string{"arg1", "arg2", "flag1", "value1", "flag1", "value2"},
 		},
 	}
 

--- a/tests/k8s/1-038_validate_controller_extra_command_args/02-add-extraCommandArgs.yaml
+++ b/tests/k8s/1-038_validate_controller_extra_command_args/02-add-extraCommandArgs.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   controller:
     extraCommandArgs:
-    - --app-hard-resync
+    - --hydrator-enabled

--- a/tests/k8s/1-038_validate_controller_extra_command_args/02-assert.yaml
+++ b/tests/k8s/1-038_validate_controller_extra_command_args/02-assert.yaml
@@ -23,4 +23,4 @@ spec:
         - info
         - --logformat
         - text
-        - --app-hard-resync
+        - --hydrator-enabled

--- a/tests/k8s/1-038_validate_controller_extra_command_args/03-errors.yaml
+++ b/tests/k8s/1-038_validate_controller_extra_command_args/03-errors.yaml
@@ -23,4 +23,4 @@ spec:
         - info
         - --logformat
         - text
-        - --app-hard-resync
+        - --hydrator-enabled


### PR DESCRIPTION
**What type of PR is this?**
`appendUniqueArgs` func update
- This function merges two slices of CLI arguments (cmd and extraArgs) while avoiding duplication and ensuring correct override behavior.
It handles the following scenarios:
- Preserves argument order, starting with all args from cmd.
- Flags in cmd are treated as non-repeatable — if the same flag appears in extraArgs, it replaces the one from cmd. (To update the existing flags I have added this logic orelse the multiple values for single flag logic will cause bug here)
- Skips duplicate flag+value pairs if already present.
- Allows repeatable flags with different values, only if the flag is not already in cmd. (flags in cmd are preexisting and is non-repeatable)
- Correctly pairs flags with their values (e.g., --flag value).
- Safely handles flags with no values (e.g., --flag alone). eg - --hydrator-enabled


Fixed and updated unit tests and e2e test to work accordingly


JIRA - https://issues.redhat.com/browse/GITOPS-6703
