### PR TITLE
Add default health value in CM to get Health status in the Application CR

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -800,18 +800,15 @@ func (r *ReconcileArgoCD) reconcileArgoCmdParamsConfigMap(cr *argoproj.ArgoCD) e
 	cm := newConfigMapWithName(common.ArgoCDCmdParamsConfigMapName, cr)
 	cm.Data = make(map[string]string)
 
+	// Set default for controller.resource.health.persist to "true"
+	const healthPersistKey = "controller.resource.health.persist"
+	cm.Data[healthPersistKey] = "true"
+
 	// Copy user-specified command parameters if any
 	if len(cr.Spec.CmdParams) > 0 {
 		for k, v := range cr.Spec.CmdParams {
 			cm.Data[k] = v
 		}
-	}
-
-	// Set default for controller.resource.health.persist to "true"
-	// only if user hasn't provided it explicitly
-	const healthPersistKey = "controller.resource.health.persist"
-	if _, exists := cm.Data[healthPersistKey]; !exists {
-		cm.Data[healthPersistKey] = "true"
 	}
 
 	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -21,8 +21,6 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/utils/pointer"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -613,8 +611,7 @@ func getArgoControllerContainerEnv(cr *argoproj.ArgoCD, replicas int32) []corev1
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: common.ArgoCDCmdParamsConfigMapName,
 				},
-				Key:      "controller.resource.health.persist",
-				Optional: pointer.Bool(true),
+				Key: "controller.resource.health.persist",
 			},
 		},
 	},

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -21,6 +21,8 @@ import (
 	"strconv"
 	"time"
 
+	"k8s.io/utils/pointer"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -604,6 +606,19 @@ func getArgoControllerContainerEnv(cr *argoproj.ArgoCD, replicas int32) []corev1
 		})
 	}
 
+	env = append(env, corev1.EnvVar{
+		Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST",
+		ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: common.ArgoCDCmdParamsConfigMapName,
+				},
+				Key:      "controller.resource.health.persist",
+				Optional: pointer.Bool(true),
+			},
+		},
+	},
+	)
 	return env
 }
 
@@ -783,6 +798,10 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 						{
 							Key:  "controller.profile.enabled",
 							Path: "profiler.enabled",
+						},
+						{
+							Key:  "controller.resource.health.persist",
+							Path: "controller.resource.health.persist",
 						},
 					},
 				},

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -72,6 +72,10 @@ func controllerDefaultVolumes() []corev1.Volume {
 							Key:  "controller.profile.enabled",
 							Path: "profiler.enabled",
 						},
+						{
+							Key:  "controller.resource.health.persist",
+							Path: "controller.resource.health.persist",
+						},
 					},
 				},
 			},
@@ -208,7 +212,9 @@ func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {
 		"--status-processors", "20",
 		"--kubectl-parallelism-limit", "10",
 		"--loglevel", "info",
-		"--logformat", "text"}
+		"--logformat", "text",
+		"--persist-resource-health",
+	}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}
@@ -254,7 +260,8 @@ func TestReconcileArgoCD_reconcileApplicationController_withRedisTLS(t *testing.
 		"--status-processors", "20",
 		"--kubectl-parallelism-limit", "10",
 		"--loglevel", "info",
-		"--logformat", "text"}
+		"--logformat", "text",
+		"--persist-resource-health"}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}
@@ -293,7 +300,8 @@ func TestReconcileArgoCD_reconcileApplicationController_withUpdate(t *testing.T)
 		"--status-processors", "30",
 		"--kubectl-parallelism-limit", "10",
 		"--loglevel", "info",
-		"--logformat", "text"}
+		"--logformat", "text",
+		"--persist-resource-health"}
 	if diff := cmp.Diff(want, command); diff != "" {
 		t.Fatalf("reconciliation failed:\n%s", diff)
 	}
@@ -401,6 +409,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			},
 			replicas: 1,
 			vars: []corev1.EnvVar{
+				{Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.ArgoCDCmdParamsConfigMapName},
+						Key:                  "controller.resource.health.persist",
+					},
+				}},
 				{Name: "HOME", Value: "/home/argocd"},
 				{Name: "REDIS_PASSWORD", Value: "",
 					ValueFrom: &corev1.EnvVarSource{
@@ -421,6 +435,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			replicas: 1,
 			vars: []corev1.EnvVar{
 				{Name: "ARGOCD_CONTROLLER_REPLICAS", Value: "1"},
+				{Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.ArgoCDCmdParamsConfigMapName},
+						Key:                  "controller.resource.health.persist",
+					},
+				}},
 				{Name: "HOME", Value: "/home/argocd"},
 				{Name: "REDIS_PASSWORD", Value: "",
 					ValueFrom: &corev1.EnvVarSource{
@@ -441,6 +461,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			replicas: 3,
 			vars: []corev1.EnvVar{
 				{Name: "ARGOCD_CONTROLLER_REPLICAS", Value: "3"},
+				{Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.ArgoCDCmdParamsConfigMapName},
+						Key:                  "controller.resource.health.persist",
+					},
+				}},
 				{Name: "HOME", Value: "/home/argocd"},
 				{Name: "REDIS_PASSWORD", Value: "",
 					ValueFrom: &corev1.EnvVarSource{
@@ -463,6 +489,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 			replicas: 2,
 			vars: []corev1.EnvVar{
 				{Name: "ARGOCD_CONTROLLER_REPLICAS", Value: "2"},
+				{Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST", ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: common.ArgoCDCmdParamsConfigMapName},
+						Key:                  "controller.resource.health.persist",
+					},
+				}},
 				{Name: "HOME", Value: "/home/argocd"},
 				{Name: "REDIS_PASSWORD", Value: "",
 					ValueFrom: &corev1.EnvVarSource{
@@ -520,6 +552,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 func TestReconcileArgoCD_reconcileApplicationController_withAppSync(t *testing.T) {
 
 	expectedEnv := []corev1.EnvVar{
+		{Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST", ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: common.ArgoCDCmdParamsConfigMapName},
+				Key:                  "controller.resource.health.persist",
+			},
+		}},
 		{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "600s"},
 		{Name: "HOME", Value: "/home/argocd"},
 		{Name: "REDIS_PASSWORD", Value: "",
@@ -567,6 +605,12 @@ func TestReconcileArgoCD_reconcileApplicationController_withAppSync(t *testing.T
 func TestReconcileArgoCD_reconcileApplicationController_withEnv(t *testing.T) {
 
 	expectedEnv := []corev1.EnvVar{
+		{Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST", ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: common.ArgoCDCmdParamsConfigMapName},
+				Key:                  "controller.resource.health.persist",
+			},
+		}},
 		{Name: "CUSTOM_ENV_VAR", Value: "custom-value"},
 		{Name: "HOME", Value: "/home/argocd"},
 		{Name: "REDIS_PASSWORD", Value: "",

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -177,6 +177,16 @@ func getArgoApplicationControllerCommand(cr *argoproj.ArgoCD, useTLSForRedis boo
 	cmd = append(cmd, "--logformat")
 	cmd = append(cmd, getLogFormat(cr.Spec.Controller.LogFormat))
 
+	persistHealth := "true" // default
+	if val, ok := cr.Spec.CmdParams["controller.resource.health.persist"]; ok {
+		persistHealth = val
+	}
+
+	// set the command only if persistHealth is true
+	if persistHealth == "true" {
+		cmd = append(cmd, "--persist-resource-health")
+	}
+
 	// check if extra args are present
 	extraArgs := cr.Spec.Controller.ExtraCommandArgs
 	cmd = appendUniqueArgs(cmd, extraArgs)

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -376,6 +377,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 		"info",
 		"--logformat",
 		"text",
+		"--persist-resource-health",
 	}
 
 	controllerProcesorsChangedResult := func(n string) []string {
@@ -395,6 +397,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 			"info",
 			"--logformat",
 			"text",
+			"--persist-resource-health",
 		}
 	}
 
@@ -415,6 +418,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 			"info",
 			"--logformat",
 			"text",
+			"--persist-resource-health",
 		}
 	}
 
@@ -433,6 +437,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 			"info",
 			"--logformat",
 			"text",
+			"--persist-resource-health",
 			"--operation-processors",
 			n,
 		}
@@ -455,6 +460,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 			"info",
 			"--logformat",
 			"text",
+			"--persist-resource-health",
 		}
 	}
 
@@ -475,6 +481,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 			"info",
 			"--logformat",
 			f,
+			"--persist-resource-health",
 		}
 	}
 
@@ -495,6 +502,7 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 			l,
 			"--logformat",
 			"text",
+			"--persist-resource-health",
 		}
 	}
 
@@ -637,7 +645,13 @@ func TestGetArgoApplicationContainerEnv(t *testing.T) {
 					Key: "admin.password",
 				},
 			}},
-		{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "60s", ValueFrom: (*v1.EnvVarSource)(nil)}}
+		{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "60s", ValueFrom: (*v1.EnvVarSource)(nil)},
+		{Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST", ValueFrom: &corev1.EnvVarSource{
+			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: common.ArgoCDCmdParamsConfigMapName},
+				Key:                  "controller.resource.health.persist",
+			},
+		}}}
 
 	cmdTests := []struct {
 		name string

--- a/tests/k8s/1-007_validate_volume_mounts/01-assert.yaml
+++ b/tests/k8s/1-007_validate_volume_mounts/01-assert.yaml
@@ -159,5 +159,7 @@ spec:
           items:
           - key: controller.profile.enabled
             path: profiler.enabled
+          - key: controller.resource.health.persist
+            path: controller.resource.health.persist
       - name: argocd-application-controller-tmp
         emptyDir: {}

--- a/tests/k8s/1-038_validate_controller_extra_command_args/02-assert.yaml
+++ b/tests/k8s/1-038_validate_controller_extra_command_args/02-assert.yaml
@@ -23,4 +23,5 @@ spec:
         - info
         - --logformat
         - text
+        - --persist-resource-health
         - --hydrator-enabled

--- a/tests/k8s/1-038_validate_controller_extra_command_args/03-errors.yaml
+++ b/tests/k8s/1-038_validate_controller_extra_command_args/03-errors.yaml
@@ -23,4 +23,5 @@ spec:
         - info
         - --logformat
         - text
+        - --persist-resource-health
         - --hydrator-enabled

--- a/tests/k8s/1-038_validate_controller_extra_command_args/04-errors.yaml
+++ b/tests/k8s/1-038_validate_controller_extra_command_args/04-errors.yaml
@@ -22,6 +22,7 @@ spec:
         - --loglevel
         - info
         - --logformat
+        - --persist-resource-health
         - text
 ---
 apiVersion: apps/v1
@@ -49,6 +50,7 @@ spec:
         - info
         - --logformat
         - text
+        - --persist-resource-health
         - --status-processors
         - "15"
         - --kubectl-parallelism-limit


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/GITOPS-7009

Steps to test -
Update [this](https://github.com/argoproj-labs/argocd-operator/blob/master/common/defaults.go#L73) value to ArgoCD version 3.0.0  
then apply :
apiVersion: argoproj.io/v1beta1
kind: ArgoCD
metadata:
  name: example-argocd
spec:
  cmdParams:
    controller.resource.health.persist: "true"

Create an Application CR to see the CR status of application is working as expected

