### PR TITLE
[release-0.13] Avoid spec.RBAC.scope sync with rbac configmap when sso keycloak (#1667)

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -548,8 +548,12 @@ func (r *ReconcileArgoCD) reconcileRBACConfigMap(cm *corev1.ConfigMap, cr *argop
 
 	// Scopes
 	if cr.Spec.RBAC.Scopes != nil && cm.Data[common.ArgoCDKeyRBACScopes] != *cr.Spec.RBAC.Scopes {
-		cm.Data[common.ArgoCDKeyRBACScopes] = *cr.Spec.RBAC.Scopes
-		changed = true
+		if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
+			log.Info("cr.Spec.RBAC.Scopes value could be out of sync with the RBACConfigMap, since keycloak sso is enabled and scopes are fixed to [groups,mails]")
+		} else {
+			cm.Data[common.ArgoCDKeyRBACScopes] = *cr.Spec.RBAC.Scopes
+			changed = true
+		}
 	}
 
 	if changed {


### PR DESCRIPTION
cherry-pick https://github.com/argoproj-labs/argocd-operator/pull/1667

(cherry picked from commit b1ec29f77a3741f07355d554c7f8ea4e7d3a4528) 

**What does this PR do / why we need it**:
This PR adds logic to preserve the RBAC scope configuration in the RBAC ConfigMap when updating to SSO Keycloak. Previously, it was set to '[groups,email]' in the RBAC ConfigMap without updating the Spec.RBAC.Scopes, which caused a conflict during the ConfigMap sync when switching to Keycloak SSO and updating the ArgoCDConfiguration.

