### PR TITLE
fix: ArgoCD agent CM TLS allow-generate False by default

### DIFF
--- a/controllers/argocdagent/configmap.go
+++ b/controllers/argocdagent/configmap.go
@@ -311,7 +311,7 @@ func getPrincipalTLSServerAllowGenerate() string {
 	if value := os.Getenv(EnvArgoCDPrincipalTLSServerAllowGenerate); value != "" {
 		return value
 	}
-	return "true"
+	return "false"
 }
 
 func getPrincipalTLSServerRootCAPath() string {

--- a/tests/k8s/1-051_validate_argocd_agent_principal/01-assert.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/01-assert.yaml
@@ -119,7 +119,7 @@ data:
   principal.metrics.port: '8000'
   principal.listen.host: ''
   principal.namespace-create.pattern: ''
-  principal.tls.server.allow-generate: 'true'
+  principal.tls.server.allow-generate: 'false'
   principal.redis-compression-type: gzip
   principal.tls.secret-name: argocd-agent-principal-tls
   principal.resource-proxy.ca.path: ''

--- a/tests/k8s/1-051_validate_argocd_agent_principal/03-assert.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/03-assert.yaml
@@ -119,7 +119,7 @@ data:
   principal.metrics.port: '8000'
   principal.listen.host: ''
   principal.namespace-create.pattern: ''
-  principal.tls.server.allow-generate: 'true'
+  principal.tls.server.allow-generate: 'false'
   principal.redis-compression-type: gzip
   principal.tls.secret-name: argocd-agent-principal-tls
   principal.resource-proxy.ca.path: ''


### PR DESCRIPTION
/kind bug

This PR is to change default value of `principal.tls.server.allow-generate` field in `argocd-agent-params` configmap.