### PR TITLE
Enable ApplicationFineGrainedRBACInheritance by default

### DIFF
--- a/common/keys.go
+++ b/common/keys.go
@@ -193,6 +193,10 @@ const (
 	// to used for the Redis container.
 	ArgoCDRedisImageEnvName = "ARGOCD_REDIS_IMAGE"
 
+	// ArgoCDServerRBACDisableFineGrainedInheritance is needed to specify if it is not possible to deny
+	// fine-grained permissions for a sub-resource if the action was explicitly allowed on the application
+	ArgoCDServerRBACDisableFineGrainedInheritance = "server.rbac.disableApplicationFineGrainedRBACInheritance"
+
 	// ArgoCDDeletionFinalizer is a finalizer to implement pre-delete hooks
 	ArgoCDDeletionFinalizer = "argoproj.io/finalizer"
 

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -443,6 +443,11 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 		}
 	}
 
+	// Check and set default value for server.rbac.disableApplicationFineGrainedRBACInheritance if not present
+	if _, exists := cm.Data[common.ArgoCDServerRBACDisableFineGrainedInheritance]; !exists {
+		cm.Data[common.ArgoCDServerRBACDisableFineGrainedInheritance] = "false"
+	}
+
 	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
 		return err
 	}

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -233,9 +233,10 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 		"oidc.config":                        "",
 		"resource.inclusions":                "",
 		"resource.exclusions":                "",
-		"statusbadge.enabled":                "false",
-		"url":                                "https://argocd-server",
-		"users.anonymous.enabled":            "false",
+		"server.rbac.disableApplicationFineGrainedRBACInheritance": "false",
+		"statusbadge.enabled":     "false",
+		"url":                     "https://argocd-server",
+		"users.anonymous.enabled": "false",
 	}
 
 	cmdTests := []struct {

--- a/tests/k8s/1-018_validate_extra_config/01-assert.yaml
+++ b/tests/k8s/1-018_validate_extra_config/01-assert.yaml
@@ -15,3 +15,4 @@ metadata:
   name: argocd-cm
 data:
   admin.enabled: "true"
+  server.rbac.disableApplicationFineGrainedRBACInheritance: "false"

--- a/tests/k8s/1-018_validate_extra_config/06-assert.yaml
+++ b/tests/k8s/1-018_validate_extra_config/06-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+data:
+  server.rbac.disableApplicationFineGrainedRBACInheritance: "true"

--- a/tests/k8s/1-018_validate_extra_config/06-override-rbac-inheritance-using-extraconfig.yaml
+++ b/tests/k8s/1-018_validate_extra_config/06-override-rbac-inheritance-using-extraconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  disableAdmin: true
+  extraConfig:
+    "server.rbac.disableApplicationFineGrainedRBACInheritance": "true"


### PR DESCRIPTION
**What does this PR do / why we need it**:
In Argo CD 3.0, fine grained RBAC inheritance of Applications have been disable.  This PR updates the operator codebase to set the new flag `server.rbac.disableApplicationFineGrainedRBACInheritance=false` in `argocd-cm` configmap to preserve the old RBAC behaviour. Users can override this behaviour using .spec.extraConfig in ArgoCD CR if they want to use the new fine grained rbac functionality.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-6889 