### PR TITLE
Cleanup after e2e test 1_047

### DIFF
--- a/tests/k8s/1-047_validate_impersonation_namespace_scoped_instance/99-delete.yaml
+++ b/tests/k8s/1-047_validate_impersonation_namespace_scoped_instance/99-delete.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: argoproj.io/v1beta1
+  kind: ArgoCD
+  name: argocd-test
+  namespace: argocd-test-ns-scoped
+- apiVersion: v1
+  kind: Namespace
+  name: argocd-test-ns-scoped
+- apiVersion: v1
+  kind: Namespace
+  name: guestbook
+- apiVersion: v1
+  kind: Namespace
+  name: guestbook-dev


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

E2E test `1-047_validate_impersonation_namespace_scoped_instance` creates a number of artifacts that don't get cleaned up after the test finishes.  This PR adds the needed cleanup.
