### PR TITLE
Fix linter warnings including deprecation warning SA1019

### DIFF
--- a/api/v1alpha1/argocd_conversion.go
+++ b/api/v1alpha1/argocd_conversion.go
@@ -61,13 +61,14 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.ExtraConfig = src.Spec.ExtraConfig
 	dst.Spec.GATrackingID = src.Spec.GATrackingID
 	dst.Spec.GAAnonymizeUsers = src.Spec.GAAnonymizeUsers
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	dst.Spec.Grafana = *ConvertAlphaToBetaGrafana(&src.Spec.Grafana)
 	dst.Spec.HA = *ConvertAlphaToBetaHA(&src.Spec.HA)
 	dst.Spec.HelpChatURL = src.Spec.HelpChatURL
 	dst.Spec.HelpChatText = src.Spec.HelpChatText
 	dst.Spec.Image = src.Spec.Image
 	dst.Spec.Import = (*v1beta1.ArgoCDImportSpec)(src.Spec.Import)
+	//lint:ignore SA1019 known to be deprecated
 	dst.Spec.InitialRepositories = src.Spec.InitialRepositories
 	dst.Spec.InitialSSHKnownHosts = v1beta1.SSHHostsSpec(src.Spec.InitialSSHKnownHosts)
 	dst.Spec.KustomizeBuildOptions = src.Spec.KustomizeBuildOptions
@@ -80,6 +81,7 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.RBAC = v1beta1.ArgoCDRBACSpec(src.Spec.RBAC)
 	dst.Spec.Redis = *ConvertAlphaToBetaRedis(&src.Spec.Redis)
 	dst.Spec.Repo = *ConvertAlphaToBetaRepo(&src.Spec.Repo)
+	//lint:ignore SA1019 known to be deprecated
 	dst.Spec.RepositoryCredentials = src.Spec.RepositoryCredentials
 	dst.Spec.ResourceHealthChecks = ConvertAlphaToBetaResourceHealthChecks(src.Spec.ResourceHealthChecks)
 	dst.Spec.ResourceIgnoreDifferences = ConvertAlphaToBetaResourceIgnoreDifferences(src.Spec.ResourceIgnoreDifferences)
@@ -131,13 +133,14 @@ func (dst *ArgoCD) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.ExtraConfig = src.Spec.ExtraConfig
 	dst.Spec.GATrackingID = src.Spec.GATrackingID
 	dst.Spec.GAAnonymizeUsers = src.Spec.GAAnonymizeUsers
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	dst.Spec.Grafana = *ConvertBetaToAlphaGrafana(&src.Spec.Grafana)
 	dst.Spec.HA = *ConvertBetaToAlphaHA(&src.Spec.HA)
 	dst.Spec.HelpChatURL = src.Spec.HelpChatURL
 	dst.Spec.HelpChatText = src.Spec.HelpChatText
 	dst.Spec.Image = src.Spec.Image
 	dst.Spec.Import = (*ArgoCDImportSpec)(src.Spec.Import)
+	//lint:ignore SA1019 known to be deprecated
 	dst.Spec.InitialRepositories = src.Spec.InitialRepositories
 	dst.Spec.InitialSSHKnownHosts = SSHHostsSpec(src.Spec.InitialSSHKnownHosts)
 	dst.Spec.KustomizeBuildOptions = src.Spec.KustomizeBuildOptions
@@ -150,6 +153,7 @@ func (dst *ArgoCD) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.RBAC = ArgoCDRBACSpec(src.Spec.RBAC)
 	dst.Spec.Redis = *ConvertBetaToAlphaRedis(&src.Spec.Redis)
 	dst.Spec.Repo = *ConvertBetaToAlphaRepo(&src.Spec.Repo)
+	//lint:ignore SA1019 known to be deprecated
 	dst.Spec.RepositoryCredentials = src.Spec.RepositoryCredentials
 	dst.Spec.ResourceHealthChecks = ConvertBetaToAlphaResourceHealthChecks(src.Spec.ResourceHealthChecks)
 	dst.Spec.ResourceIgnoreDifferences = ConvertBetaToAlphaResourceIgnoreDifferences(src.Spec.ResourceIgnoreDifferences)

--- a/api/v1alpha1/argocd_conversion_test.go
+++ b/api/v1alpha1/argocd_conversion_test.go
@@ -489,7 +489,7 @@ func TestAlphaToBetaConversion(t *testing.T) {
 						Termination: routev1.TLSTerminationEdge,
 					},
 				}
-				//nolint:staticcheck
+				//lint:ignore SA1019 known to be deprecated
 				cr.Spec.Grafana.Route = v1beta1.ArgoCDRouteSpec{
 					Enabled: true,
 					TLS: &routev1.TLSConfig{

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -45,7 +45,7 @@ func applicationSetDefaultVolumeMounts() []v1.VolumeMount {
 		"argocd-repo-server-tls":              true,
 		common.ArgoCDRedisServerTLSSecretName: true,
 	}
-	mounts := make([]v1.VolumeMount, len(repoMounts)-len(ignoredMounts), len(repoMounts)-len(ignoredMounts))
+	mounts := make([]v1.VolumeMount, len(repoMounts)-len(ignoredMounts))
 	j := 0
 	for _, mount := range repoMounts {
 		if !ignoredMounts[mount.Name] {
@@ -64,7 +64,7 @@ func applicationSetDefaultVolumes() []v1.Volume {
 		"argocd-repo-server-tls":              true,
 		common.ArgoCDRedisServerTLSSecretName: true,
 	}
-	volumes := make([]v1.Volume, len(repoVolumes)-len(ignoredVolumes), len(repoVolumes)-len(ignoredVolumes))
+	volumes := make([]v1.Volume, len(repoVolumes)-len(ignoredVolumes))
 	j := 0
 	for _, volume := range repoVolumes {
 		if !ignoredVolumes[volume.Name] {
@@ -926,9 +926,7 @@ func TestReconcileApplicationSet_Role(t *testing.T) {
 	foundResources := []string{}
 
 	for _, rule := range role.Rules {
-		for _, resource := range rule.Resources {
-			foundResources = append(foundResources, resource)
-		}
+		foundResources = append(foundResources, rule.Resources...)
 	}
 
 	sort.Strings(expectedResources)

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -413,12 +413,12 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 	cm.Data[common.ArgoCDKeyUsersAnonymousEnabled] = fmt.Sprint(cr.Spec.UsersAnonymousEnabled)
 
 	// deprecated: log warning for deprecated field InitialRepositories
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if cr.Spec.InitialRepositories != "" {
 		log.Info(initialRepositoriesWarning)
 	}
 	// deprecated: log warning for deprecated field RepositoryCredential
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if cr.Spec.RepositoryCredentials != "" {
 		log.Info(repositoryCredentialsWarning)
 	}
@@ -506,7 +506,7 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 
 // reconcileGrafanaConfiguration will ensure that the Grafana configuration ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoproj.ArgoCD) error {
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if !cr.Spec.Grafana.Enabled {
 		return nil // Grafana not enabled, do nothing.
 	}
@@ -518,7 +518,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoproj.ArgoCD) err
 
 // reconcileGrafanaDashboards will ensure that the Grafana dashboards ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileGrafanaDashboards(cr *argoproj.ArgoCD) error {
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if !cr.Spec.Grafana.Enabled {
 		return nil // Grafana not enabled, do nothing.
 	}

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -451,7 +451,8 @@ func (r *ReconcileArgoCD) reconcileDeployments(cr *argoproj.ArgoCD, useTLSForRed
 
 // reconcileGrafanaDeployment will ensure the Deployment resource is present for the ArgoCD Grafana component.
 func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoproj.ArgoCD) error {
-	//nolint:staticcheck
+
+	//lint:ignore SA1019 known to be deprecated
 	if !cr.Spec.Grafana.Enabled {
 		return nil // Grafana not enabled, do nothing.
 	}

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -719,6 +719,7 @@ func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
 
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		//lint:ignore SA1019 known to be deprecated
 		a.Spec.Grafana.Enabled = true
 		a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 			Provider: argoproj.SSOProviderTypeDex,

--- a/controllers/argocd/ingress.go
+++ b/controllers/argocd/ingress.go
@@ -286,10 +286,11 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoproj.ArgoCD) er
 func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("grafana", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
-		//nolint:staticcheck
+		//lint:ignore SA1019 known to be deprecated
 		if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Ingress.Enabled {
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
 			var explanation string
+			//lint:ignore SA1019 known to be deprecated
 			if !cr.Spec.Grafana.Enabled {
 				explanation = "grafana is disabled"
 			} else {
@@ -302,7 +303,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoproj.ArgoCD) error {
 		return nil // Ingress found and enabled, do nothing
 	}
 
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Ingress.Enabled {
 		return nil // Grafana itself or Ingress not enabled, move along...
 	}

--- a/controllers/argocd/prometheus_test.go
+++ b/controllers/argocd/prometheus_test.go
@@ -71,7 +71,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 							},
 							Expr: intstr.IntOrString{
 								Type:   intstr.String,
-								StrVal: fmt.Sprintf("kube_statefulset_status_replicas{statefulset=\"%s\", namespace=\"%s\"} != kube_statefulset_status_replicas_ready{statefulset=\"%s\", namespace=\"%s\"} ", fmt.Sprintf(test.argocd.Name+"-application-controller"), test.argocd.Namespace, fmt.Sprintf(test.argocd.Name+"-application-controller"), test.argocd.Namespace),
+								StrVal: fmt.Sprintf("kube_statefulset_status_replicas{statefulset=\"%s\", namespace=\"%s\"} != kube_statefulset_status_replicas_ready{statefulset=\"%s\", namespace=\"%s\"} ", test.argocd.Name+"-application-controller", test.argocd.Namespace, test.argocd.Name+"-application-controller", test.argocd.Namespace),
 							},
 							For: ptr.To((monitoringv1.Duration)("1m")),
 							Labels: map[string]string{
@@ -85,7 +85,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 							},
 							Expr: intstr.IntOrString{
 								Type:   intstr.String,
-								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", fmt.Sprintf(test.argocd.Name+"-server"), test.argocd.Namespace, fmt.Sprintf(test.argocd.Name+"-server"), test.argocd.Namespace),
+								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", test.argocd.Name+"-server", test.argocd.Namespace, test.argocd.Name+"-server", test.argocd.Namespace),
 							},
 							For: ptr.To((monitoringv1.Duration)("1m")),
 							Labels: map[string]string{
@@ -99,7 +99,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 							},
 							Expr: intstr.IntOrString{
 								Type:   intstr.String,
-								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", fmt.Sprintf(test.argocd.Name+"-repo-server"), test.argocd.Namespace, fmt.Sprintf(test.argocd.Name+"-repo-server"), test.argocd.Namespace),
+								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", test.argocd.Name+"-repo-server", test.argocd.Namespace, test.argocd.Name+"-repo-server", test.argocd.Namespace),
 							},
 							For: ptr.To((monitoringv1.Duration)("1m")),
 							Labels: map[string]string{
@@ -113,7 +113,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 							},
 							Expr: intstr.IntOrString{
 								Type:   intstr.String,
-								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", fmt.Sprintf(test.argocd.Name+"-applicationset-controller"), test.argocd.Namespace, fmt.Sprintf(test.argocd.Name+"-applicationset-controller"), test.argocd.Namespace),
+								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", test.argocd.Name+"-applicationset-controller", test.argocd.Namespace, test.argocd.Name+"-applicationset-controller", test.argocd.Namespace),
 							},
 							For: ptr.To((monitoringv1.Duration)("5m")),
 							Labels: map[string]string{
@@ -127,7 +127,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 							},
 							Expr: intstr.IntOrString{
 								Type:   intstr.String,
-								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", fmt.Sprintf(test.argocd.Name+"-dex-server"), test.argocd.Namespace, fmt.Sprintf(test.argocd.Name+"-dex-server"), test.argocd.Namespace),
+								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", test.argocd.Name+"-dex-server", test.argocd.Namespace, test.argocd.Name+"-dex-server", test.argocd.Namespace),
 							},
 							For: ptr.To((monitoringv1.Duration)("5m")),
 							Labels: map[string]string{
@@ -141,7 +141,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 							},
 							Expr: intstr.IntOrString{
 								Type:   intstr.String,
-								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", fmt.Sprintf(test.argocd.Name+"-notifications-controller"), test.argocd.Namespace, fmt.Sprintf(test.argocd.Name+"-notifications-controller"), test.argocd.Namespace),
+								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", test.argocd.Name+"-notifications-controller", test.argocd.Namespace, test.argocd.Name+"-notifications-controller", test.argocd.Namespace),
 							},
 							For: ptr.To((monitoringv1.Duration)("5m")),
 							Labels: map[string]string{
@@ -155,7 +155,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 							},
 							Expr: intstr.IntOrString{
 								Type:   intstr.String,
-								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", fmt.Sprintf(test.argocd.Name+"-redis"), test.argocd.Namespace, fmt.Sprintf(test.argocd.Name+"-redis"), test.argocd.Namespace),
+								StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", test.argocd.Name+"-redis", test.argocd.Namespace, test.argocd.Name+"-redis", test.argocd.Namespace),
 							},
 							For: ptr.To((monitoringv1.Duration)("5m")),
 							Labels: map[string]string{

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -106,7 +106,7 @@ func (r *ReconcileArgoCD) reconcileRoutes(cr *argoproj.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileGrafanaRoute(cr *argoproj.ArgoCD) error {
 	route := newRouteWithSuffix("grafana", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route) {
-		//nolint:staticcheck
+		//lint:ignore SA1019 known to be deprecated
 		if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Route.Enabled {
 			// Route exists but enabled flag has been set to false, delete the Route
 			argoutil.LogResourceDeletion(log, route, "grafana or grafana route is disabled")
@@ -116,7 +116,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaRoute(cr *argoproj.ArgoCD) error {
 		return nil // Route found, do nothing
 	}
 
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Route.Enabled {
 		return nil // Grafana itself or Route not enabled, do nothing.
 	}

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -125,7 +125,7 @@ func newCertificateSecret(suffix string, caCert *x509.Certificate, caKey *rsa.Pr
 		fmt.Sprintf("%s.%s.svc.cluster.local", cr.ObjectMeta.Name, cr.ObjectMeta.Namespace),
 	}
 
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if cr.Spec.Grafana.Enabled {
 		log.Info(grafanaDeprecatedWarning)
 	}
@@ -381,7 +381,7 @@ func (r *ReconcileArgoCD) reconcileExistingArgoSecret(cr *argoproj.ArgoCD, secre
 
 // reconcileGrafanaSecret will ensure that the Grafana Secret is present.
 func (r *ReconcileArgoCD) reconcileGrafanaSecret(cr *argoproj.ArgoCD) error {
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if !cr.Spec.Grafana.Enabled {
 		return nil // Grafana not enabled, do nothing.
 	}

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -71,7 +71,7 @@ func newServiceWithSuffix(suffix string, component string, cr *argoproj.ArgoCD) 
 func (r *ReconcileArgoCD) reconcileGrafanaService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("grafana", "grafana", cr)
 	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
-		//nolint:staticcheck
+		//lint:ignore SA1019 known to be deprecated
 		if !cr.Spec.Grafana.Enabled {
 			// Service exists but enabled flag has been set to false, delete the Service
 			argoutil.LogResourceDeletion(log, svc, "grafana is disabled")
@@ -81,7 +81,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaService(cr *argoproj.ArgoCD) error {
 		return nil // Service found, do nothing
 	}
 
-	//nolint:staticcheck
+	//lint:ignore SA1019 known to be deprecated
 	if !cr.Spec.Grafana.Enabled {
 		return nil // Grafana not enabled, do nothing.
 	}

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -306,7 +306,7 @@ func (r *ReconcileArgoCDExport) argocdName(namespace string) (string, error) {
 		return "", err
 	}
 	if len(argocds.Items) != 1 {
-		return "", fmt.Errorf("No Argo CD instance found in namespace %s", namespace)
+		return "", fmt.Errorf("no Argo CD instance found in namespace %s", namespace)
 	}
 	argocd := argocds.Items[0]
 	return argocd.Name, nil

--- a/controllers/notificationsconfiguration/configmap.go
+++ b/controllers/notificationsconfiguration/configmap.go
@@ -70,7 +70,7 @@ func (r *NotificationsConfigurationReconciler) reconcileNotificationsConfigmap(c
 	// check context separately as converting context map to string produce different string due to random serialization of map value
 	changed := checkIfContextChanged(cr, NotificationsConfigMap)
 
-	for k, _ := range expectedConfiguration {
+	for k := range expectedConfiguration {
 		if !reflect.DeepEqual(expectedConfiguration[k], NotificationsConfigMap.Data[k]) && k != "context" {
 			changed = true
 		}

--- a/controllers/suite_testx.go
+++ b/controllers/suite_testx.go
@@ -19,8 +19,8 @@ package controllers
 import (
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo" //lint:ignore ST1001 Allowed for ginkgo
+	. "github.com/onsi/gomega" //lint:ignore ST1001 Allowed for gomega
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
- This PR fixes a number of warnings within the argocd-operator codebase.
- The main one being 'SA1019', which is reported against our own deprecated APIs.
    - We were previously using `//nolint:staticcheck` for this, but `//lint:ignore SA1019 known to be deprecated` appears to be more effective
    - Let me know if this differs for you in your IDE of choice (I tested from VS Code)
- Also fixed ginkgo import warning, sprintf warning, and more.

