### PR TITLE
Argo CD Agent: Add support for redis proxy (#1788)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 test: manifests generate fmt vet envtest ## Run tests.
-	go test ./... -coverprofile cover.out
+	REDIS_CONFIG_PATH="build/redis" go test ./... -coverprofile cover.out
 
 ##@ Build
 

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -36,11 +36,6 @@ func getArgoServerServiceType(cr *argoproj.ArgoCD) corev1.ServiceType {
 		return cr.Spec.Server.Service.Type
 	}
 
-	// If Principal is enabled, use LoadBalancer service type
-	if cr.Spec.ArgoCDAgent != nil && cr.Spec.ArgoCDAgent.Principal != nil && cr.Spec.ArgoCDAgent.Principal.IsEnabled() {
-		return corev1.ServiceTypeLoadBalancer
-	}
-
 	return corev1.ServiceTypeClusterIP
 }
 
@@ -319,13 +314,7 @@ func (r *ReconcileArgoCD) reconcileRedisService(cr *argoproj.ArgoCD) error {
 		return nil // Service found, do nothing
 	}
 
-	// If Principal is enabled, use LoadBalancer service type
-	if cr.Spec.ArgoCDAgent != nil && cr.Spec.ArgoCDAgent.Principal != nil && cr.Spec.ArgoCDAgent.Principal.IsEnabled() {
-		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-	} else {
-		// TODO: Existing and current service is not compared and updated
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
-	}
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
 
 	if cr.Spec.HA.Enabled || !cr.Spec.Redis.IsEnabled() {
 		return nil //return as Ha is enabled do nothing

--- a/controllers/argocdagent/deployment.go
+++ b/controllers/argocdagent/deployment.go
@@ -147,9 +147,14 @@ func buildPorts(compName string) []corev1.ContainerPort {
 		{
 			ContainerPort: 8443,
 			Name:          compName,
-		}, {
+		},
+		{
 			ContainerPort: 8000,
 			Name:          "metrics",
+		},
+		{
+			ContainerPort: 6379,
+			Name:          "redis",
 		},
 	}
 }

--- a/controllers/argocdagent/deployment_test.go
+++ b/controllers/argocdagent/deployment_test.go
@@ -357,7 +357,7 @@ func TestReconcilePrincipalDeployment_VerifyDeploymentSpec(t *testing.T) {
 	assert.Equal(t, corev1.SeccompProfileType("RuntimeDefault"), container.SecurityContext.SeccompProfile.Type)
 
 	// Verify ports configuration
-	assert.Len(t, container.Ports, 2)
+	assert.Len(t, container.Ports, 3)
 	principalPort := container.Ports[0]
 	assert.Equal(t, testCompName, principalPort.Name)
 	assert.Equal(t, int32(8443), principalPort.ContainerPort)

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -174,3 +174,7 @@ func LogResourceAction(log logr.Logger, action string, object metav1.Object, exp
 
 	log.Info(msg)
 }
+
+func GenerateAgentPrincipalRedisProxyServiceName(crName string) string {
+	return fmt.Sprintf("%s-agent-%s", crName, "principal-redisproxy")
+}

--- a/tests/k8s/1-051_validate_argocd_agent_principal/01-assert.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/01-assert.yaml
@@ -52,7 +52,7 @@ metadata:
   name: argocd-agent-principal-metrics
   namespace: argocd-e2e-cluster-config
 spec:
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -60,7 +60,7 @@ metadata:
   name: argocd-redis
   namespace: argocd-e2e-cluster-config
 spec:
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -76,7 +76,23 @@ metadata:
   name: argocd-server
   namespace: argocd-e2e-cluster-config
 spec:
-  type: LoadBalancer
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-agent-principal-redisproxy
+  namespace: argocd-e2e-cluster-config  
+spec:
+  ports:
+  - name: redis
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app.kubernetes.io/name: argocd-agent-principal
+  sessionAffinity: None
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:

This is a cherry pick of https://github.com/argoproj-labs/argocd-operator/pull/1788

- Argo CD agent now includes support for proxying redis traffic from principal to agents. This means that it is no longer required to loadbalance the principal redis endpoint.
- This PR removes loadbalancer from principal redis endpoint, and ensures that other workloads reference the redis proxy (via a new Service)



**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
