### PR TITLE
fix: argocd-agent: remove LoadBalancer from repo-server

### DIFF
--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -466,13 +466,8 @@ func (r *ReconcileArgoCD) reconcileRepoService(cr *argoproj.ArgoCD) error {
 		return nil
 	}
 
-	// If Principal is enabled, use LoadBalancer service type
-	if cr.Spec.ArgoCDAgent != nil && cr.Spec.ArgoCDAgent.Principal != nil && cr.Spec.ArgoCDAgent.Principal.IsEnabled() {
-		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-	} else {
-		// TODO: Existing and current service is not compared and updated
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
-	}
+	// TODO: Existing and current service is not compared and updated
+	svc.Spec.Type = corev1.ServiceTypeClusterIP
 
 	_, err = ensureAutoTLSAnnotation(r.Client, svc, common.ArgoCDRepoServerTLSSecretName, cr.Spec.Repo.WantsAutoTLS())
 	if err != nil {

--- a/tests/k8s/1-051_validate_argocd_agent_principal/01-assert.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/01-assert.yaml
@@ -68,7 +68,7 @@ metadata:
   name: argocd-repo-server
   namespace: argocd-e2e-cluster-config
 spec:
-  type: LoadBalancer  
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:

At present, when argocd-agent is enabled, the repo server `Service` will be converted to a LoadBalancer. As discussed on internal Slack, repo server no longer need to be exposed via a LoadBalancer.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.
