### PR TITLE
fix: ArgoCD agent principal image configurations

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -300,6 +300,9 @@ vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOf
 
 	// ArgoCDCmdParamsConfigMapName is the upstream hard-coded ArgoCD command params ConfigMap name.
 	ArgoCDCmdParamsConfigMapName = "argocd-cmd-params-cm"
+
+	// ArgoCDAgentPrincipalDefaultImageName is the default image name for the ArgoCD agent principal.
+	ArgoCDAgentPrincipalDefaultImageName = "quay.io/repository/argoprojlabs/argocd-agent:v0.3.2"
 )
 
 // DefaultLabels returns the default set of labels for controllers.

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -302,7 +302,7 @@ vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOf
 	ArgoCDCmdParamsConfigMapName = "argocd-cmd-params-cm"
 
 	// ArgoCDAgentPrincipalDefaultImageName is the default image name for the ArgoCD agent principal.
-	ArgoCDAgentPrincipalDefaultImageName = "quay.io/repository/argoprojlabs/argocd-agent:v0.3.2"
+	ArgoCDAgentPrincipalDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.3.2"
 )
 
 // DefaultLabels returns the default set of labels for controllers.

--- a/controllers/argocdagent/configmap.go
+++ b/controllers/argocdagent/configmap.go
@@ -110,6 +110,7 @@ const (
 	EnvArgoCDPrincipalResourceProxyCaPath       = "ARGOCD_PRINCIPAL_RESOURCE_PROXY_CA_PATH"
 	EnvArgoCDPrincipalJwtSecretName             = "ARGOCD_PRINCIPAL_JWT_SECRET_NAME"
 	EnvRedisPassword                            = "REDIS_PASSWORD"
+	EnvArgoCDPrincipalImage                     = "ARGOCD_PRINCIPAL_IMAGE"
 )
 
 const cmSuffix = "-agent-principal-params"

--- a/controllers/argocdagent/deployment_test.go
+++ b/controllers/argocdagent/deployment_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 // Helper function to create a test deployment
@@ -453,7 +454,7 @@ func TestReconcilePrincipalDeployment_DefaultImage(t *testing.T) {
 		Namespace: cr.Namespace,
 	}, deployment)
 	assert.NoError(t, err)
-	assert.Equal(t, "quay.io/argoproj/argocd-agent:v1", deployment.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "quay.io/repository/argoprojlabs/argocd-agent:v0.3.2", deployment.Spec.Template.Spec.Containers[0].Image)
 }
 
 func TestReconcilePrincipalDeployment_VolumeMountsAndVolumes(t *testing.T) {
@@ -506,4 +507,78 @@ func TestReconcilePrincipalDeployment_VolumeMountsAndVolumes(t *testing.T) {
 	assert.Equal(t, "userpass-passwd", userpassVolume.Name)
 	assert.Equal(t, "argocd-agent-principal-userpass", userpassVolume.VolumeSource.Secret.SecretName)
 	assert.Equal(t, ptr.To(true), userpassVolume.VolumeSource.Secret.Optional)
+}
+
+func TestBuildPrincipalImage(t *testing.T) {
+	tests := []struct {
+		name          string
+		cr            *argoproj.ArgoCD
+		envImage      string
+		expectedImage string
+		description   string
+	}{
+		{
+			name: "CR specification takes precedence",
+			cr: makeTestArgoCD(
+				withPrincipalEnabled(true),
+				withPrincipalImage("custom-registry/argocd-agent:custom-tag"),
+			),
+			envImage:      "env-registry/argocd-agent:env-tag",
+			expectedImage: "custom-registry/argocd-agent:custom-tag",
+			description:   "When CR specifies an image, it should take precedence over environment variable and default",
+		},
+		{
+			name: "Environment variable used when CR image not specified",
+			cr: makeTestArgoCD(
+				withPrincipalEnabled(true),
+			),
+			envImage:      "env-registry/argocd-agent:env-tag",
+			expectedImage: "env-registry/argocd-agent:env-tag",
+			description:   "When CR doesn't specify an image but environment variable is set, use environment variable",
+		},
+		{
+			name: "Default image used when neither CR nor environment specified",
+			cr: makeTestArgoCD(
+				withPrincipalEnabled(true),
+			),
+			envImage:      "",
+			expectedImage: common.ArgoCDAgentPrincipalDefaultImageName,
+			description:   "When neither CR nor environment variable specifies an image, use default",
+		},
+		{
+			name: "Empty CR image should not override environment variable",
+			cr: makeTestArgoCD(
+				withPrincipalEnabled(true),
+				withPrincipalImage(""),
+			),
+			envImage:      "env-registry/argocd-agent:env-tag",
+			expectedImage: "env-registry/argocd-agent:env-tag",
+			description:   "When CR specifies empty image, environment variable should be used",
+		},
+		{
+			name: "Default image used when CR image is empty and no environment variable",
+			cr: makeTestArgoCD(
+				withPrincipalEnabled(true),
+				withPrincipalImage(""),
+			),
+			envImage:      "",
+			expectedImage: common.ArgoCDAgentPrincipalDefaultImageName,
+			description:   "When CR specifies empty image and no environment variable, use default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable if specified
+			if tt.envImage != "" {
+				t.Setenv("ARGOCD_PRINCIPAL_IMAGE", tt.envImage)
+			} else {
+				// Clear environment variable
+				t.Setenv("ARGOCD_PRINCIPAL_IMAGE", "")
+			}
+
+			result := buildPrincipalImage(tt.cr)
+			assert.Equal(t, tt.expectedImage, result, tt.description)
+		})
+	}
 }

--- a/controllers/argocdagent/deployment_test.go
+++ b/controllers/argocdagent/deployment_test.go
@@ -454,7 +454,7 @@ func TestReconcilePrincipalDeployment_DefaultImage(t *testing.T) {
 		Namespace: cr.Namespace,
 	}, deployment)
 	assert.NoError(t, err)
-	assert.Equal(t, "quay.io/repository/argoprojlabs/argocd-agent:v0.3.2", deployment.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, "quay.io/argoprojlabs/argocd-agent:v0.3.2", deployment.Spec.Template.Spec.Containers[0].Image)
 }
 
 func TestReconcilePrincipalDeployment_VolumeMountsAndVolumes(t *testing.T) {

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,7 +8,7 @@
 
 Before beginning, make sure you have push access to the following repositories in quay.io:
 
-  * [https://quay.io/repository/argoprojlabs/argocd-operator-util](https://quay.io/repository/argoprojlabs/argocd-operator-util)
+  * [https://quay.io/argoprojlabs/argocd-operator-util](https://quay.io/argoprojlabs/argocd-operator-util)
   * [http://quay.io/argoprojlabs/argocd-operator](http://quay.io/argoprojlabs/argocd-operator)
   * [http://quay.io/argoprojlabs/argocd-operator-registry](http://quay.io/argoprojlabs/argocd-operator-registry) 
 

--- a/tests/k8s/1-051_validate_argocd_agent_principal/01-install.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/01-install.yaml
@@ -19,7 +19,7 @@ spec:
       jwtAllowGenerate: true
       auth: "mtls:CN=([^,]+)"
       logLevel: "trace"
-      image: "quay.io/user/argocd-agent:v1"
+      image: "quay.io/user/argocd-agent:v1"  # specify a custom image
   sourceNamespaces:
     - "agent-managed"
     - "agent-autonomous"

--- a/tests/k8s/1-051_validate_argocd_agent_principal/02-delete.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/02-delete.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: argoproj.io/v1beta1
+  kind: ArgoCD
+  name: argocd
+  namespace: argocd-e2e-cluster-config
+commands:
+  # Sleep to allow resources to be completely deleted
+  - command: sleep 30s

--- a/tests/k8s/1-051_validate_argocd_agent_principal/03-assert.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/03-assert.yaml
@@ -174,4 +174,4 @@ spec:
     spec:
       containers:
       - name: argocd-agent-principal
-        image: quay.io/repository/argoprojlabs/argocd-agent:v0.3.2
+        image: quay.io/argoprojlabs/argocd-agent:v0.3.2

--- a/tests/k8s/1-051_validate_argocd_agent_principal/03-assert.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/03-assert.yaml
@@ -174,4 +174,4 @@ spec:
     spec:
       containers:
       - name: argocd-agent-principal
-        image: quay.io/user/argocd-agent:v1
+        image: quay.io/repository/argoprojlabs/argocd-agent:v0.3.2

--- a/tests/k8s/1-051_validate_argocd_agent_principal/03-install.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/03-install.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd-e2e-cluster-config
+---
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: argocd
+  namespace: argocd-e2e-cluster-config
+spec:
+  controller:
+    enabled: false
+  argoCDAgent:
+    principal:
+      enabled: true
+      allowedNamespaces:
+        - "*"
+      jwtAllowGenerate: true
+      auth: "mtls:CN=([^,]+)"
+      logLevel: "trace"
+  sourceNamespaces:
+    - "agent-managed"
+    - "agent-autonomous"


### PR DESCRIPTION
/kind bug

This PR is to add logic for principal where image name is first taken from ArgoCD resource, if not available then it is taken from an env variable. If that is also not available then default is used.

Fixes: https://issues.redhat.com/browse/GITOPS-7605