### PR TITLE
fix: Truncate Kubernetes resource names and labels to comply with 63-…

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -943,7 +943,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetService(cr *argoproj.ArgoCD) er
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix(common.ApplicationSetServiceNameSuffix, cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix(common.ApplicationSetServiceNameSuffix, cr)),
 	}
 
 	if err := controllerutil.SetControllerReference(cr, svc, r.Scheme); err != nil {

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -390,23 +390,26 @@ func newDeployment(cr *argoproj.ArgoCD) *appsv1.Deployment {
 // newDeploymentWithName returns a new Deployment instance for the given ArgoCD using the given name.
 func newDeploymentWithName(name string, component string, cr *argoproj.ArgoCD) *appsv1.Deployment {
 	deploy := newDeployment(cr)
-	deploy.Name = name
+
+	// Truncate the name for both deployment name and labels to stay within 63 character limit
+	truncatedName := argoutil.TruncateWithHash(name)
+	deploy.Name = truncatedName
 
 	lbls := deploy.Labels
-	lbls[common.ArgoCDKeyName] = name
+	lbls[common.ArgoCDKeyName] = truncatedName
 	lbls[common.ArgoCDKeyComponent] = component
 	deploy.Labels = lbls
 
 	deploy.Spec = appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				common.ArgoCDKeyName: name,
+				common.ArgoCDKeyName: truncatedName,
 			},
 		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					common.ArgoCDKeyName: name,
+					common.ArgoCDKeyName: truncatedName,
 				},
 				Annotations: make(map[string]string),
 			},

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -513,7 +513,7 @@ func (r *ReconcileArgoCD) reconcileDexService(cr *argoproj.ArgoCD) error {
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("dex-server", cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("dex-server", cr)),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{

--- a/controllers/argocd/networkpolicies.go
+++ b/controllers/argocd/networkpolicies.go
@@ -55,7 +55,7 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app.kubernetes.io/name": fmt.Sprintf("%s-%s", cr.Name, "redis"),
+					"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", cr.Name, "redis")),
 				},
 			},
 			PolicyTypes: []networkingv1.PolicyType{
@@ -67,21 +67,21 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": fmt.Sprintf("%s-%s", cr.Name, "application-controller"),
+									"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", cr.Name, "application-controller")),
 								},
 							},
 						},
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": fmt.Sprintf("%s-%s", cr.Name, "repo-server"),
+									"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", cr.Name, "repo-server")),
 								},
 							},
 						},
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": fmt.Sprintf("%s-%s", cr.Name, "server"),
+									"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", cr.Name, "server")),
 								},
 							},
 						},
@@ -101,7 +101,7 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 		networkPolicy.Spec.Ingress[0].From = append(networkPolicy.Spec.Ingress[0].From, networkingv1.NetworkPolicyPeer{
 			PodSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app.kubernetes.io/name": fmt.Sprintf("%s-agent-%s", cr.Name, "principal"),
+					"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-agent-%s", cr.Name, "principal")),
 				},
 			},
 		})
@@ -186,7 +186,7 @@ func (r *ReconcileArgoCD) ReconcileRedisHANetworkPolicy(cr *argoproj.ArgoCD) err
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app.kubernetes.io/name": fmt.Sprintf("%s-%s", cr.Name, "redis-ha-haproxy"),
+					"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", cr.Name, "redis-ha-haproxy")),
 				},
 			},
 			PolicyTypes: []networkingv1.PolicyType{
@@ -198,21 +198,21 @@ func (r *ReconcileArgoCD) ReconcileRedisHANetworkPolicy(cr *argoproj.ArgoCD) err
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": fmt.Sprintf("%s-%s", cr.Name, "application-controller"),
+									"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", cr.Name, "application-controller")),
 								},
 							},
 						},
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": fmt.Sprintf("%s-%s", cr.Name, "repo-server"),
+									"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", cr.Name, "repo-server")),
 								},
 							},
 						},
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": fmt.Sprintf("%s-%s", cr.Name, "server"),
+									"app.kubernetes.io/name": argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", cr.Name, "server")),
 								},
 							},
 						},

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -578,7 +578,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsMetricsService(cr *argoproj.Argo
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix(component, cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix(component, cr)),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{

--- a/controllers/argocd/prometheus.go
+++ b/controllers/argocd/prometheus.go
@@ -147,7 +147,7 @@ func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoproj.ArgoCD) er
 
 	sm.Spec.Selector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			common.ArgoCDKeyName: nameWithSuffix(common.ArgoCDKeyMetrics, cr),
+			common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix(common.ArgoCDKeyMetrics, cr)),
 		},
 	}
 	sm.Spec.Endpoints = []monitoringv1.Endpoint{
@@ -221,7 +221,7 @@ func (r *ReconcileArgoCD) reconcileRepoServerServiceMonitor(cr *argoproj.ArgoCD)
 
 	sm.Spec.Selector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			common.ArgoCDKeyName: nameWithSuffix("repo-server", cr),
+			common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("repo-server", cr)),
 		},
 	}
 	sm.Spec.Endpoints = []monitoringv1.Endpoint{
@@ -259,7 +259,7 @@ func (r *ReconcileArgoCD) reconcileServerMetricsServiceMonitor(cr *argoproj.Argo
 
 	sm.Spec.Selector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			common.ArgoCDKeyName: nameWithSuffix("server-metrics", cr),
+			common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("server-metrics", cr)),
 		},
 	}
 	sm.Spec.Endpoints = []monitoringv1.Endpoint{

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -96,7 +96,10 @@ func getRoleBindingNameForSourceNamespaces(argocdName, targetNamespace string) s
 // newRoleBindingWithname creates a new RoleBinding with the given name for the given ArgCD.
 func newRoleBindingWithname(name string, cr *argoproj.ArgoCD) *v1.RoleBinding {
 	roleBinding := newRoleBinding(cr)
-	roleBinding.Name = fmt.Sprintf("%s-%s", cr.Name, name)
+
+	// Truncate the name to stay within 63 character limit
+	fullName := fmt.Sprintf("%s-%s", cr.Name, name)
+	roleBinding.Name = truncateWithHash(fullName)
 
 	labels := roleBinding.Labels
 	labels[common.ArgoCDKeyName] = name

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -53,10 +53,13 @@ func newService(cr *argoproj.ArgoCD) *corev1.Service {
 // newServiceWithName returns a new Service instance for the given ArgoCD using the given name.
 func newServiceWithName(name string, component string, cr *argoproj.ArgoCD) *corev1.Service {
 	svc := newService(cr)
-	svc.Name = name
+
+	// Truncate the name for both service name and labels to stay within 63 character limit
+	truncatedName := argoutil.TruncateWithHash(name)
+	svc.Name = truncatedName
 
 	lbls := svc.Labels
-	lbls[common.ArgoCDKeyName] = name
+	lbls[common.ArgoCDKeyName] = truncatedName
 	lbls[common.ArgoCDKeyComponent] = component
 	svc.Labels = lbls
 
@@ -108,7 +111,7 @@ func (r *ReconcileArgoCD) reconcileMetricsService(cr *argoproj.ArgoCD) error {
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("application-controller", cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("application-controller", cr)),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{
@@ -160,8 +163,8 @@ func (r *ReconcileArgoCD) reconcileRedisHAAnnounceServices(cr *argoproj.ArgoCD) 
 		svc.Spec.PublishNotReadyAddresses = true
 
 		svc.Spec.Selector = map[string]string{
-			common.ArgoCDKeyName:               nameWithSuffix("redis-ha", cr),
-			common.ArgoCDKeyStatefulSetPodName: nameWithSuffix(fmt.Sprintf("redis-ha-server-%d", i), cr),
+			common.ArgoCDKeyName:               argoutil.TruncateWithHash(nameWithSuffix("redis-ha", cr)),
+			common.ArgoCDKeyStatefulSetPodName: argoutil.TruncateWithHash(nameWithSuffix(fmt.Sprintf("redis-ha-server-%d", i), cr)),
 		}
 
 		svc.Spec.Ports = []corev1.ServicePort{
@@ -216,7 +219,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAMasterService(cr *argoproj.ArgoCD) err
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("redis-ha", cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("redis-ha", cr)),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{
@@ -281,7 +284,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyService(cr *argoproj.ArgoCD) erro
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("redis-ha-haproxy", cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("redis-ha-haproxy", cr)),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{
@@ -361,7 +364,7 @@ func (r *ReconcileArgoCD) reconcileRedisService(cr *argoproj.ArgoCD) error {
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("redis", cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("redis", cr)),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{
@@ -480,7 +483,7 @@ func (r *ReconcileArgoCD) reconcileRepoService(cr *argoproj.ArgoCD) error {
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("repo-server", cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("repo-server", cr)),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{
@@ -521,7 +524,7 @@ func (r *ReconcileArgoCD) reconcileServerMetricsService(cr *argoproj.ArgoCD) err
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("server", cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("server", cr)),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{
@@ -563,7 +566,7 @@ func (r *ReconcileArgoCD) reconcileServerService(cr *argoproj.ArgoCD) error {
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("server", cr),
+		common.ArgoCDKeyName: argoutil.TruncateWithHash(nameWithSuffix("server", cr)),
 	}
 
 	svc.Spec.Type = getArgoServerServiceType(cr)

--- a/controllers/argoutil/secret.go
+++ b/controllers/argoutil/secret.go
@@ -60,7 +60,8 @@ func NewSecretWithName(cr *argoproj.ArgoCD, name string) *corev1.Secret {
 
 	secret.Name = name
 	secret.Namespace = cr.Namespace
-	secret.Labels[common.ArgoCDKeyName] = name
+	// Truncate the name for labels to stay within 63 character limit
+	secret.Labels[common.ArgoCDKeyName] = TruncateWithHash(name)
 
 	return secret
 }
@@ -68,6 +69,13 @@ func NewSecretWithName(cr *argoproj.ArgoCD, name string) *corev1.Secret {
 // NewSecretWithSuffix returns a new Secret based on the given metadata with the provided suffix on the Name.
 func NewSecretWithSuffix(cr *argoproj.ArgoCD, suffix string) *corev1.Secret {
 	return NewSecretWithName(cr, fmt.Sprintf("%s-%s", cr.Name, suffix))
+}
+
+// GetSecretNameWithSuffix returns the truncated secret name for the given suffix.
+// This function should be used when referencing secret names in other resources.
+func GetSecretNameWithSuffix(cr *argoproj.ArgoCD, suffix string) string {
+	fullName := fmt.Sprintf("%s-%s", cr.Name, suffix)
+	return TruncateWithHash(fullName)
 }
 
 func CreateTLSSecret(client client.Client, name string, namespace string, data map[string][]byte) error {


### PR DESCRIPTION
…character limit

**What type of PR is this?**
These changes fixes length validation errors that occur when creating ArgoCD
instances with long names by implementing comprehensive truncation with hash
suffixes to ensure uniqueness while staying within Kubernetes limits.


[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

 /kind bug 
 
 
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
