### PR TITLE
chore: Use SkipNameValidation to skip controller name validation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,6 +53,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -89,6 +90,7 @@ func main() {
 
 	var secureMetrics = false
 	var enableHTTP2 = false
+	var skipControllerNameValidation = true
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", fmt.Sprintf(":%d", common.OperatorMetricsPort), "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -172,6 +174,12 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b674928d.argoproj.io",
+		// With controller-runtime v0.19.0, unique controller name validation is
+		// enforced. The operator may fail to start due to this as we don't have unique
+		// names. Use SkipNameValidation to ingnore the uniquness check and prevent panic.
+		Controller: controllerconfig.Controller{
+			SkipNameValidation: &skipControllerNameValidation,
+		},
 	}
 
 	if watchedNsCache := getDefaultWatchedNamespacesCacheOptions(); watchedNsCache != nil {


### PR DESCRIPTION
**What type of PR is this?**
 /kind chore

**What does this PR do / why we need it**:

With controller-runtime v0.19.0, unique controller name validation is enforced. The operator may fail to start due to this as we don't have unique names. Use SkipNameValidation to ignore the uniqueness check and prevent 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
