### PR TITLE
bug: fix redis ha proxy pod fails to restart after upgrade

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -936,6 +936,14 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) e
 			explanation += "container security context"
 			changed = true
 		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.SecurityContext, existing.Spec.Template.Spec.SecurityContext) {
+			existing.Spec.Template.Spec.SecurityContext = deploy.Spec.Template.Spec.SecurityContext
+			if changed {
+				explanation += ", "
+			}
+			explanation += "pod security context"
+			changed = true
+		}
 		if changed {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			return r.Update(context.TODO(), existing)


### PR DESCRIPTION
**What type of PR is this?**

<!-- /kind bug -->


**What does this PR do / why we need it**:
This PR fixes the bug where redis ha proxy pod fails to restart with error related to security context after upgrade

**Which issue(s) this PR fixes**:

Fixes #?
[GITOPS-7180](https://issues.redhat.com/browse/GITOPS-7180)

**How to test changes / Special notes to the reviewer**:
