### PR TITLE
fix: prevent 'unable to update status of ArgoCD' error on deleted CR

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1760,6 +1760,10 @@ func updateStatusConditionOfArgoCD(ctx context.Context, condition metav1.Conditi
 	if changed {
 		// get the latest version of argocd instance before updating
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr); err != nil {
+			if apierrors.IsNotFound(err) {
+				// if ArgoCD CR no longer exists, there is no status update needed, so just return.
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug 

**What does this PR do / why we need it**:

At present, you will see the following error in the argocd-operator logs after an `ArgoCD` CR is deleted:
```
2025-04-05T00:43:51-04:00	ERROR	controller_argocd	unable to update status of ArgoCD	{"error": "ArgoCD.argoproj.io \"\" not found"}
github.com/argoproj-labs/argocd-operator/controllers/argocd.(*ReconcileArgoCD).Reconcile
	/home/jgw/workspace/argo-cd/argocd-operator/controllers/argocd/argocd_controller.go:103
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/home/jgw/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:119
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/jgw/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:316
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/jgw/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/home/jgw/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/internal/controller/controller.go:227
```

This is because the status update logic is assuming that, in all cases, the `ArgoCD` CR always exists. However, in the case where `ArgoCD` instance is deleted, `Reconcile` will still be called, but the CR will no longer exist.

The fix is just to skip update of `.status` if the `ArgoCD` CR no longer exists (since there is no longer a CR to update).