### PR TITLE
fix: add missing env variables in deployment

### DIFF
--- a/controllers/argocdagent/configmap.go
+++ b/controllers/argocdagent/configmap.go
@@ -102,12 +102,12 @@ const (
 	EnvArgoCDPrincipalRedisServerAddress        = "ARGOCD_PRINCIPAL_REDIS_SERVER_ADDRESS"
 	EnvArgoCDPrincipalRedisCompressionType      = "ARGOCD_PRINCIPAL_REDIS_COMPRESSION_TYPE"
 	EnvArgoCDPrincipalPprofPort                 = "ARGOCD_PRINCIPAL_PPROF_PORT"
-	EncArgoCDPrincipalTlsSecretName             = "ARGOCD_PRINCIPAL_TLS_SECRET_NAME"
-	EncArgoCDPrincipalTlsServerRootCASecretName = "ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_SECRET_NAME"
-	EncArgoCDPrincipalResourceProxySecretName   = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_SECRET_NAME"
-	EncArgoCDPrincipalResourceProxyCaSecretName = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_SECRET_NAME"
-	EncArgoCDPrincipalResourceProxyCaPath       = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_PATH"
-	EncArgoCDPrincipalJwtSecretName             = "ARGOCD_PRINCIPAL_JWT_SECRET_NAME"
+	EnvArgoCDPrincipalTlsSecretName             = "ARGOCD_PRINCIPAL_TLS_SECRET_NAME"
+	EnvArgoCDPrincipalTlsServerRootCASecretName = "ARGOCD_PRINCIPAL_TLS_SERVER_ROOT_CA_SECRET_NAME"
+	EnvArgoCDPrincipalResourceProxySecretName   = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_SECRET_NAME"
+	EnvArgoCDPrincipalResourceProxyCaSecretName = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_SECRET_NAME"
+	EnvArgoCDPrincipalResourceProxyCaPath       = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_PATH"
+	EnvArgoCDPrincipalJwtSecretName             = "ARGOCD_PRINCIPAL_JWT_SECRET_NAME"
 )
 
 const cmSuffix = "-agent-principal-params"
@@ -413,42 +413,42 @@ func getPrincipalPprofPort() string {
 }
 
 func getPrincipalJwtSecretName() string {
-	if value := os.Getenv(EncArgoCDPrincipalJwtSecretName); value != "" {
+	if value := os.Getenv(EnvArgoCDPrincipalJwtSecretName); value != "" {
 		return value
 	}
 	return "argocd-agent-jwt"
 }
 
 func getPrincipalResourceProxyCaPath() string {
-	if value := os.Getenv(EncArgoCDPrincipalResourceProxyCaPath); value != "" {
+	if value := os.Getenv(EnvArgoCDPrincipalResourceProxyCaPath); value != "" {
 		return value
 	}
 	return ""
 }
 
 func getPrincipalResourceProxyCaSecretName() string {
-	if value := os.Getenv(EncArgoCDPrincipalResourceProxyCaSecretName); value != "" {
+	if value := os.Getenv(EnvArgoCDPrincipalResourceProxyCaSecretName); value != "" {
 		return value
 	}
 	return "argocd-agent-ca"
 }
 
 func getPrincipalResourceProxySecretName() string {
-	if value := os.Getenv(EncArgoCDPrincipalResourceProxySecretName); value != "" {
+	if value := os.Getenv(EnvArgoCDPrincipalResourceProxySecretName); value != "" {
 		return value
 	}
 	return "argocd-agent-resource-proxy-tls"
 }
 
 func getPrincipalTlsSecretName() string {
-	if value := os.Getenv(EncArgoCDPrincipalTlsSecretName); value != "" {
+	if value := os.Getenv(EnvArgoCDPrincipalTlsSecretName); value != "" {
 		return value
 	}
 	return "argocd-agent-principal-tls"
 }
 
 func getPrincipalTlsServerRootCASecretName() string {
-	if value := os.Getenv(EncArgoCDPrincipalTlsServerRootCASecretName); value != "" {
+	if value := os.Getenv(EnvArgoCDPrincipalTlsServerRootCASecretName); value != "" {
 		return value
 	}
 	return "argocd-agent-ca"

--- a/controllers/argocdagent/configmap.go
+++ b/controllers/argocdagent/configmap.go
@@ -71,6 +71,7 @@ const (
 	PrincipalKeepAliveMinInterval      = "principal.keep-alive-min-interval"
 	PrincipalRedisCompressionType      = "principal.redis-compression-type"
 	PrincipalPprofPort                 = "principal.pprof-port"
+	PrincipalRedisPassword             = "auth"
 
 	// Environment variable names for Principal configuration
 	// These constants define the environment variable names that can override default values
@@ -108,6 +109,7 @@ const (
 	EnvArgoCDPrincipalResourceProxyCaSecretName = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_SECRET_NAME"
 	EnvArgoCDPrincipalResourceProxyCaPath       = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_PATH"
 	EnvArgoCDPrincipalJwtSecretName             = "ARGOCD_PRINCIPAL_JWT_SECRET_NAME"
+	EnvRedisPassword                            = "REDIS_PASSWORD"
 )
 
 const cmSuffix = "-agent-principal-params"

--- a/controllers/argocdagent/deployment.go
+++ b/controllers/argocdagent/deployment.go
@@ -533,6 +533,60 @@ func buildPrincipalContainerEnv(cr *argoproj.ArgoCD) []corev1.EnvVar {
 					Optional:             ptr.To(true),
 				},
 			},
+		}, {
+			Name: EnvArgoCDPrincipalTlsSecretName,
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  PrincipalTLSSecretName,
+					LocalObjectReference: ref,
+					Optional:             ptr.To(true),
+				},
+			},
+		}, {
+			Name: EnvArgoCDPrincipalTlsServerRootCASecretName,
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  PrincipalTLSServerRootCASecretName,
+					LocalObjectReference: ref,
+					Optional:             ptr.To(true),
+				},
+			},
+		}, {
+			Name: EnvArgoCDPrincipalResourceProxySecretName,
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  PrincipalResourceProxySecretName,
+					LocalObjectReference: ref,
+					Optional:             ptr.To(true),
+				},
+			},
+		}, {
+			Name: EnvArgoCDPrincipalResourceProxyCaPath,
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  PrincipalResourceProxyCAPath,
+					LocalObjectReference: ref,
+					Optional:             ptr.To(true),
+				},
+			},
+		}, {
+			Name: EnvArgoCDPrincipalResourceProxyCaSecretName,
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  PrincipalResourceProxyCASecretName,
+					LocalObjectReference: ref,
+					Optional:             ptr.To(true),
+				},
+			},
+		}, {
+			Name: EnvArgoCDPrincipalJwtSecretName,
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  PrincipalJwtSecretName,
+					LocalObjectReference: ref,
+					Optional:             ptr.To(true),
+				},
+			},
 		}}
 
 	return env

--- a/controllers/argocdagent/deployment.go
+++ b/controllers/argocdagent/deployment.go
@@ -587,6 +587,17 @@ func buildPrincipalContainerEnv(cr *argoproj.ArgoCD) []corev1.EnvVar {
 					Optional:             ptr.To(true),
 				},
 			},
+		}, {
+			Name: EnvRedisPassword,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: PrincipalRedisPassword,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "argocd-redis",
+					},
+					Optional: ptr.To(true),
+				},
+			},
 		}}
 
 	return env


### PR DESCRIPTION
/kind bug

This PR is to add few missing env variables from deployment manifest, that were added in configmap later but missed from deployment.
