### PR TITLE
feat: modify controller-runtime builder using hooks

### DIFF
--- a/controllers/argocd/hooks.go
+++ b/controllers/argocd/hooks.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -31,4 +33,17 @@ func applyReconcilerHook(cr *argoproj.ArgoCD, i interface{}, hint string) error 
 		}
 	}
 	return nil
+}
+
+// BuilderHook can be used to modify the controller-runtime builder.
+type BuilderHook struct {
+	client.Client
+	*builder.Builder
+}
+
+func newBuilderHook(client client.Client, builder *builder.Builder) *BuilderHook {
+	return &BuilderHook{
+		Client:  client,
+		Builder: builder,
+	}
 }

--- a/controllers/argocd/hooks.go
+++ b/controllers/argocd/hooks.go
@@ -3,9 +3,10 @@ package argocd
 import (
 	"sync"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 var (

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1150,6 +1150,12 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 
 	bldr.Watches(&corev1.Namespace{}, namespaceHandler, builder.WithPredicates(namespaceFilterPredicate()))
 
+	bldrHook := newBuilderHook(r.Client, bldr)
+	err := applyReconcilerHook(&argoproj.ArgoCD{}, bldrHook, "")
+	if err != nil {
+		log.Error(err, "failed to apply builder hook")
+	}
+
 	return bldr
 }
 


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind enhancement 

**What does this PR do / why we need it**:

Currently, the Argo CD CR controller can be imported by different vendor-specific operators. This PR allows the vendor operators to write external hooks and modify the controller-runtime builder of the Argo CD controller. For example, we can apply hooks to add additional watches without modifying the main [SetupWithManager](https://github.com/argoproj-labs/argocd-operator/blob/1739a0112b194f21022ed5ffbb1dc51ad08c86b9/controllers/argocd/argocd_controller.go#L250)

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
