### PR TITLE
chore: enable gosec and ginkgo golangci linter and fix errors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,9 +15,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.1.6
-          only-new-issues: true
-
+      - name: "Ensure code passes 'go-sec' - run 'make gosec' to identify issues"
+        run: |
+          make gosec
+      - name: "Ensure code passes 'golangci-lint' - run 'make lint' to identify issues"
+        run: |
+          make lint 
+      - name: Ensure there is no diff in code
+        run: |
+          git diff --ignore-matching-lines='.*createdAt:.*' --exit-code -- .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 linters:
   enable:
+    - ginkgolinter   # https://github.com/nunnatsa/ginkgolinter
     - govet
     - unused
     - ineffassign
@@ -14,7 +15,6 @@ linters:
       - legacy
       - std-error-handling
     paths:
-      - .*_test\.go
       - vendor/
       - third_party$
       - builtin$
@@ -29,7 +29,6 @@ formatters:
   exclusions:
     generated: lax
     paths:
-      - .*_test\.go
       - vendor/
       - third_party$
       - builtin$

--- a/api/v1alpha1/argocd_conversion.go
+++ b/api/v1alpha1/argocd_conversion.go
@@ -56,21 +56,21 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.ExtraConfig = src.Spec.ExtraConfig
 	dst.Spec.ApplicationInstanceLabelKey = src.Spec.ApplicationInstanceLabelKey
 	//lint:ignore SA1019 known to be deprecated
-	dst.Spec.ConfigManagementPlugins = src.Spec.ConfigManagementPlugins
+	dst.Spec.ConfigManagementPlugins = src.Spec.ConfigManagementPlugins //nolint:staticcheck // SA1019: We must test deprecated fields.
 	dst.Spec.Controller = *ConvertAlphaToBetaController(&src.Spec.Controller)
 	dst.Spec.DisableAdmin = src.Spec.DisableAdmin
 	dst.Spec.ExtraConfig = src.Spec.ExtraConfig
 	dst.Spec.GATrackingID = src.Spec.GATrackingID
 	dst.Spec.GAAnonymizeUsers = src.Spec.GAAnonymizeUsers
 	//lint:ignore SA1019 known to be deprecated
-	dst.Spec.Grafana = *ConvertAlphaToBetaGrafana(&src.Spec.Grafana)
+	dst.Spec.Grafana = *ConvertAlphaToBetaGrafana(&src.Spec.Grafana) //nolint:staticcheck // SA1019: We must test deprecated fields.
 	dst.Spec.HA = *ConvertAlphaToBetaHA(&src.Spec.HA)
 	dst.Spec.HelpChatURL = src.Spec.HelpChatURL
 	dst.Spec.HelpChatText = src.Spec.HelpChatText
 	dst.Spec.Image = src.Spec.Image
 	dst.Spec.Import = (*v1beta1.ArgoCDImportSpec)(src.Spec.Import)
 	//lint:ignore SA1019 known to be deprecated
-	dst.Spec.InitialRepositories = src.Spec.InitialRepositories
+	dst.Spec.InitialRepositories = src.Spec.InitialRepositories //nolint:staticcheck // SA1019: We must test deprecated fields.
 	dst.Spec.InitialSSHKnownHosts = v1beta1.SSHHostsSpec(src.Spec.InitialSSHKnownHosts)
 	dst.Spec.KustomizeBuildOptions = src.Spec.KustomizeBuildOptions
 	dst.Spec.KustomizeVersions = ConvertAlphaToBetaKustomizeVersions(src.Spec.KustomizeVersions)
@@ -83,7 +83,7 @@ func (src *ArgoCD) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Redis = *ConvertAlphaToBetaRedis(&src.Spec.Redis)
 	dst.Spec.Repo = *ConvertAlphaToBetaRepo(&src.Spec.Repo)
 	//lint:ignore SA1019 known to be deprecated
-	dst.Spec.RepositoryCredentials = src.Spec.RepositoryCredentials
+	dst.Spec.RepositoryCredentials = src.Spec.RepositoryCredentials //nolint:staticcheck // SA1019: We must test deprecated fields.
 	dst.Spec.ResourceHealthChecks = ConvertAlphaToBetaResourceHealthChecks(src.Spec.ResourceHealthChecks)
 	dst.Spec.ResourceIgnoreDifferences = ConvertAlphaToBetaResourceIgnoreDifferences(src.Spec.ResourceIgnoreDifferences)
 	dst.Spec.ResourceActions = ConvertAlphaToBetaResourceActions(src.Spec.ResourceActions)
@@ -131,21 +131,21 @@ func (dst *ArgoCD) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.ExtraConfig = src.Spec.ExtraConfig
 	dst.Spec.ApplicationInstanceLabelKey = src.Spec.ApplicationInstanceLabelKey
 	//lint:ignore SA1019 known to be deprecated
-	dst.Spec.ConfigManagementPlugins = src.Spec.ConfigManagementPlugins
+	dst.Spec.ConfigManagementPlugins = src.Spec.ConfigManagementPlugins //nolint:staticcheck // SA1019: We must test deprecated fields.
 	dst.Spec.Controller = *ConvertBetaToAlphaController(&src.Spec.Controller)
 	dst.Spec.DisableAdmin = src.Spec.DisableAdmin
 	dst.Spec.ExtraConfig = src.Spec.ExtraConfig
 	dst.Spec.GATrackingID = src.Spec.GATrackingID
 	dst.Spec.GAAnonymizeUsers = src.Spec.GAAnonymizeUsers
 	//lint:ignore SA1019 known to be deprecated
-	dst.Spec.Grafana = *ConvertBetaToAlphaGrafana(&src.Spec.Grafana)
+	dst.Spec.Grafana = *ConvertBetaToAlphaGrafana(&src.Spec.Grafana) //nolint:staticcheck // SA1019: We must test deprecated fields.
 	dst.Spec.HA = *ConvertBetaToAlphaHA(&src.Spec.HA)
 	dst.Spec.HelpChatURL = src.Spec.HelpChatURL
 	dst.Spec.HelpChatText = src.Spec.HelpChatText
 	dst.Spec.Image = src.Spec.Image
 	dst.Spec.Import = (*ArgoCDImportSpec)(src.Spec.Import)
 	//lint:ignore SA1019 known to be deprecated
-	dst.Spec.InitialRepositories = src.Spec.InitialRepositories
+	dst.Spec.InitialRepositories = src.Spec.InitialRepositories //nolint:staticcheck // SA1019: We must test deprecated fields.
 	dst.Spec.InitialSSHKnownHosts = SSHHostsSpec(src.Spec.InitialSSHKnownHosts)
 	dst.Spec.KustomizeBuildOptions = src.Spec.KustomizeBuildOptions
 	dst.Spec.KustomizeVersions = ConvertBetaToAlphaKustomizeVersions(src.Spec.KustomizeVersions)
@@ -158,7 +158,7 @@ func (dst *ArgoCD) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.Spec.Redis = *ConvertBetaToAlphaRedis(&src.Spec.Redis)
 	dst.Spec.Repo = *ConvertBetaToAlphaRepo(&src.Spec.Repo)
 	//lint:ignore SA1019 known to be deprecated
-	dst.Spec.RepositoryCredentials = src.Spec.RepositoryCredentials
+	dst.Spec.RepositoryCredentials = src.Spec.RepositoryCredentials //nolint:staticcheck // SA1019: We must test deprecated fields.
 	dst.Spec.ResourceHealthChecks = ConvertBetaToAlphaResourceHealthChecks(src.Spec.ResourceHealthChecks)
 	dst.Spec.ResourceIgnoreDifferences = ConvertBetaToAlphaResourceIgnoreDifferences(src.Spec.ResourceIgnoreDifferences)
 	dst.Spec.ResourceActions = ConvertBetaToAlphaResourceActions(src.Spec.ResourceActions)

--- a/api/v1alpha1/argocd_conversion_test.go
+++ b/api/v1alpha1/argocd_conversion_test.go
@@ -502,7 +502,7 @@ func TestAlphaToBetaConversion(t *testing.T) {
 					},
 				}
 				//lint:ignore SA1019 known to be deprecated
-				cr.Spec.Grafana.Route = v1beta1.ArgoCDRouteSpec{
+				cr.Spec.Grafana.Route = v1beta1.ArgoCDRouteSpec{ //nolint:staticcheck // SA1019: We must test deprecated fields.
 					Enabled: true,
 					TLS: &routev1.TLSConfig{
 						Termination: routev1.TLSTerminationEdge,
@@ -529,7 +529,8 @@ func TestAlphaToBetaConversion(t *testing.T) {
 			var hub conversion.Hub = &v1beta1.ArgoCD{}
 
 			// Call ConvertTo function to convert v1alpha1 version to v1beta1
-			test.input.ConvertTo(hub)
+			err := test.input.ConvertTo(hub)
+			assert.NoError(t, err)
 
 			// Fetch the converted object
 			result := hub.(*v1beta1.ArgoCD)
@@ -626,7 +627,8 @@ func TestBetaToAlphaConversion(t *testing.T) {
 
 			result := &ArgoCD{}
 			// Call ConvertFrom function to convert v1beta1 version to v1alpha
-			result.ConvertFrom(hub)
+			err := result.ConvertFrom(hub)
+			assert.NoError(t, err)
 
 			// Compare converted object with expected.
 			assert.Equal(t, test.expectedOutput, result)

--- a/common/keys.go
+++ b/common/keys.go
@@ -81,7 +81,7 @@ const (
 	ArgoCDKeyIngressSSLRedirect = "nginx.ingress.kubernetes.io/force-ssl-redirect"
 
 	// ArgoCDKeyIngressSSLPassthrough is the ssl passthrough key for labels.
-	ArgoCDKeyIngressSSLPassthrough = "nginx.ingress.kubernetes.io/ssl-passthrough"
+	ArgoCDKeyIngressSSLPassthrough = "nginx.ingress.kubernetes.io/ssl-passthrough" // #nosec G101
 
 	// ArgoCDKeyKustomizeBuildOptions is the configuration key for the kustomize build options.
 	ArgoCDKeyKustomizeBuildOptions = "kustomize.buildOptions"
@@ -210,7 +210,7 @@ const (
 	ArgoCDDefaultServer = "https://kubernetes.default.svc"
 
 	// ArgoCDSecretTypeLabel is needed for cluster secrets
-	ArgoCDSecretTypeLabel = "argocd.argoproj.io/secret-type"
+	ArgoCDSecretTypeLabel = "argocd.argoproj.io/secret-type" // #nosec G101
 
 	// ArgoCDManagedByLabel is needed to identify namespace managed by an instance on ArgoCD
 	ArgoCDManagedByLabel = "argocd.argoproj.io/managed-by"
@@ -228,7 +228,7 @@ const (
 	ArgoCDServerClusterRoleEnvName = "SERVER_CLUSTER_ROLE"
 
 	// ArgoCDDexSecretKey is used to reference Dex secret from Argo CD secret into Argo CD configmap
-	ArgoCDDexSecretKey = "oidc.dex.clientSecret"
+	ArgoCDDexSecretKey = "oidc.dex.clientSecret" // #nosec G101
 
 	// Label Selector is an env variable for ArgoCD instance reconcilliation.
 	ArgoCDLabelSelectorKey = "ARGOCD_LABEL_SELECTOR"

--- a/common/values.go
+++ b/common/values.go
@@ -78,10 +78,10 @@ const (
 	ArgoCDRedisServerTLSSecretName = "argocd-operator-redis-tls"
 
 	// ArgoCDRepoServerTLSSecretName is the name of the TLS secret for the repo-server
-	ArgoCDRepoServerTLSSecretName = "argocd-repo-server-tls"
+	ArgoCDRepoServerTLSSecretName = "argocd-repo-server-tls" // #nosec G101
 
 	// ArgoCDServerTLSSecretName is the name of the TLS secret for the argocd-server
-	ArgoCDServerTLSSecretName = "argocd-server-tls"
+	ArgoCDServerTLSSecretName = "argocd-server-tls" // #nosec G101
 
 	//ApplicationSetServiceNameSuffix is the suffix for Apllication Set Controller Service
 	ApplicationSetServiceNameSuffix = "applicationset-controller"

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -124,7 +124,7 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 	reqLogger.Info("Reconciling ArgoCD")
 
 	argocd := &argoproj.ArgoCD{}
-	err := r.Client.Get(ctx, request.NamespacedName, argocd)
+	err := r.Get(ctx, request.NamespacedName, argocd)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -227,7 +227,7 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 	}
 
 	// get the latest version of argocd instance before reconciling
-	if err = r.Client.Get(ctx, request.NamespacedName, argocd); err != nil {
+	if err = r.Get(ctx, request.NamespacedName, argocd); err != nil {
 		return reconcile.Result{}, argocd, err
 	}
 

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -43,7 +43,7 @@ func (r *ReconcileArgoCD) createRBACConfigMap(cm *corev1.ConfigMap, cr *argoproj
 		return err
 	}
 	argoutil.LogResourceCreation(log, cm)
-	return r.Client.Create(context.TODO(), cm)
+	return r.Create(context.TODO(), cm)
 }
 
 // getApplicationInstanceLabelKey will return the application instance label key  for the given ArgoCD.
@@ -284,11 +284,11 @@ func newConfigMap(cr *argoproj.ArgoCD) *corev1.ConfigMap {
 // newConfigMapWithName creates a new ConfigMap with the given name for the given ArgCD.
 func newConfigMapWithName(name string, cr *argoproj.ArgoCD) *corev1.ConfigMap {
 	cm := newConfigMap(cr)
-	cm.ObjectMeta.Name = name
+	cm.Name = name
 
-	lbls := cm.ObjectMeta.Labels
+	lbls := cm.Labels
 	lbls[common.ArgoCDKeyName] = name
-	cm.ObjectMeta.Labels = lbls
+	cm.Labels = lbls
 
 	return cm
 }
@@ -380,7 +380,7 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoproj.ArgoCD) error {
 		return err
 	}
 	argoutil.LogResourceCreation(log, cm)
-	return r.Client.Create(context.TODO(), cm)
+	return r.Create(context.TODO(), cm)
 }
 
 // reconcileConfiguration will ensure that the main ConfigMap for ArgoCD is present.
@@ -443,12 +443,12 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 
 	// deprecated: log warning for deprecated field InitialRepositories
 	//lint:ignore SA1019 known to be deprecated
-	if cr.Spec.InitialRepositories != "" {
+	if cr.Spec.InitialRepositories != "" { //nolint:staticcheck // SA1019: We must test deprecated fields.
 		log.Info(initialRepositoriesWarning)
 	}
 	// deprecated: log warning for deprecated field RepositoryCredential
 	//lint:ignore SA1019 known to be deprecated
-	if cr.Spec.RepositoryCredentials != "" {
+	if cr.Spec.RepositoryCredentials != "" { //nolint:staticcheck // SA1019: We must test deprecated fields.
 		log.Info(repositoryCredentialsWarning)
 	}
 
@@ -546,19 +546,19 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 				explanation += ", owner reference"
 			}
 			argoutil.LogResourceUpdate(log, existingCM, explanation)
-			return r.Client.Update(context.TODO(), existingCM)
+			return r.Update(context.TODO(), existingCM)
 		}
 		return nil // Do nothing as there is no change in the configmap.
 	}
 	argoutil.LogResourceCreation(log, cm)
-	return r.Client.Create(context.TODO(), cm)
+	return r.Create(context.TODO(), cm)
 
 }
 
 // reconcileGrafanaConfiguration will ensure that the Grafana configuration ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoproj.ArgoCD) error {
 	//lint:ignore SA1019 known to be deprecated
-	if !cr.Spec.Grafana.Enabled {
+	if !cr.Spec.Grafana.Enabled { //nolint:staticcheck // SA1019: We must test deprecated fields.
 		return nil // Grafana not enabled, do nothing.
 	}
 
@@ -570,7 +570,7 @@ func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoproj.ArgoCD) err
 // reconcileGrafanaDashboards will ensure that the Grafana dashboards ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileGrafanaDashboards(cr *argoproj.ArgoCD) error {
 	//lint:ignore SA1019 known to be deprecated
-	if !cr.Spec.Grafana.Enabled {
+	if !cr.Spec.Grafana.Enabled { //nolint:staticcheck // SA1019: We must test deprecated fields.
 		return nil // Grafana not enabled, do nothing.
 	}
 
@@ -641,7 +641,7 @@ func (r *ReconcileArgoCD) reconcileRBACConfigMap(cm *corev1.ConfigMap, cr *argop
 	if changed {
 		argoutil.LogResourceUpdate(log, cm, "updating", explanation)
 		// TODO: Reload server (and dex?) if RBAC settings change?
-		return r.Client.Update(context.TODO(), cm)
+		return r.Update(context.TODO(), cm)
 	}
 	return nil // ConfigMap exists and nothing to do, move along...
 }
@@ -720,7 +720,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoproj.ArgoCD, u
 		if exists {
 			// ConfigMap exists but HA enabled flag has been set to false, delete the ConfigMap
 			argoutil.LogResourceDeletion(log, cm, "redis ha is disabled")
-			return r.Client.Delete(context.TODO(), existingCM)
+			return r.Delete(context.TODO(), existingCM)
 		}
 		return nil // Nothing to do since HA is not enabled and ConfigMap does not exist
 	}
@@ -739,12 +739,12 @@ func (r *ReconcileArgoCD) reconcileRedisHAHealthConfigMap(cr *argoproj.ArgoCD, u
 		if !reflect.DeepEqual(cm.Data, existingCM.Data) {
 			existingCM.Data = cm.Data
 			argoutil.LogResourceUpdate(log, existingCM, "updating", "Redis HA Health ConfigMap")
-			return r.Client.Update(context.TODO(), existingCM)
+			return r.Update(context.TODO(), existingCM)
 		}
 		return nil // No changes detected
 	}
 	argoutil.LogResourceCreation(log, cm)
-	return r.Client.Create(context.TODO(), cm)
+	return r.Create(context.TODO(), cm)
 }
 
 // reconcileRedisHAConfigMap will ensure that the Redis HA ConfigMap is present for the given ArgoCD.
@@ -769,7 +769,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAConfigMap(cr *argoproj.ArgoCD, useTLSF
 		if exists {
 			// ConfigMap exists but HA enabled flag has been set to false, delete the ConfigMap
 			argoutil.LogResourceDeletion(log, cm, "redis ha is disabled")
-			return r.Client.Delete(context.TODO(), existingCM)
+			return r.Delete(context.TODO(), existingCM)
 		}
 		return nil // Nothing to do since HA is not enabled and ConfigMap does not exist
 	}
@@ -789,13 +789,13 @@ func (r *ReconcileArgoCD) reconcileRedisHAConfigMap(cr *argoproj.ArgoCD, useTLSF
 		if !reflect.DeepEqual(cm.Data, existingCM.Data) {
 			existingCM.Data = cm.Data
 			argoutil.LogResourceUpdate(log, existingCM, "updating", "Redis HA ConfigMap")
-			return r.Client.Update(context.TODO(), existingCM)
+			return r.Update(context.TODO(), existingCM)
 		}
 		return nil // No changes detected
 	}
 	argoutil.LogResourceCreation(log, cm)
 	// Create the ConfigMap if it does not exist
-	return r.Client.Create(context.TODO(), cm)
+	return r.Create(context.TODO(), cm)
 }
 
 func (r *ReconcileArgoCD) recreateRedisHAConfigMap(cr *argoproj.ArgoCD, useTLSForRedis bool) error {
@@ -807,7 +807,7 @@ func (r *ReconcileArgoCD) recreateRedisHAConfigMap(cr *argoproj.ArgoCD, useTLSFo
 	}
 	if exists {
 		argoutil.LogResourceDeletion(log, cm, "deleting config map in order to recreate it")
-		if err := r.Client.Delete(context.TODO(), cm); err != nil {
+		if err := r.Delete(context.TODO(), cm); err != nil {
 			return err
 		}
 	}
@@ -823,7 +823,7 @@ func (r *ReconcileArgoCD) recreateRedisHAHealthConfigMap(cr *argoproj.ArgoCD, us
 	}
 	if exists {
 		argoutil.LogResourceDeletion(log, cm, "deleting config map in order to recreate it")
-		if err := r.Client.Delete(context.TODO(), cm); err != nil {
+		if err := r.Delete(context.TODO(), cm); err != nil {
 			return err
 		}
 	}
@@ -849,7 +849,7 @@ func (r *ReconcileArgoCD) reconcileSSHKnownHosts(cr *argoproj.ArgoCD) error {
 		return err
 	}
 	argoutil.LogResourceCreation(log, cm)
-	return r.Client.Create(context.TODO(), cm)
+	return r.Create(context.TODO(), cm)
 }
 
 // reconcileTLSCerts will ensure that the ArgoCD TLS Certs ConfigMap is present.
@@ -869,7 +869,7 @@ func (r *ReconcileArgoCD) reconcileTLSCerts(cr *argoproj.ArgoCD) error {
 		return err
 	}
 	argoutil.LogResourceCreation(log, cm)
-	return r.Client.Create(context.TODO(), cm)
+	return r.Create(context.TODO(), cm)
 }
 
 // reconcileGPGKeysConfigMap creates a gpg-keys config map
@@ -886,7 +886,7 @@ func (r *ReconcileArgoCD) reconcileGPGKeysConfigMap(cr *argoproj.ArgoCD) error {
 		return err
 	}
 	argoutil.LogResourceCreation(log, cm)
-	return r.Client.Create(context.TODO(), cm)
+	return r.Create(context.TODO(), cm)
 }
 
 // reconcileArgoCmdParamsConfigMap will ensure that the ConfigMap containing command line parameters for ArgoCD is present.

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -55,7 +55,7 @@ func TestReconcileArgoCD_reconcileTLSCerts(t *testing.T) {
 	assert.NoError(t, r.reconcileTLSCerts(a))
 
 	configMap := &corev1.ConfigMap{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      common.ArgoCDTLSCertsConfigMapName,
@@ -83,7 +83,7 @@ func TestReconcileArgoCD_reconcileTLSCerts_configMapUpdate(t *testing.T) {
 	assert.NoError(t, r.reconcileTLSCerts(a))
 
 	configMap := &corev1.ConfigMap{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      common.ArgoCDTLSCertsConfigMapName,
@@ -100,7 +100,7 @@ func TestReconcileArgoCD_reconcileTLSCerts_configMapUpdate(t *testing.T) {
 	testPEM := generateEncodedPEM(t)
 
 	configMap.Data["example.com"] = string(testPEM)
-	assert.NoError(t, r.Client.Update(context.TODO(), configMap))
+	assert.NoError(t, r.Update(context.TODO(), configMap))
 
 	// verify that a new reconciliation does not remove example.com from
 	// argocd-tls-certs-cm
@@ -216,7 +216,7 @@ func TestReconcileArgoCD_reconcileTLSCerts_withInitialCertsUpdate(t *testing.T) 
 	assert.NoError(t, r.reconcileTLSCerts(a))
 
 	configMap := &corev1.ConfigMap{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      common.ArgoCDTLSCertsConfigMapName,
@@ -340,7 +340,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 		assert.NoError(t, err)
 
 		cm := &corev1.ConfigMap{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
@@ -351,7 +351,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap(t *testing.T) {
 		if diff := cmp.Diff(want, cm.Data); diff != "" {
 			t.Fatalf("reconcileArgoConfigMap (%s) failed:\n%s", tt.name, diff)
 		}
-		assert.True(t, argoutil.IsTrackedByOperator(cm.ObjectMeta.Labels))
+		assert.True(t, argoutil.IsTrackedByOperator(cm.Labels))
 	}
 }
 
@@ -375,19 +375,19 @@ func TestReconcileArgoCD_reconcileEmptyArgoConfigMap(t *testing.T) {
 	}
 	argoutil.AddTrackedByOperatorLabel(&emptyArgoConfigmap.ObjectMeta)
 
-	err := r.Client.Create(context.TODO(), emptyArgoConfigmap)
+	err := r.Create(context.TODO(), emptyArgoConfigmap)
 	assert.NoError(t, err)
 
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
 	assert.NoError(t, err)
-	assert.True(t, argoutil.IsTrackedByOperator(cm.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(cm.Labels))
 }
 
 func TestReconcileArgoCD_reconcileArgoConfigMap_withDisableAdmin(t *testing.T) {
@@ -407,7 +407,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDisableAdmin(t *testing.T) {
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -505,7 +505,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexConnector(t *testing.T) {
 			assert.NoError(t, err)
 
 			cm := &corev1.ConfigMap{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      common.ArgoCDConfigMapName,
 				Namespace: testNamespace,
 			}, cm)
@@ -580,7 +580,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withDexDisabled(t *testing.T) {
 			assert.NoError(t, err)
 
 			cm := &corev1.ConfigMap{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      common.ArgoCDConfigMapName,
 				Namespace: testNamespace,
 			}, cm)
@@ -659,7 +659,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_dexConfigDeletedwhenDexDisabled(
 			assert.NoError(t, err)
 
 			cm := &corev1.ConfigMap{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      common.ArgoCDConfigMapName,
 				Namespace: testNamespace,
 			}, cm)
@@ -676,7 +676,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_dexConfigDeletedwhenDexDisabled(
 			err = r.reconcileDexConfiguration(cm, test.argoCD)
 			assert.NoError(t, err)
 
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      common.ArgoCDConfigMapName,
 				Namespace: testNamespace,
 			}, cm)
@@ -714,7 +714,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withKustomizeVersions(t *testing
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -742,7 +742,7 @@ func TestReconcileArgoCD_reconcileGPGKeysConfigMap(t *testing.T) {
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDGPGKeysConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -766,7 +766,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 
 	cm := &corev1.ConfigMap{}
 	t.Run("Check default tracking method", func(t *testing.T) {
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
@@ -778,7 +778,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 	})
 
 	t.Run("Tracking method label", func(t *testing.T) {
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
@@ -794,7 +794,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 		err = r.reconcileArgoConfigMap(a)
 		assert.NoError(t, err)
 
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
@@ -810,7 +810,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 		err = r.reconcileArgoConfigMap(a)
 		assert.NoError(t, err)
 
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
@@ -827,7 +827,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceTrackingMethod(t *te
 		err = r.reconcileArgoConfigMap(a)
 		assert.NoError(t, err)
 
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
@@ -860,7 +860,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceInclusions(t *testin
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -874,7 +874,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withResourceInclusions(t *testin
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -980,7 +980,7 @@ managedfieldsmanagers:
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1019,7 +1019,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withExtraConfig(t *testing.T) {
 
 	// Verify Argo CD configmap is created.
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1027,13 +1027,13 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withExtraConfig(t *testing.T) {
 
 	// Verify that updates to the configmap are rejected(reconciled back to default) by the operator.
 	cm.Data["ping"] = "pong"
-	err = r.Client.Update(context.TODO(), cm)
+	err = r.Update(context.TODO(), cm)
 	assert.NoError(t, err)
 
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1049,7 +1049,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withExtraConfig(t *testing.T) {
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1064,7 +1064,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withExtraConfig(t *testing.T) {
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1079,7 +1079,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withExtraConfig(t *testing.T) {
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1106,7 +1106,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withRespectRBAC(t *testing.T) {
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDConfigMapName, Namespace: testNamespace}, cm))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDConfigMapName, Namespace: testNamespace}, cm))
 
 	if c := cm.Data["resource.respectRBAC"]; c != "normal" {
 		t.Fatalf("reconcileArgoConfigMap failed got %q, want %q", c, "false")
@@ -1118,7 +1118,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withRespectRBAC(t *testing.T) {
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDConfigMapName, Namespace: testNamespace}, cm))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDConfigMapName, Namespace: testNamespace}, cm))
 	if c := cm.Data["resource.respectRBAC"]; c != "strict" {
 		t.Fatalf("reconcileArgoConfigMap failed got %q, want %q", c, "false")
 	}
@@ -1129,7 +1129,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withRespectRBAC(t *testing.T) {
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDConfigMapName, Namespace: testNamespace}, cm))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: common.ArgoCDConfigMapName, Namespace: testNamespace}, cm))
 	if c := cm.Data["resource.respectRBAC"]; c != "" {
 		t.Fatalf("reconcileArgoConfigMap failed got %q, want %q", c, "false")
 	}
@@ -1156,7 +1156,7 @@ func Test_reconcileRBAC(t *testing.T) {
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1176,7 +1176,7 @@ func Test_reconcileRBAC(t *testing.T) {
 	assert.NoError(t, err)
 
 	cm = &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1195,7 +1195,7 @@ func Test_reconcileRBAC(t *testing.T) {
 	assert.NoError(t, err)
 
 	cm = &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1270,7 +1270,7 @@ func Test_validateOwnerReferences(t *testing.T) {
 	assert.Equal(t, cm.OwnerReferences[0].Kind, "ArgoCD")
 	assert.Equal(t, cm.OwnerReferences[0].Name, "argocd")
 	assert.Equal(t, cm.OwnerReferences[0].UID, uid)
-	assert.True(t, argoutil.IsTrackedByOperator(cm.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(cm.Labels))
 }
 
 func TestReconcileArgoCD_reconcileArgoConfigMap_withInstallationID(t *testing.T) {
@@ -1292,12 +1292,12 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withInstallationID(t *testing.T)
 	assert.NoError(t, err)
 
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
 	assert.NoError(t, err)
-	assert.True(t, argoutil.IsTrackedByOperator(cm.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(cm.Labels))
 	// Verify installationID is set as a top-level key
 	assert.Equal(t, "test-id", cm.Data[common.ArgoCDKeyInstallationID])
 
@@ -1307,7 +1307,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withInstallationID(t *testing.T)
 	assert.NoError(t, err)
 
 	cm = &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1320,7 +1320,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withInstallationID(t *testing.T)
 	err = r.reconcileArgoConfigMap(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm)
@@ -1328,7 +1328,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withInstallationID(t *testing.T)
 
 	// Verify installationID was removed
 	assert.NotContains(t, cm.Data, common.ArgoCDKeyInstallationID)
-	assert.True(t, argoutil.IsTrackedByOperator(cm.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(cm.Labels))
 }
 
 func TestReconcileArgoCD_reconcileArgoConfigMap_withMultipleInstances(t *testing.T) {
@@ -1360,7 +1360,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withMultipleInstances(t *testing
 	assert.NoError(t, err)
 
 	cm1 := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm1)
@@ -1368,13 +1368,13 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withMultipleInstances(t *testing
 
 	// Verify first instance's installationID
 	assert.Equal(t, "instance-1", cm1.Data[common.ArgoCDKeyInstallationID])
-	assert.True(t, argoutil.IsTrackedByOperator(cm1.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(cm1.Labels))
 	// Test second instance
 	err = r.reconcileArgoConfigMap(argocd2)
 	assert.NoError(t, err)
 
 	cm2 := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: testNamespace,
 	}, cm2)
@@ -1382,7 +1382,7 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_withMultipleInstances(t *testing
 
 	// Verify second instance's installationID
 	assert.Equal(t, "instance-2", cm2.Data[common.ArgoCDKeyInstallationID])
-	assert.True(t, argoutil.IsTrackedByOperator(cm2.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(cm2.Labels))
 }
 
 func TestReconcileArgoCD_RBACPolicyWithLogsPermissions(t *testing.T) {
@@ -1411,7 +1411,7 @@ func TestReconcileArgoCD_RBACPolicyWithLogsPermissions(t *testing.T) {
 	assert.NoError(t, err)
 
 	createdCM := &corev1.ConfigMap{}
-	err = r.Client.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: a.Namespace,
 	}, createdCM)
@@ -1431,7 +1431,7 @@ p, role:readonly, logs, get, */*, allow`
 	err = r.reconcileRBAC(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: a.Namespace,
 	}, createdCM)
@@ -1452,7 +1452,7 @@ p, role:admin, logs, get, */*, allow`
 	err = r.reconcileRBAC(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: a.Namespace,
 	}, createdCM)
@@ -1472,7 +1472,7 @@ p, role:admin, logs, get, */*, allow`
 	err = r.reconcileRBAC(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: a.Namespace,
 	}, createdCM)
@@ -1491,7 +1491,7 @@ p, role:custom-app-viewer, logs, get, */*, allow`
 	err = r.reconcileRBAC(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: a.Namespace,
 	}, createdCM)
@@ -1510,7 +1510,7 @@ p, role:custom-app-viewer, logs, get, */*, allow`
 	err = r.reconcileRBAC(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: a.Namespace,
 	}, createdCM)
@@ -1523,7 +1523,7 @@ p, role:custom-app-viewer, logs, get, */*, allow`
 
 	// Test 7: Verify no default policy is restored when custom policy is removed
 	// Clean up ConfigMap to simulate a reset state
-	err = r.Client.Delete(ctx, createdCM)
+	err = r.Delete(ctx, createdCM)
 	assert.NoError(t, err)
 
 	a.Spec.RBAC.Policy = nil
@@ -1532,7 +1532,7 @@ p, role:custom-app-viewer, logs, get, */*, allow`
 	err = r.reconcileRBAC(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      common.ArgoCDRBACConfigMapName,
 		Namespace: a.Namespace,
 	}, createdCM)
@@ -1544,7 +1544,7 @@ p, role:custom-app-viewer, logs, get, */*, allow`
 
 	// Test 8: Verify server.rbac.log.enforce.enable is not set in argocd-cm
 	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(ctx, types.NamespacedName{
+	err = r.Get(ctx, types.NamespacedName{
 		Name:      common.ArgoCDConfigMapName,
 		Namespace: a.Namespace,
 	}, cm)
@@ -1640,7 +1640,7 @@ func TestReconcileArgoCD_reconcileArgoCmdParamsConfigMap(t *testing.T) {
 			assert.NoError(t, err)
 
 			cm := &corev1.ConfigMap{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      common.ArgoCDCmdParamsConfigMapName,
 				Namespace: testNamespace,
 			}, cm)

--- a/controllers/argocd/custommapper_test.go
+++ b/controllers/argocd/custommapper_test.go
@@ -584,7 +584,7 @@ func TestReconcileArgoCD_namespaceResourceMapperWithManagedByLabel(t *testing.T)
 
 	// Fake client returns an error if ResourceVersion is not nil
 	a.ResourceVersion = ""
-	assert.NoError(t, r.Client.Create(context.TODO(), a))
+	assert.NoError(t, r.Create(context.TODO(), a))
 
 	type test struct {
 		name string
@@ -648,7 +648,7 @@ func TestReconcileArgoCD_namespaceResourceMapperForSpecificNamespaceWithoutManag
 	// Fake client returns an error if ResourceVersion is not nil
 	argocd1.ResourceVersion = ""
 
-	assert.NoError(t, r.Client.Create(context.TODO(), argocd1))
+	assert.NoError(t, r.Create(context.TODO(), argocd1))
 
 	type test struct {
 		name string
@@ -708,7 +708,7 @@ func TestReconcileArgoCD_namespaceResourceMapperForWildCardPatternNamespaceWitho
 	// Fake client returns an error if ResourceVersion is not nil
 	argocd1.ResourceVersion = ""
 
-	assert.NoError(t, r.Client.Create(context.TODO(), argocd1))
+	assert.NoError(t, r.Create(context.TODO(), argocd1))
 
 	type test struct {
 		name string
@@ -784,7 +784,7 @@ func TestReconcileArgoCD_namespaceResourceMapperForMultipleSourceNamespacesWitho
 	// Fake client returns an error if ResourceVersion is not nil
 	argocd1.ResourceVersion = ""
 
-	assert.NoError(t, r.Client.Create(context.TODO(), argocd1))
+	assert.NoError(t, r.Create(context.TODO(), argocd1))
 
 	type test struct {
 		name string
@@ -876,7 +876,7 @@ func TestReconcileArgoCD_namespaceResourceMapperForWildCardNamespaceWithoutManag
 	// Fake client returns an error if ResourceVersion is not nil
 	argocd1.ResourceVersion = ""
 
-	assert.NoError(t, r.Client.Create(context.TODO(), argocd1))
+	assert.NoError(t, r.Create(context.TODO(), argocd1))
 
 	type test struct {
 		name string

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -77,7 +77,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_replicas(t *testing.T) {
 			assert.NoError(t, err)
 
 			deployment := &appsv1.Deployment{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-repo-server",
 				Namespace: testNamespace,
 			}, deployment)
@@ -146,7 +146,7 @@ func TestReconcileArgoCD_reconcile_ServerDeployment_replicas(t *testing.T) {
 			assert.NoError(t, err)
 
 			deployment := &appsv1.Deployment{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-server",
 				Namespace: testNamespace,
 			}, deployment)
@@ -158,7 +158,7 @@ func TestReconcileArgoCD_reconcile_ServerDeployment_replicas(t *testing.T) {
 			assert.NoError(t, err)
 
 			deployment = &appsv1.Deployment{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-server",
 				Namespace: testNamespace,
 			}, deployment)
@@ -201,7 +201,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_loglevel(t *testing.T) {
 		err := r.reconcileRepoDeployment(lglv, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -241,7 +241,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_volumes(t *testing.T) {
 		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -272,7 +272,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_volumes(t *testing.T) {
 		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -308,7 +308,7 @@ func TestReconcileArgoCD_reconcile_ServerDeployment_env(t *testing.T) {
 		err := r.reconcileServerDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -349,7 +349,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -378,7 +378,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -411,7 +411,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -435,7 +435,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
 		err := r.reconcileRepoDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -461,7 +461,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 		assert.NoError(t, err)
 
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -491,7 +491,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 		assert.NoError(t, err)
 
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -522,7 +522,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 		assert.NoError(t, err)
 
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-repo-server",
 			Namespace: testNamespace,
 		}, deployment)
@@ -585,7 +585,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_initContainers(t *testing.T) {
 	assert.NoError(t, err)
 
 	deployment := &appsv1.Deployment{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-repo-server",
 		Namespace: testNamespace,
 	}, deployment)
@@ -626,7 +626,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_missingInitContainers(t *testin
 	err := r.reconcileRepoDeployment(a, false)
 	assert.NoError(t, err)
 	deployment := &appsv1.Deployment{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-repo-server",
 		Namespace: testNamespace,
 	}, deployment)
@@ -673,7 +673,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_unexpectedInitContainer(t *test
 	err := r.reconcileRepoDeployment(a, false)
 	assert.NoError(t, err)
 	deployment := &appsv1.Deployment{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-repo-server",
 		Namespace: testNamespace,
 	}, deployment)
@@ -697,7 +697,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_command(t *testing.T) {
 	assert.NoError(t, err)
 
 	deployment := &appsv1.Deployment{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-repo-server",
 		Namespace: testNamespace,
 	}, deployment)
@@ -721,7 +721,7 @@ func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 		//lint:ignore SA1019 known to be deprecated
-		a.Spec.Grafana.Enabled = true
+		a.Spec.Grafana.Enabled = true //nolint:staticcheck // SA1019: We must test deprecated fields.
 		a.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 			Provider: argoproj.SSOProviderTypeDex,
 			Dex: &argoproj.ArgoCDDexSpec{
@@ -842,7 +842,7 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy_with_resources(t *testing
 	assert.NoError(t, r.reconcileRedisHAProxyDeployment(a))
 
 	deployment := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      a.Name + "-redis-ha-haproxy",
@@ -877,7 +877,7 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy_with_resources(t *testing
 	a.Spec.HA.Resources = &newResources
 	assert.NoError(t, r.reconcileRedisHAProxyDeployment(a))
 
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      a.Name + "-redis-ha-haproxy",
@@ -905,7 +905,7 @@ func TestReconcileArgoCD_reconcileRedisHAProxyDeployment_ModifyContainerSpec(t *
 	assert.NoError(t, r.reconcileRedisHAProxyDeployment(a))
 
 	deployment := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-redis-ha-haproxy",
@@ -919,13 +919,13 @@ func TestReconcileArgoCD_reconcileRedisHAProxyDeployment_ModifyContainerSpec(t *
 		Value: "test",
 	})
 
-	assert.NoError(t, r.Client.Update(context.TODO(), deployment))
+	assert.NoError(t, r.Update(context.TODO(), deployment))
 
 	// Reconcile again
 	assert.NoError(t, r.reconcileRedisHAProxyDeployment(a))
 
 	// Check if the environment variable changes were reverted
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-redis-ha-haproxy",
@@ -944,13 +944,13 @@ func TestReconcileArgoCD_reconcileRedisHAProxyDeployment_ModifyContainerSpec(t *
 		Value: "test",
 	})
 
-	assert.NoError(t, r.Client.Update(context.TODO(), deployment))
+	assert.NoError(t, r.Update(context.TODO(), deployment))
 
 	// Reconcile again
 	assert.NoError(t, r.reconcileRedisHAProxyDeployment(a))
 
 	// Check if the environment variable changes were reverted
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-redis-ha-haproxy",
@@ -975,13 +975,13 @@ func TestReconcileArgoCD_reconcileRedisHAProxyDeployment_ModifyContainerSpec(t *
 		MountPath: "/test",
 	})
 
-	assert.NoError(t, r.Client.Update(context.TODO(), deployment))
+	assert.NoError(t, r.Update(context.TODO(), deployment))
 
 	// Reconcile again
 	assert.NoError(t, r.reconcileRedisHAProxyDeployment(a))
 
 	// Check if the volume changes were reverted
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-redis-ha-haproxy",
@@ -1040,7 +1040,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_updatesVolumeMounts(t *testing.
 	assert.NoError(t, err)
 
 	deployment := &appsv1.Deployment{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-repo-server",
 		Namespace: testNamespace,
 	}, deployment)
@@ -1104,7 +1104,7 @@ func TestReconcileArgoCD_reconcileDeployment_nodePlacement(t *testing.T) {
 	err := r.reconcileRepoDeployment(a, false) //can use other deployments as well
 	assert.NoError(t, err)
 	deployment := &appsv1.Deployment{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-repo-server",
 		Namespace: testNamespace,
 	}, deployment)
@@ -1160,7 +1160,7 @@ func TestReconcileArgocd_reconcileRepoServerRedisTLS(t *testing.T) {
 		assert.NoError(t, r.reconcileRepoDeployment(a, true))
 
 		deployment := &appsv1.Deployment{}
-		assert.NoError(t, r.Client.Get(
+		assert.NoError(t, r.Get(
 			context.TODO(),
 			types.NamespacedName{
 				Name:      "argocd-repo-server",
@@ -1196,7 +1196,7 @@ func TestReconcileArgocd_reconcileRepoServerRedisTLS(t *testing.T) {
 		assert.NoError(t, r.reconcileRepoDeployment(a, true))
 
 		deployment := &appsv1.Deployment{}
-		assert.NoError(t, r.Client.Get(
+		assert.NoError(t, r.Get(
 			context.TODO(),
 			types.NamespacedName{
 				Name:      "argocd-repo-server",
@@ -1231,7 +1231,7 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
 	deployment := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1320,7 +1320,7 @@ func TestReconcileArgoCD_reconcileServerDeployment(t *testing.T) {
 
 	assert.NoError(t, r.reconcileServerDeployment(a, true))
 	deployment = &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1383,7 +1383,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1404,7 +1404,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 	}
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1438,7 +1438,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 	}
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1464,7 +1464,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 	}
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1480,7 +1480,7 @@ func TestArgoCDServerDeploymentCommand(t *testing.T) {
 	a.Spec.Server.ExtraCommandArgs = []string{}
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1511,7 +1511,7 @@ func TestReconcileServer_InitContainers(t *testing.T) {
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1527,7 +1527,7 @@ func TestReconcileServer_InitContainers(t *testing.T) {
 	a.Spec.Server.InitContainers = []corev1.Container{}
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1559,7 +1559,7 @@ func TestReconcile_SidecarContainers(t *testing.T) {
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1575,7 +1575,7 @@ func TestReconcile_SidecarContainers(t *testing.T) {
 	a.Spec.Server.SidecarContainers = []corev1.Container{}
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1601,7 +1601,7 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1619,7 +1619,7 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 	for _, vol := range deployment.Spec.Template.Spec.Volumes {
 		if vol.Name == "rollout-extensions" {
 			foundVolume = true
-			assert.NotNil(t, vol.VolumeSource.EmptyDir)
+			assert.NotNil(t, vol.EmptyDir)
 		}
 	}
 	assert.True(t, foundVolume, "expected volume 'rollout-extensions' to be present")
@@ -1628,7 +1628,7 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 	a.Spec.Server.EnableRolloutsUI = false
 
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1675,7 +1675,7 @@ func TestReconcileArgoCD_reconcileServerDeploymentWithInsecure(t *testing.T) {
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
 	deployment := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1783,7 +1783,7 @@ func TestReconcileArgoCD_reconcileServerDeploymentChangedToInsecure(t *testing.T
 	assert.NoError(t, r.reconcileServerDeployment(a, false))
 
 	deployment := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-server",
@@ -1891,7 +1891,7 @@ func TestReconcileArgoCD_reconcileRedisDeploymentWithoutTLS(t *testing.T) {
 
 	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
 	d := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
 	got := d.Spec.Template.Spec.Containers[0].Args
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Reconciliation unsucessful: got: %v, want: %v", got, want)
@@ -1921,7 +1921,7 @@ func TestReconcileArgoCD_reconcileRedisDeploymentWithTLS(t *testing.T) {
 
 	assert.NoError(t, r.reconcileRedisDeployment(cr, true))
 	d := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
 	got := d.Spec.Template.Spec.Containers[0].Args
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Reconciliation unsucessful: got: %v, want: %v", got, want)
@@ -1944,7 +1944,7 @@ func TestReconcileArgoCD_reconcileRedisDeployment(t *testing.T) {
 
 	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
 	d := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
 	assert.Equal(t, int32(3), *d.Spec.Replicas)
 }
 
@@ -1965,14 +1965,14 @@ func TestReconcileArgoCD_reconcileRedisDeployment_testImageUpgrade(t *testing.T)
 	// Verify redis deployment
 	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
 	existing := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, existing))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, existing))
 
 	// Verify Image upgrade
 	t.Setenv("ARGOCD_REDIS_IMAGE", "docker.io/redis/redis:latest")
 	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
 
 	newRedis := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, newRedis))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, newRedis))
 	assert.Equal(t, newRedis.Spec.Template.Spec.Containers[0].Image, "docker.io/redis/redis:latest")
 }
 
@@ -2039,14 +2039,14 @@ func TestReconcileRedisDeployment_serviceAccountNameUpdate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			existing := &appsv1.Deployment{}
-			assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, existing))
+			assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, existing))
 
 			existing.Spec.Template.Spec.ServiceAccountName = test.SA
 			assert.NoError(t, cl.Update(context.TODO(), existing))
 			assert.NoError(t, r.reconcileRedisDeployment(cr, false))
 
 			newRedis := &appsv1.Deployment{}
-			assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, newRedis))
+			assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, newRedis))
 			assert.Equal(t, newRedis.Spec.Template.Spec.ServiceAccountName, test.expectedSA)
 		})
 	}
@@ -2427,12 +2427,13 @@ func TestReconcileArgoCD_reconcile_RepoServerChanges(t *testing.T) {
 					Labels:    argoutil.LabelsForCluster(a),
 				},
 			}
-			r.Client.Create(context.TODO(), sa)
-			err := r.reconcileRepoDeployment(a, false)
+			err := r.Create(context.TODO(), sa)
+			assert.NoError(t, err)
+			err = r.reconcileRepoDeployment(a, false)
 			assert.NoError(t, err)
 
 			deployment := &appsv1.Deployment{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-repo-server",
 				Namespace: testNamespace,
 			}, deployment)
@@ -2475,7 +2476,7 @@ func TestArgoCDRepoServerDeploymentCommand(t *testing.T) {
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.reconcileRepoDeployment(a, false))
 
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-repo-server",
@@ -2497,7 +2498,7 @@ func TestArgoCDRepoServerDeploymentCommand(t *testing.T) {
 	}
 
 	assert.NoError(t, r.reconcileRepoDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-repo-server",
@@ -2526,7 +2527,7 @@ func TestArgoCDRepoServerDeploymentCommand(t *testing.T) {
 	}
 
 	assert.NoError(t, r.reconcileRepoDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-repo-server",
@@ -2540,7 +2541,7 @@ func TestArgoCDRepoServerDeploymentCommand(t *testing.T) {
 	a.Spec.Repo.ExtraRepoCommandArgs = []string{}
 
 	assert.NoError(t, r.reconcileRepoDeployment(a, false))
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-repo-server",
@@ -2613,7 +2614,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_serviceAccount(t *testing.T) {
 				Namespace: testNamespace,
 			}
 
-			err = r.Client.Get(context.TODO(), key, deployment)
+			err = r.Get(context.TODO(), key, deployment)
 
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
@@ -2626,7 +2627,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_serviceAccount(t *testing.T) {
 				err = r.reconcileRepoDeployment(a, false)
 				assert.NoError(t, err)
 
-				err = r.Client.Get(context.TODO(), key, deployment)
+				err = r.Get(context.TODO(), key, deployment)
 
 				assert.NoError(t, err)
 				assert.Equal(t, test.newExpectedServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
@@ -2663,7 +2664,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_sidecarContainerImage(t *testin
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.reconcileRepoDeployment(a, false))
 
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-repo-server",
@@ -2698,14 +2699,14 @@ func TestReconcileArgoCD_reconcileRedisWithRemote(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 
-	assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d),
+	assert.ErrorContains(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d),
 		"deployments.apps \""+cr.Name+"-redis\" not found")
 
 	// once remote is set to nil, reconciliation should trigger deployment resource creation
 	cr.Spec.Redis.Remote = nil
 
 	assert.NoError(t, r.reconcileRedisDeployment(cr, false))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, d))
 }
 
 func TestReconcileArgoCD_reconcileRepoServerWithRemote(t *testing.T) {
@@ -2725,14 +2726,14 @@ func TestReconcileArgoCD_reconcileRepoServerWithRemote(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 
-	assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d),
+	assert.ErrorContains(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d),
 		"deployments.apps \""+cr.Name+"-repo-server\" not found")
 
 	// once remote is set to nil, reconciliation should trigger deployment resource creation
 	cr.Spec.Repo.Remote = nil
 
 	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
 }
 
 func Test_getRolloutInitContainer(t *testing.T) {
@@ -2795,7 +2796,7 @@ func TestSetReplicasAndEnvVar_WhenServerReplicasIsDefined(t *testing.T) {
 		err := r.reconcileServerDeployment(a, false)
 		assert.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-server",
 			Namespace: testNamespace,
 		}, deployment)

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -63,7 +63,7 @@ func TestReconcileArgoCD_reconcileDexDeployment_with_dex_disabled(t *testing.T) 
 			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
 
 			deployment := &appsv1.Deployment{}
-			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, deployment)
+			err := r.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, deployment)
 			assert.True(t, apierrors.IsNotFound(err))
 		})
 	}
@@ -135,7 +135,7 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 
 			// ensure deployment was created correctly
 			deployment := &appsv1.Deployment{}
-			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, deployment)
+			err := r.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, deployment)
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
@@ -147,7 +147,7 @@ func TestReconcileArgoCD_reconcileDexDeployment_removes_dex_when_disabled(t *tes
 
 			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
 			deployment = &appsv1.Deployment{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, deployment)
+			err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, deployment)
 
 			if test.wantDeploymentDeleted {
 				assertNotFound(t, err)
@@ -206,7 +206,7 @@ func TestReconcileArgoCD_reconcileDeployments_Dex_with_resources(t *testing.T) {
 			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
 
 			deployment := &appsv1.Deployment{}
-			assert.NoError(t, r.Client.Get(
+			assert.NoError(t, r.Get(
 				context.TODO(),
 				types.NamespacedName{
 					Name:      test.argoCD.Name + "-dex-server",
@@ -274,7 +274,7 @@ func TestReconcileArgoCD_reconcileDeployments_Dex_with_volumes(t *testing.T) {
 			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
 
 			deployment := &appsv1.Deployment{}
-			assert.NoError(t, r.Client.Get(
+			assert.NoError(t, r.Get(
 				context.TODO(),
 				types.NamespacedName{
 					Name:      test.argoCD.Name + "-dex-server",
@@ -334,7 +334,7 @@ func TestReconcileArgoCD_reconcileDexDeployment(t *testing.T) {
 	assert.NoError(t, r.reconcileDexDeployment(a))
 
 	deployment := &appsv1.Deployment{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-dex-server",
@@ -758,7 +758,7 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 
 			// ensure deployment was created correctly
 			deployment := &appsv1.Deployment{}
-			assert.NoError(t, r.Client.Get(
+			assert.NoError(t, r.Get(
 				context.TODO(),
 				types.NamespacedName{
 					Name:      "argocd-dex-server",
@@ -837,7 +837,7 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 
 			// ensure service was created correctly
 			service := &corev1.Service{}
-			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, service)
+			err := r.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, service)
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
@@ -849,7 +849,7 @@ func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testin
 
 			assert.NoError(t, r.reconcileDexService(test.argoCD))
 			service = &corev1.Service{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, service)
+			err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-dex-server", Namespace: test.argoCD.Namespace}, service)
 
 			if test.wantServiceDeleted {
 				assertNotFound(t, err)
@@ -926,7 +926,7 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 			assert.NoError(t, err)
 
 			// ensure serviceaccount was created correctly
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: test.argoCD.Namespace}, sa)
+			err = r.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: test.argoCD.Namespace}, sa)
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
@@ -939,7 +939,7 @@ func TestReconcileArgoCD_reconcileDexServiceAccount_removes_dex_when_disabled(t 
 			_, err = r.reconcileServiceAccount(common.ArgoCDDexServerComponent, test.argoCD)
 			assert.NoError(t, err)
 
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: test.argoCD.Namespace}, sa)
+			err = r.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: test.argoCD.Namespace}, sa)
 
 			if test.wantServiceAccountDeleted {
 				assertNotFound(t, err)
@@ -1021,7 +1021,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 			assert.NoError(t, err)
 
 			// ensure role was created correctly
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: test.argoCD.Namespace}, role)
+			err = r.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: test.argoCD.Namespace}, role)
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
@@ -1034,7 +1034,7 @@ func TestReconcileArgoCD_reconcileRole_dex_disabled(t *testing.T) {
 			_, err = r.reconcileRole(common.ArgoCDDexServerComponent, rules, test.argoCD)
 			assert.NoError(t, err)
 
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: test.argoCD.Namespace}, role)
+			err = r.Get(context.TODO(), types.NamespacedName{Name: role.Name, Namespace: test.argoCD.Namespace}, role)
 
 			if test.wantRoleDeleted {
 				assertNotFound(t, err)
@@ -1113,10 +1113,10 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 			}
 
 			assert.NoError(t, r.reconcileRoleBinding(common.ArgoCDDexServerComponent, rules, test.argoCD))
-			assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: test.argoCD.Namespace}, roleBinding))
+			assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: test.argoCD.Namespace}, roleBinding))
 
 			// ensure roleBinding was created correctly
-			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: test.argoCD.Namespace}, roleBinding)
+			err := r.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: test.argoCD.Namespace}, roleBinding)
 			assert.NoError(t, err)
 
 			if test.updateEnvFunc != nil {
@@ -1129,7 +1129,7 @@ func TestReconcileArgoCD_reconcileRoleBinding_dex_disabled(t *testing.T) {
 			err = r.reconcileRoleBinding(common.ArgoCDDexServerComponent, rules, test.argoCD)
 			assert.NoError(t, err)
 
-			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: test.argoCD.Namespace}, roleBinding)
+			err = r.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: test.argoCD.Namespace}, roleBinding)
 
 			if test.wantRoleBindingDeleted {
 				assertNotFound(t, err)

--- a/controllers/argocd/hpa.go
+++ b/controllers/argocd/hpa.go
@@ -44,11 +44,11 @@ func newHorizontalPodAutoscaler(cr *argoproj.ArgoCD) *autoscaling.HorizontalPodA
 
 func newHorizontalPodAutoscalerWithName(name string, cr *argoproj.ArgoCD) *autoscaling.HorizontalPodAutoscaler {
 	hpa := newHorizontalPodAutoscaler(cr)
-	hpa.ObjectMeta.Name = name
+	hpa.Name = name
 
-	lbls := hpa.ObjectMeta.Labels
+	lbls := hpa.Labels
 	lbls[common.ArgoCDKeyName] = name
-	hpa.ObjectMeta.Labels = lbls
+	hpa.Labels = lbls
 
 	return hpa
 }
@@ -80,7 +80,7 @@ func (r *ReconcileArgoCD) reconcileServerHPA(cr *argoproj.ArgoCD) error {
 	if hpaExists {
 		if !cr.Spec.Server.Autoscale.Enabled {
 			argoutil.LogResourceDeletion(log, existingHPA, "server autoscaling is disabled")
-			return r.Client.Delete(context.TODO(), existingHPA) // HorizontalPodAutoscaler found but globally disabled, delete it.
+			return r.Delete(context.TODO(), existingHPA) // HorizontalPodAutoscaler found but globally disabled, delete it.
 		}
 
 		changed := false
@@ -94,7 +94,7 @@ func (r *ReconcileArgoCD) reconcileServerHPA(cr *argoproj.ArgoCD) error {
 
 		if changed {
 			argoutil.LogResourceUpdate(log, existingHPA, "due to differences from ArgoCD CR")
-			return r.Client.Update(context.TODO(), existingHPA)
+			return r.Update(context.TODO(), existingHPA)
 		}
 
 		// HorizontalPodAutoscaler found, no changes detected
@@ -111,7 +111,7 @@ func (r *ReconcileArgoCD) reconcileServerHPA(cr *argoproj.ArgoCD) error {
 	}
 
 	argoutil.LogResourceCreation(log, defaultHPA)
-	return r.Client.Create(context.TODO(), defaultHPA)
+	return r.Create(context.TODO(), defaultHPA)
 }
 
 // reconcileAutoscalers will ensure that all HorizontalPodAutoscalers are present for the given ArgoCD.

--- a/controllers/argocd/hpa_test.go
+++ b/controllers/argocd/hpa_test.go
@@ -58,7 +58,7 @@ func TestReconcileHPA(t *testing.T) {
 		},
 	}
 
-	err := r.Client.Get(context.TODO(), types.NamespacedName{
+	err := r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-server",
 		Namespace: testNamespace,
 	}, existingHPA)
@@ -69,7 +69,7 @@ func TestReconcileHPA(t *testing.T) {
 	err = r.reconcileServerHPA(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-server",
 		Namespace: testNamespace,
 	}, existingHPA)
@@ -81,7 +81,7 @@ func TestReconcileHPA(t *testing.T) {
 	err = r.reconcileServerHPA(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-server",
 		Namespace: testNamespace,
 	}, existingHPA)
@@ -93,7 +93,7 @@ func TestReconcileHPA(t *testing.T) {
 	err = r.reconcileServerHPA(a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-server",
 		Namespace: testNamespace,
 	}, existingHPA)

--- a/controllers/argocd/ingress.go
+++ b/controllers/argocd/ingress.go
@@ -51,11 +51,11 @@ func newIngress(cr *argoproj.ArgoCD) *networkingv1.Ingress {
 // newIngressWithName returns a new Ingress with the given name and ArgoCD.
 func newIngressWithName(name string, cr *argoproj.ArgoCD) *networkingv1.Ingress {
 	ingress := newIngress(cr)
-	ingress.ObjectMeta.Name = name
+	ingress.Name = name
 
-	lbls := ingress.ObjectMeta.Labels
+	lbls := ingress.Labels
 	lbls[common.ArgoCDKeyName] = name
-	ingress.ObjectMeta.Labels = lbls
+	ingress.Labels = lbls
 
 	return ingress
 }
@@ -104,7 +104,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoproj.ArgoCD) error 
 		if objectFound {
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
 			argoutil.LogResourceDeletion(log, ingress, "server ingress is disabled")
-			return r.Client.Delete(context.TODO(), ingress)
+			return r.Delete(context.TODO(), ingress)
 		}
 		return nil // Ingress not enabled, move along...
 	}
@@ -119,7 +119,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoproj.ArgoCD) error 
 		atns = cr.Spec.Server.Ingress.Annotations
 	}
 
-	ingress.ObjectMeta.Annotations = atns
+	ingress.Annotations = atns
 
 	ingress.Spec.IngressClassName = cr.Spec.Server.Ingress.IngressClassName
 
@@ -172,8 +172,8 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoproj.ArgoCD) error 
 			explanation = "ingress class name"
 			changed = true
 		}
-		if !reflect.DeepEqual(cr.Spec.Server.Ingress.Annotations, existingIngress.ObjectMeta.Annotations) {
-			existingIngress.ObjectMeta.Annotations = cr.Spec.Server.Ingress.Annotations
+		if !reflect.DeepEqual(cr.Spec.Server.Ingress.Annotations, existingIngress.Annotations) {
+			existingIngress.Annotations = cr.Spec.Server.Ingress.Annotations
 			if changed {
 				explanation += ", "
 			}
@@ -198,7 +198,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoproj.ArgoCD) error 
 		}
 		if changed {
 			argoutil.LogResourceUpdate(log, existingIngress, "updating", explanation)
-			return r.Client.Update(context.TODO(), existingIngress)
+			return r.Update(context.TODO(), existingIngress)
 		}
 		return nil // Ingress with no changes to apply, do nothing
 	}
@@ -206,7 +206,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerIngress(cr *argoproj.ArgoCD) error 
 		return err
 	}
 	argoutil.LogResourceCreation(log, ingress)
-	return r.Client.Create(context.TODO(), ingress)
+	return r.Create(context.TODO(), ingress)
 }
 
 // reconcileArgoServerGRPCIngress will ensure that the ArgoCD Server GRPC Ingress is present.
@@ -221,7 +221,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoproj.ArgoCD) er
 		if !cr.Spec.Server.GRPC.Ingress.Enabled {
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
 			argoutil.LogResourceDeletion(log, ingress, "server grpc ingress is disabled")
-			return r.Client.Delete(context.TODO(), ingress)
+			return r.Delete(context.TODO(), ingress)
 		}
 		return nil // Ingress found and enabled, do nothing
 	}
@@ -239,7 +239,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoproj.ArgoCD) er
 		atns = cr.Spec.Server.GRPC.Ingress.Annotations
 	}
 
-	ingress.ObjectMeta.Annotations = atns
+	ingress.Annotations = atns
 
 	ingress.Spec.IngressClassName = cr.Spec.Server.GRPC.Ingress.IngressClassName
 
@@ -288,7 +288,7 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoproj.ArgoCD) er
 		return err
 	}
 	argoutil.LogResourceCreation(log, ingress)
-	return r.Client.Create(context.TODO(), ingress)
+	return r.Create(context.TODO(), ingress)
 }
 
 // reconcileGrafanaIngress will ensure that the ArgoCD Server GRPC Ingress is present.
@@ -300,24 +300,24 @@ func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoproj.ArgoCD) error {
 	}
 	if ingressExists {
 		//lint:ignore SA1019 known to be deprecated
-		if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Ingress.Enabled {
+		if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Ingress.Enabled { //nolint:staticcheck // SA1019: We must test deprecated fields.
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
 			var explanation string
 			//lint:ignore SA1019 known to be deprecated
-			if !cr.Spec.Grafana.Enabled {
+			if !cr.Spec.Grafana.Enabled { //nolint:staticcheck // SA1019: We must test deprecated fields.
 				explanation = "grafana is disabled"
 			} else {
 				explanation = "grafana ingress is disabled"
 			}
 			argoutil.LogResourceDeletion(log, ingress, explanation)
-			return r.Client.Delete(context.TODO(), ingress)
+			return r.Delete(context.TODO(), ingress)
 		}
 		log.Info(grafanaDeprecatedWarning)
 		return nil // Ingress found and enabled, do nothing
 	}
 
 	//lint:ignore SA1019 known to be deprecated
-	if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Ingress.Enabled {
+	if !cr.Spec.Grafana.Enabled || !cr.Spec.Grafana.Ingress.Enabled { //nolint:staticcheck // SA1019: We must test deprecated fields.
 		return nil // Grafana itself or Ingress not enabled, move along...
 	}
 
@@ -343,7 +343,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoproj.ArgoCD) error 
 				explanation = "prometheus ingress is disabled"
 			}
 			argoutil.LogResourceDeletion(log, ingress, explanation)
-			return r.Client.Delete(context.TODO(), ingress)
+			return r.Delete(context.TODO(), ingress)
 		}
 		return nil // Ingress found and enabled, do nothing
 	}
@@ -362,7 +362,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoproj.ArgoCD) error 
 		atns = cr.Spec.Prometheus.Ingress.Annotations
 	}
 
-	ingress.ObjectMeta.Annotations = atns
+	ingress.Annotations = atns
 
 	ingress.Spec.IngressClassName = cr.Spec.Prometheus.Ingress.IngressClassName
 
@@ -409,7 +409,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoproj.ArgoCD) error 
 		return err
 	}
 	argoutil.LogResourceCreation(log, ingress)
-	return r.Client.Create(context.TODO(), ingress)
+	return r.Create(context.TODO(), ingress)
 }
 
 // reconcileApplicationSetControllerIngress will ensure that the ApplicationSetController Ingress is present.
@@ -428,7 +428,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetControllerIngress(cr *argoproj.
 				explanation = "applicationset webhook ingress is disabled"
 			}
 			argoutil.LogResourceDeletion(log, ingress, explanation)
-			return r.Client.Delete(context.TODO(), ingress)
+			return r.Delete(context.TODO(), ingress)
 		}
 		return nil // Ingress found and enabled, do nothing
 	}
@@ -448,7 +448,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetControllerIngress(cr *argoproj.
 		atns = cr.Spec.ApplicationSet.WebhookServer.Ingress.Annotations
 	}
 
-	ingress.ObjectMeta.Annotations = atns
+	ingress.Annotations = atns
 
 	pathType := networkingv1.PathTypeImplementationSpecific
 	httpServerHost, err := getApplicationSetHTTPServerHost(cr)
@@ -490,5 +490,5 @@ func (r *ReconcileArgoCD) reconcileApplicationSetControllerIngress(cr *argoproj.
 		return err
 	}
 	argoutil.LogResourceCreation(log, ingress)
-	return r.Client.Create(context.TODO(), ingress)
+	return r.Create(context.TODO(), ingress)
 }

--- a/controllers/argocd/ingress_test.go
+++ b/controllers/argocd/ingress_test.go
@@ -55,7 +55,7 @@ func TestReconcileArgoCD_reconcile_ServerIngress_ingressClassName(t *testing.T) 
 			assert.NoError(t, err)
 
 			ingress := &networkingv1.Ingress{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-server",
 				Namespace: testNamespace,
 			}, ingress)
@@ -99,7 +99,7 @@ func TestReconcileArgoCD_reconcile_ServerIngress_serverHost(t *testing.T) {
 			assert.NoError(t, err)
 
 			ingress := &networkingv1.Ingress{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-server",
 				Namespace: testNamespace,
 			}, ingress)
@@ -114,7 +114,7 @@ func TestReconcileArgoCD_reconcile_ServerIngress_serverHost(t *testing.T) {
 
 			err = r.reconcileArgoServerIngress(a)
 			assert.NoError(t, err)
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-server",
 				Namespace: testNamespace,
 			}, ingress)
@@ -158,7 +158,7 @@ func TestReconcileArgoCD_reconcile_ServerIngress_ingressClassName_update(t *test
 	assert.NoError(t, err)
 
 	updatedIngress := &networkingv1.Ingress{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      "argocd-server",
 		Namespace: testNamespace,
 	}, updatedIngress)
@@ -205,7 +205,7 @@ func TestReconcileArgoCD_reconcile_ServerGRPCIngress_ingressClassName(t *testing
 			assert.NoError(t, err)
 
 			ingress := &networkingv1.Ingress{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-grpc",
 				Namespace: testNamespace,
 			}, ingress)
@@ -254,7 +254,7 @@ func TestReconcileArgoCD_reconcile_PrometheusIngress_ingressClassName(t *testing
 			assert.NoError(t, err)
 
 			ingress := &networkingv1.Ingress{}
-			err = r.Client.Get(context.TODO(), types.NamespacedName{
+			err = r.Get(context.TODO(), types.NamespacedName{
 				Name:      "argocd-prometheus",
 				Namespace: testNamespace,
 			}, ingress)
@@ -285,5 +285,5 @@ func TestReconcileApplicationSetService_Ingress(t *testing.T) {
 
 	ingress := newIngressWithSuffix(common.ApplicationSetServiceNameSuffix, a)
 	assert.NoError(t, r.reconcileApplicationSetControllerIngress(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Namespace: ingress.Namespace, Name: ingress.Name}, ingress))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Namespace: ingress.Namespace, Name: ingress.Name}, ingress))
 }

--- a/controllers/argocd/keycloak.go
+++ b/controllers/argocd/keycloak.go
@@ -57,7 +57,7 @@ const (
 	// ExpectedReplicas is used to identify the keycloak running status.
 	expectedReplicas int32 = 1
 	// ServingCertSecretName is a secret that holds the service certificate.
-	servingCertSecretName = "sso-x509-https-secret"
+	servingCertSecretName = "sso-x509-https-secret" // #nosec G101
 	// Authentication api path for keycloak.
 	authURL = "/auth/realms/master/protocol/openid-connect/token"
 	// Realm api path for keycloak.
@@ -654,7 +654,7 @@ func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoproj.ArgoCD) error {
 
 	// Create Keycloak Ingress
 	ing := newKeycloakIngress(cr)
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: ing.Name,
+	err := r.Get(context.TODO(), types.NamespacedName{Name: ing.Name,
 		Namespace: ing.Namespace}, ing)
 
 	if err != nil {
@@ -663,7 +663,7 @@ func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoproj.ArgoCD) error {
 				return err
 			}
 			argoutil.LogResourceCreation(log, ing)
-			err = r.Client.Create(context.TODO(), ing)
+			err = r.Create(context.TODO(), ing)
 			if err != nil {
 				return err
 			}
@@ -674,7 +674,7 @@ func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoproj.ArgoCD) error {
 
 	// Create Keycloak Service
 	svc := newKeycloakService(cr)
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: svc.Name,
+	err = r.Get(context.TODO(), types.NamespacedName{Name: svc.Name,
 		Namespace: svc.Namespace}, svc)
 
 	if err != nil {
@@ -683,7 +683,7 @@ func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoproj.ArgoCD) error {
 				return err
 			}
 			argoutil.LogResourceCreation(log, svc)
-			err = r.Client.Create(context.TODO(), svc)
+			err = r.Create(context.TODO(), svc)
 			if err != nil {
 				return err
 			}
@@ -694,7 +694,7 @@ func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoproj.ArgoCD) error {
 
 	// Create Keycloak Deployment
 	dep := newKeycloakDeployment(cr)
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: dep.Name,
+	err = r.Get(context.TODO(), types.NamespacedName{Name: dep.Name,
 		Namespace: dep.Namespace}, dep)
 
 	if err != nil {
@@ -703,7 +703,7 @@ func (r *ReconcileArgoCD) newKeycloakInstance(cr *argoproj.ArgoCD) error {
 				return err
 			}
 			argoutil.LogResourceCreation(log, dep)
-			err = r.Client.Create(context.TODO(), dep)
+			err = r.Create(context.TODO(), dep)
 			if err != nil {
 				return err
 			}
@@ -728,7 +728,7 @@ func (r *ReconcileArgoCD) prepareKeycloakConfig(cr *argoproj.ArgoCD) (*keycloakC
 			Namespace: cr.Namespace,
 		},
 	}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: existingKeycloakRoute.Name,
+	err := r.Get(context.TODO(), types.NamespacedName{Name: existingKeycloakRoute.Name,
 		Namespace: existingKeycloakRoute.Namespace}, existingKeycloakRoute)
 	if err != nil {
 		return nil, err
@@ -742,7 +742,7 @@ func (r *ReconcileArgoCD) prepareKeycloakConfig(cr *argoproj.ArgoCD) (*keycloakC
 			Namespace: cr.Namespace,
 		},
 	}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingArgoCDRoute.Name,
+	err = r.Get(context.TODO(), types.NamespacedName{Name: existingArgoCDRoute.Name,
 		Namespace: existingArgoCDRoute.Namespace}, existingArgoCDRoute)
 	if err != nil {
 		return nil, err
@@ -756,7 +756,7 @@ func (r *ReconcileArgoCD) prepareKeycloakConfig(cr *argoproj.ArgoCD) (*keycloakC
 			Namespace: cr.Namespace,
 		},
 	}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingSecret.Name,
+	err = r.Get(context.TODO(), types.NamespacedName{Name: existingSecret.Name,
 		Namespace: existingSecret.Namespace}, existingSecret)
 	if err != nil {
 		return nil, err
@@ -805,7 +805,7 @@ func (r *ReconcileArgoCD) prepareKeycloakConfigForK8s(cr *argoproj.ArgoCD) (*key
 			Namespace: cr.Namespace,
 		},
 	}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: existingKeycloakIng.Name,
+	err := r.Get(context.TODO(), types.NamespacedName{Name: existingKeycloakIng.Name,
 		Namespace: existingKeycloakIng.Namespace}, existingKeycloakIng)
 	if err != nil {
 		return nil, err
@@ -819,7 +819,7 @@ func (r *ReconcileArgoCD) prepareKeycloakConfigForK8s(cr *argoproj.ArgoCD) (*key
 			Namespace: cr.Namespace,
 		},
 	}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingArgoCDIng.Name,
+	err = r.Get(context.TODO(), types.NamespacedName{Name: existingArgoCDIng.Name,
 		Namespace: existingArgoCDIng.Namespace}, existingArgoCDIng)
 	if err != nil {
 		return nil, err
@@ -973,7 +973,7 @@ func (r *ReconcileArgoCD) getKCServerCert(cr *argoproj.ArgoCD) ([]byte, error) {
 		},
 	}
 
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: sslCertsSecret.Name, Namespace: sslCertsSecret.Namespace}, sslCertsSecret)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: sslCertsSecret.Name, Namespace: sslCertsSecret.Namespace}, sslCertsSecret)
 
 	switch {
 	case err == nil:
@@ -1000,7 +1000,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoproj.ArgoCD, kRouteU
 		},
 	}
 
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDSecret.Name, Namespace: argoCDSecret.Namespace}, argoCDSecret)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: argoCDSecret.Name, Namespace: argoCDSecret.Namespace}, argoCDSecret)
 	if err != nil {
 		message := fmt.Sprintf("ArgoCD secret not found for ArgoCD %s in namespace %s", cr.Name, cr.Namespace)
 		log.Error(err, message)
@@ -1009,7 +1009,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoproj.ArgoCD, kRouteU
 
 	argoCDSecret.Data["oidc.keycloak.clientSecret"] = []byte(oAuthClientSecret)
 	argoutil.LogResourceUpdate(log, argoCDSecret, "updating client secret for keycloak oidc")
-	err = r.Client.Update(context.TODO(), argoCDSecret)
+	err = r.Update(context.TODO(), argoCDSecret)
 	if err != nil {
 		message := fmt.Sprintf("Error updating ArgoCD Secret for ArgoCD %s in namespace %s", cr.Name, cr.Namespace)
 		log.Error(err, message)
@@ -1038,11 +1038,11 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoproj.ArgoCD, kRouteU
 			return err
 		}
 
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: oAuthClient.Name}, oAuthClient)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: oAuthClient.Name}, oAuthClient)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				argoutil.LogResourceCreation(log, oAuthClient)
-				err = r.Client.Create(context.TODO(), oAuthClient)
+				err = r.Create(context.TODO(), oAuthClient)
 				if err != nil {
 					return err
 				}
@@ -1070,7 +1070,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoproj.ArgoCD, kRouteU
 	}
 
 	argoCDCM := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: argoCDCM.Name, Namespace: argoCDCM.Namespace}, argoCDCM)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: argoCDCM.Name, Namespace: argoCDCM.Namespace}, argoCDCM)
 	if err != nil {
 		message := fmt.Sprintf("ArgoCD configmap not found for ArgoCD %s in namespace %s", cr.Name, cr.Namespace)
 		log.Error(err, message)
@@ -1079,7 +1079,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoproj.ArgoCD, kRouteU
 
 	argoCDCM.Data[common.ArgoCDKeyOIDCConfig] = string(o)
 	argoutil.LogResourceUpdate(log, argoCDCM, "updating oidc config with keycloak realm")
-	err = r.Client.Update(context.TODO(), argoCDCM)
+	err = r.Update(context.TODO(), argoCDCM)
 	if err != nil {
 		message := fmt.Sprintf("Error updating OIDC Configuration for ArgoCD %s in namespace %s", cr.Name, cr.Namespace)
 		log.Error(err, message)
@@ -1088,7 +1088,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoproj.ArgoCD, kRouteU
 
 	// Update RBAC for ArgoCD Instance.
 	argoRBACCM := newConfigMapWithName(common.ArgoCDRBACConfigMapName, cr)
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: argoRBACCM.Name, Namespace: argoRBACCM.Namespace}, argoRBACCM)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: argoRBACCM.Name, Namespace: argoRBACCM.Namespace}, argoRBACCM)
 	if err != nil {
 		message := fmt.Sprintf("ArgoCD RBAC configmap not found for ArgoCD %s in namespace %s", cr.Name, cr.Namespace)
 		log.Error(err, message)
@@ -1097,7 +1097,7 @@ func (r *ReconcileArgoCD) updateArgoCDConfiguration(cr *argoproj.ArgoCD, kRouteU
 
 	argoRBACCM.Data["scopes"] = "[groups,email]"
 	argoutil.LogResourceUpdate(log, argoRBACCM, "updating rbac scopes for keycloak")
-	err = r.Client.Update(context.TODO(), argoRBACCM)
+	err = r.Update(context.TODO(), argoRBACCM)
 	if err != nil {
 		message := fmt.Sprintf("Error updating ArgoCD RBAC configmap %s in namespace %s", cr.Name, cr.Namespace)
 		log.Error(err, message)
@@ -1308,7 +1308,7 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoproj.ArgoCD) err
 	if err != nil {
 		return err
 	}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: templateInstanceRef.Name,
+	err = r.Get(context.TODO(), types.NamespacedName{Name: templateInstanceRef.Name,
 		Namespace: templateInstanceRef.Namespace}, &template.TemplateInstance{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -1320,7 +1320,7 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoproj.ArgoCD) err
 			}
 
 			argoutil.LogResourceCreation(log, templateInstanceRef)
-			err = r.Client.Create(context.TODO(), templateInstanceRef)
+			err = r.Create(context.TODO(), templateInstanceRef)
 			if err != nil {
 				return err
 			}
@@ -1335,7 +1335,7 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoproj.ArgoCD) err
 			Namespace: cr.Namespace,
 		},
 	}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingDC.Name, Namespace: existingDC.Namespace}, existingDC)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: existingDC.Name, Namespace: existingDC.Namespace}, existingDC)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Keycloak Deployment not found or being created for ArgoCD %s in namespace %s",
 			cr.Name, cr.Namespace))
@@ -1363,7 +1363,7 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoproj.ArgoCD) err
 		if changed {
 			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				argoutil.LogResourceUpdate(log, existingDC, "updating", explanation)
-				return r.Client.Update(context.TODO(), existingDC)
+				return r.Update(context.TODO(), existingDC)
 			})
 
 			if err != nil {
@@ -1408,7 +1408,7 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoproj.ArgoCD) err
 				}
 
 				// Update Realm creation. This will avoid posting of realm configuration on further reconciliations.
-				err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingDC.Name, Namespace: existingDC.Namespace}, existingDC)
+				err = r.Get(context.TODO(), types.NamespacedName{Name: existingDC.Name, Namespace: existingDC.Namespace}, existingDC)
 				if err != nil {
 					return err
 				}
@@ -1416,7 +1416,7 @@ func (r *ReconcileArgoCD) reconcileKeycloakForOpenShift(cr *argoproj.ArgoCD) err
 				existingDC.Annotations["argocd.argoproj.io/realm-created"] = "true"
 				err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 					argoutil.LogResourceUpdate(log, existingDC, "setting the realm created status annotation to true")
-					return r.Client.Update(context.TODO(), existingDC)
+					return r.Update(context.TODO(), existingDC)
 				})
 
 				if err != nil {
@@ -1456,7 +1456,7 @@ func (r *ReconcileArgoCD) reconcileKeycloak(cr *argoproj.ArgoCD) error {
 		},
 	}
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: existingDeployment.Name, Namespace: existingDeployment.Namespace}, existingDeployment)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: existingDeployment.Name, Namespace: existingDeployment.Namespace}, existingDeployment)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("Keycloak Deployment not found or being created for ArgoCD %s in namespace %s",
 			cr.Name, cr.Namespace))
@@ -1484,7 +1484,7 @@ func (r *ReconcileArgoCD) reconcileKeycloak(cr *argoproj.ArgoCD) error {
 		if changed {
 			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				argoutil.LogResourceUpdate(log, existingDeployment, "updating", explanation)
-				return r.Client.Update(context.TODO(), existingDeployment)
+				return r.Update(context.TODO(), existingDeployment)
 			})
 
 			if err != nil {
@@ -1520,7 +1520,7 @@ func (r *ReconcileArgoCD) reconcileKeycloak(cr *argoproj.ArgoCD) error {
 				// Update Realm creation. This will avoid posting of realm configuration on further reconciliations.
 				existingDeployment.Annotations["argocd.argoproj.io/realm-created"] = "true"
 				argoutil.LogResourceUpdate(log, existingDeployment, "setting the realm created status annotation to true")
-				err = r.Client.Update(context.TODO(), existingDeployment)
+				err = r.Update(context.TODO(), existingDeployment)
 				if err != nil {
 					return err
 				}

--- a/controllers/argocd/keycloak_client.go
+++ b/controllers/argocd/keycloak_client.go
@@ -147,14 +147,14 @@ func defaultRequester(serverCert []byte, verifyTLS bool) (requester, error) {
 // An Insecure config is returned also when .spec.SSO.verifyTLS is set to false.
 func createTLSConfig(serverCert []byte, verifyTLS bool) (*tls.Config, error) {
 	if serverCert == nil || !verifyTLS {
-		return &tls.Config{InsecureSkipVerify: true}, nil
+		return &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, nil // #nosec G402
 	}
 
 	rootCAPool := x509.NewCertPool()
 	if ok := rootCAPool.AppendCertsFromPEM(serverCert); !ok {
 		return nil, errors.Errorf("unable to successfully load certificate")
 	}
-	return &tls.Config{RootCAs: rootCAPool}, nil
+	return &tls.Config{RootCAs: rootCAPool, MinVersion: tls.VersionTLS12}, nil
 }
 
 // Get Keycloak URL.

--- a/controllers/argocd/keycloak_client_test.go
+++ b/controllers/argocd/keycloak_client_test.go
@@ -7,12 +7,13 @@ import (
 
 	"encoding/pem"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 func TestKeycloak_testRealmCreation(t *testing.T) {

--- a/controllers/argocd/keycloak_test.go
+++ b/controllers/argocd/keycloak_test.go
@@ -243,7 +243,7 @@ func TestNewKeycloakTemplate_testDeploymentConfig(t *testing.T) {
 	}
 	assert.Equal(t, dc.Spec.Strategy, strategy)
 
-	assert.Equal(t, dc.Spec.Template.ObjectMeta.Name, "${APPLICATION_NAME}")
+	assert.Equal(t, dc.Spec.Template.Name, "${APPLICATION_NAME}")
 	assert.Equal(t, dc.Spec.Template.Spec.Volumes, fakeVolumes)
 }
 
@@ -320,7 +320,7 @@ func TestKeycloakResources(t *testing.T) {
 func TestNewKeycloakTemplate_testConfigmap(t *testing.T) {
 	cm := getKeycloakConfigMapTemplate(fakeNs)
 	assert.Equal(t, cm.Name, "${APPLICATION_NAME}-service-ca")
-	assert.True(t, argoutil.IsTrackedByOperator(cm.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(cm.Labels))
 	assert.Equal(t, cm.Namespace, fakeNs)
 }
 
@@ -410,13 +410,14 @@ func TestKeycloak_testServerCert(t *testing.T) {
 			"tls.crt": []byte("asdasfsff"),
 		},
 	}
-	r.Client.Create(context.TODO(), sslCertsSecret)
+	err := r.Create(context.TODO(), sslCertsSecret)
+	assert.NoError(t, err)
 
-	_, err := r.getKCServerCert(a)
+	_, err = r.getKCServerCert(a)
 	assert.NoError(t, err)
 
 	sslCertsSecret.Data["tls.crt"] = nil
-	assert.NoError(t, r.Client.Update(context.TODO(), sslCertsSecret))
+	assert.NoError(t, r.Update(context.TODO(), sslCertsSecret))
 
 	_, err = r.getKCServerCert(a)
 	assert.NoError(t, err)
@@ -482,7 +483,8 @@ func TestKeycloakConfigVerifyTLSForOpenShift(t *testing.T) {
 					Host: "test-host",
 				},
 			}
-			r.Client.Create(context.TODO(), keycloakRoute)
+			err := r.Create(context.TODO(), keycloakRoute)
+			assert.NoError(t, err)
 
 			argoCDRoute := &routev1.Route{
 				ObjectMeta: metav1.ObjectMeta{
@@ -493,7 +495,8 @@ func TestKeycloakConfigVerifyTLSForOpenShift(t *testing.T) {
 					Host: "test-argocd-host",
 				},
 			}
-			r.Client.Create(context.TODO(), argoCDRoute)
+			err = r.Create(context.TODO(), argoCDRoute)
+			assert.NoError(t, err)
 
 			keycloakSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -502,7 +505,8 @@ func TestKeycloakConfigVerifyTLSForOpenShift(t *testing.T) {
 				},
 				Data: map[string][]byte{"SSO_USERNAME": []byte("username"), "SSO_PASSWORD": []byte("password")},
 			}
-			r.Client.Create(context.TODO(), keycloakSecret)
+			err = r.Create(context.TODO(), keycloakSecret)
+			assert.NoError(t, err)
 
 			sslCertsSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -513,7 +517,8 @@ func TestKeycloakConfigVerifyTLSForOpenShift(t *testing.T) {
 					"tls.crt": []byte("asdasfsff"),
 				},
 			}
-			r.Client.Create(context.TODO(), sslCertsSecret)
+			err = r.Create(context.TODO(), sslCertsSecret)
+			assert.NoError(t, err)
 
 			keyCloakConfig, err := r.prepareKeycloakConfig(test.argoCD)
 			assert.NoError(t, err)

--- a/controllers/argocd/namespaceManagement_test.go
+++ b/controllers/argocd/namespaceManagement_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
-	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +13,9 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 func TestReconcileNamespaceManagement_FeatureEnabled(t *testing.T) {
@@ -60,10 +61,10 @@ func TestReconcileNamespaceManagement_FeatureEnabled(t *testing.T) {
 	defer os.Unsetenv(common.EnableManagedNamespace)
 
 	// Create both CRs
-	err := r.Client.Create(context.Background(), nm)
+	err := r.Create(context.Background(), nm)
 	assert.NoError(t, err)
 
-	err = r.Client.Create(context.Background(), nmDisallowed)
+	err = r.Create(context.Background(), nmDisallowed)
 	assert.NoError(t, err)
 
 	// Reconcile
@@ -72,7 +73,7 @@ func TestReconcileNamespaceManagement_FeatureEnabled(t *testing.T) {
 	assert.Contains(t, err.Error(), "Namespace disallowed-ns is not permitted for management by ArgoCD instance argocd based on NamespaceManagement rules")
 
 	// Verify success status on allowed namespace
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      nm.Name,
 		Namespace: nm.Namespace,
 	}, nm)
@@ -92,7 +93,7 @@ func TestReconcileNamespaceManagement_FeatureEnabled(t *testing.T) {
 	reconciledCondition = nil
 
 	// Verify error status on disallowed namespace
-	err = r.Client.Get(context.TODO(), types.NamespacedName{
+	err = r.Get(context.TODO(), types.NamespacedName{
 		Name:      nmDisallowed.Name,
 		Namespace: nmDisallowed.Namespace,
 	}, nmDisallowed)
@@ -366,7 +367,7 @@ func TestReconcileNamespaceManagement_DifferentManagedBy(t *testing.T) {
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-	err := r.Client.Create(context.Background(), nmOther)
+	err := r.Create(context.Background(), nmOther)
 	assert.NoError(t, err)
 
 	os.Setenv(common.EnableManagedNamespace, "true")
@@ -405,7 +406,7 @@ func TestReconcileNamespaceManagement_ExplicitlyDisallowed(t *testing.T) {
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 	logf.SetLogger(ZapLogger(true))
 
-	err := r.Client.Create(context.Background(), nm)
+	err := r.Create(context.Background(), nm)
 	assert.NoError(t, err)
 
 	os.Setenv(common.EnableManagedNamespace, "true")
@@ -443,7 +444,7 @@ func TestReconcileNamespaceManagement_DeduplicateNamespaces(t *testing.T) {
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-	err := r.Client.Create(context.Background(), nm)
+	err := r.Create(context.Background(), nm)
 	assert.NoError(t, err)
 
 	r.ManagedNamespaces = &corev1.NamespaceList{

--- a/controllers/argocd/networkpolicies.go
+++ b/controllers/argocd/networkpolicies.go
@@ -147,7 +147,7 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
-			err := r.Client.Update(context.TODO(), existing)
+			err := r.Update(context.TODO(), existing)
 			if err != nil {
 				log.Error(err, "Failed to update redis network policy")
 				return fmt.Errorf("failed to update redis network policy. error: %w", err)
@@ -272,7 +272,7 @@ func (r *ReconcileArgoCD) ReconcileRedisHANetworkPolicy(cr *argoproj.ArgoCD) err
 
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
-			err := r.Client.Update(context.TODO(), existing)
+			err := r.Update(context.TODO(), existing)
 			if err != nil {
 				log.Error(err, "Failed to update redis ha network policy")
 				return fmt.Errorf("failed to update redis ha network policy. error: %w", err)

--- a/controllers/argocd/networkpolicies_test.go
+++ b/controllers/argocd/networkpolicies_test.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"testing"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 func TestReconcileNetworkPolicies(t *testing.T) {

--- a/controllers/argocd/prometheus.go
+++ b/controllers/argocd/prometheus.go
@@ -110,12 +110,12 @@ func newServiceMonitor(cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
 // newServiceMonitorWithName returns a new ServiceMonitor instance for the given ArgoCD using the given name.
 func newServiceMonitorWithName(name string, cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
 	svcmon := newServiceMonitor(cr)
-	svcmon.ObjectMeta.Name = name
+	svcmon.Name = name
 
-	lbls := svcmon.ObjectMeta.Labels
+	lbls := svcmon.Labels
 	lbls[common.ArgoCDKeyName] = name
 	lbls[common.ArgoCDKeyRelease] = "prometheus-operator"
-	svcmon.ObjectMeta.Labels = lbls
+	svcmon.Labels = lbls
 
 	return svcmon
 }
@@ -136,7 +136,7 @@ func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoproj.ArgoCD) er
 		if !cr.Spec.Prometheus.Enabled {
 			// ServiceMonitor exists but enabled flag has been set to false, delete the ServiceMonitor
 			argoutil.LogResourceDeletion(log, sm, "prometheus is disabled")
-			return r.Client.Delete(context.TODO(), sm)
+			return r.Delete(context.TODO(), sm)
 		}
 		return nil // ServiceMonitor found, do nothing
 	}
@@ -160,7 +160,7 @@ func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoproj.ArgoCD) er
 		return err
 	}
 	argoutil.LogResourceCreation(log, sm)
-	return r.Client.Create(context.TODO(), sm)
+	return r.Create(context.TODO(), sm)
 }
 
 // reconcilePrometheus will ensure that Prometheus is present for ArgoCD metrics.
@@ -174,12 +174,12 @@ func (r *ReconcileArgoCD) reconcilePrometheus(cr *argoproj.ArgoCD) error {
 		if !cr.Spec.Prometheus.Enabled {
 			// Prometheus exists but enabled flag has been set to false, delete the Prometheus
 			argoutil.LogResourceDeletion(log, prometheus, "prometheus is disabled")
-			return r.Client.Delete(context.TODO(), prometheus)
+			return r.Delete(context.TODO(), prometheus)
 		}
 		if hasPrometheusSpecChanged(prometheus, cr) {
 			prometheus.Spec.Replicas = cr.Spec.Prometheus.Size
 			argoutil.LogResourceUpdate(log, prometheus, "updating replica count")
-			return r.Client.Update(context.TODO(), prometheus)
+			return r.Update(context.TODO(), prometheus)
 		}
 		return nil // Prometheus found, do nothing
 	}
@@ -196,7 +196,7 @@ func (r *ReconcileArgoCD) reconcilePrometheus(cr *argoproj.ArgoCD) error {
 		return err
 	}
 	argoutil.LogResourceCreation(log, prometheus)
-	return r.Client.Create(context.TODO(), prometheus)
+	return r.Create(context.TODO(), prometheus)
 }
 
 // reconcileRepoServerServiceMonitor will ensure that the ServiceMonitor is present for the Repo Server metrics Service.
@@ -210,7 +210,7 @@ func (r *ReconcileArgoCD) reconcileRepoServerServiceMonitor(cr *argoproj.ArgoCD)
 		if !cr.Spec.Prometheus.Enabled {
 			// ServiceMonitor exists but enabled flag has been set to false, delete the ServiceMonitor
 			argoutil.LogResourceDeletion(log, sm, "prometheus is disabled")
-			return r.Client.Delete(context.TODO(), sm)
+			return r.Delete(context.TODO(), sm)
 		}
 		return nil // ServiceMonitor found, do nothing
 	}
@@ -234,7 +234,7 @@ func (r *ReconcileArgoCD) reconcileRepoServerServiceMonitor(cr *argoproj.ArgoCD)
 		return err
 	}
 	argoutil.LogResourceCreation(log, sm)
-	return r.Client.Create(context.TODO(), sm)
+	return r.Create(context.TODO(), sm)
 }
 
 // reconcileServerMetricsServiceMonitor will ensure that the ServiceMonitor is present for the ArgoCD Server metrics Service.
@@ -248,7 +248,7 @@ func (r *ReconcileArgoCD) reconcileServerMetricsServiceMonitor(cr *argoproj.Argo
 		if !cr.Spec.Prometheus.Enabled {
 			// ServiceMonitor exists but enabled flag has been set to false, delete the ServiceMonitor
 			argoutil.LogResourceDeletion(log, sm, "prometheus is disabled")
-			return r.Client.Delete(context.TODO(), sm)
+			return r.Delete(context.TODO(), sm)
 		}
 		return nil // ServiceMonitor found, do nothing
 	}
@@ -272,7 +272,7 @@ func (r *ReconcileArgoCD) reconcileServerMetricsServiceMonitor(cr *argoproj.Argo
 		return err
 	}
 	argoutil.LogResourceCreation(log, sm)
-	return r.Client.Create(context.TODO(), sm)
+	return r.Create(context.TODO(), sm)
 }
 
 // reconcilePrometheusRule reconciles the PrometheusRule that triggers alerts based on workload statuses
@@ -291,7 +291,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 			// PrometheusRule exists but enabled flag has been set to false, delete the PrometheusRule
 			log.Info("instance monitoring disabled, deleting component status tracking prometheusRule")
 			argoutil.LogResourceDeletion(log, promRule, "instance monitoring is disabled")
-			return r.Client.Delete(context.TODO(), promRule)
+			return r.Delete(context.TODO(), promRule)
 		}
 		return nil // PrometheusRule found, do nothing
 	}
@@ -412,7 +412,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 	}
 
 	argoutil.LogResourceCreation(log, promRule, "for component status tracking, since instance monitoring is enabled")
-	return r.Client.Create(context.TODO(), promRule) // Create PrometheusRule
+	return r.Create(context.TODO(), promRule) // Create PrometheusRule
 }
 
 // newPrometheusRule returns an empty PrometheusRule

--- a/controllers/argocd/prometheus_test.go
+++ b/controllers/argocd/prometheus_test.go
@@ -178,7 +178,8 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 			assert.NoError(t, err)
 
 			if test.existingPromRule {
-				r.Client.Create(context.TODO(), newPrometheusRule(test.argocd.Namespace, "argocd-component-status-alert"))
+				err := r.Create(context.TODO(), newPrometheusRule(test.argocd.Namespace, "argocd-component-status-alert"))
+				assert.NoError(t, err)
 			}
 
 			err = r.reconcilePrometheusRule(test.argocd)
@@ -191,7 +192,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 			} else {
 				// reconciler either needs to create rule or delete it
 				testRule := &monitoringv1.PrometheusRule{}
-				err = r.Client.Get(context.TODO(), types.NamespacedName{
+				err = r.Get(context.TODO(), types.NamespacedName{
 					Name:      "argocd-component-status-alert",
 					Namespace: test.argocd.Namespace,
 				}, testRule)

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -42,22 +42,22 @@ func TestReconcileArgoCD_reconcileRole(t *testing.T) {
 
 	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
 	reconciledRole := &v1.Role{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// check if roles are created for the new namespace as well
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "newNamespaceTest"}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "newNamespaceTest"}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// update reconciledRole policy rules to RedisHa policy rules
 	reconciledRole.Rules = policyRuleForRedisHa(r.Client)
-	assert.NoError(t, r.Client.Update(context.TODO(), reconciledRole))
+	assert.NoError(t, r.Update(context.TODO(), reconciledRole))
 
 	// Check if the RedisHa policy rules are overwritten to Application Controller
 	// policy rules by the reconciler
 	_, err = r.reconcileRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 }
 func TestReconcileArgoCD_reconcileRole_for_new_namespace(t *testing.T) {
@@ -83,21 +83,21 @@ func TestReconcileArgoCD_reconcileRole_for_new_namespace(t *testing.T) {
 	dexRoles, err := r.reconcileRole(workloadIdentifier, expectedDexServerRules, a)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedNumberOfRoles, len(dexRoles))
-	assert.Equal(t, expectedRoleNamespace, dexRoles[0].ObjectMeta.Namespace)
+	assert.Equal(t, expectedRoleNamespace, dexRoles[0].Namespace)
 	// check no redisHa role is created for the new namespace with managed-by label
 	workloadIdentifier = common.ArgoCDRedisHAComponent
 	expectedRedisHaRules := policyRuleForRedisHa(r.Client)
 	redisHaRoles, err := r.reconcileRole(workloadIdentifier, expectedRedisHaRules, a)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedNumberOfRoles, len(redisHaRoles))
-	assert.Equal(t, expectedRoleNamespace, redisHaRoles[0].ObjectMeta.Namespace)
+	assert.Equal(t, expectedRoleNamespace, redisHaRoles[0].Namespace)
 	// check no redis role is created for the new namespace with managed-by label
 	workloadIdentifier = common.ArgoCDRedisComponent
 	expectedRedisRules := policyRuleForRedis(r.Client)
 	redisRoles, err := r.reconcileRole(workloadIdentifier, expectedRedisRules, a)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedNumberOfRoles, len(redisRoles))
-	assert.Equal(t, expectedRoleNamespace, redisRoles[0].ObjectMeta.Namespace)
+	assert.Equal(t, expectedRoleNamespace, redisRoles[0].Namespace)
 }
 
 func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
@@ -120,7 +120,7 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	// cluster role should not be created
 	//assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, &v1.ClusterRole{}), "not found")
 	//TODO: https://github.com/stretchr/testify/pull/1022 introduced ErrorContains, but is not yet available in a tagged release. Revert to ErrorContains once this becomes available
-	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, &v1.ClusterRole{}))
+	assert.Error(t, r.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, &v1.ClusterRole{}))
 	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, &v1.ClusterRole{}).Error(), "not found")
 
 	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
@@ -128,18 +128,18 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	assert.NoError(t, err)
 
 	reconciledClusterRole := &v1.ClusterRole{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 	assert.Equal(t, expectedRules, reconciledClusterRole.Rules)
 
 	// update reconciledRole policy rules to RedisHa policy rules
 	reconciledClusterRole.Rules = policyRuleForRedisHa(r.Client)
-	assert.NoError(t, r.Client.Update(context.TODO(), reconciledClusterRole))
+	assert.NoError(t, r.Update(context.TODO(), reconciledClusterRole))
 
 	// Check if the RedisHa policy rules are overwritten to Application Controller
 	// policy rules for cluster role by the reconciler
 	_, err = r.reconcileClusterRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 	assert.Equal(t, expectedRules, reconciledClusterRole.Rules)
 
 	// Check if the CLuster Role gets deleted
@@ -148,7 +148,7 @@ func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	assert.NoError(t, err)
 	//assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole), "not found")
 	//TODO: https://github.com/stretchr/testify/pull/1022 introduced ErrorContains, but is not yet available in a tagged release. Revert to ErrorContains once this becomes available
-	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.Error(t, r.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole).Error(), "not found")
 }
 
@@ -171,7 +171,7 @@ func TestReconcileArgoCD_reconcileClusterRole_custom_cluster_role(t *testing.T) 
 
 	t.Log("Mode 1: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	t.Log("Mode 2: Enable default ClusterRole")
 	enableDefaultClusterRoles(t, ctx, a, cl)
@@ -226,7 +226,7 @@ func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.
 	reconciledRole := &v1.Role{}
 
 	// check if roles are created for the new namespace
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: sourceNamespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: sourceNamespace}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// check if appset rules are added for server-role when new appset namespace is added
@@ -241,7 +241,7 @@ func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.
 	err = r.reconcileRoleForApplicationSourceNamespaces(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 	reconciledRole = &v1.Role{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: sourceNamespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: sourceNamespace}, reconciledRole))
 	assert.Equal(t, append(expectedRules, policyRuleForServerApplicationSetSourceNamespaces()...), reconciledRole.Rules)
 
 	// check if appset rules are removed for server-role when appset namespace is removed from the list
@@ -256,7 +256,7 @@ func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.
 	err = r.reconcileRoleForApplicationSourceNamespaces(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 	reconciledRole = &v1.Role{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: sourceNamespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: sourceNamespace}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 }
 
@@ -306,11 +306,11 @@ func TestReconcileArgoCD_reconcileRole_custom_role(t *testing.T) {
 
 	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
 	reconciledRole := &v1.Role{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// check if roles are created for the new namespace as well
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "namespace-custom-role"}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "namespace-custom-role"}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// set the custom role as env variable
@@ -320,12 +320,12 @@ func TestReconcileArgoCD_reconcileRole_custom_role(t *testing.T) {
 	assert.NoError(t, err)
 
 	// check if the default cluster roles are removed
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
 	if err == nil || !errors.IsNotFound(err) {
 		t.Fatal(err)
 	}
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "namespace-custom-role"}, reconciledRole)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "namespace-custom-role"}, reconciledRole)
 	if err == nil || !errors.IsNotFound(err) {
 		t.Fatal(err)
 	}
@@ -356,11 +356,11 @@ func TestReconcileRoles_ManagedTerminatingNamespace(t *testing.T) {
 
 	expectedName := fmt.Sprintf("%s-%s", a.Name, workloadIdentifier)
 	reconciledRole := &v1.Role{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// Check if roles are created for the new namespace as well
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS"}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS"}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 
 	// Create a configmap with an invalid finalizer in the "managedNS".
@@ -373,24 +373,26 @@ func TestReconcileRoles_ManagedTerminatingNamespace(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, r.Client.Create(
+	assert.NoError(t, r.Create(
 		context.TODO(), configMap))
 
 	// Delete the newNamespaceTest ns.
 	// Verify that operator should not reconcile back to create the roles in terminating ns.
 	newNS := &corev1.Namespace{}
-	r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "managedNS", Name: "managedNS"}, newNS)
-	r.Client.Delete(context.TODO(), newNS)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: "managedNS"}, newNS)
+	assert.NoError(t, err)
+	err = r.Delete(context.TODO(), newNS)
+	assert.NoError(t, err)
 
 	// Verify that the namespace exists and is in terminating state.
-	r.Client.Get(context.TODO(), types.NamespacedName{Namespace: "managedNS", Name: "managedNS"}, newNS)
+	_ = r.Get(context.TODO(), types.NamespacedName{Name: "managedNS"}, newNS)
 	assert.NotEqual(t, newNS.DeletionTimestamp, nil)
 
 	_, err = r.reconcileRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
 	// Verify that the roles are deleted
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, reconciledRole)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, reconciledRole)
 	assert.ErrorContains(t, err, "not found")
 
 	// Create another managed namespace
@@ -400,7 +402,7 @@ func TestReconcileRoles_ManagedTerminatingNamespace(t *testing.T) {
 	_, err = r.reconcileRole(workloadIdentifier, expectedRules, a)
 	assert.NoError(t, err)
 
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: "managedNS2"}, reconciledRole))
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 }
 
@@ -455,9 +457,9 @@ func TestReconcileArgoCD_reconcileClusterRole_aggregated_view(t *testing.T) {
 
 	t.Log("Change ClusterRole fields.")
 	reconciledClusterRole := &v1.ClusterRole{}
-	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.NoError(t, r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 	reconciledClusterRole.Labels = map[string]string{"test": "test"}
-	assert.NoError(t, r.Client.Update(ctx, reconciledClusterRole))
+	assert.NoError(t, r.Update(ctx, reconciledClusterRole))
 
 	t.Log("Reconcile ClusterRole.")
 	_, err = r.reconcileClusterRole(componentName, policyRuleForApplicationControllerView(), a)
@@ -485,10 +487,10 @@ func TestReconcileArgoCD_reconcileClusterRole_aggregated_admin(t *testing.T) {
 	validateAggregatedAdminClusterRole(t, ctx, r, a, reconciledClusterRole, clusterRoleName)
 
 	t.Log("Change ClusterRole fields.")
-	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.NoError(t, r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 	reconciledClusterRole.Labels = map[string]string{"test": "test"}
 	reconciledClusterRole.AggregationRule = &v1.AggregationRule{}
-	assert.NoError(t, r.Client.Update(ctx, reconciledClusterRole))
+	assert.NoError(t, r.Update(ctx, reconciledClusterRole))
 
 	t.Log("Reconcile ClusterRole.")
 	_, err = r.reconcileClusterRole(componentName, policyRuleForApplicationControllerAdmin(), a)
@@ -526,7 +528,7 @@ func TestReconcileArgoCD_reconcileClusterRole_view_aggregated_and_default(t *tes
 	assert.NoError(t, err)
 
 	t.Log("Mode 2: Verify aggregated ClusterRole for View permission is deleted now.")
-	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	err = r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "not found")
 
@@ -570,7 +572,7 @@ func TestReconcileArgoCD_reconcileClusterRole_admin_aggregated_and_default(t *te
 	assert.NoError(t, err)
 
 	t.Log("Mode 2: Verify aggregated ClusterRole for Admin permission is deleted now.")
-	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	err = r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "not found")
 
@@ -617,13 +619,13 @@ func TestReconcileArgoCD_reconcileClusterRole_view_aggregated_and_custom(t *test
 	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
 
 	t.Log("Mode 2: Verify aggregated ClusterRole for View permission is deleted now.")
-	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	err = r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "not found")
 
 	t.Log("Mode 2: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	//------- Aggregated Mode -------
 	t.Log("Mode 1: Switch back to aggregated ClusterRole.")
@@ -668,13 +670,13 @@ func TestReconcileArgoCD_reconcileClusterRole_admin_aggregated_and_custom(t *tes
 	validateCustomClusterRole(t, ctx, r, clusterRoleName, reconciledClusterRole)
 
 	t.Log("Mode 2: Verify aggregated ClusterRole for Admin permission is deleted now.")
-	err = r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	err = r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "not found")
 
 	t.Log("Mode 2: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	//------- Aggregated Mode -------
 	t.Log("Mode 1: Switch back to aggregated ClusterRole.")
@@ -756,7 +758,7 @@ func TestReconcileArgoCD_reconcileClusterRole_default_and_custom(t *testing.T) {
 
 	t.Log("Mode 2: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	//----- Default Mode -----
 	t.Log("Mode 1: Switch back to default ClusterRole.")
@@ -791,7 +793,7 @@ func TestReconcileArgoCD_reconcileClusterRole_custom_and_aggregated(t *testing.T
 
 	t.Log("Mode 1: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	//----- Aggregated Mode -----
 	t.Log("Mode 2: Switch to aggregated ClusterRole.")
@@ -845,7 +847,7 @@ func TestReconcileArgoCD_reconcileClusterRole_default_to_custom_to_aggregated(t 
 
 	t.Log("Mode 2: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	//------- Aggregated Mode -------
 	t.Log("Mode 3: Switch to aggregated ClusterRole.")
@@ -899,7 +901,7 @@ func TestReconcileArgoCD_reconcileClusterRole_default_to_aggregated_to_custom(t 
 
 	t.Log("Mode 3: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 }
 
 // This test is to verify the scenario when user is switching from custom to default ClusterRole and then to aggregated ClusterRole.
@@ -923,7 +925,7 @@ func TestReconcileArgoCD_reconcileClusterRole_custom_to_default_to_aggregated(t 
 
 	t.Log("Mode 1: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	//------- Default Mode -------
 	t.Log("Mode 2: Switch to default ClusterRole.")
@@ -966,7 +968,7 @@ func TestReconcileArgoCD_reconcileClusterRole_custom_to_aggregated_to_default(t 
 
 	t.Log("Mode 1: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	//------- Aggregated Mode -------
 	t.Log("Mode 2: Switch to aggregated ClusterRole.")
@@ -1034,7 +1036,7 @@ func TestReconcileArgoCD_reconcileClusterRole_aggregated_to_default_to_custom(t 
 
 	t.Log("Mode 3: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 }
 
 // This test is to verify the scenario when user is switching from aggregated to custom ClusterRole and then to default ClusterRole.
@@ -1069,7 +1071,7 @@ func TestReconcileArgoCD_reconcileClusterRole_aggregated_to_custom_to_default(t 
 
 	t.Log("Mode 2: Create a custom ClusterRole.")
 	customClusterRole := newClusterRole(clusterRoleName, []v1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get"}}}, a)
-	assert.NoError(t, r.Client.Create(ctx, customClusterRole))
+	assert.NoError(t, r.Create(ctx, customClusterRole))
 
 	//------- Default Mode -------
 	t.Log("Mode 3: Switch to default ClusterRole.")
@@ -1102,7 +1104,7 @@ func setup(t *testing.T) (context.Context, *ReconcileArgoCD, *argoproj.ArgoCD, c
 func validateAggregatedViewClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, clusterRoleName string) {
 	// Ensure aggregated ClusterRole for view permission is created
 	reconciledClusterRole := &v1.ClusterRole{}
-	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.NoError(t, r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 
 	// Ensure ClusterRole has expected Labels
 	assert.EqualValues(t, reconciledClusterRole.Labels[common.ArgoCDAggregateToControllerLabelKey], "true")
@@ -1113,7 +1115,7 @@ func validateAggregatedViewClusterRole(t *testing.T, ctx context.Context, r *Rec
 // validateAggregatedAdminClusterRole checks that ClusterRole for Admin permissions has field values configured in aggregated mode
 func validateAggregatedAdminClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, a *argoproj.ArgoCD, reconciledClusterRole *v1.ClusterRole, clusterRoleName string) {
 
-	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.NoError(t, r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 
 	// Ensure ClusterRole has expected AggregationRule
 	expectedAggregationRule := &v1.AggregationRule{ClusterRoleSelectors: []metav1.LabelSelector{{
@@ -1129,7 +1131,7 @@ func validateAggregatedAdminClusterRole(t *testing.T, ctx context.Context, r *Re
 // validateAggregatedControllerClusterRole checks that ClusterRole has field values configured in aggregated mode
 func validateAggregatedControllerClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, a *argoproj.ArgoCD, reconciledClusterRole *v1.ClusterRole, clusterRoleName string) {
 
-	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.NoError(t, r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 
 	// Ensure ClusterRole has expected AggregationRule
 	expectedAggregationRule := &v1.AggregationRule{ClusterRoleSelectors: []metav1.LabelSelector{{
@@ -1145,7 +1147,7 @@ func validateAggregatedControllerClusterRole(t *testing.T, ctx context.Context, 
 // validateDefaultClusterRole checks that ClusterRole has field values configured in default mode
 func validateDefaultClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, reconciledClusterRole *v1.ClusterRole, clusterRoleName string) {
 
-	assert.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
+	assert.NoError(t, r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole))
 
 	// Ensure ClusterRole does not have AggregationRule
 	assert.Empty(t, reconciledClusterRole.AggregationRule)
@@ -1157,7 +1159,7 @@ func validateDefaultClusterRole(t *testing.T, ctx context.Context, r *ReconcileA
 
 // validateCustomClusterRole checks that default ClusterRole is deleted
 func validateCustomClusterRole(t *testing.T, ctx context.Context, r *ReconcileArgoCD, clusterRoleName string, reconciledClusterRole *v1.ClusterRole) {
-	err := r.Client.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
+	err := r.Get(ctx, types.NamespacedName{Name: clusterRoleName}, reconciledClusterRole)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "not found")
 }
@@ -1203,7 +1205,7 @@ func TestReconcileArgoCD_reconcileRole_enable_controller_role(t *testing.T) {
 
 	expectedName := fmt.Sprintf("%s-%s", a.Name, componentName)
 	reconciledRole := &v1.Role{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
 
 	flag := false
 	a.Spec.Controller.Enabled = &flag
@@ -1211,7 +1213,7 @@ func TestReconcileArgoCD_reconcileRole_enable_controller_role(t *testing.T) {
 	_, err = r.reconcileRole(componentName, []v1.PolicyRule{}, a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
 	assert.Error(t, err)
 	assertNotFound(t, err)
 }
@@ -1236,7 +1238,7 @@ func TestReconcileArgoCD_reconcileRole_enable_redis_role(t *testing.T) {
 
 	expectedName := fmt.Sprintf("%s-%s", a.Name, componentName)
 	reconciledRole := &v1.Role{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
 
 	flag := false
 	a.Spec.Redis.Enabled = &flag
@@ -1244,7 +1246,7 @@ func TestReconcileArgoCD_reconcileRole_enable_redis_role(t *testing.T) {
 	_, err = r.reconcileRole(componentName, []v1.PolicyRule{}, a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
 	assert.Error(t, err)
 	assertNotFound(t, err)
 }
@@ -1269,7 +1271,7 @@ func TestReconcileArgoCD_reconcileRole_enable_server_role(t *testing.T) {
 
 	expectedName := fmt.Sprintf("%s-%s", a.Name, componentName)
 	reconciledRole := &v1.Role{}
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole))
 
 	flag := false
 	a.Spec.Server.Enabled = &flag
@@ -1277,7 +1279,7 @@ func TestReconcileArgoCD_reconcileRole_enable_server_role(t *testing.T) {
 	_, err = r.reconcileRole(componentName, []v1.PolicyRule{}, a)
 	assert.NoError(t, err)
 
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledRole)
 	assert.Error(t, err)
 	assertNotFound(t, err)
 }

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -13,9 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	testclient "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -59,7 +57,7 @@ func TestReconcileRouteSetLabels(t *testing.T) {
 	assert.NoError(t, err)
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	if diff := cmp.Diff("my-value", loaded.Labels["my-key"]); diff != "" {
@@ -95,7 +93,7 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 	assert.NoError(t, err)
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
@@ -113,18 +111,18 @@ func TestReconcileRouteSetsInsecure(t *testing.T) {
 	}
 
 	// second reconciliation after changing the Insecure flag.
-	err = r.Client.Get(ctx, req.NamespacedName, argoCD)
+	err = r.Get(ctx, req.NamespacedName, argoCD)
 	fatalIfError(t, err, "failed to load ArgoCD %q: %s", testArgoCDName+"-server", err)
 
 	argoCD.Spec.Server.Insecure = true
-	err = r.Client.Update(ctx, argoCD)
+	err = r.Update(ctx, argoCD)
 	fatalIfError(t, err, "failed to update the ArgoCD: %s", err)
 
 	_, err = r.Reconcile(context.TODO(), req)
 	fatalIfError(t, err, "reconcile: (%v): %s", req, err)
 
 	loaded = &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig = &routev1.TLSConfig{
@@ -171,7 +169,7 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 	assert.NoError(t, err)
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
@@ -189,18 +187,18 @@ func TestReconcileRouteUnsetsInsecure(t *testing.T) {
 	}
 
 	// second reconciliation after changing the Insecure flag.
-	err = r.Client.Get(ctx, req.NamespacedName, argoCD)
+	err = r.Get(ctx, req.NamespacedName, argoCD)
 	fatalIfError(t, err, "failed to load ArgoCD %q: %s", testArgoCDName+"-server", err)
 
 	argoCD.Spec.Server.Insecure = false
-	err = r.Client.Update(ctx, argoCD)
+	err = r.Update(ctx, argoCD)
 	fatalIfError(t, err, "failed to update the ArgoCD: %s", err)
 
 	_, err = r.Reconcile(context.TODO(), req)
 	assert.NoError(t, err)
 
 	loaded = &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig = &routev1.TLSConfig{
@@ -254,7 +252,7 @@ func TestReconcileRouteApplicationSetHost(t *testing.T) {
 	assert.NoError(t, err)
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", testArgoCDName, common.ApplicationSetControllerWebhookSuffix), Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", testArgoCDName, common.ApplicationSetControllerWebhookSuffix), Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
@@ -310,7 +308,7 @@ func TestReconcileRouteApplicationSetTlsTermination(t *testing.T) {
 	assert.NoError(t, err)
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", testArgoCDName, common.ApplicationSetControllerWebhookSuffix), Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", testArgoCDName, common.ApplicationSetControllerWebhookSuffix), Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 	wantTLSConfig := &routev1.TLSConfig{
@@ -388,7 +386,7 @@ func TestReconcileRouteApplicationSetTls(t *testing.T) {
 	}
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: expectedRouteName, Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: expectedRouteName, Namespace: testNamespace}, loaded)
 	fatalIfError(t, err, "failed to load route %q: %s", expectedRouteName, err)
 
 	// Verify TLS configuration
@@ -492,18 +490,18 @@ func TestReconcileRouteForShorteningHostname(t *testing.T) {
 			assert.NoError(t, err)
 
 			// second reconciliation after changing the hostname.
-			err = r.Client.Get(ctx, req.NamespacedName, argoCD)
+			err = r.Get(ctx, req.NamespacedName, argoCD)
 			fatalIfError(t, err, "failed to load ArgoCD %q: %s", testArgoCDName+"-server", err)
 
 			argoCD.Spec.Server.Host = v.hostname
-			err = r.Client.Update(ctx, argoCD)
+			err = r.Update(ctx, argoCD)
 			fatalIfError(t, err, "failed to update the ArgoCD: %s", err)
 
 			_, err = r.Reconcile(context.TODO(), req)
 			assert.NoError(t, err)
 
 			loaded := &routev1.Route{}
-			err = r.Client.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
+			err = r.Get(ctx, types.NamespacedName{Name: testArgoCDName + "-server", Namespace: testNamespace}, loaded)
 			fatalIfError(t, err, "failed to load route %q: %s", testArgoCDName+"-server", err)
 
 			if diff := cmp.Diff(v.expected, loaded.Spec.Host); diff != "" {
@@ -572,7 +570,7 @@ func TestReconcileRouteForShorteningRoutename(t *testing.T) {
 	}
 
 	loaded := &routev1.Route{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: expectedRouteName, Namespace: testNamespace}, loaded)
+	err = r.Get(ctx, types.NamespacedName{Name: expectedRouteName, Namespace: testNamespace}, loaded)
 	assert.NoError(t, err)
 	assert.LessOrEqual(t, len(loaded.Name), 63)
 }
@@ -683,7 +681,7 @@ func TestReconcileRouteTLSConfig(t *testing.T) {
 			assert.Nil(t, err)
 
 			route := &routev1.Route{}
-			err = reconciler.Client.Get(ctx, types.NamespacedName{Name: argoCD.Name + "-server", Namespace: argoCD.Namespace}, route)
+			err = reconciler.Get(ctx, types.NamespacedName{Name: argoCD.Name + "-server", Namespace: argoCD.Namespace}, route)
 			assert.Nil(t, err)
 			assert.Equal(t, test.want, route.Spec.TLS.Termination)
 
@@ -753,27 +751,6 @@ func TestIsCreatedByServiceCA(t *testing.T) {
 	}
 }
 
-func makeReconciler(t *testing.T, acd *argoproj.ArgoCD, objs ...runtime.Object) *ReconcileArgoCD {
-	t.Helper()
-	s := scheme.Scheme
-	s.AddKnownTypes(argoproj.GroupVersion, acd)
-	routev1.Install(s)
-	configv1.Install(s)
-
-	clientObjs := []client.Object{}
-	for _, obj := range objs {
-		clientObj := obj.(client.Object)
-		clientObjs = append(clientObjs, clientObj)
-	}
-
-	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).WithStatusSubresource(clientObjs...).Build()
-
-	return &ReconcileArgoCD{
-		Client: cl,
-		Scheme: s,
-	}
-}
-
 func makeArgoCD(opts ...func(*argoproj.ArgoCD)) *argoproj.ArgoCD {
 	argoCD := &argoproj.ArgoCD{
 		ObjectMeta: metav1.ObjectMeta{
@@ -793,14 +770,6 @@ func fatalIfError(t *testing.T, err error, format string, a ...interface{}) {
 	if err != nil {
 		t.Fatalf(format, a...)
 	}
-}
-
-func loadSecret(t *testing.T, c client.Client, name string) *corev1.Secret {
-	t.Helper()
-	secret := &corev1.Secret{}
-	err := c.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: testNamespace}, secret)
-	fatalIfError(t, err, "failed to load secret %q", name)
-	return secret
 }
 
 func testNamespacedName(name string) types.NamespacedName {

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -137,20 +137,23 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 		}
 
 		// Workloads should have been requested to re-rollout on a change
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
-		deplRollout, ok := serverDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		assert.NoError(t, err)
+		deplRollout, ok := serverDepl.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok {
-			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRollout, ok := repoDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		assert.NoError(t, err)
+		repoRollout, ok := repoDepl.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok {
-			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
-		ctrlRollout, ok := ctrlSts.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		assert.NoError(t, err)
+		ctrlRollout, ok := ctrlSts.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok {
-			t.Errorf("Expected rollout of argocd-application-server, but it didn't happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-application-server, but it didn't happen: %v", ctrlSts.Spec.Template.Labels)
 		}
 
 		// Second run - no change
@@ -163,26 +166,31 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 		}
 
 		// This time, label should not have changed
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
-		deplRolloutNew, ok := serverDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		assert.NoError(t, err)
+		deplRolloutNew, ok := serverDepl.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok || deplRollout != deplRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-server, but it did happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-server, but it did happen: %v", serverDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRolloutNew, ok := repoDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		assert.NoError(t, err)
+		repoRolloutNew, ok := repoDepl.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok || repoRollout != repoRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-repo-server, but it did happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-repo-server, but it did happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
-		ctrlRolloutNew, ok := ctrlSts.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		assert.NoError(t, err)
+		ctrlRolloutNew, ok := ctrlSts.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok || ctrlRollout != ctrlRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-application-server, but it did happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-application-server, but it did happen: %v", ctrlSts.Spec.Template.Labels)
 		}
 
 		// Update certificate in the secret must trigger new rollout
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server-tls", Namespace: "argocd-operator"}, secret)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server-tls", Namespace: "argocd-operator"}, secret)
+		assert.NoError(t, err)
 		secret.Data["tls.crt"] = []byte("bar")
-		r.Client.Update(context.TODO(), secret)
+		err = r.Update(context.TODO(), secret)
+		assert.NoError(t, err)
 
 		sumOver = []byte{}
 		sumOver = append(sumOver, []byte("bar")...)
@@ -199,20 +207,23 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 		}
 
 		// This time, label should have changed
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
-		deplRolloutNew, ok = serverDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		assert.NoError(t, err)
+		deplRolloutNew, ok = serverDepl.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok || deplRollout == deplRolloutNew {
-			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRolloutNew, ok = repoDepl.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		assert.NoError(t, err)
+		repoRolloutNew, ok = repoDepl.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok || repoRollout == repoRolloutNew {
-			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
-		ctrlRolloutNew, ok = ctrlSts.Spec.Template.ObjectMeta.Labels["repo.tls.cert.changed"]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		assert.NoError(t, err)
+		ctrlRolloutNew, ok = ctrlSts.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok || ctrlRollout == ctrlRolloutNew {
-			t.Errorf("Expected rollout of argocd-application-controller, but it didn't happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-application-controller, but it didn't happen: %v", ctrlSts.Spec.Template.Labels)
 		}
 
 	})
@@ -238,23 +249,26 @@ func Test_ReconcileArgoCD_ReconcileExistingArgoSecret(t *testing.T) {
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-	r.Client.Create(context.TODO(), clusterSecret)
-	r.Client.Create(context.TODO(), tlsSecret)
+	err := r.Create(context.TODO(), clusterSecret)
+	assert.NoError(t, err)
+	err = r.Create(context.TODO(), tlsSecret)
+	assert.NoError(t, err)
 
-	err := r.reconcileArgoSecret(argocd)
+	err = r.reconcileArgoSecret(argocd)
 
 	assert.NoError(t, err)
 
 	testSecret := &corev1.Secret{}
-	secretErr := r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
+	secretErr := r.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
 	assert.NoError(t, secretErr)
 
 	// if you remove the secret.Data it should come back, including the secretKey
 	testSecret.Data = nil
-	r.Client.Update(context.TODO(), testSecret)
+	err = r.Update(context.TODO(), testSecret)
+	assert.NoError(t, err)
 
 	_ = r.reconcileExistingArgoSecret(argocd, testSecret, clusterSecret, tlsSecret)
-	_ = r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
+	_ = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
 
 	if testSecret.Data == nil {
 		t.Errorf("Expected data for data.server but got nothing")
@@ -263,7 +277,7 @@ func Test_ReconcileArgoCD_ReconcileExistingArgoSecret(t *testing.T) {
 	if testSecret.Data[common.ArgoCDKeyServerSecretKey] == nil {
 		t.Errorf("Expected data for data.server.secretKey but got nothing")
 	}
-	assert.True(t, argoutil.IsTrackedByOperator(testSecret.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(testSecret.Labels))
 }
 
 func Test_ReconcileArgoCD_ReconcileShouldNotChangeWhenUpdatedAdminPass(t *testing.T) {
@@ -285,27 +299,30 @@ func Test_ReconcileArgoCD_ReconcileShouldNotChangeWhenUpdatedAdminPass(t *testin
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-	r.Client.Create(context.TODO(), clusterSecret)
-	r.Client.Create(context.TODO(), tlsSecret)
+	err := r.Create(context.TODO(), clusterSecret)
+	assert.NoError(t, err)
+	err = r.Create(context.TODO(), tlsSecret)
+	assert.NoError(t, err)
 
-	err := r.reconcileArgoSecret(argocd)
+	err = r.reconcileArgoSecret(argocd)
 
 	assert.NoError(t, err)
 
 	testSecret := &corev1.Secret{}
-	secretErr := r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
+	secretErr := r.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
 	assert.NoError(t, secretErr)
-	assert.True(t, argoutil.IsTrackedByOperator(testSecret.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(testSecret.Labels))
 
 	// simulating update of argo-cd Admin password from cli or argocd dashboard
 	hashedPassword, _ := argopass.HashPassword("updated_password")
 	testSecret.Data[common.ArgoCDKeyAdminPassword] = []byte(hashedPassword)
 	mTime := nowBytes()
 	testSecret.Data[common.ArgoCDKeyAdminPasswordMTime] = mTime
-	r.Client.Update(context.TODO(), testSecret)
+	err = r.Update(context.TODO(), testSecret)
+	assert.NoError(t, err)
 
 	_ = r.reconcileExistingArgoSecret(argocd, testSecret, clusterSecret, tlsSecret)
-	_ = r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
+	_ = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
 
 	// checking if reconciliation updates the ArgoCDKeyAdminPassword and ArgoCDKeyAdminPasswordMTime
 	if string(testSecret.Data[common.ArgoCDKeyAdminPassword]) != hashedPassword {
@@ -317,10 +334,11 @@ func Test_ReconcileArgoCD_ReconcileShouldNotChangeWhenUpdatedAdminPass(t *testin
 
 	// if you remove the secret.Data it should come back, including the secretKey
 	testSecret.Data = nil
-	r.Client.Update(context.TODO(), testSecret)
+	err = r.Update(context.TODO(), testSecret)
+	assert.NoError(t, err)
 
 	_ = r.reconcileExistingArgoSecret(argocd, testSecret, clusterSecret, tlsSecret)
-	_ = r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
+	_ = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-secret", Namespace: "argocd-operator"}, testSecret)
 
 	if testSecret.Data == nil {
 		t.Errorf("Expected data for data.server but got nothing")
@@ -329,7 +347,7 @@ func Test_ReconcileArgoCD_ReconcileShouldNotChangeWhenUpdatedAdminPass(t *testin
 	if testSecret.Data[common.ArgoCDKeyServerSecretKey] == nil {
 		t.Errorf("Expected data for data.server.secretKey but got nothing")
 	}
-	assert.True(t, argoutil.IsTrackedByOperator(testSecret.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(testSecret.Labels))
 }
 
 func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
@@ -414,25 +432,29 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 		certChangedLabel := "redis.tls.cert.changed"
 
 		// Workloads should have been requested to re-rollout on a change
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
-		deplRollout, ok := serverDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		assert.NoError(t, err)
+		deplRollout, ok := serverDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok {
-			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRollout, ok := repoDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		assert.NoError(t, err)
+		repoRollout, ok := repoDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok {
-			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
-		redisRollout, ok := redisDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
+		assert.NoError(t, err)
+		redisRollout, ok := redisDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok {
-			t.Errorf("Expected rollout of argocd-redis, but it didn't happen: %v", redisDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-redis, but it didn't happen: %v", redisDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
-		ctrlRollout, ok := ctrlSts.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		assert.NoError(t, err)
+		ctrlRollout, ok := ctrlSts.Spec.Template.Labels[certChangedLabel]
 		if !ok {
-			t.Errorf("Expected rollout of argocd-application-server, but it didn't happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-application-server, but it didn't happen: %v", ctrlSts.Spec.Template.Labels)
 		}
 
 		// Second run - no change
@@ -445,31 +467,36 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 		}
 
 		// This time, label should not have changed
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
-		deplRolloutNew, ok := serverDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		assert.NoError(t, err)
+		deplRolloutNew, ok := serverDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok || deplRollout != deplRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-server, but it did happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-server, but it did happen: %v", serverDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRolloutNew, ok := repoDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		assert.NoError(t, err)
+		repoRolloutNew, ok := repoDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok || repoRollout != repoRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-repo-server, but it did happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-repo-server, but it did happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
-		redisRolloutNew, ok := redisDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
+		assert.NoError(t, err)
+		redisRolloutNew, ok := redisDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok || redisRollout != redisRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-redis, but it did happen: %v", redisDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-redis, but it did happen: %v", redisDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
-		ctrlRolloutNew, ok := ctrlSts.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		assert.NoError(t, err)
+		ctrlRolloutNew, ok := ctrlSts.Spec.Template.Labels[certChangedLabel]
 		if !ok || ctrlRollout != ctrlRolloutNew {
-			t.Errorf("Did not expect rollout of argocd-application-server, but it did happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Did not expect rollout of argocd-application-server, but it did happen: %v", ctrlSts.Spec.Template.Labels)
 		}
 
 		// Update certificate in the secret must trigger new rollout
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server-tls", Namespace: "argocd-operator"}, secret)
+		_ = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server-tls", Namespace: "argocd-operator"}, secret)
 		secret.Data["tls.crt"] = []byte("bar")
-		r.Client.Update(context.TODO(), secret)
+		err = r.Update(context.TODO(), secret)
+		assert.NoError(t, err)
 
 		sumOver = []byte{}
 		sumOver = append(sumOver, []byte("bar")...)
@@ -486,25 +513,29 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 		}
 
 		// This time, label should have changed
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
-		deplRolloutNew, ok = serverDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-server", Namespace: "argocd-operator"}, serverDepl)
+		assert.NoError(t, err)
+		deplRolloutNew, ok = serverDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok || deplRollout == deplRolloutNew {
-			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-server, but it didn't happen: %v", serverDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
-		repoRolloutNew, ok = repoDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: "argocd-operator"}, repoDepl)
+		assert.NoError(t, err)
+		repoRolloutNew, ok = repoDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok || repoRollout == repoRolloutNew {
-			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
-		redisRolloutNew, ok = repoDepl.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-redis", Namespace: "argocd-operator"}, redisDepl)
+		assert.NoError(t, err)
+		redisRolloutNew, ok = repoDepl.Spec.Template.Labels[certChangedLabel]
 		if !ok || redisRollout == redisRolloutNew {
-			t.Errorf("Expected rollout of argocd-redis, but it didn't happen: %v", redisDepl.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-redis, but it didn't happen: %v", redisDepl.Spec.Template.Labels)
 		}
-		r.Client.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
-		ctrlRolloutNew, ok = ctrlSts.Spec.Template.ObjectMeta.Labels[certChangedLabel]
+		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		assert.NoError(t, err)
+		ctrlRolloutNew, ok = ctrlSts.Spec.Template.Labels[certChangedLabel]
 		if !ok || ctrlRollout == ctrlRolloutNew {
-			t.Errorf("Expected rollout of argocd-application-controller, but it didn't happen: %v", ctrlSts.Spec.Template.ObjectMeta.Labels)
+			t.Errorf("Expected rollout of argocd-application-controller, but it didn't happen: %v", ctrlSts.Spec.Template.Labels)
 		}
 	})
 }
@@ -525,27 +556,28 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	testSecret := argoutil.NewSecretWithSuffix(a, "default-cluster-config")
 	//assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret), "not found")
 	//TODO: https://github.com/stretchr/testify/pull/1022 introduced ErrorContains, but is not yet available in a tagged release. Revert to ErrorContains once this becomes available
-	assert.Error(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
+	assert.Error(t, r.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
 	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret).Error(), "not found")
 
 	assert.NoError(t, r.reconcileClusterPermissionsSecret(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
 	assert.Equal(t, string(testSecret.Data["namespaces"]), a.Namespace)
 
 	want := "argocd,someRandomNamespace"
 	testSecret.Data["namespaces"] = []byte("someRandomNamespace")
-	r.Client.Update(context.TODO(), testSecret)
+	err := r.Update(context.TODO(), testSecret)
+	assert.NoError(t, err)
 
 	// reconcile to check namespace with the label gets added
 	assert.NoError(t, r.reconcileClusterPermissionsSecret(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
 	assert.Equal(t, string(testSecret.Data["namespaces"]), want)
 
 	assert.NoError(t, createNamespace(r, "xyz", a.Namespace))
 	want = "argocd,someRandomNamespace,xyz"
 	// reconcile to check namespace with the label gets added
 	assert.NoError(t, r.reconcileClusterPermissionsSecret(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
 	assert.Equal(t, string(testSecret.Data["namespaces"]), want)
 
 	t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
@@ -553,9 +585,9 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	assert.NoError(t, r.reconcileClusterPermissionsSecret(a))
 	//assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret), "not found")
 	//TODO: https://github.com/stretchr/testify/pull/1022 introduced ErrorContains, but is not yet available in a tagged release. Revert to ErrorContains once this becomes available
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
-	assert.Nil(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
-	assert.True(t, argoutil.IsTrackedByOperator(testSecret.ObjectMeta.Labels))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
+	assert.Nil(t, r.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
+	assert.True(t, argoutil.IsTrackedByOperator(testSecret.Labels))
 }
 
 func TestGenerateSortedManagedNamespaceListForArgoCDCR(t *testing.T) {

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -43,11 +43,11 @@ func newServiceAccount(cr *argoproj.ArgoCD) *corev1.ServiceAccount {
 // newServiceAccountWithName creates a new ServiceAccount with the given name for the given ArgCD.
 func newServiceAccountWithName(name string, cr *argoproj.ArgoCD) *corev1.ServiceAccount {
 	sa := newServiceAccount(cr)
-	sa.ObjectMeta.Name = getServiceAccountName(cr.Name, name)
+	sa.Name = getServiceAccountName(cr.Name, name)
 
-	lbls := sa.ObjectMeta.Labels
+	lbls := sa.Labels
 	lbls[common.ArgoCDKeyName] = name
-	sa.ObjectMeta.Labels = lbls
+	sa.Labels = lbls
 
 	return sa
 }
@@ -121,7 +121,7 @@ func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoproj.Argo
 		if name == common.ArgoCDDexServerComponent && !UseDex(cr) {
 			// Delete any existing Service Account created for Dex since dex is disabled
 			argoutil.LogResourceDeletion(log, sa, "dex is being uninstalled")
-			return sa, r.Client.Delete(context.TODO(), sa)
+			return sa, r.Delete(context.TODO(), sa)
 		}
 		return sa, nil
 	}
@@ -131,7 +131,7 @@ func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoproj.Argo
 	}
 
 	argoutil.LogResourceCreation(log, sa)
-	err := r.Client.Create(context.TODO(), sa)
+	err := r.Create(context.TODO(), sa)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/argocd/service_test.go
+++ b/controllers/argocd/service_test.go
@@ -107,7 +107,7 @@ func TestReconcileServerService(t *testing.T) {
 	})
 	serverService := newServiceWithSuffix("server", "server", a)
 	t.Run("Server Service Created when the Server Service is not found ", func(t *testing.T) {
-		err := r.Client.Get(context.TODO(), types.NamespacedName{
+		err := r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-server",
 			Namespace: testNamespace,
 		}, serverService)
@@ -116,7 +116,7 @@ func TestReconcileServerService(t *testing.T) {
 		err = r.reconcileServerService(a)
 		assert.NoError(t, err)
 
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-server",
 			Namespace: testNamespace,
 		}, serverService)
@@ -133,7 +133,7 @@ func TestReconcileServerService(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Existing Server is found and has the argoCD new Server Service Type
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
+		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      "argocd-server",
 			Namespace: testNamespace,
 		}, serverService)
@@ -160,7 +160,7 @@ func TestReconcileArgoCD_reconcileRedisWithRemoteEn(t *testing.T) {
 
 	s := &corev1.Service{}
 
-	assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, s),
+	assert.ErrorContains(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-redis", Namespace: cr.Namespace}, s),
 		"services \"argocd-redis\" not found")
 }
 
@@ -181,6 +181,6 @@ func TestReconcileArgoCD_reconcileRepoServerWithRemoteEnabled(t *testing.T) {
 
 	s := &corev1.Service{}
 
-	assert.ErrorContains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, s),
+	assert.ErrorContains(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, s),
 		"services \"argocd-repo-server\" not found")
 }

--- a/controllers/argocd/sso_test.go
+++ b/controllers/argocd/sso_test.go
@@ -34,8 +34,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 )
 
 func TestReconcile_testKeycloakTemplateInstance(t *testing.T) {
@@ -57,7 +58,7 @@ func TestReconcile_testKeycloakTemplateInstance(t *testing.T) {
 	assert.NoError(t, r.reconcileSSO(a))
 
 	templateInstance := &templatev1.TemplateInstance{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "rhsso",
@@ -292,7 +293,7 @@ func TestReconcile_KeycloakTemplateWithoutDeploymentConfig(t *testing.T) {
 
 	// Verify that the Template instance is not created.
 	templateInstance := &templatev1.TemplateInstance{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "rhsso", Namespace: a.Namespace}, templateInstance)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: "rhsso", Namespace: a.Namespace}, templateInstance)
 	assert.NotNil(t, err)
 	assert.True(t, apierrors.IsNotFound(err))
 }
@@ -317,7 +318,7 @@ func TestReconcile_testKeycloakInstanceResources(t *testing.T) {
 
 	// Keycloak Deployment
 	deployment := &k8sappsv1.Deployment{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: a.Namespace}, deployment)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: a.Namespace}, deployment)
 	assert.NoError(t, err)
 
 	assert.Equal(t, deployment.Name, defaultKeycloakIdentifier)
@@ -335,7 +336,7 @@ func TestReconcile_testKeycloakInstanceResources(t *testing.T) {
 	}
 	assert.Equal(t, deployment.Spec.Selector, testSelector)
 
-	assert.Equal(t, deployment.Spec.Template.ObjectMeta.Labels, testLabels)
+	assert.Equal(t, deployment.Spec.Template.Labels, testLabels)
 	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Name,
 		defaultKeycloakIdentifier)
 	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Image,
@@ -351,7 +352,7 @@ func TestReconcile_testKeycloakInstanceResources(t *testing.T) {
 
 	// Keycloak Service
 	svc := &corev1.Service{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: a.Namespace}, svc)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: a.Namespace}, svc)
 	assert.NoError(t, err)
 
 	assert.Equal(t, svc.Name, defaultKeycloakIdentifier)
@@ -364,7 +365,7 @@ func TestReconcile_testKeycloakInstanceResources(t *testing.T) {
 	// Keycloak Ingress
 	ing := &networkingv1.Ingress{}
 	testPathType := networkingv1.PathTypeImplementationSpecific
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: a.Namespace}, ing)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: a.Namespace}, ing)
 	assert.NoError(t, err)
 
 	assert.Equal(t, ing.Name, defaultKeycloakIdentifier)
@@ -425,7 +426,7 @@ func TestReconcile_testKeycloakIngressHost(t *testing.T) {
 	// Keycloak Ingress
 	ing := &networkingv1.Ingress{}
 	testPathType := networkingv1.PathTypeImplementationSpecific
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: a.Namespace}, ing)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: defaultKeycloakIdentifier, Namespace: a.Namespace}, ing)
 	assert.NoError(t, err)
 
 	assert.Equal(t, ing.Name, defaultKeycloakIdentifier)
@@ -497,7 +498,7 @@ func TestReconcile_testKeycloakRouteHost(t *testing.T) {
 			Namespace: a.Namespace,
 		},
 	}
-	err := r.Client.Get(context.Background(), client.ObjectKeyFromObject(&templ), &templ)
+	err := r.Get(context.Background(), client.ObjectKeyFromObject(&templ), &templ)
 	assert.NoError(t, err)
 
 	// TemplateInstance contains a set of Objects, but we only care about the Route

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -133,7 +133,7 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_disabled(t *testing.T) {
 
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
 	// resource Creation should fail as HA was disabled
-	assert.Errorf(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s), "not found")
+	assert.Errorf(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s), "not found")
 }
 
 func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_enabled(t *testing.T) {
@@ -153,7 +153,7 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_enabled(t *testing.T) {
 	a.Spec.HA.Enabled = true
 	// test resource is Created when HA is enabled
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 
 	// test resource is Updated on reconciliation
 	a.Spec.Redis.Image = testRedisImage
@@ -170,7 +170,7 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_enabled(t *testing.T) {
 	}
 	a.Spec.HA.Resources = &newResources
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 	for _, container := range s.Spec.Template.Spec.Containers {
 		assert.Equal(t, container.Image, fmt.Sprintf("%s:%s", testRedisImage, testRedisImageVersion))
 		assert.Equal(t, container.Resources, newResources)
@@ -180,7 +180,7 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_enabled(t *testing.T) {
 	// test resource is Deleted, when HA is disabled
 	a.Spec.HA.Enabled = false
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
-	assert.Errorf(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s), "not found")
+	assert.Errorf(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s), "not found")
 }
 
 func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {
@@ -197,7 +197,7 @@ func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss := &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -243,7 +243,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withRedisTLS(t *testing.
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, true))
 
 	ss := &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -285,7 +285,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withUpdate(t *testing.T)
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss := &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -320,10 +320,10 @@ func TestReconcileArgoCD_reconcileApplicationController_withUpgrade(t *testing.T
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 	deploy := newDeploymentWithSuffix("application-controller", "application-controller", a)
-	assert.NoError(t, r.Client.Create(context.TODO(), deploy))
+	assert.NoError(t, r.Create(context.TODO(), deploy))
 
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, deploy)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, deploy)
 	assert.Errorf(t, err, "not found")
 }
 
@@ -354,7 +354,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withResources(t *testing
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss := &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -526,7 +526,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 		assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 		ss := &appsv1.StatefulSet{}
-		assert.NoError(t, r.Client.Get(
+		assert.NoError(t, r.Get(
 			context.TODO(),
 			types.NamespacedName{
 				Name:      "argocd-application-controller",
@@ -586,7 +586,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withAppSync(t *testing.T
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss := &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -642,7 +642,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withEnv(t *testing.T) {
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss := &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -832,13 +832,13 @@ func TestReconcileArgoCD_reconcileApplicationController_withDynamicSharding(t *t
 		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-		assert.NoError(t, r.Client.Create(context.TODO(), clusterSecret1))
-		assert.NoError(t, r.Client.Create(context.TODO(), clusterSecret2))
-		assert.NoError(t, r.Client.Create(context.TODO(), clusterSecret3))
+		assert.NoError(t, r.Create(context.TODO(), clusterSecret1))
+		assert.NoError(t, r.Create(context.TODO(), clusterSecret2))
+		assert.NoError(t, r.Create(context.TODO(), clusterSecret3))
 
 		replicas := r.getApplicationControllerReplicaCount(a)
 
-		assert.Equal(t, int32(st.expectedReplicas), replicas)
+		assert.Equal(t, st.expectedReplicas, replicas)
 
 	}
 }
@@ -863,7 +863,7 @@ func TestReconcileAppController_Initcontainer(t *testing.T) {
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss := &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -880,7 +880,7 @@ func TestReconcileAppController_Initcontainer(t *testing.T) {
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss = &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -911,7 +911,7 @@ func TestReconcileArgoCD_sidecarcontainer(t *testing.T) {
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss := &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -928,7 +928,7 @@ func TestReconcileArgoCD_sidecarcontainer(t *testing.T) {
 	assert.NoError(t, r.reconcileApplicationControllerStatefulSet(a, false))
 
 	ss = &appsv1.StatefulSet{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      "argocd-application-controller",
@@ -955,18 +955,18 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_ModifyContainerSpec(t *testin
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
 
 	s := newStatefulSetWithSuffix("redis-ha-server", "redis", a)
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 
 	// Modify the container environment variable
 	s.Spec.Template.Spec.Containers[0].Env = append(s.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  "NEW_ENV_VAR",
 		Value: "new-value",
 	})
-	assert.NoError(t, r.Client.Update(context.TODO(), s))
+	assert.NoError(t, r.Update(context.TODO(), s))
 
 	// Reconcile again and check if the environment variable is reverted
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 
 	envVarFound := false
 	for _, env := range s.Spec.Template.Spec.Containers[0].Env {
@@ -978,17 +978,17 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_ModifyContainerSpec(t *testin
 	assert.False(t, envVarFound, "NEW_ENV_VAR should not be present")
 
 	// Modify the SecurityContext
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 	expectedSecurityContext := s.Spec.Template.Spec.SecurityContext
 	fsGroup := int64(2000)
 	newSecurityContext := &corev1.PodSecurityContext{
 		FSGroup: &fsGroup,
 	}
 	s.Spec.Template.Spec.SecurityContext = newSecurityContext
-	assert.NoError(t, r.Client.Update(context.TODO(), s))
+	assert.NoError(t, r.Update(context.TODO(), s))
 	// Reconcile again and check if the SecurityContext is reverted
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 	assert.Equal(t, true, reflect.DeepEqual(expectedSecurityContext, s.Spec.Template.Spec.SecurityContext))
 
 	// Modify the initcontainer environment variable
@@ -996,11 +996,11 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_ModifyContainerSpec(t *testin
 		Name:  "NEW_ENV_VAR",
 		Value: "new-value",
 	})
-	assert.NoError(t, r.Client.Update(context.TODO(), s))
+	assert.NoError(t, r.Update(context.TODO(), s))
 
 	// Reconcile again and check if the environment variable is reverted
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 
 	envVarFound = false
 	for _, env := range s.Spec.Template.Spec.InitContainers[0].Env {
@@ -1022,10 +1022,10 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_ModifyContainerSpec(t *testin
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	})
-	assert.NoError(t, r.Client.Update(context.TODO(), s))
+	assert.NoError(t, r.Update(context.TODO(), s))
 	// Reconcile again and check if the volume mount is reverted
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
-	assert.NoError(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 
 	volumeMountFound := false
 	for _, vm := range s.Spec.Template.Spec.Containers[0].VolumeMounts {

--- a/controllers/argocd/status.go
+++ b/controllers/argocd/status.go
@@ -457,7 +457,7 @@ func (r *ReconcileArgoCD) reconcileStatusHost(cr *argoproj.ArgoCD) error {
 			Namespace: cr.Namespace,
 		}
 
-		if err := r.Client.List(context.TODO(), routeList, opts); err != nil {
+		if err := r.List(context.TODO(), routeList, opts); err != nil {
 			return err
 		}
 

--- a/controllers/argocd/status_test.go
+++ b/controllers/argocd/status_test.go
@@ -39,14 +39,16 @@ func TestReconcileArgoCD_reconcileStatusKeycloak_K8s(t *testing.T) {
 	assert.Equal(t, "Unknown", a.Status.SSO)
 
 	// keycloak installation started
-	r.Client.Create(context.TODO(), d)
+	err := r.Create(context.TODO(), d)
+	assert.NoError(t, err)
 
 	_ = r.reconcileStatusKeycloak(a)
 	assert.Equal(t, "Pending", a.Status.SSO)
 
 	// keycloak installation completed
 	d.Status.ReadyReplicas = *d.Spec.Replicas
-	r.Client.Status().Update(context.TODO(), d)
+	err = r.Client.Status().Update(context.TODO(), d)
+	assert.NoError(t, err)
 
 	_ = r.reconcileStatusKeycloak(a)
 	assert.Equal(t, "Running", a.Status.SSO)
@@ -72,7 +74,7 @@ func TestReconcileArgoCD_reconcileStatusKeycloak_OpenShift(t *testing.T) {
 	defer removeTemplateAPI()
 
 	dc := getKeycloakDeploymentConfigTemplate(a)
-	dc.ObjectMeta.Name = defaultKeycloakIdentifier
+	dc.Name = defaultKeycloakIdentifier
 
 	// keycloak not installed
 	_ = r.reconcileStatusKeycloak(a)
@@ -174,9 +176,9 @@ func TestReconcileArgoCD_reconcileStatusSSO(t *testing.T) {
 
 			assert.NoError(t, createNamespace(r, test.argoCD.Namespace, ""))
 
-			r.reconcileSSO(test.argoCD)
+			_ = r.reconcileSSO(test.argoCD)
 
-			r.reconcileStatusSSO(test.argoCD)
+			_ = r.reconcileStatusSSO(test.argoCD)
 
 			assert.Equal(t, test.wantSSOStatus, test.argoCD.Status.SSO)
 		})
@@ -278,11 +280,11 @@ func TestReconcileArgoCD_reconcileStatusHost(t *testing.T) {
 			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 			if test.routeEnabled {
-				err := r.Client.Create(context.TODO(), route)
+				err := r.Create(context.TODO(), route)
 				assert.NoError(t, err)
 
 			} else if test.ingressEnabled {
-				err := r.Client.Create(context.TODO(), ingress)
+				err := r.Create(context.TODO(), ingress)
 				assert.NoError(t, err)
 				assert.NotEqual(t, "Pending", a.Status.Phase)
 			}

--- a/controllers/argocd/testing.go
+++ b/controllers/argocd/testing.go
@@ -290,7 +290,7 @@ func createNamespace(r *ReconcileArgoCD, n string, managedBy string) error {
 	}
 	r.ManagedNamespaces.Items = append(r.ManagedNamespaces.Items, *ns)
 
-	return r.Client.Create(context.TODO(), ns)
+	return r.Create(context.TODO(), ns)
 }
 
 func createNamespaceManagedByClusterArgoCDLabel(r *ReconcileArgoCD, n string, managedBy string) error {
@@ -304,7 +304,7 @@ func createNamespaceManagedByClusterArgoCDLabel(r *ReconcileArgoCD, n string, ma
 	}
 	r.ManagedSourceNamespaces[ns.Name] = ""
 
-	return r.Client.Create(context.TODO(), ns)
+	return r.Create(context.TODO(), ns)
 }
 
 func merge(base map[string]string, diff map[string]string) map[string]string {

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -635,18 +634,18 @@ func TestGetArgoApplicationControllerCommand(t *testing.T) {
 
 func TestGetArgoApplicationContainerEnv(t *testing.T) {
 
-	sync60s := []v1.EnvVar{
-		{Name: "HOME", Value: "/home/argocd", ValueFrom: (*v1.EnvVarSource)(nil)},
+	sync60s := []corev1.EnvVar{
+		{Name: "HOME", Value: "/home/argocd", ValueFrom: (*corev1.EnvVarSource)(nil)},
 		{Name: "REDIS_PASSWORD", Value: "",
-			ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "argocd-redis-initial-password",
 					},
 					Key: "admin.password",
 				},
 			}},
-		{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "60s", ValueFrom: (*v1.EnvVarSource)(nil)},
+		{Name: "ARGOCD_RECONCILIATION_TIMEOUT", Value: "60s", ValueFrom: (*corev1.EnvVarSource)(nil)},
 		{Name: "ARGOCD_CONTROLLER_RESOURCE_HEALTH_PERSIST", ValueFrom: &corev1.EnvVarSource{
 			ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{Name: common.ArgoCDCmdParamsConfigMapName},
@@ -657,7 +656,7 @@ func TestGetArgoApplicationContainerEnv(t *testing.T) {
 	cmdTests := []struct {
 		name string
 		opts []argoCDOpt
-		want []v1.EnvVar
+		want []corev1.EnvVar
 	}{
 		{
 			"configured apsync to 60s",
@@ -774,47 +773,47 @@ func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-	nsArgocd := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+	nsArgocd := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: a.Namespace,
 	}}
-	err := r.Client.Create(context.TODO(), nsArgocd)
+	err := r.Create(context.TODO(), nsArgocd)
 	assert.NoError(t, err)
 
-	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "testNamespace",
 		Labels: map[string]string{
 			common.ArgoCDManagedByLabel: a.Namespace,
 		}},
 	}
 
-	err = r.Client.Create(context.TODO(), ns)
+	err = r.Create(context.TODO(), ns)
 	assert.NoError(t, err)
 
-	ns2 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+	ns2 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "testNamespace2",
 		Labels: map[string]string{
 			common.ArgoCDManagedByLabel: a.Namespace,
 		}},
 	}
 
-	err = r.Client.Create(context.TODO(), ns2)
+	err = r.Create(context.TODO(), ns2)
 	assert.NoError(t, err)
 
-	ns3 := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+	ns3 := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "testNamespace3",
 		Labels: map[string]string{
 			common.ArgoCDManagedByLabel: "newNamespace",
 		}},
 	}
 
-	err = r.Client.Create(context.TODO(), ns3)
+	err = r.Create(context.TODO(), ns3)
 	assert.NoError(t, err)
 
 	err = r.removeManagedByLabelFromNamespaces(a.Namespace)
 	assert.NoError(t, err)
 
-	nsList := &v1.NamespaceList{}
-	err = r.Client.List(context.TODO(), nsList)
+	nsList := &corev1.NamespaceList{}
+	err = r.List(context.TODO(), nsList)
 	assert.NoError(t, err)
 	for _, n := range nsList.Items {
 		if n.Name == ns3.Name {
@@ -830,7 +829,7 @@ func TestRemoveManagedByLabelFromNamespaces(t *testing.T) {
 func TestSetManagedNamespaces(t *testing.T) {
 	a := makeTestArgoCD()
 
-	ns1 := v1.Namespace{
+	ns1 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-1",
 			Labels: map[string]string{
@@ -839,7 +838,7 @@ func TestSetManagedNamespaces(t *testing.T) {
 		},
 	}
 
-	ns2 := v1.Namespace{
+	ns2 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-2",
 			Labels: map[string]string{
@@ -848,7 +847,7 @@ func TestSetManagedNamespaces(t *testing.T) {
 		},
 	}
 
-	ns3 := v1.Namespace{
+	ns3 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-3",
 			Labels: map[string]string{
@@ -857,7 +856,7 @@ func TestSetManagedNamespaces(t *testing.T) {
 		},
 	}
 
-	ns4 := v1.Namespace{
+	ns4 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-4",
 		},
@@ -889,7 +888,7 @@ func TestSetManagedSourceNamespaces(t *testing.T) {
 			"test-namespace-1",
 		},
 	}
-	ns1 := v1.Namespace{
+	ns1 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-1",
 			Labels: map[string]string{
@@ -919,18 +918,18 @@ func TestGetSourceNamespacesWithWildcardPatternNamespace(t *testing.T) {
 			"test*",
 		},
 	}
-	ns1 := v1.Namespace{
+	ns1 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-1",
 		},
 	}
 
-	ns2 := v1.Namespace{
+	ns2 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-2",
 		},
 	}
-	ns3 := v1.Namespace{
+	ns3 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "other-namespace",
 		},
@@ -958,17 +957,17 @@ func TestGetSourceNamespacesWithSpecificNamespace(t *testing.T) {
 			"test",
 		},
 	}
-	ns1 := v1.Namespace{
+	ns1 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 		},
 	}
-	ns2 := v1.Namespace{
+	ns2 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-1",
 		},
 	}
-	ns3 := v1.Namespace{
+	ns3 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "other-namespace",
 		},
@@ -997,22 +996,22 @@ func TestGetSourceNamespacesWithMultipleSourceNamespaces(t *testing.T) {
 			"dev*",
 		},
 	}
-	ns1 := v1.Namespace{
+	ns1 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 		},
 	}
-	ns2 := v1.Namespace{
+	ns2 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-1",
 		},
 	}
-	ns3 := v1.Namespace{
+	ns3 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dev-namespace-1",
 		},
 	}
-	ns4 := v1.Namespace{
+	ns4 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "other-namespace",
 		},
@@ -1041,17 +1040,17 @@ func TestGetSourceNamespacesWithWildCardNamespace(t *testing.T) {
 			"*",
 		},
 	}
-	ns1 := v1.Namespace{
+	ns1 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-1",
 		},
 	}
-	ns2 := v1.Namespace{
+	ns2 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace-2",
 		},
 	}
-	ns3 := v1.Namespace{
+	ns3 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "other-namespace",
 		},
@@ -1078,17 +1077,17 @@ func TestGetSourceNamespacesWithRegExpNamespace(t *testing.T) {
 			"/^test.*test$/",
 		},
 	}
-	ns1 := v1.Namespace{
+	ns1 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testtest",
 		},
 	}
-	ns2 := v1.Namespace{
+	ns2 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test123test",
 		},
 	}
-	ns3 := v1.Namespace{
+	ns3 := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-abc-test",
 		},
@@ -1275,7 +1274,7 @@ func TestUpdateStatusConditionOfArgoCD_Success(t *testing.T) {
 	}
 
 	assert.NoError(t, createNamespace(r, argocd.Namespace, ""))
-	assert.NoError(t, r.Client.Create(ctx, &argocd))
+	assert.NoError(t, r.Create(ctx, &argocd))
 	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition(""), &argocd, r.Client, log))
 
 	assert.Equal(t, argocd.Status.Conditions[0].Type, argoproj.ArgoCDConditionType)
@@ -1303,7 +1302,7 @@ func TestUpdateStatusConditionOfArgoCD_Fail(t *testing.T) {
 	}
 
 	assert.NoError(t, createNamespace(r, argocd.Namespace, ""))
-	assert.NoError(t, r.Client.Create(ctx, &argocd))
+	assert.NoError(t, r.Create(ctx, &argocd))
 	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition("some error"), &argocd, r.Client, log))
 
 	assert.Equal(t, argocd.Status.Conditions[0].Type, argoproj.ArgoCDConditionType)
@@ -1514,7 +1513,7 @@ func TestNamespaceManagementHandlers(t *testing.T) {
 		})
 
 		// Remove the ArgoCDManagedBy label to allow cleanup to proceed
-		ns := &v1.Namespace{
+		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testNamespace,
 			},
@@ -1558,7 +1557,7 @@ func TestNamespaceManagementHandlers(t *testing.T) {
 			Spec:       argoproj.NamespaceManagementSpec{ManagedBy: "new"},
 		}
 
-		ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name: "old",
 		}}
 

--- a/controllers/argocdagent/configmap.go
+++ b/controllers/argocdagent/configmap.go
@@ -46,7 +46,7 @@ const (
 	PrincipalLogFormat                 = "principal.log.format"
 	PrincipalJwtAllowGenerate          = "principal.jwt.allow-generate"
 	PrincipalJWTKeyPath                = "principal.jwt.key-path"
-	PrincipalJwtSecretName             = "principal.jwt.secret-name"
+	PrincipalJwtSecretName             = "principal.jwt.secret-name" // #nosec G101
 	PrincipalListenHost                = "principal.listen.host"
 	PrincipalListenPort                = "principal.listen.port"
 	PrincipalNamespaceCreateEnable     = "principal.namespace-create.enable"
@@ -64,8 +64,8 @@ const (
 	PrincipalTLSServerRootCAPath       = "principal.tls.server.root-ca-path"
 	PrincipalTLSClientCertRequire      = "principal.tls.client-cert.require"
 	PrincipalTLSClientCertMatchSubject = "principal.tls.client-cert.match-subject"
-	PrincipalTLSSecretName             = "principal.tls.secret-name"
-	PrincipalTLSServerRootCASecretName = "principal.tls.server.root-ca-secret-name"
+	PrincipalTLSSecretName             = "principal.tls.secret-name"                // #nosec G101
+	PrincipalTLSServerRootCASecretName = "principal.tls.server.root-ca-secret-name" // #nosec G101
 	PrincipalEnableWebSocket           = "principal.enable-websocket"
 	PrincipalEnableResourceProxy       = "principal.enable-resource-proxy"
 	PrincipalKeepAliveMinInterval      = "principal.keep-alive-min-interval"

--- a/controllers/argocdagent/configmap_test.go
+++ b/controllers/argocdagent/configmap_test.go
@@ -91,7 +91,6 @@ func TestReconcilePrincipalConfigMap_ConfigMapExists_PrincipalDisabled(t *testin
 	cr := makeTestArgoCD(withPrincipalEnabled(false))
 
 	sch := makeTestReconcilerScheme()
-	cl := makeTestReconcilerClient(sch, []client.Object{cr})
 
 	// Create existing ConfigMap
 	existingCM := &corev1.ConfigMap{
@@ -105,7 +104,7 @@ func TestReconcilePrincipalConfigMap_ConfigMapExists_PrincipalDisabled(t *testin
 
 	// Recreate client with all objects
 	resObjs := []client.Object{cr, existingCM}
-	cl = makeTestReconcilerClient(sch, resObjs)
+	cl := makeTestReconcilerClient(sch, resObjs)
 
 	err := ReconcilePrincipalConfigMap(cl, testCompName, cr, sch)
 	assert.NoError(t, err)
@@ -126,7 +125,6 @@ func TestReconcilePrincipalConfigMap_ConfigMapExists_PrincipalEnabled_SameData(t
 	cr := makeTestArgoCD(withPrincipalEnabled(true))
 
 	sch := makeTestReconcilerScheme()
-	cl := makeTestReconcilerClient(sch, []client.Object{cr})
 
 	expectedData := buildData(cr)
 	existingCM := &corev1.ConfigMap{
@@ -140,7 +138,7 @@ func TestReconcilePrincipalConfigMap_ConfigMapExists_PrincipalEnabled_SameData(t
 
 	// Recreate client with all objects
 	resObjs := []client.Object{cr, existingCM}
-	cl = makeTestReconcilerClient(sch, resObjs)
+	cl := makeTestReconcilerClient(sch, resObjs)
 
 	err := ReconcilePrincipalConfigMap(cl, testCompName, cr, sch)
 	assert.NoError(t, err)
@@ -201,7 +199,6 @@ func TestReconcilePrincipalConfigMap_ConfigMapExists_PrincipalNotSet(t *testing.
 	cr := makeTestArgoCD() // No principal configuration
 
 	sch := makeTestReconcilerScheme()
-	cl := makeTestReconcilerClient(sch, []client.Object{cr})
 
 	existingCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -214,7 +211,7 @@ func TestReconcilePrincipalConfigMap_ConfigMapExists_PrincipalNotSet(t *testing.
 
 	// Recreate client with all objects
 	resObjs := []client.Object{cr, existingCM}
-	cl = makeTestReconcilerClient(sch, resObjs)
+	cl := makeTestReconcilerClient(sch, resObjs)
 
 	err := ReconcilePrincipalConfigMap(cl, testCompName, cr, sch)
 	assert.NoError(t, err)

--- a/controllers/argocdagent/deployment_test.go
+++ b/controllers/argocdagent/deployment_test.go
@@ -117,7 +117,7 @@ func TestReconcilePrincipalDeployment_DeploymentDoesNotExist_PrincipalEnabled(t 
 	// Verify Deployment has expected spec
 	expectedSpec := buildPrincipalSpec(testCompName, saName, cr)
 	assert.Equal(t, expectedSpec.Selector, deployment.Spec.Selector)
-	assert.Equal(t, expectedSpec.Template.ObjectMeta.Labels, deployment.Spec.Template.ObjectMeta.Labels)
+	assert.Equal(t, expectedSpec.Template.Labels, deployment.Spec.Template.Labels)
 	assert.Equal(t, expectedSpec.Template.Spec.ServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
 
 	// Verify container configuration
@@ -390,19 +390,19 @@ func TestReconcilePrincipalDeployment_VerifyDeploymentSpec(t *testing.T) {
 	assert.Len(t, deployment.Spec.Template.Spec.Volumes, 2)
 	jwtVolume := deployment.Spec.Template.Spec.Volumes[0]
 	assert.Equal(t, "jwt-secret", jwtVolume.Name)
-	assert.NotNil(t, jwtVolume.VolumeSource.Secret)
-	assert.Equal(t, "argocd-agent-jwt", jwtVolume.VolumeSource.Secret.SecretName)
-	assert.Equal(t, ptr.To(true), jwtVolume.VolumeSource.Secret.Optional)
-	assert.Len(t, jwtVolume.VolumeSource.Secret.Items, 1)
+	assert.NotNil(t, jwtVolume.Secret)
+	assert.Equal(t, "argocd-agent-jwt", jwtVolume.Secret.SecretName)
+	assert.Equal(t, ptr.To(true), jwtVolume.Secret.Optional)
+	assert.Len(t, jwtVolume.Secret.Items, 1)
 	assert.Equal(t, "jwt.key", jwtVolume.VolumeSource.Secret.Items[0].Key)
 	assert.Equal(t, "jwt.key", jwtVolume.VolumeSource.Secret.Items[0].Path)
 
 	userpassVolume := deployment.Spec.Template.Spec.Volumes[1]
 	assert.Equal(t, "userpass-passwd", userpassVolume.Name)
-	assert.NotNil(t, userpassVolume.VolumeSource.Secret)
-	assert.Equal(t, "argocd-agent-principal-userpass", userpassVolume.VolumeSource.Secret.SecretName)
-	assert.Equal(t, ptr.To(true), userpassVolume.VolumeSource.Secret.Optional)
-	assert.Len(t, userpassVolume.VolumeSource.Secret.Items, 1)
+	assert.NotNil(t, userpassVolume.Secret)
+	assert.Equal(t, "argocd-agent-principal-userpass", userpassVolume.Secret.SecretName)
+	assert.Equal(t, ptr.To(true), userpassVolume.Secret.Optional)
+	assert.Len(t, userpassVolume.Secret.Items, 1)
 	assert.Equal(t, "passwd", userpassVolume.VolumeSource.Secret.Items[0].Key)
 	assert.Equal(t, "passwd", userpassVolume.VolumeSource.Secret.Items[0].Path)
 }
@@ -499,11 +499,11 @@ func TestReconcilePrincipalDeployment_VolumeMountsAndVolumes(t *testing.T) {
 	assert.Len(t, deployment.Spec.Template.Spec.Volumes, 2)
 	jwtVolume := deployment.Spec.Template.Spec.Volumes[0]
 	assert.Equal(t, "jwt-secret", jwtVolume.Name)
-	assert.Equal(t, "argocd-agent-jwt", jwtVolume.VolumeSource.Secret.SecretName)
-	assert.Equal(t, ptr.To(true), jwtVolume.VolumeSource.Secret.Optional)
+	assert.Equal(t, "argocd-agent-jwt", jwtVolume.Secret.SecretName)
+	assert.Equal(t, ptr.To(true), jwtVolume.Secret.Optional)
 
 	userpassVolume := deployment.Spec.Template.Spec.Volumes[1]
 	assert.Equal(t, "userpass-passwd", userpassVolume.Name)
-	assert.Equal(t, "argocd-agent-principal-userpass", userpassVolume.VolumeSource.Secret.SecretName)
-	assert.Equal(t, ptr.To(true), userpassVolume.VolumeSource.Secret.Optional)
+	assert.Equal(t, "argocd-agent-principal-userpass", userpassVolume.Secret.SecretName)
+	assert.Equal(t, ptr.To(true), userpassVolume.Secret.Optional)
 }

--- a/controllers/argocdagent/service_test.go
+++ b/controllers/argocdagent/service_test.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/argoproj-labs/argocd-operator/common"
-	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 )
 
 func TestReconcilePrincipalService_ServiceDoesNotExist_PrincipalDisabled(t *testing.T) {

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -121,9 +121,9 @@ func NameWithSuffix(meta metav1.ObjectMeta, suffix string) string {
 
 func newEvent(meta metav1.ObjectMeta) *corev1.Event {
 	event := &corev1.Event{}
-	event.ObjectMeta.GenerateName = fmt.Sprintf("%s-", meta.Name)
-	event.ObjectMeta.Labels = meta.Labels
-	event.ObjectMeta.Namespace = meta.Namespace
+	event.GenerateName = fmt.Sprintf("%s-", meta.Name)
+	event.Labels = meta.Labels
+	event.Namespace = meta.Namespace
 	return event
 }
 
@@ -136,7 +136,7 @@ func LabelsForCluster(cr *argoproj.ArgoCD) map[string]string {
 // annotationsForCluster returns the annotations for all cluster resources.
 func AnnotationsForCluster(cr *argoproj.ArgoCD) map[string]string {
 	annotations := common.DefaultAnnotations(cr.Name, cr.Namespace)
-	for key, val := range cr.ObjectMeta.Annotations {
+	for key, val := range cr.Annotations {
 		annotations[key] = val
 	}
 	return annotations

--- a/controllers/argoutil/secret.go
+++ b/controllers/argoutil/secret.go
@@ -58,9 +58,9 @@ func NewSecret(cr *argoproj.ArgoCD) *corev1.Secret {
 func NewSecretWithName(cr *argoproj.ArgoCD, name string) *corev1.Secret {
 	secret := NewSecret(cr)
 
-	secret.ObjectMeta.Name = name
-	secret.ObjectMeta.Namespace = cr.Namespace
-	secret.ObjectMeta.Labels[common.ArgoCDKeyName] = name
+	secret.Name = name
+	secret.Namespace = cr.Namespace
+	secret.Labels[common.ArgoCDKeyName] = name
 
 	return secret
 }

--- a/controllers/argoutil/volume.go
+++ b/controllers/argoutil/volume.go
@@ -49,7 +49,7 @@ func NewPersistentVolumeClaim(meta metav1.ObjectMeta) *corev1.PersistentVolumeCl
 // NewPersistentVolumeClaimWithName returns a new PersistentVolumeClaim instance with the given name.
 func NewPersistentVolumeClaimWithName(name string, meta metav1.ObjectMeta) *corev1.PersistentVolumeClaim {
 	pvc := NewPersistentVolumeClaim(meta)
-	pvc.ObjectMeta.Name = name
-	pvc.ObjectMeta.Labels[common.ArgoCDKeyName] = name
+	pvc.Name = name
+	pvc.Labels[common.ArgoCDKeyName] = name
 	return pvc
 }

--- a/controllers/notificationsconfiguration/configmap.go
+++ b/controllers/notificationsconfiguration/configmap.go
@@ -38,7 +38,7 @@ func (r *NotificationsConfigurationReconciler) reconcileNotificationsConfigmap(c
 		}
 		argoutil.AddTrackedByOperatorLabel(&NotificationsConfigMap.ObjectMeta)
 		argoutil.LogResourceCreation(log, NotificationsConfigMap)
-		err := r.Client.Create(context.TODO(), NotificationsConfigMap)
+		err := r.Create(context.TODO(), NotificationsConfigMap)
 		if err != nil {
 			return err
 		}
@@ -79,7 +79,7 @@ func (r *NotificationsConfigurationReconciler) reconcileNotificationsConfigmap(c
 	if changed {
 		NotificationsConfigMap.Data = expectedConfiguration
 		argoutil.LogResourceUpdate(log, NotificationsConfigMap, "updating config map data")
-		err := r.Client.Update(context.TODO(), NotificationsConfigMap)
+		err := r.Update(context.TODO(), NotificationsConfigMap)
 		if err != nil {
 			return err
 		}

--- a/controllers/notificationsconfiguration/configmap_test.go
+++ b/controllers/notificationsconfiguration/configmap_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,6 +12,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
 	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 )
@@ -100,14 +101,14 @@ func TestReconcileNotifications_CreateConfigMap(t *testing.T) {
 
 	// Verify if the ConfigMap is created
 	testCM := &corev1.ConfigMap{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      ArgoCDNotificationsConfigMap,
 			Namespace: a.Namespace,
 		},
 		testCM))
-	assert.True(t, argoutil.IsTrackedByOperator(testCM.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(testCM.Labels))
 
 	// Verify that the configmap has the default template
 	assert.NotEqual(t, testCM.Data["template.app-created"], "")
@@ -152,7 +153,7 @@ func TestReconcileNotifications_UpdateConfigMap(t *testing.T) {
 
 	// Verify if the ConfigMap is created
 	testCM := &corev1.ConfigMap{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      ArgoCDNotificationsConfigMap,
@@ -167,14 +168,14 @@ func TestReconcileNotifications_UpdateConfigMap(t *testing.T) {
 	assert.NoError(t, err)
 
 	testCM = &corev1.ConfigMap{}
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      ArgoCDNotificationsConfigMap,
 			Namespace: a.Namespace,
 		},
 		testCM))
-	assert.True(t, argoutil.IsTrackedByOperator(testCM.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(testCM.Labels))
 	// Verify that the updated configuration
 	assert.Equal(t, testCM.Data["trigger.on-sync-status-test"],
 		"- when: app.status.sync.status == 'Unknown' \n send: [my-custom-template]")
@@ -209,21 +210,21 @@ func TestReconcileNotifications_DeleteConfigMap(t *testing.T) {
 			Namespace: a.Namespace,
 		},
 	}
-	assert.NoError(t, r.Client.Delete(
+	assert.NoError(t, r.Delete(
 		context.TODO(), testCM))
 
 	// Reconcile to check if the ConfigMap is recreated
 	err = r.reconcileNotificationsConfigmap(a)
 	assert.NoError(t, err)
 
-	assert.NoError(t, r.Client.Get(
+	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      ArgoCDNotificationsConfigMap,
 			Namespace: a.Namespace,
 		},
 		testCM))
-	assert.True(t, argoutil.IsTrackedByOperator(testCM.ObjectMeta.Labels))
+	assert.True(t, argoutil.IsTrackedByOperator(testCM.Labels))
 	// Verify if ConfigMap is created with required data
 	assert.Equal(t, testCM.Data["trigger.on-sync-status-test"],
 		"- when: app.status.sync.status == 'Unknown' \n send: [my-custom-template]")

--- a/controllers/notificationsconfiguration/notificationsconfiguration_controller.go
+++ b/controllers/notificationsconfiguration/notificationsconfiguration_controller.go
@@ -58,7 +58,7 @@ func (r *NotificationsConfigurationReconciler) Reconcile(ctx context.Context, re
 	reqLogger.Info("Reconciling NotificationsConfiguration")
 
 	notificationsConfig := &v1alpha1.NotificationsConfiguration{}
-	err := r.Client.Get(ctx, request.NamespacedName, notificationsConfig)
+	err := r.Get(ctx, request.NamespacedName, notificationsConfig)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/controllers/suite_testx.go
+++ b/controllers/suite_testx.go
@@ -19,8 +19,10 @@ package controllers
 import (
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo" //lint:ignore ST1001 Allowed for ginkgo
-	. "github.com/onsi/gomega" //lint:ignore ST1001 Allowed for gomega
+	//lint:ignore ST1001 "This is a common practice in Gomega tests for readability."
+	. "github.com/onsi/ginkgo" //nolint:all
+	//lint:ignore ST1001 "This is a common practice in Gomega tests for readability."
+	. "github.com/onsi/gomega" //nolint:all
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/tests/auxiliary/smtplistener/internal/processor/filewriter.go
+++ b/tests/auxiliary/smtplistener/internal/processor/filewriter.go
@@ -26,7 +26,7 @@ var FileWriter = func() backends.Decorator {
 				stringer = e
 				data := []byte(stringer.String())
 				key := fmt.Sprintf("%s%s", "/tmp/", e.QueuedId)
-				err := os.WriteFile(key, data, 0666)
+				err := os.WriteFile(key, data, 0666) // #nosec G306
 				fmt.Println(err)
 				return p.Process(e, task)
 			} else {


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:
- Adds gosec check, and a new linter to golangci-lint
- Previously golangci-lint would ignore checks in  '*_test.go', this PR removes that restriction.
- Fixes all issues that gosec/golangci-lint identified.


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

