### PR TITLE
Add default resource.exclusions in ConfigMap

### DIFF
--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -235,6 +235,9 @@ func TestReconcileArgoCD_reconcileTLSCerts_withInitialCertsUpdate(t *testing.T) 
 func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
+	defaultExclusions, err := yaml.Marshal(getDefaultResourceExclusions())
+	assert.NoError(t, err)
+
 	defaultConfigMapData := map[string]string{
 		"application.instanceLabelKey":       common.ArgoCDDefaultApplicationInstanceLabelKey,
 		"application.resourceTrackingMethod": argoproj.ResourceTrackingMethodLabel.String(),
@@ -247,7 +250,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 		"kustomize.buildOptions":             "",
 		"oidc.config":                        "",
 		"resource.inclusions":                "",
-		"resource.exclusions":                "",
+		"resource.exclusions":                string(defaultExclusions),
 		"server.rbac.disableApplicationFineGrainedRBACInheritance": "false",
 		"statusbadge.enabled":     "false",
 		"url":                     "https://argocd-server",
@@ -320,6 +323,22 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 				"ui.bannerpermanent": "true",
 				"ui.bannerposition":  "top",
 			},
+		},
+		{
+			"resource-exclusions",
+			[]argoCDOpt{func(a *argoproj.ArgoCD) {
+			}},
+			func() map[string]string {
+				all := getDefaultResourceExclusions()
+				raw, err := yaml.Marshal(all)
+				if err != nil {
+					panic(err)
+				}
+				fmt.Println(string(raw))
+				return map[string]string{
+					"resource.exclusions": string(raw),
+				}
+			}(),
 		},
 	}
 


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/GITOPS-6890

As mentioned [here](https://github.com/argoproj-labs/argocd-operator/blob/master/api/v1alpha1/argocd_types.go#L786) customizations field is deprecated in v1beta1  and in the ticket I see they have added customizations - https://github.com/argoproj/argo-cd/pull/21760/files#diff-d4871b2556f24756487ca6be13230ab1bcba17792d8fca91ca138d9b9727f614R13, does this mean this field is not deprecated? If not i will add the logic to add defaults for customizations as well