### PR TITLE
[release-0.14] Fix: Process regular expressions at getSourceNamespaces (#1726)

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1458,7 +1458,7 @@ func (r *ReconcileArgoCD) getSourceNamespaces(cr *argoproj.ArgoCD) ([]string, er
 	}
 
 	for _, namespace := range namespaces.Items {
-		if glob.MatchStringInList(cr.Spec.SourceNamespaces, namespace.Name, glob.GLOB) {
+		if glob.MatchStringInList(cr.Spec.SourceNamespaces, namespace.Name, glob.REGEXP) {
 			sourceNamespaces = append(sourceNamespaces, namespace.Name)
 		}
 	}

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1038,6 +1038,43 @@ func TestGetSourceNamespacesWithWildCardNamespace(t *testing.T) {
 	assert.Contains(t, sourceNamespaces, "test-namespace-1")
 	assert.Contains(t, sourceNamespaces, "test-namespace-2")
 }
+func TestGetSourceNamespacesWithRegExpNamespace(t *testing.T) {
+	a := makeTestArgoCD()
+	a.Spec = argoproj.ArgoCDSpec{
+		SourceNamespaces: []string{
+			"/^test.*test$/",
+		},
+	}
+	ns1 := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testtest",
+		},
+	}
+	ns2 := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test123test",
+		},
+	}
+	ns3 := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-abc-test",
+		},
+	}
+
+	resObjs := []client.Object{a, &ns1, &ns2, &ns3}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch)
+
+	sourceNamespaces, err := r.getSourceNamespaces(a)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(sourceNamespaces))
+	assert.Contains(t, sourceNamespaces, "testtest")
+	assert.Contains(t, sourceNamespaces, "test123test")
+	assert.Contains(t, sourceNamespaces, "test-abc-test")
+}
 
 func TestGenerateRandomString(t *testing.T) {
 


### PR DESCRIPTION
(cherry picked from commit f3e10338e02fcfb52013a33c6319318662c8c793)

**What does this PR do / why we need it**:
Updates the  operator code to use new regex option using glob.REGEXP instead of glob.GLOB when processing getSourceNamespaces

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-6675
