### PR TITLE
Fix: Process regular expressions at getSourceNamespaces

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1460,7 +1460,7 @@ func (r *ReconcileArgoCD) getSourceNamespaces(cr *argoproj.ArgoCD) ([]string, er
 	}
 
 	for _, namespace := range namespaces.Items {
-		if glob.MatchStringInList(cr.Spec.SourceNamespaces, namespace.Name, glob.GLOB) {
+		if glob.MatchStringInList(cr.Spec.SourceNamespaces, namespace.Name, glob.REGEXP) {
 			sourceNamespaces = append(sourceNamespaces, namespace.Name)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug 

**What does this PR do / why we need it**:
Updates the  operator code to use new regex option using glob.REGEXP instead of glob.GLOB when processing getSourceNamespaces

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-6675

**How to test changes / Special notes to the reviewer**:
