### PR TITLE
IsObjectFound function should not bury unexpected errors

### DIFF
--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -159,17 +159,22 @@ func checkExpectedDeploymentValues(t *testing.T, r *ReconcileArgoCD, deployment 
 		},
 	}
 
-	if a.Spec.ApplicationSet.SCMRootCAConfigMap != "" && argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a) {
-		volumes = append(volumes, v1.Volume{
-			Name: "appset-gitlab-scm-tls-cert",
-			VolumeSource: v1.VolumeSource{
-				ConfigMap: &v1.ConfigMapVolumeSource{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName,
+	if a.Spec.ApplicationSet.SCMRootCAConfigMap != "" {
+
+		exists, err := argoutil.IsObjectFound(r.Client, a.Namespace, common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName, a)
+		assert.Nil(t, err)
+		if exists {
+			volumes = append(volumes, v1.Volume{
+				Name: "appset-gitlab-scm-tls-cert",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: common.ArgoCDAppSetGitlabSCMTLSCertsConfigMapName,
+						},
 					},
 				},
-			},
-		})
+			})
+		}
 	}
 
 	if extraVolumes != nil {

--- a/controllers/argocd/argocd_controller_test.go
+++ b/controllers/argocd/argocd_controller_test.go
@@ -356,7 +356,9 @@ func TestReconcileArgoCD_CleanUp(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
-			if argoutil.IsObjectFound(r.Client, "", test.name, test.resource) {
+			found, err := argoutil.IsObjectFound(r.Client, "", test.name, test.resource)
+			assert.Nil(t, err)
+			if found {
 				t.Errorf("Expected %s to be deleted", test.name)
 			}
 		})

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -132,20 +132,27 @@ func TestReconcileArgoCD_reconcileRedisHAHealthConfigMap(t *testing.T) {
 
 	// Modify ConfigMap data to simulate external changes
 	existingCM := &corev1.ConfigMap{}
-	assert.True(t, argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAHealthConfigMapName, existingCM))
+
+	exists, err := argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAHealthConfigMapName, existingCM)
+	assert.Nil(t, err)
+	assert.True(t, exists)
 	existingCM.Data["redis_liveness.sh"] = "modified_script_content"
 	assert.NoError(t, cl.Update(context.TODO(), existingCM))
 
 	// Reconcile again and verify changes are reverted
 	assert.NoError(t, r.reconcileRedisHAHealthConfigMap(cr, false))
 	existingCMAfter := &corev1.ConfigMap{}
-	assert.True(t, argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAHealthConfigMapName, existingCMAfter))
+	exists, err = argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAHealthConfigMapName, existingCMAfter)
+	assert.True(t, exists)
+	assert.Nil(t, err)
 	assert.Equal(t, getRedisLivenessScript(false), existingCMAfter.Data["redis_liveness.sh"])
 
 	// Disable HA and ensure ConfigMap is deleted
 	cr.Spec.HA.Enabled = false
 	assert.NoError(t, r.reconcileRedisHAHealthConfigMap(cr, false))
-	assert.False(t, argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAHealthConfigMapName, existingCM))
+	exists, err = argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAHealthConfigMapName, existingCM)
+	assert.Nil(t, err)
+	assert.False(t, exists)
 }
 
 // TestReconcileArgoCD_reconcileRedisHAConfigMap tests the reconcileRedisHAConfigMap function.
@@ -169,20 +176,26 @@ func TestReconcileArgoCD_reconcileRedisHAConfigMap(t *testing.T) {
 
 	// Modify ConfigMap data to simulate external changes
 	existingCM := &corev1.ConfigMap{}
-	assert.True(t, argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAConfigMapName, existingCM))
+	exists, err := argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAConfigMapName, existingCM)
+	assert.Nil(t, err)
+	assert.True(t, exists)
 	existingCM.Data["haproxy.cfg"] = "modified_config_content"
 	assert.NoError(t, cl.Update(context.TODO(), existingCM))
 
 	// Reconcile again and verify changes are reverted
 	assert.NoError(t, r.reconcileRedisHAConfigMap(cr, false))
 	existingCMAfter := &corev1.ConfigMap{}
-	assert.True(t, argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAConfigMapName, existingCMAfter))
+	exists, err = argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAConfigMapName, existingCMAfter)
+	assert.Nil(t, err)
+	assert.True(t, exists)
 	assert.Equal(t, getRedisHAProxyConfig(cr, false), existingCMAfter.Data["haproxy.cfg"])
 
 	// Disable HA and ensure ConfigMap is deleted
 	cr.Spec.HA.Enabled = false
 	assert.NoError(t, r.reconcileRedisHAConfigMap(cr, false))
-	assert.False(t, argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAConfigMapName, existingCM))
+	exists, err = argoutil.IsObjectFound(cl, cr.Namespace, common.ArgoCDRedisHAConfigMapName, existingCM)
+	assert.Nil(t, err)
+	assert.False(t, exists)
 }
 
 func TestReconcileArgoCD_reconcileTLSCerts_withInitialCertsUpdate(t *testing.T) {

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -129,7 +129,11 @@ func (r *ReconcileArgoCD) reconcileDexConfiguration(cm *corev1.ConfigMap, cr *ar
 
 		// Trigger rollout of Dex Deployment to pick up changes.
 		deploy := newDeploymentWithSuffix("dex-server", "dex-server", cr)
-		if !argoutil.IsObjectFound(r.Client, deploy.Namespace, deploy.Name, deploy) {
+		deplExists, err := argoutil.IsObjectFound(r.Client, deploy.Namespace, deploy.Name, deploy)
+		if err != nil {
+			return err
+		}
+		if !deplExists {
 			log.Info("unable to locate dex deployment")
 			return nil
 		}
@@ -150,6 +154,11 @@ func (r *ReconcileArgoCD) getOpenShiftDexConfig(cr *argoproj.ArgoCD) (string, er
 		groups = cr.Spec.SSO.Dex.Groups
 	}
 
+	redirectURI, err := r.getDexOAuthRedirectURI(cr)
+	if err != nil {
+		return "", err
+	}
+
 	connector := DexConnector{
 		Type: "openshift",
 		ID:   "openshift",
@@ -158,7 +167,7 @@ func (r *ReconcileArgoCD) getOpenShiftDexConfig(cr *argoproj.ArgoCD) (string, er
 			"issuer":       "https://kubernetes.default.svc", // TODO: Should this be hard-coded?
 			"clientID":     getDexOAuthClientID(cr),
 			"clientSecret": "$oidc.dex.clientSecret",
-			"redirectURI":  r.getDexOAuthRedirectURI(cr),
+			"redirectURI":  redirectURI,
 			"insecureCA":   true, // TODO: Configure for openshift CA,
 			"groups":       groups,
 		},
@@ -211,7 +220,10 @@ func (r *ReconcileArgoCD) reconcileDexServiceAccount(cr *argoproj.ArgoCD) error 
 	}
 
 	// Get the OAuth redirect URI that should be used.
-	uri := r.getDexOAuthRedirectURI(cr)
+	uri, err := r.getDexOAuthRedirectURI(cr)
+	if err != nil {
+		return err
+	}
 	log.Info(fmt.Sprintf("URI: %s", uri))
 
 	// Get the current redirect URI
@@ -353,7 +365,11 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoproj.ArgoCD) error {
 	}
 
 	existing := newDeploymentWithSuffix("dex-server", "dex-server", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, existing.Name, existing) {
+	deplExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, existing.Name, existing)
+	if err != nil {
+		return err
+	}
+	if deplExists {
 
 		// dex uninstallation requested
 		if !UseDex(cr) {
@@ -470,7 +486,12 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoproj.ArgoCD) error {
 // reconcileDexService will ensure that the Service for Dex is present.
 func (r *ReconcileArgoCD) reconcileDexService(cr *argoproj.ArgoCD) error {
 	svc := newServiceWithSuffix("dex-server", "dex-server", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
+
+	svcExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc)
+	if err != nil {
+		return err
+	}
+	if svcExists {
 
 		// dex uninstallation requested
 		if !UseDex(cr) {
@@ -584,7 +605,11 @@ func (r *ReconcileArgoCD) deleteDexResources(cr *argoproj.ArgoCD) error {
 	// since reconcileArgoConfigMap won't call reconcileDexConfiguration once dex has been disabled (to avoid reconciling on
 	// dexconfig unnecessarily when it isn't enabled)
 	cm := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm) {
+	cmExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm)
+	if err != nil {
+		return err
+	}
+	if cmExists {
 		if err := r.reconcileDexConfiguration(cm, cr); err != nil {
 			log.Error(err, "error reconciling dex configuration in configmap")
 		}

--- a/controllers/argocd/dexUtil.go
+++ b/controllers/argocd/dexUtil.go
@@ -52,9 +52,12 @@ func getDexContainerImage(cr *argoproj.ArgoCD) string {
 }
 
 // getDexOAuthRedirectURI will return the OAuth redirect URI for the Dex server.
-func (r *ReconcileArgoCD) getDexOAuthRedirectURI(cr *argoproj.ArgoCD) string {
-	uri := r.getArgoServerURI(cr)
-	return uri + common.ArgoCDDefaultDexOAuthRedirectPath
+func (r *ReconcileArgoCD) getDexOAuthRedirectURI(cr *argoproj.ArgoCD) (string, error) {
+	uri, err := r.getArgoServerURI(cr)
+	if err != nil {
+		return "", err
+	}
+	return uri + common.ArgoCDDefaultDexOAuthRedirectPath, nil
 }
 
 // getDexOAuthClientID will return the OAuth client ID for the given ArgoCD.

--- a/controllers/argocd/hpa.go
+++ b/controllers/argocd/hpa.go
@@ -73,7 +73,11 @@ func (r *ReconcileArgoCD) reconcileServerHPA(cr *argoproj.ArgoCD) error {
 	}
 
 	existingHPA := newHorizontalPodAutoscalerWithSuffix("server", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, existingHPA.Name, existingHPA) {
+	hpaExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, existingHPA.Name, existingHPA)
+	if err != nil {
+		return err
+	}
+	if hpaExists {
 		if !cr.Spec.Server.Autoscale.Enabled {
 			argoutil.LogResourceDeletion(log, existingHPA, "server autoscaling is disabled")
 			return r.Client.Delete(context.TODO(), existingHPA) // HorizontalPodAutoscaler found but globally disabled, delete it.

--- a/controllers/argocd/ingress.go
+++ b/controllers/argocd/ingress.go
@@ -94,7 +94,11 @@ func (r *ReconcileArgoCD) reconcileIngresses(cr *argoproj.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("server", cr)
 	existingIngress := newIngressWithSuffix("server", cr)
-	objectFound := argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, existingIngress)
+
+	objectFound, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, existingIngress)
+	if err != nil {
+		return err
+	}
 
 	if !cr.Spec.Server.Ingress.Enabled {
 		if objectFound {
@@ -208,7 +212,12 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoproj.ArgoCD) error 
 // reconcileArgoServerGRPCIngress will ensure that the ArgoCD Server GRPC Ingress is present.
 func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("grpc", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
+
+	ingressExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress)
+	if err != nil {
+		return err
+	}
+	if ingressExists {
 		if !cr.Spec.Server.GRPC.Ingress.Enabled {
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
 			argoutil.LogResourceDeletion(log, ingress, "server grpc ingress is disabled")
@@ -285,7 +294,11 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoproj.ArgoCD) er
 // reconcileGrafanaIngress will ensure that the ArgoCD Server GRPC Ingress is present.
 func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("grafana", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
+	ingressExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress)
+	if err != nil {
+		return err
+	}
+	if ingressExists {
 		//lint:ignore SA1019 known to be deprecated
 		if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Ingress.Enabled {
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
@@ -316,7 +329,11 @@ func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoproj.ArgoCD) error {
 // reconcilePrometheusIngress will ensure that the Prometheus Ingress is present.
 func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("prometheus", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
+	ingressExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress)
+	if err != nil {
+		return err
+	}
+	if ingressExists {
 		if !cr.Spec.Prometheus.Enabled || !cr.Spec.Prometheus.Ingress.Enabled {
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
 			var explanation string
@@ -398,7 +415,11 @@ func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoproj.ArgoCD) error 
 // reconcileApplicationSetControllerIngress will ensure that the ApplicationSetController Ingress is present.
 func (r *ReconcileArgoCD) reconcileApplicationSetControllerIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix(common.ApplicationSetServiceNameSuffix, cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
+	ingressExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress)
+	if err != nil {
+		return err
+	}
+	if ingressExists {
 		if cr.Spec.ApplicationSet == nil || !cr.Spec.ApplicationSet.WebhookServer.Ingress.Enabled {
 			var explanation string
 			if cr.Spec.ApplicationSet == nil {

--- a/controllers/argocd/networkpolicies.go
+++ b/controllers/argocd/networkpolicies.go
@@ -115,7 +115,11 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 		},
 	}
 
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, existing.Name, existing) {
+	npExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, existing.Name, existing)
+	if err != nil {
+		return err
+	}
+	if npExists {
 
 		modified := false
 		explanation := ""
@@ -162,8 +166,7 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 	}
 
 	argoutil.LogResourceCreation(log, networkPolicy)
-	err := r.Client.Create(context.TODO(), networkPolicy)
-	if err != nil {
+	if err := r.Create(context.TODO(), networkPolicy); err != nil {
 		log.Error(err, "Failed to create redis network policy")
 		return fmt.Errorf("failed to create redis network policy. error: %w", err)
 	}
@@ -237,7 +240,11 @@ func (r *ReconcileArgoCD) ReconcileRedisHANetworkPolicy(cr *argoproj.ArgoCD) err
 		},
 	}
 
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, existing.Name, existing) {
+	npExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, existing.Name, existing)
+	if err != nil {
+		return err
+	}
+	if npExists {
 
 		modified := false
 		explanation := ""
@@ -284,8 +291,8 @@ func (r *ReconcileArgoCD) ReconcileRedisHANetworkPolicy(cr *argoproj.ArgoCD) err
 	}
 
 	argoutil.LogResourceCreation(log, networkPolicy)
-	err := r.Client.Create(context.TODO(), networkPolicy)
-	if err != nil {
+
+	if err := r.Create(context.TODO(), networkPolicy); err != nil {
 		log.Error(err, "Failed to create redis ha network policy")
 		return fmt.Errorf("failed to create redis ha network policy. error: %w", err)
 	}

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -570,7 +570,11 @@ func (r *ReconcileArgoCD) reconcileNotificationsMetricsService(cr *argoproj.Argo
 	var suffix = "notifications-controller-metrics"
 
 	svc := newServiceWithSuffix(suffix, component, cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc) {
+	svcExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, svc.Name, svc)
+	if err != nil {
+		return err
+	}
+	if svcExists {
 		// Service found, do nothing
 		return nil
 	}
@@ -598,9 +602,17 @@ func (r *ReconcileArgoCD) reconcileNotificationsMetricsService(cr *argoproj.Argo
 // reconcileNotificationsServiceMonitor will ensure that the ServiceMonitor for the Notifications controller metrics is present.
 func (r *ReconcileArgoCD) reconcileNotificationsServiceMonitor(cr *argoproj.ArgoCD) error {
 
+	if !IsPrometheusAPIAvailable() {
+		return nil
+	}
+
 	name := fmt.Sprintf("%s-%s", cr.Name, "notifications-controller-metrics")
 	serviceMonitor := newServiceMonitorWithName(name, cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, serviceMonitor.Name, serviceMonitor) {
+	smExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, serviceMonitor.Name, serviceMonitor)
+	if err != nil {
+		return err
+	}
+	if smExists {
 		// Service found, do nothing
 		return nil
 	}

--- a/controllers/argocd/prometheus.go
+++ b/controllers/argocd/prometheus.go
@@ -128,7 +128,11 @@ func newServiceMonitorWithSuffix(suffix string, cr *argoproj.ArgoCD) *monitoring
 // reconcileMetricsServiceMonitor will ensure that the ServiceMonitor is present for the ArgoCD metrics Service.
 func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoproj.ArgoCD) error {
 	sm := newServiceMonitorWithSuffix(common.ArgoCDKeyMetrics, cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm) {
+	smExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm)
+	if err != nil {
+		return err
+	}
+	if smExists {
 		if !cr.Spec.Prometheus.Enabled {
 			// ServiceMonitor exists but enabled flag has been set to false, delete the ServiceMonitor
 			argoutil.LogResourceDeletion(log, sm, "prometheus is disabled")
@@ -162,7 +166,11 @@ func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoproj.ArgoCD) er
 // reconcilePrometheus will ensure that Prometheus is present for ArgoCD metrics.
 func (r *ReconcileArgoCD) reconcilePrometheus(cr *argoproj.ArgoCD) error {
 	prometheus := newPrometheus(cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, prometheus.Name, prometheus) {
+	prExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, prometheus.Name, prometheus)
+	if err != nil {
+		return err
+	}
+	if prExists {
 		if !cr.Spec.Prometheus.Enabled {
 			// Prometheus exists but enabled flag has been set to false, delete the Prometheus
 			argoutil.LogResourceDeletion(log, prometheus, "prometheus is disabled")
@@ -194,7 +202,11 @@ func (r *ReconcileArgoCD) reconcilePrometheus(cr *argoproj.ArgoCD) error {
 // reconcileRepoServerServiceMonitor will ensure that the ServiceMonitor is present for the Repo Server metrics Service.
 func (r *ReconcileArgoCD) reconcileRepoServerServiceMonitor(cr *argoproj.ArgoCD) error {
 	sm := newServiceMonitorWithSuffix("repo-server-metrics", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm) {
+	smExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm)
+	if err != nil {
+		return err
+	}
+	if smExists {
 		if !cr.Spec.Prometheus.Enabled {
 			// ServiceMonitor exists but enabled flag has been set to false, delete the ServiceMonitor
 			argoutil.LogResourceDeletion(log, sm, "prometheus is disabled")
@@ -228,7 +240,11 @@ func (r *ReconcileArgoCD) reconcileRepoServerServiceMonitor(cr *argoproj.ArgoCD)
 // reconcileServerMetricsServiceMonitor will ensure that the ServiceMonitor is present for the ArgoCD Server metrics Service.
 func (r *ReconcileArgoCD) reconcileServerMetricsServiceMonitor(cr *argoproj.ArgoCD) error {
 	sm := newServiceMonitorWithSuffix("server-metrics", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm) {
+	smExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, sm.Name, sm)
+	if err != nil {
+		return err
+	}
+	if smExists {
 		if !cr.Spec.Prometheus.Enabled {
 			// ServiceMonitor exists but enabled flag has been set to false, delete the ServiceMonitor
 			argoutil.LogResourceDeletion(log, sm, "prometheus is disabled")
@@ -264,7 +280,12 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 
 	promRule := newPrometheusRule(cr.Namespace, "argocd-component-status-alert")
 
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, promRule.Name, promRule) {
+	prExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, promRule.Name, promRule)
+	if err != nil {
+		return err
+	}
+
+	if prExists {
 
 		if !cr.Spec.Monitoring.Enabled {
 			// PrometheusRule exists but enabled flag has been set to false, delete the PrometheusRule

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -108,7 +108,11 @@ func (r *ReconcileArgoCD) reconcileRoutes(cr *argoproj.ArgoCD) error {
 // reconcileGrafanaRoute will ensure that the ArgoCD Grafana Route is present.
 func (r *ReconcileArgoCD) reconcileGrafanaRoute(cr *argoproj.ArgoCD) error {
 	route := newRouteWithSuffix("grafana", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route) {
+	rExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)
+	if err != nil {
+		return err
+	}
+	if rExists {
 		//lint:ignore SA1019 known to be deprecated
 		if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Route.Enabled {
 			// Route exists but enabled flag has been set to false, delete the Route
@@ -132,7 +136,11 @@ func (r *ReconcileArgoCD) reconcileGrafanaRoute(cr *argoproj.ArgoCD) error {
 // reconcilePrometheusRoute will ensure that the ArgoCD Prometheus Route is present.
 func (r *ReconcileArgoCD) reconcilePrometheusRoute(cr *argoproj.ArgoCD) error {
 	route := newRouteWithSuffix("prometheus", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route) {
+	rExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)
+	if err != nil {
+		return err
+	}
+	if rExists {
 		if !cr.Spec.Prometheus.Enabled || !cr.Spec.Prometheus.Route.Enabled {
 			// Route exists but enabled flag has been set to false, delete the Route
 			var explanation string
@@ -201,7 +209,10 @@ func (r *ReconcileArgoCD) reconcilePrometheusRoute(cr *argoproj.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoproj.ArgoCD) error {
 
 	route := newRouteWithSuffix("server", cr)
-	found := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)
+	found, err := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)
+	if err != nil {
+		return err
+	}
 	if found {
 		if !cr.Spec.Server.Route.Enabled {
 			// Route exists but enabled flag has been set to false, delete the Route
@@ -255,7 +266,10 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoproj.ArgoCD) error {
 		}
 
 		tlsSecret := &corev1.Secret{}
-		isTLSSecretFound := argoutil.IsObjectFound(r.Client, cr.Namespace, common.ArgoCDServerTLSSecretName, tlsSecret)
+		isTLSSecretFound, err := argoutil.IsObjectFound(r.Client, cr.Namespace, common.ArgoCDServerTLSSecretName, tlsSecret)
+		if err != nil {
+			return err
+		}
 		// Since Passthrough was the default policy in the previous versions of the operator, we don't want to
 		// break users who have already configured a TLS secret for Passthrough.
 		// We continue with Passthrough if we find a TLS secret that was manually configured
@@ -336,7 +350,11 @@ func (r *ReconcileArgoCD) reconcileApplicationSetControllerWebhookRoute(cr *argo
 	}
 	route := newRouteWithName(baseName, cr)
 
-	found := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)
+	found, err := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)
+	if err != nil {
+		return err
+	}
+
 	if found {
 		if cr.Spec.ApplicationSet == nil || !cr.Spec.ApplicationSet.WebhookServer.Route.Enabled {
 			// Route exists but enabled flag has been set to false, delete the Route

--- a/controllers/argocd/service_test.go
+++ b/controllers/argocd/service_test.go
@@ -30,14 +30,16 @@ func TestEnsureAutoTLSAnnotation(t *testing.T) {
 		svc := newService(a)
 
 		// Annotation is inserted, update is required
-		needUpdate := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
+		needUpdate, err := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
+		assert.Nil(t, err)
 		assert.Equal(t, needUpdate, true)
 		atls, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
 		assert.Equal(t, ok, true)
 		assert.Equal(t, atls, "some-secret")
 
 		// Annotation already set, doesn't need update
-		needUpdate = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
+		needUpdate, err = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
+		assert.Nil(t, err)
 		assert.Equal(t, needUpdate, false)
 	})
 	t.Run("Ensure annotation will be unset for OpenShift", func(t *testing.T) {
@@ -47,19 +49,22 @@ func TestEnsureAutoTLSAnnotation(t *testing.T) {
 		svc.Annotations[common.AnnotationOpenShiftServiceCA] = "some-secret"
 
 		// Annotation getting removed, update required
-		needUpdate := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
+		needUpdate, err := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
+		assert.Nil(t, err)
 		assert.Equal(t, needUpdate, true)
 		_, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
 		assert.Equal(t, ok, false)
 
 		// Annotation does not exist, no update required
-		needUpdate = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
+		needUpdate, err = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
+		assert.Nil(t, err)
 		assert.Equal(t, needUpdate, false)
 	})
 	t.Run("Ensure annotation will not be set for non-OpenShift", func(t *testing.T) {
 		routeAPIFound = false
 		svc := newService(a)
-		needUpdate := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
+		needUpdate, err := ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", true)
+		assert.Nil(t, err)
 		assert.Equal(t, needUpdate, false)
 		_, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
 		assert.Equal(t, ok, false)
@@ -75,13 +80,15 @@ func TestEnsureAutoTLSAnnotation(t *testing.T) {
 		}
 		err := fakeClient.Create(context.Background(), secret)
 		assert.NoError(t, err)
-		needUpdate := ensureAutoTLSAnnotation(fakeClient, svc, secret.Name, true)
+		needUpdate, err := ensureAutoTLSAnnotation(fakeClient, svc, secret.Name, true)
+		assert.Nil(t, err)
 		assert.Equal(t, needUpdate, false)
 		_, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
 		assert.Equal(t, ok, false)
 
 		// Annotation does not exist, no update required
-		needUpdate = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
+		needUpdate, err = ensureAutoTLSAnnotation(fakeClient, svc, "some-secret", false)
+		assert.Nil(t, err)
 		assert.Equal(t, needUpdate, false)
 	})
 }

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -79,7 +79,11 @@ func (r *ReconcileArgoCD) reconcileStatusApplicationController(cr *argoproj.Argo
 	status := "Unknown"
 
 	ss := newStatefulSetWithSuffix("application-controller", "application-controller", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, ss.Name, ss) {
+	ssExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ss.Name, ss)
+	if err != nil {
+		return err
+	}
+	if ssExists {
 		status = "Pending"
 
 		if ss.Spec.Replicas != nil {
@@ -101,7 +105,11 @@ func (r *ReconcileArgoCD) reconcileStatusDex(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("dex-server", "dex-server", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy) {
+	deplExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy)
+	if err != nil {
+		return err
+	}
+	if deplExists {
 		status = "Pending"
 
 		if deploy.Spec.Replicas != nil {
@@ -139,7 +147,11 @@ func (r *ReconcileArgoCD) reconcileStatusKeycloak(cr *argoproj.ArgoCD) error {
 				Namespace: cr.Namespace,
 			},
 		}
-		if argoutil.IsObjectFound(r.Client, cr.Namespace, dc.Name, dc) {
+		dcExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, dc.Name, dc)
+		if err != nil {
+			return err
+		}
+		if dcExists {
 			status = "Pending"
 
 			if dc.Status.ReadyReplicas == dc.Spec.Replicas {
@@ -157,7 +169,11 @@ func (r *ReconcileArgoCD) reconcileStatusKeycloak(cr *argoproj.ArgoCD) error {
 
 	} else {
 		d := newDeploymentWithName(defaultKeycloakIdentifier, defaultKeycloakIdentifier, cr)
-		if argoutil.IsObjectFound(r.Client, cr.Namespace, d.Name, d) {
+		deplExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, d.Name, d)
+		if err != nil {
+			return err
+		}
+		if deplExists {
 			status = "Pending"
 
 			if d.Spec.Replicas != nil {
@@ -190,7 +206,11 @@ func (r *ReconcileArgoCD) reconcileStatusApplicationSetController(cr *argoproj.A
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("applicationset-controller", "controller", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy) {
+	deplExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy)
+	if err != nil {
+		return err
+	}
+	if deplExists {
 		status = "Pending"
 
 		if deploy.Spec.Replicas != nil {
@@ -267,7 +287,11 @@ func (r *ReconcileArgoCD) reconcileStatusRedis(cr *argoproj.ArgoCD) error {
 
 	if !cr.Spec.HA.Enabled {
 		deploy := newDeploymentWithSuffix("redis", "redis", cr)
-		if argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy) {
+		deplExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy)
+		if err != nil {
+			return err
+		}
+		if deplExists {
 			status = "Pending"
 
 			if deploy.Spec.Replicas != nil {
@@ -286,7 +310,11 @@ func (r *ReconcileArgoCD) reconcileStatusRedis(cr *argoproj.ArgoCD) error {
 		}
 	} else {
 		ss := newStatefulSetWithSuffix("redis-ha-server", "redis-ha-server", cr)
-		if argoutil.IsObjectFound(r.Client, cr.Namespace, ss.Name, ss) {
+		ssExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ss.Name, ss)
+		if err != nil {
+			return err
+		}
+		if ssExists {
 			status = "Pending"
 
 			if ss.Status.ReadyReplicas == *ss.Spec.Replicas {
@@ -308,7 +336,11 @@ func (r *ReconcileArgoCD) reconcileStatusRepo(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("repo-server", "repo-server", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy) {
+	deplExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy)
+	if err != nil {
+		return err
+	}
+	if deplExists {
 		status = "Pending"
 
 		if deploy.Spec.Replicas != nil {
@@ -338,7 +370,11 @@ func (r *ReconcileArgoCD) reconcileStatusServer(cr *argoproj.ArgoCD) error {
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("server", "server", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy) {
+	deplExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy)
+	if err != nil {
+		return err
+	}
+	if deplExists {
 		status = "Pending"
 
 		// TODO: Refactor these checks.
@@ -369,7 +405,11 @@ func (r *ReconcileArgoCD) reconcileStatusNotifications(cr *argoproj.ArgoCD) erro
 	status := "Unknown"
 
 	deploy := newDeploymentWithSuffix("notifications-controller", "controller", cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy) {
+	deplExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, deploy.Name, deploy)
+	if err != nil {
+		return err
+	}
+	if deplExists {
 		status = "Pending"
 
 		if deploy.Spec.Replicas != nil {
@@ -454,7 +494,11 @@ func (r *ReconcileArgoCD) reconcileStatusHost(cr *argoproj.ArgoCD) error {
 		}
 	} else if cr.Spec.Server.Ingress.Enabled {
 		ingress := newIngressWithSuffix("server", cr)
-		if !argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress) {
+		ingressExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ingress.Name, ingress)
+		if err != nil {
+			return err
+		}
+		if !ingressExists {
 			log.Info("argocd-server ingress requested but not found on cluster")
 			cr.Status.Phase = "Pending"
 			return nil

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -268,7 +268,8 @@ func TestGetArgoServerURI(t *testing.T) {
 			cr := makeTestArgoCD(tt.opts...)
 			r := &ReconcileArgoCD{}
 			setRouteAPIFound(t, tt.routeEnabled)
-			result := r.getArgoServerURI(cr)
+			result, err := r.getArgoServerURI(cr)
+			assert.Nil(t, err)
 			if result != tt.want {
 				t.Errorf("%s test failed, got=%q want=%q", tt.name, result, tt.want)
 			}

--- a/controllers/argocdexport/export.go
+++ b/controllers/argocdexport/export.go
@@ -66,7 +66,11 @@ func (r *ReconcileArgoCDExport) reconcileExportSecret(cr *argoprojv1alpha1.ArgoC
 	a := &argoproj.ArgoCD{}
 	a.ObjectMeta = cr.ObjectMeta
 	secret := argoutil.NewSecretWithName(a, name)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, name, secret) {
+	secretExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, name, secret)
+	if err != nil {
+		return err
+	}
+	if secretExists {
 		backupKey := secret.Data[common.ArgoCDKeyBackupKey]
 		if len(backupKey) <= 0 {
 			backupKey, err := generateBackupKey()

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -238,7 +238,11 @@ func (r *ReconcileArgoCDExport) reconcileCronJob(cr *argoproj.ArgoCDExport) erro
 	}
 
 	cj := newCronJob(cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, cj.Name, cj) {
+	cjExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, cj.Name, cj)
+	if err != nil {
+		return err
+	}
+	if cjExists {
 		if *cr.Spec.Schedule != cj.Spec.Schedule {
 			cj.Spec.Schedule = *cr.Spec.Schedule
 			argoutil.LogResourceUpdate(log, cj, "updating the schedule")
@@ -275,7 +279,11 @@ func (r *ReconcileArgoCDExport) reconcileJob(cr *argoproj.ArgoCDExport) error {
 	}
 
 	job := newJob(cr)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, job.Name, job) {
+	jobExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, job.Name, job)
+	if err != nil {
+		return err
+	}
+	if jobExists {
 		if job.Status.Succeeded > 0 && cr.Status.Phase != common.ArgoCDStatusCompleted {
 			// Mark status Phase as Complete
 			cr.Status.Phase = common.ArgoCDStatusCompleted

--- a/controllers/argocdexport/local.go
+++ b/controllers/argocdexport/local.go
@@ -46,7 +46,11 @@ func (r *ReconcileArgoCDExport) reconcilePVC(cr *argoproj.ArgoCDExport) error {
 	}
 
 	pvc := argoutil.NewPersistentVolumeClaim(cr.ObjectMeta)
-	if argoutil.IsObjectFound(r.Client, cr.Namespace, pvc.Name, pvc) {
+	pvcExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, pvc.Name, pvc)
+	if err != nil {
+		return err
+	}
+	if pvcExists {
 		return nil // PVC exists, move along...
 	}
 

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -96,8 +96,21 @@ func FetchStorageSecretName(export *argoprojv1alpha1.ArgoCDExport) string {
 
 // IsObjectFound will perform a basic check that the given object exists via the Kubernetes API.
 // If an error occurs as part of the check, the function will return false.
-func IsObjectFound(client client.Client, namespace string, name string, obj client.Object) bool {
-	return !apierrors.IsNotFound(FetchObject(client, namespace, name, obj))
+func IsObjectFound(client client.Client, namespace string, name string, obj client.Object) (bool, error) {
+
+	if err := FetchObject(client, namespace, name, obj); err != nil {
+
+		if apierrors.IsNotFound(err) {
+			// Object was not found
+			return false, nil
+		}
+
+		// Another error occurred besides the object not being found
+		return false, err
+	}
+
+	// Object was found
+	return true, nil
 }
 
 // NameWithSuffix will return a string using the Name from the given ObjectMeta with the provded suffix appended.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug 

**What does this PR do / why we need it**:

Currently, the `IsObjectFound` utility function is used to check whether a particular object exists on the cluster. It is used across the codebase, and with many different types of objects.

Unfortunately, `IsObjectFound` is making an incorrect assumption: this function assumes that ANY error that occurs (besides is not found) should be treated the same as the object not existing.

For example:

| Cause      | Return value      |
| ------------- | ------------- |
|A) No error on Get object call|`IsObjectFound` returns true|
|B) Not found error on Get object call|`IsObjectFound` returns false|
|C) Any other error occurs on Get object call (network error, permission error, TLS error, etc)|`IsObjectFound` returns false|

Notice that B and C, despite very different causes, return the same false of `false`.

This PR updates the function signature of `IsObjectFound` to return (rather than burying) the `error`, and updates all locations in the code where it is called.
