### PR TITLE
Fix: Doc typos intialCerts->initialCerts

### DIFF
--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -224,7 +224,7 @@ func TestReconcileArgoCD_reconcileTLSCerts_withInitialCertsUpdate(t *testing.T) 
 		},
 		configMap))
 
-	// Any certs added to .spec.tls.intialCerts of Argo CD CR after the cluster creation
+	// Any certs added to .spec.tls.initialCerts of Argo CD CR after the cluster creation
 	// should not affect the argocd-tls-certs-cm configmap.
 	want := []string{}
 	if k := stringMapKeys(configMap.Data); !reflect.DeepEqual(want, k) {

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -1746,7 +1746,7 @@ spec:
     initialCerts: []
 ```
 
-### IntialCerts Example
+### InitialCerts Example
 
 Initial set of repository certificates to be configured in Argo CD upon creation of the cluster.
 
@@ -1758,7 +1758,7 @@ kind: ArgoCD
 metadata:
   name: example-argocd
   labels:
-    example: intialCerts
+    example: initialCerts
 spec:
   tls:
     ca: {}


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
/kind documentation
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

None

**How to test changes / Special notes to the reviewer**:
