### PR TITLE
Add deprecated API message to previously deprecated .spec.configManagementPlugins field

### DIFF
--- a/api/v1alpha1/argocd_conversion.go
+++ b/api/v1alpha1/argocd_conversion.go
@@ -55,6 +55,7 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.ApplicationSet = ConvertAlphaToBetaApplicationSet(src.Spec.ApplicationSet)
 	dst.Spec.ExtraConfig = src.Spec.ExtraConfig
 	dst.Spec.ApplicationInstanceLabelKey = src.Spec.ApplicationInstanceLabelKey
+	//lint:ignore SA1019 known to be deprecated
 	dst.Spec.ConfigManagementPlugins = src.Spec.ConfigManagementPlugins
 	dst.Spec.Controller = *ConvertAlphaToBetaController(&src.Spec.Controller)
 	dst.Spec.DisableAdmin = src.Spec.DisableAdmin
@@ -127,6 +128,7 @@ func (dst *ArgoCD) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.ApplicationSet = ConvertBetaToAlphaApplicationSet(src.Spec.ApplicationSet)
 	dst.Spec.ExtraConfig = src.Spec.ExtraConfig
 	dst.Spec.ApplicationInstanceLabelKey = src.Spec.ApplicationInstanceLabelKey
+	//lint:ignore SA1019 known to be deprecated
 	dst.Spec.ConfigManagementPlugins = src.Spec.ConfigManagementPlugins
 	dst.Spec.Controller = *ConvertBetaToAlphaController(&src.Spec.Controller)
 	dst.Spec.DisableAdmin = src.Spec.DisableAdmin

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -694,7 +694,7 @@ type ArgoCDSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Installation ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	InstallationID string `json:"installationID,omitempty"`
 
-	// ConfigManagementPlugins is used to specify additional config management plugins.
+	// Deprecated: ConfigManagementPlugins field is no longer supported. Argo CD now requires plugins to be defined as sidecar containers of repo server component. See '.spec.repo.sidecarContainers'. ConfigManagementPlugins was previously used to specify additional config management plugins.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Management Plugins'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ConfigManagementPlugins string `json:"configManagementPlugins,omitempty"`
 

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -808,7 +808,7 @@ type ArgoCDSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Installation ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	InstallationID string `json:"installationID,omitempty"`
 
-	// ConfigManagementPlugins is used to specify additional config management plugins.
+	// Deprecated: ConfigManagementPlugins field is no longer supported. Argo CD now requires plugins to be defined as sidecar containers of repo server component. See '.spec.repo.sidecarContainers'. ConfigManagementPlugins was previously used to specify additional config management plugins.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Management Plugins'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ConfigManagementPlugins string `json:"configManagementPlugins,omitempty"`
 

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2025-04-28T04:16:03Z"
+    createdAt: "2025-05-14T11:29:42Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -441,8 +441,10 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: ConfigManagementPlugins is used to specify additional config
-          management plugins.
+      - description: 'Deprecated: ConfigManagementPlugins field is no longer supported.
+          Argo CD now requires plugins to be defined as sidecar containers of repo
+          server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
+          was previously used to specify additional config management plugins.'
         displayName: Config Management Plugins'
         path: configManagementPlugins
         x-descriptors:
@@ -1058,8 +1060,10 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: ConfigManagementPlugins is used to specify additional config
-          management plugins.
+      - description: 'Deprecated: ConfigManagementPlugins field is no longer supported.
+          Argo CD now requires plugins to be defined as sidecar containers of repo
+          server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
+          was previously used to specify additional config management plugins.'
         displayName: Config Management Plugins'
         path: configManagementPlugins
         x-descriptors:

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -454,8 +454,11 @@ spec:
                 - content
                 type: object
               configManagementPlugins:
-                description: ConfigManagementPlugins is used to specify additional
-                  config management plugins.
+                description: 'Deprecated: ConfigManagementPlugins field is no longer
+                  supported. Argo CD now requires plugins to be defined as sidecar
+                  containers of repo server component. See ''.spec.repo.sidecarContainers''.
+                  ConfigManagementPlugins was previously used to specify additional
+                  config management plugins.'
                 type: string
               controller:
                 description: Controller defines the Application Controller options
@@ -9649,8 +9652,11 @@ spec:
                 - content
                 type: object
               configManagementPlugins:
-                description: ConfigManagementPlugins is used to specify additional
-                  config management plugins.
+                description: 'Deprecated: ConfigManagementPlugins field is no longer
+                  supported. Argo CD now requires plugins to be defined as sidecar
+                  containers of repo server component. See ''.spec.repo.sidecarContainers''.
+                  ConfigManagementPlugins was previously used to specify additional
+                  config management plugins.'
                 type: string
               controller:
                 description: Controller defines the Application Controller options

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -81,9 +81,6 @@ const (
 	// ArgoCDDefaultBackupKeyNumSymbols is the number of symbols to use for the generated default backup key.
 	ArgoCDDefaultBackupKeyNumSymbols = 5
 
-	// ArgoCDDefaultConfigManagementPlugins is the default configuration value for the config management plugins.
-	ArgoCDDefaultConfigManagementPlugins = ""
-
 	// ArgoCDDefaultControllerResourceLimitCPU is the default CPU limit when not specified for the Argo CD application
 	// controller contianer.
 	ArgoCDDefaultControllerResourceLimitCPU = "1000m"

--- a/common/keys.go
+++ b/common/keys.go
@@ -44,9 +44,6 @@ const (
 	// ArgoCDKeyBackupKey is the "backup key" key for ConfigMaps.
 	ArgoCDKeyBackupKey = "backup.key"
 
-	// ArgoCDKeyConfigManagementPlugins is the configuration key for config management plugins.
-	ArgoCDKeyConfigManagementPlugins = "configManagementPlugins"
-
 	// ArgoCDKeyComponent is the resource component key for labels.
 	ArgoCDKeyComponent = "app.kubernetes.io/component"
 

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -443,8 +443,11 @@ spec:
                 - content
                 type: object
               configManagementPlugins:
-                description: ConfigManagementPlugins is used to specify additional
-                  config management plugins.
+                description: 'Deprecated: ConfigManagementPlugins field is no longer
+                  supported. Argo CD now requires plugins to be defined as sidecar
+                  containers of repo server component. See ''.spec.repo.sidecarContainers''.
+                  ConfigManagementPlugins was previously used to specify additional
+                  config management plugins.'
                 type: string
               controller:
                 description: Controller defines the Application Controller options
@@ -9638,8 +9641,11 @@ spec:
                 - content
                 type: object
               configManagementPlugins:
-                description: ConfigManagementPlugins is used to specify additional
-                  config management plugins.
+                description: 'Deprecated: ConfigManagementPlugins field is no longer
+                  supported. Argo CD now requires plugins to be defined as sidecar
+                  containers of repo server component. See ''.spec.repo.sidecarContainers''.
+                  ConfigManagementPlugins was previously used to specify additional
+                  config management plugins.'
                 type: string
               controller:
                 description: Controller defines the Application Controller options

--- a/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
@@ -289,8 +289,10 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: ConfigManagementPlugins is used to specify additional config
-          management plugins.
+      - description: 'Deprecated: ConfigManagementPlugins field is no longer supported.
+          Argo CD now requires plugins to be defined as sidecar containers of repo
+          server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
+          was previously used to specify additional config management plugins.'
         displayName: Config Management Plugins'
         path: configManagementPlugins
         x-descriptors:
@@ -865,8 +867,10 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: ConfigManagementPlugins is used to specify additional config
-          management plugins.
+      - description: 'Deprecated: ConfigManagementPlugins field is no longer supported.
+          Argo CD now requires plugins to be defined as sidecar containers of repo
+          server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
+          was previously used to specify additional config management plugins.'
         displayName: Config Management Plugins'
         path: configManagementPlugins
         x-descriptors:

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -80,15 +80,6 @@ func getSCMRootCAConfigMapName(cr *argoproj.ArgoCD) string {
 	return ""
 }
 
-// getConfigManagementPlugins will return the config management plugins for the given ArgoCD.
-func getConfigManagementPlugins(cr *argoproj.ArgoCD) string {
-	plugins := common.ArgoCDDefaultConfigManagementPlugins
-	if len(cr.Spec.ConfigManagementPlugins) > 0 {
-		plugins = cr.Spec.ConfigManagementPlugins
-	}
-	return plugins
-}
-
 // getGATrackingID will return the google analytics tracking ID for the given Argo CD.
 func getGATrackingID(cr *argoproj.ArgoCD) string {
 	id := common.ArgoCDDefaultGATrackingID
@@ -364,7 +355,6 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 	cm.Data = make(map[string]string)
 	cm.Data = setRespectRBAC(cr, cm.Data)
 	cm.Data[common.ArgoCDKeyApplicationInstanceLabelKey] = getApplicationInstanceLabelKey(cr)
-	cm.Data[common.ArgoCDKeyConfigManagementPlugins] = getConfigManagementPlugins(cr)
 	cm.Data[common.ArgoCDKeyAdminEnabled] = fmt.Sprintf("%t", !cr.Spec.DisableAdmin)
 	cm.Data[common.ArgoCDKeyGATrackingID] = getGATrackingID(cr)
 	cm.Data[common.ArgoCDKeyGAAnonymizeUsers] = fmt.Sprint(cr.Spec.GAAnonymizeUsers)

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -224,7 +224,6 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 		"application.instanceLabelKey":       common.ArgoCDDefaultApplicationInstanceLabelKey,
 		"application.resourceTrackingMethod": argoproj.ResourceTrackingMethodLabel.String(),
 		"admin.enabled":                      "true",
-		"configManagementPlugins":            "",
 		"dex.config":                         "",
 		"ga.anonymizeusers":                  "false",
 		"ga.trackingid":                      "",

--- a/deploy/olm-catalog/argocd-operator/0.14.0/argocd-operator.v0.14.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.14.0/argocd-operator.v0.14.0.clusterserviceversion.yaml
@@ -247,7 +247,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2025-04-28T04:16:03Z"
+    createdAt: "2025-05-14T11:29:42Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -441,8 +441,10 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: ConfigManagementPlugins is used to specify additional config
-          management plugins.
+      - description: 'Deprecated: ConfigManagementPlugins field is no longer supported.
+          Argo CD now requires plugins to be defined as sidecar containers of repo
+          server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
+          was previously used to specify additional config management plugins.'
         displayName: Config Management Plugins'
         path: configManagementPlugins
         x-descriptors:
@@ -1058,8 +1060,10 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-      - description: ConfigManagementPlugins is used to specify additional config
-          management plugins.
+      - description: 'Deprecated: ConfigManagementPlugins field is no longer supported.
+          Argo CD now requires plugins to be defined as sidecar containers of repo
+          server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
+          was previously used to specify additional config management plugins.'
         displayName: Config Management Plugins'
         path: configManagementPlugins
         x-descriptors:

--- a/deploy/olm-catalog/argocd-operator/0.14.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.14.0/argoproj.io_argocds.yaml
@@ -454,8 +454,11 @@ spec:
                 - content
                 type: object
               configManagementPlugins:
-                description: ConfigManagementPlugins is used to specify additional
-                  config management plugins.
+                description: 'Deprecated: ConfigManagementPlugins field is no longer
+                  supported. Argo CD now requires plugins to be defined as sidecar
+                  containers of repo server component. See ''.spec.repo.sidecarContainers''.
+                  ConfigManagementPlugins was previously used to specify additional
+                  config management plugins.'
                 type: string
               controller:
                 description: Controller defines the Application Controller options
@@ -9649,8 +9652,11 @@ spec:
                 - content
                 type: object
               configManagementPlugins:
-                description: ConfigManagementPlugins is used to specify additional
-                  config management plugins.
+                description: 'Deprecated: ConfigManagementPlugins field is no longer
+                  supported. Argo CD now requires plugins to be defined as sidecar
+                  containers of repo server component. See ''.spec.repo.sidecarContainers''.
+                  ConfigManagementPlugins was previously used to specify additional
+                  config management plugins.'
                 type: string
               controller:
                 description: Controller defines the Application Controller options

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -13,7 +13,6 @@ Name | Default | Description
 --- | --- | ---
 [**ApplicationInstanceLabelKey**](#application-instance-label-key) | `mycompany.com/appname` |  The metadata.label key name where Argo CD injects the app name as a tracking label.
 [**ApplicationSet**](#applicationset-controller-options) | [Object] | ApplicationSet controller configuration options.
-[**ConfigManagementPlugins**](#config-management-plugins) | [Empty] | Configuration to add a config management plugin.
 [**Controller**](#controller-options) | [Object] | Argo CD Application Controller options.
 [**DisableAdmin**](#disable-admin) | `false` | Disable the admin user.
 [**ExtraConfig**](#extra-config) | [Empty] | A catch-all mechanism to populate the argocd-cm configmap.
@@ -160,29 +159,6 @@ data:
     -----END CERTIFICATE-----
 ```    
 
-## Config Management Plugins
-
-Configuration to add a config management plugin. This property maps directly to the `configManagementPlugins` field in the `argocd-cm` ConfigMap.
-
-### Config Management Plugins Example
-
-The following example sets a value in the `argocd-cm` ConfigMap using the `ConfigManagementPlugins` property on the `ArgoCD` resource.
-
-``` yaml
-apiVersion: argoproj.io/v1alpha1
-kind: ArgoCD
-metadata:
-  name: example-argocd
-  labels:
-    example: config-management-plugins
-spec:
-  configManagementPlugins: |
-    - name: kasane
-      init:
-        command: [kasane, update]
-      generate:
-        command: [kasane, show]
-```
 
 ## Controller Options
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What does this PR do / why we need it**:

The `.spec.configManagementPlugins` field was previously deprecated, as Argo CD (as of v2.8) no longer uses the value of this field in the `argocd-cm` `ConfigMap`.

This PR adds a message to the field to make that clear.


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
