### PR TITLE
docs: Use argocd favicon in docs page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/argoproj-labs/argocd-operator
 strict: true
 theme:
   name: material
+  favicon: 'assets/logo.png'
   palette:
   - media: '(prefers-color-scheme: light)'
     primary: teal


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind documentation

**What does this PR do / why we need it**:

The current docs has a default mkdocs material favicon:
![image](https://github.com/user-attachments/assets/80782c45-277e-4021-90c3-f8624763baed)

This change fixes that and use the logo that is already present in the docs as the new favicon:
![image](https://github.com/user-attachments/assets/8b4147df-b12d-4ac5-aa0f-c605f136108b)


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [X] Documentation has been updated.

**How to test changes / Special notes to the reviewer**:

Run the docs locally with `mkdocs serve` and test the favicon is changed