### PR TITLE
fix (bug): Host name error for ApplicationSet Webhook Server route

### DIFF
--- a/common/values.go
+++ b/common/values.go
@@ -86,6 +86,9 @@ const (
 	//ApplicationSetServiceNameSuffix is the suffix for Apllication Set Controller Service
 	ApplicationSetServiceNameSuffix = "applicationset-controller"
 
+	// ApplicationSetControllerWebhookSuffix is the suffix for ApplicationSet Webhook
+	ApplicationSetControllerWebhookSuffix = "appset-webhook"
+
 	// ArgoCDAggregateToControllerLabelKey is label to configure base aggregated ClusterRole for Argo CD Application Controller.
 	ArgoCDAggregateToControllerLabelKey = "argocd/aggregate-to-controller"
 

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -377,7 +377,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetControllerWebhookRoute(cr *argo
 		// Generate the default host
 		baseHost := fmt.Sprintf("%s-%s-%s", cr.Name, common.ApplicationSetControllerWebhookSuffix, cr.Namespace)
 		ingressConfig := &configv1.Ingress{}
-		err := r.Client.Get(context.TODO(), client.ObjectKey{Name: "cluster"}, ingressConfig)
+		err := r.Get(context.TODO(), client.ObjectKey{Name: "cluster"}, ingressConfig)
 		if err != nil {
 			return err
 		}

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -329,7 +329,7 @@ func isCreatedByServiceCA(crName string, secret corev1.Secret) bool {
 // reconcileApplicationSetControllerWebhookRoute will ensure that the ArgoCD Server Route is present.
 func (r *ReconcileArgoCD) reconcileApplicationSetControllerWebhookRoute(cr *argoproj.ArgoCD) error {
 	// Generate a base name for the route
-	baseName := fmt.Sprintf("%s-%s", cr.Name, "applicationset-controller-webhook")
+	baseName := fmt.Sprintf("%s-%s", cr.Name, common.ApplicationSetControllerWebhookSuffix)
 	// Truncate to 63 characters if needed (Kubernetes label value limit)
 	if len(baseName) > maxLabelLength {
 		baseName = baseName[:maxLabelLength]
@@ -375,7 +375,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetControllerWebhookRoute(cr *argo
 		host = cr.Spec.ApplicationSet.WebhookServer.Host
 	} else {
 		// Generate the default host
-		baseHost := fmt.Sprintf("%s-%s-%s", cr.Name, "applicationset-controller-webhook", cr.Namespace)
+		baseHost := fmt.Sprintf("%s-%s-%s", cr.Name, common.ApplicationSetControllerWebhookSuffix, cr.Namespace)
 		ingressConfig := &configv1.Ingress{}
 		err := r.Client.Get(context.TODO(), client.ObjectKey{Name: "cluster"}, ingressConfig)
 		if err != nil {

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -25,11 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	configv1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
-	configv1 "github.com/openshift/api/config/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -327,8 +327,14 @@ func isCreatedByServiceCA(crName string, secret corev1.Secret) bool {
 
 // reconcileApplicationSetControllerWebhookRoute will ensure that the ArgoCD Server Route is present.
 func (r *ReconcileArgoCD) reconcileApplicationSetControllerWebhookRoute(cr *argoproj.ArgoCD) error {
-	name := fmt.Sprintf("%s-%s", common.ApplicationSetServiceNameSuffix, "webhook")
-	route := newRouteWithSuffix(name, cr)
+	// Generate a base name for the route
+	baseName := fmt.Sprintf("%s-%s", cr.Name, "applicationset-controller-webhook")
+	// Truncate to 63 characters if needed (Kubernetes label value limit)
+	if len(baseName) > maxLabelLength {
+		baseName = baseName[:maxLabelLength]
+	}
+	route := newRouteWithName(baseName, cr)
+
 	found := argoutil.IsObjectFound(r.Client, cr.Namespace, route.Name, route)
 	if found {
 		if cr.Spec.ApplicationSet == nil || !cr.Spec.ApplicationSet.WebhookServer.Route.Enabled {

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -253,7 +253,7 @@ func TestReconcileRouteApplicationSetHost(t *testing.T) {
 	assert.NoError(t, err)
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s-%s", testArgoCDName, common.ApplicationSetServiceNameSuffix, "webhook"), Namespace: testNamespace}, loaded)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", testArgoCDName, common.ApplicationSetControllerWebhookSuffix), Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
@@ -309,7 +309,7 @@ func TestReconcileRouteApplicationSetTlsTermination(t *testing.T) {
 	assert.NoError(t, err)
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s-%s", testArgoCDName, common.ApplicationSetServiceNameSuffix, "webhook"), Namespace: testNamespace}, loaded)
+	err = r.Client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", testArgoCDName, common.ApplicationSetControllerWebhookSuffix), Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
@@ -381,7 +381,7 @@ func TestReconcileRouteApplicationSetTls(t *testing.T) {
 	assert.NoError(t, err)
 
 	// The route name should be based on the ArgoCD instance name
-	expectedRouteName := fmt.Sprintf("%s-%s", testArgoCDName, "applicationset-controller-webhook")
+	expectedRouteName := fmt.Sprintf("%s-%s", testArgoCDName, common.ApplicationSetControllerWebhookSuffix)
 	if len(expectedRouteName) > 63 {
 		expectedRouteName = expectedRouteName[:63]
 	}
@@ -404,7 +404,7 @@ func TestReconcileRouteApplicationSetTls(t *testing.T) {
 	}
 
 	// Verify hostname
-	expectedHost := fmt.Sprintf("%s-%s-%s.apps.example.com", testArgoCDName, "applicationset-controller-webhook", testNamespace)
+	expectedHost := fmt.Sprintf("%s-%s-%s.apps.example.com", testArgoCDName, common.ApplicationSetControllerWebhookSuffix, testNamespace)
 	if diff := cmp.Diff(expectedHost, loaded.Spec.Host); diff != "" {
 		t.Fatalf("failed to reconcile route hostname:\n%s", diff)
 	}
@@ -565,7 +565,7 @@ func TestReconcileRouteForShorteningRoutename(t *testing.T) {
 	assert.NoError(t, err)
 
 	// The route name should be truncated to 63 chars
-	expectedRouteName := longName + "-applicationset-controller-webhook"
+	expectedRouteName := longName + "-" + common.ApplicationSetControllerWebhookSuffix
 	if len(expectedRouteName) > 63 {
 		expectedRouteName = expectedRouteName[:63]
 	}

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -351,7 +351,17 @@ func TestReconcileRouteApplicationSetTls(t *testing.T) {
 		}
 	})
 
-	resObjs := []client.Object{argoCD}
+	// Create the Ingress configuration
+	ingressConfig := &configv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.IngressSpec{
+			Domain: "apps.example.com",
+		},
+	}
+
+	resObjs := []client.Object{argoCD, ingressConfig}
 	subresObjs := []client.Object{argoCD}
 	runtimeObjs := []runtime.Object{}
 	sch := makeTestReconcilerScheme(argoproj.AddToScheme, configv1.Install, routev1.Install)
@@ -370,10 +380,17 @@ func TestReconcileRouteApplicationSetTls(t *testing.T) {
 	_, err := r.Reconcile(context.TODO(), req)
 	assert.NoError(t, err)
 
-	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s-%s", testArgoCDName, common.ApplicationSetServiceNameSuffix, "webhook"), Namespace: testNamespace}, loaded)
-	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
+	// The route name should be based on the ArgoCD instance name
+	expectedRouteName := fmt.Sprintf("%s-%s", testArgoCDName, "applicationset-controller-webhook")
+	if len(expectedRouteName) > 63 {
+		expectedRouteName = expectedRouteName[:63]
+	}
 
+	loaded := &routev1.Route{}
+	err = r.Client.Get(ctx, types.NamespacedName{Name: expectedRouteName, Namespace: testNamespace}, loaded)
+	fatalIfError(t, err, "failed to load route %q: %s", expectedRouteName, err)
+
+	// Verify TLS configuration
 	wantTLSConfig := &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationEdge,
 		Certificate:                   "test-certificate",
@@ -383,28 +400,36 @@ func TestReconcileRouteApplicationSetTls(t *testing.T) {
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
 	if diff := cmp.Diff(wantTLSConfig, loaded.Spec.TLS); diff != "" {
-		t.Fatalf("failed to reconcile route:\n%s", diff)
+		t.Fatalf("failed to reconcile route TLS config:\n%s", diff)
 	}
 
-	assert.Empty(t, loaded.Spec.Host)
+	// Verify hostname
+	expectedHost := fmt.Sprintf("%s-%s-%s.apps.example.com", testArgoCDName, "applicationset-controller-webhook", testNamespace)
+	if diff := cmp.Diff(expectedHost, loaded.Spec.Host); diff != "" {
+		t.Fatalf("failed to reconcile route hostname:\n%s", diff)
+	}
 
+	// Verify port configuration
 	wantPort := &routev1.RoutePort{
 		TargetPort: intstr.FromString("webhook"),
 	}
 	if diff := cmp.Diff(wantPort, loaded.Spec.Port); diff != "" {
-		t.Fatalf("failed to reconcile route:\n%s", diff)
+		t.Fatalf("failed to reconcile route port:\n%s", diff)
 	}
 
+	// Verify annotations
 	if diff := cmp.Diff("my-annotation-value", loaded.Annotations["my-annotation-key"]); diff != "" {
-		t.Fatalf("failed to reconcile route:\n%s", diff)
+		t.Fatalf("failed to reconcile route annotations:\n%s", diff)
 	}
 
+	// Verify labels
 	if diff := cmp.Diff("my-label-value", loaded.Labels["my-label-key"]); diff != "" {
-		t.Fatalf("failed to reconcile route:\n%s", diff)
+		t.Fatalf("failed to reconcile route labels:\n%s", diff)
 	}
 
+	// Verify wildcard policy
 	if diff := cmp.Diff(wildcardPolicy, loaded.Spec.WildcardPolicy); diff != "" {
-		t.Fatalf("failed to reconcile route:\n%s", diff)
+		t.Fatalf("failed to reconcile route wildcard policy:\n%s", diff)
 	}
 }
 

--- a/tests/ocp/1-007_verify_hostname_with_route/01-assert.yaml
+++ b/tests/ocp/1-007_verify_hostname_with_route/01-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: argocd-long-name-for-route-test-applicationset-controller-webho
+spec: {}
+status:
+  ingress:
+  - host: argocd-long-name-for-route-test-applicationset-controller-webho.apps.testing.lab.upshift.rdu2.redhat.com

--- a/tests/ocp/1-007_verify_hostname_with_route/01-assert.yaml
+++ b/tests/ocp/1-007_verify_hostname_with_route/01-assert.yaml
@@ -1,8 +1,8 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: argocd-long-name-for-route-test-applicationset-controller-webho
+  name: "argocd-long-name-for-route-testiiiiiiiiiiiiiiiiiiiiiiiing-appset"
 spec: {}
 status:
   ingress:
-  - host: argocd-long-name-for-route-test-applicationset-controller-webho.apps.testing.lab.upshift.rdu2.redhat.com
+  - host: argocd-long-name-for-route-testiiiiiiiiiiiiiiiiiiiiiiiing-appset.apps.testing.lab.upshift.rdu2.redhat.com

--- a/tests/ocp/1-007_verify_hostname_with_route/01-install.yaml
+++ b/tests/ocp/1-007_verify_hostname_with_route/01-install.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: argocd-long-name-for-route-test
+  name: argocd-long-name-for-route-testiiiiiiiiiiiiiiiiiiiiiiiing
 spec:
   applicationSet:
     webhookServer:

--- a/tests/ocp/1-007_verify_hostname_with_route/01-install.yaml
+++ b/tests/ocp/1-007_verify_hostname_with_route/01-install.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-long-name-for-route-test
+spec:
+  applicationSet:
+    webhookServer:
+      route:
+        enabled: true

--- a/tests/ocp/1-007_verify_hostname_with_route/02-delete.yaml
+++ b/tests/ocp/1-007_verify_hostname_with_route/02-delete.yaml
@@ -1,0 +1,5 @@
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd-long-name-for-route-test-applicationset-controller-webho
+$delete: true


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
This PR fixes a bug where the OpenShift Route resource creation for the ApplicationSet webhook server would fail if the generated name exceeded the allowed character limits for labels (63 chars) or hostnames (253 chars). It introduces logic to truncate the generated Route.metadata.name and Route.spec.host fields safely, ensuring they stay within the maximum allowed lengths while preserving uniqueness.


This change ensures that even long ArgoCD CR names do not break the operator's ability to reconcile a valid Route for the ApplicationSet webhook server.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
