### PR TITLE
fix: Argo Rollouts UI extension installation error in initContainer due to read-only access

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -1599,10 +1599,8 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 
 	deploy.Spec.Template.Spec.Volumes = serverVolumes
 
-	rolloutsVolumeName := "rollout-extensions"
-
+	const rolloutsVolumeName = "rollout-extensions"
 	if cr.Spec.Server.EnableRolloutsUI {
-
 		deploy.Spec.Template.Spec.InitContainers = append(deploy.Spec.Template.Spec.InitContainers, getRolloutInitContainer()...)
 
 		deploy.Spec.Template.Spec.Containers[0].VolumeMounts = append(deploy.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
@@ -1620,7 +1618,6 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		deploy.Spec.Template.Spec.InitContainers = removeInitContainer(deploy.Spec.Template.Spec.InitContainers, rolloutsVolumeName)
 		deploy.Spec.Template.Spec.Volumes = removeVolume(deploy.Spec.Template.Spec.Volumes, rolloutsVolumeName)
 		deploy.Spec.Template.Spec.Containers[0].VolumeMounts = removeVolumeMount(deploy.Spec.Template.Spec.Containers[0].VolumeMounts, rolloutsVolumeName)
-
 	}
 
 	if replicas := getArgoCDServerReplicas(cr); replicas != nil {
@@ -1874,6 +1871,10 @@ func getRolloutInitContainer() []corev1.Container {
 				{
 					Name:      "rollout-extensions",
 					MountPath: "/tmp/extensions/",
+				},
+				{
+					Name:      "tmp",
+					MountPath: "/tmp",
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -1645,11 +1645,11 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 	}
 	assert.True(t, foundTmpVolumeMount, "expected volume mount 'tmp' to be present in init container")
 	foundTmpVolumeMount = false
-	for _, vol := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
-		if vol.Name == "tmp" {
+	for _, volMnt := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if volMnt.Name == "tmp" {
 			foundTmpVolumeMount = true
-			assert.NotNil(t, vol.MountPath)
-			assert.Equal(t, vol.MountPath, "/tmp")
+			assert.NotNil(t, volMnt.MountPath)
+			assert.Equal(t, volMnt.MountPath, "/tmp")
 		}
 	}
 	assert.True(t, foundTmpVolumeMount, "expected volume mount 'tmp' to be present in container")
@@ -1667,7 +1667,7 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 	for _, vol := range deployment.Spec.Template.Spec.Volumes {
 		if vol.Name == "tmp" {
 			foundTmpVolume = true
-			assert.NotNil(t, vol.VolumeSource.EmptyDir)
+			assert.NotNil(t, vol.EmptyDir)
 		}
 	}
 	assert.True(t, foundTmpVolume, "expected volume 'tmp' to be present")
@@ -1701,7 +1701,7 @@ func TestReconcileServer_RolloutUI(t *testing.T) {
 	for _, vol := range deployment.Spec.Template.Spec.Volumes {
 		if vol.Name == "tmp" {
 			foundTmpVolume = true
-			assert.NotNil(t, vol.VolumeSource.EmptyDir)
+			assert.NotNil(t, vol.EmptyDir)
 		}
 	}
 	assert.True(t, foundTmpVolume, "expected volume 'tmp' to be present even if rollouts is disabled")

--- a/tests/k8s/1-044_validate_rollout_extension/01-assert.yaml
+++ b/tests/k8s/1-044_validate_rollout_extension/01-assert.yaml
@@ -22,6 +22,8 @@ spec:
           volumeMounts:
             - name: rollout-extensions
               mountPath: /tmp/extensions/
+            - name: tmp
+              mountPath: /tmp
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/k8s/1-044_validate_rollout_extension/02-errors.yaml
+++ b/tests/k8s/1-044_validate_rollout_extension/02-errors.yaml
@@ -17,6 +17,8 @@ spec:
           volumeMounts:
             - name: extensions
               mountPath: /tmp/extensions/
+            - name: tmp
+              mountPath: /tmp
       volumes:
       - configMap:
           defaultMode: 420


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

cherry pick of https://github.com/argoproj-labs/argocd-operator/pull/1812

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-7396](https://issues.redhat.com/browse/GITOPS-7396)

**How to test changes / Special notes to the reviewer**:
