### PR TITLE
fix: Argo Rollouts UI extension installation error in initContainer due to read-only access

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1574,10 +1574,8 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 
 	deploy.Spec.Template.Spec.Volumes = serverVolumes
 
-	rolloutsVolumeName := "rollout-extensions"
-
+	const rolloutsVolumeName = "rollout-extensions"
 	if cr.Spec.Server.EnableRolloutsUI {
-
 		deploy.Spec.Template.Spec.InitContainers = append(deploy.Spec.Template.Spec.InitContainers, getRolloutInitContainer()...)
 
 		deploy.Spec.Template.Spec.Containers[0].VolumeMounts = append(deploy.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
@@ -1595,7 +1593,6 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		deploy.Spec.Template.Spec.InitContainers = removeInitContainer(deploy.Spec.Template.Spec.InitContainers, rolloutsVolumeName)
 		deploy.Spec.Template.Spec.Volumes = removeVolume(deploy.Spec.Template.Spec.Volumes, rolloutsVolumeName)
 		deploy.Spec.Template.Spec.Containers[0].VolumeMounts = removeVolumeMount(deploy.Spec.Template.Spec.Containers[0].VolumeMounts, rolloutsVolumeName)
-
 	}
 
 	if replicas := getArgoCDServerReplicas(cr); replicas != nil {
@@ -1840,6 +1837,10 @@ func getRolloutInitContainer() []corev1.Container {
 				{
 					Name:      "rollout-extensions",
 					MountPath: "/tmp/extensions/",
+				},
+				{
+					Name:      "tmp",
+					MountPath: "/tmp",
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1613,7 +1613,47 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 	assert.Equal(t, "rollout-extension", deployment.Spec.Template.Spec.InitContainers[0].Name)
 	assert.Equal(t, common.ArgoCDExtensionInstallerImage, deployment.Spec.Template.Spec.InitContainers[0].Image)
 
-	// Check for the volume
+	// assert that rollout-extensions volume is mounted at /tmp/extensions for both the initContainer and container
+	foundExtensionsVolumeMount := false
+	for _, volMnt := range deployment.Spec.Template.Spec.InitContainers[0].VolumeMounts {
+		if volMnt.Name == "rollout-extensions" {
+			foundExtensionsVolumeMount = true
+			assert.NotNil(t, volMnt.MountPath)
+			assert.Equal(t, "/tmp/extensions/", volMnt.MountPath)
+		}
+	}
+	assert.True(t, foundExtensionsVolumeMount, "expected volume mount 'rollout-extensions' to be present in init container")
+	foundExtensionsVolumeMount = false
+	for _, vol := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if vol.Name == "rollout-extensions" {
+			foundExtensionsVolumeMount = true
+			assert.NotNil(t, vol.MountPath)
+			assert.Equal(t, "/tmp/extensions/", vol.MountPath)
+		}
+	}
+	assert.True(t, foundExtensionsVolumeMount, "expected volume mount 'rollout-extensions' to be present in container")
+
+	// assert that tmp volume is mounted at /tmp for both the initContainer and container
+	foundTmpVolumeMount := false
+	for _, volMnt := range deployment.Spec.Template.Spec.InitContainers[0].VolumeMounts {
+		if volMnt.Name == "tmp" {
+			foundTmpVolumeMount = true
+			assert.NotNil(t, volMnt.MountPath)
+			assert.Equal(t, volMnt.MountPath, "/tmp")
+		}
+	}
+	assert.True(t, foundTmpVolumeMount, "expected volume mount 'tmp' to be present in init container")
+	foundTmpVolumeMount = false
+	for _, vol := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if vol.Name == "tmp" {
+			foundTmpVolumeMount = true
+			assert.NotNil(t, vol.MountPath)
+			assert.Equal(t, vol.MountPath, "/tmp")
+		}
+	}
+	assert.True(t, foundTmpVolumeMount, "expected volume mount 'tmp' to be present in container")
+
+	// Check for the volumes
 	foundVolume := false
 	for _, vol := range deployment.Spec.Template.Spec.Volumes {
 		if vol.Name == "rollout-extensions" {
@@ -1622,6 +1662,14 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 		}
 	}
 	assert.True(t, foundVolume, "expected volume 'rollout-extensions' to be present")
+	foundTmpVolume := false
+	for _, vol := range deployment.Spec.Template.Spec.Volumes {
+		if vol.Name == "tmp" {
+			foundTmpVolume = true
+			assert.NotNil(t, vol.VolumeSource.EmptyDir)
+		}
+	}
+	assert.True(t, foundTmpVolume, "expected volume 'tmp' to be present")
 
 	// Disable rollouts UI
 	a.Spec.Server.EnableRolloutsUI = false
@@ -1637,6 +1685,7 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 
 	assert.Len(t, deployment.Spec.Template.Spec.InitContainers, 0)
 	assert.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+
 	// Check that volume is removed
 	foundVolume = false
 	for _, vol := range deployment.Spec.Template.Spec.Volumes {
@@ -1646,6 +1695,26 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 	}
 	assert.False(t, foundVolume, "expected volume 'rollout-extension' to be removed")
 
+	// assert that the tmp volume is present even if rollouts UI extension is disabled.
+	foundTmpVolume = false
+	for _, vol := range deployment.Spec.Template.Spec.Volumes {
+		if vol.Name == "tmp" {
+			foundTmpVolume = true
+			assert.NotNil(t, vol.VolumeSource.EmptyDir)
+		}
+	}
+	assert.True(t, foundTmpVolume, "expected volume 'tmp' to be present even if rollouts is disabled")
+
+	// assert that tmp volume is mounted at /tmp for the container, when rollouts UI extension is disabled.
+	foundTmpVolumeMount = false
+	for _, vol := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if vol.Name == "tmp" {
+			foundTmpVolumeMount = true
+			assert.NotNil(t, vol.MountPath)
+			assert.Equal(t, vol.MountPath, "/tmp")
+		}
+	}
+	assert.True(t, foundTmpVolumeMount, "expected volume mount 'tmp' to be present in container")
 }
 
 func TestArgoCDServerCommand_isMergable(t *testing.T) {

--- a/tests/k8s/1-044_validate_rollout_extension/01-assert.yaml
+++ b/tests/k8s/1-044_validate_rollout_extension/01-assert.yaml
@@ -22,6 +22,8 @@ spec:
           volumeMounts:
             - name: rollout-extensions
               mountPath: /tmp/extensions/
+            - name: tmp
+              mountPath: /tmp
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/k8s/1-044_validate_rollout_extension/02-errors.yaml
+++ b/tests/k8s/1-044_validate_rollout_extension/02-errors.yaml
@@ -17,6 +17,8 @@ spec:
           volumeMounts:
             - name: extensions
               mountPath: /tmp/extensions/
+            - name: tmp
+              mountPath: /tmp
       volumes:
       - configMap:
           defaultMode: 420


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Description of the problem**
When Argo Rollouts UI extension was enabled, the init container failed with the following error message
```
++ basename -- file:///home/ext-installer/rollout-extension.tar
+ ext_filename=rollout-extension.tar
++ mktemp -d -t extension-XXXXXX
mktemp: failed to create directory via template '/tmp/extension-XXXXXX': Read-only file system
```
Error message was coming from this line.
https://github.com/rh-gitops-midstream/release/blob/eddad5e34e05bcd548144f65f35152377ec5c21f/containers/argocd-extensions/install.sh#L110
This breaking change was introduced by https://github.com/argoproj-labs/argocd-operator/pull/1659 when the container root file system was made `read-only` using the property setting`readOnlyRootFilesystem: true`.

Since the temp directory `/tmp` was not mounted as an empty dir, it was using the root file system and the installation step failed.

**What does this PR do / why we need it**:
It mounts an additional volume `tmp` at the mount path `/tmp` this will allow the tar file extraction to directory under `/tmp` and the `mktemp` command to succeed. There were some gaps in the existing unit tests, which was also addressed.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
