### PR TITLE
fix: ArgoCD CR .status  is intermittently out of sync with actual Argo CD workloads

### DIFF
--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -9,11 +9,9 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -543,6 +541,7 @@ func (r *ReconcileArgoCD) reconcileDexService(cr *argoproj.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcileDexResources(cr *argoproj.ArgoCD) error {
 	if _, err := r.reconcileRole(common.ArgoCDDexServerComponent, policyRuleForDexServer(), cr); err != nil {
 		log.Error(err, "error reconciling dex role")
+		return err
 	}
 
 	if err := r.reconcileRoleBinding(common.ArgoCDDexServerComponent, policyRuleForDexServer(), cr); err != nil {
@@ -556,77 +555,23 @@ func (r *ReconcileArgoCD) reconcileDexResources(cr *argoproj.ArgoCD) error {
 	// specialized handling for dex
 	if err := r.reconcileDexServiceAccount(cr); err != nil {
 		log.Error(err, "error reconciling dex serviceaccount")
+		return err
 	}
 
 	// Reconcile dex config in argocd-cm, create dex config in argocd-cm if required (right after dex is enabled)
 	if err := r.reconcileArgoConfigMap(cr); err != nil {
 		log.Error(err, "error reconciling argocd-cm configmap")
-	}
-
-	if err := r.reconcileDexService(cr); err != nil {
-		log.Error(err, "error reconciling dex service")
-	}
-
-	if err := r.reconcileDexDeployment(cr); err != nil {
-		log.Error(err, "error reconciling dex deployment")
-	}
-
-	if err := r.reconcileStatusSSO(cr); err != nil {
-		log.Error(err, "error reconciling dex status")
-	}
-
-	return nil
-}
-
-// The code to create/delete notifications resources is written within the reconciliation logic itself. However, these functions must be called
-// in the right order depending on whether resources are getting created or deleted. During creation we must create the role and sa first.
-// RoleBinding and deployment are dependent on these resouces. During deletion the order is reversed.
-// Deployment and RoleBinding must be deleted before the role and sa. deleteDexResources will only be called during
-// delete events, so we don't need to worry about duplicate, recurring reconciliation calls
-func (r *ReconcileArgoCD) deleteDexResources(cr *argoproj.ArgoCD) error {
-	sa := &corev1.ServiceAccount{}
-	role := &rbacv1.Role{}
-
-	if err := argoutil.FetchObject(r.Client, cr.Namespace, fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDDexServerComponent), sa); err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-	}
-	if err := argoutil.FetchObject(r.Client, cr.Namespace, fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDDexServerComponent), role); err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if err := r.reconcileDexDeployment(cr); err != nil {
-		log.Error(err, "error reconciling dex deployment")
-	}
-
-	if err := r.reconcileDexService(cr); err != nil {
-		log.Error(err, "error reconciling dex service")
-	}
-
-	// Reconcile dex config in argocd-cm (right after dex is disabled)
-	// this is required for a one time trigger of reconcileDexConfiguration directly in case of a dex deletion event,
-	// since reconcileArgoConfigMap won't call reconcileDexConfiguration once dex has been disabled (to avoid reconciling on
-	// dexconfig unnecessarily when it isn't enabled)
-	cm := newConfigMapWithName(common.ArgoCDConfigMapName, cr)
-	cmExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm)
-	if err != nil {
 		return err
 	}
-	if cmExists {
-		if err := r.reconcileDexConfiguration(cm, cr); err != nil {
-			log.Error(err, "error reconciling dex configuration in configmap")
-		}
+
+	if err := r.reconcileDexService(cr); err != nil {
+		log.Error(err, "error reconciling dex service")
+		return err
 	}
 
-	if err := r.reconcileRoleBinding(common.ArgoCDDexServerComponent, policyRuleForDexServer(), cr); err != nil {
-		log.Error(err, "error reconciling dex rolebinding")
-	}
-
-	if err := r.reconcileStatusSSO(cr); err != nil {
-		log.Error(err, "error reconciling dex status")
+	if err := r.reconcileDexDeployment(cr); err != nil {
+		log.Error(err, "error reconciling dex deployment")
+		return err
 	}
 
 	return nil

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -115,6 +115,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 			continue
 		}
 
+		// Look for ArgoCD CRs in the managed namespace
 		list := &argoproj.ArgoCDList{}
 		listOption := &client.ListOptions{Namespace: namespace.Name}
 		err := r.List(context.TODO(), list, listOption)
@@ -315,7 +316,7 @@ func (r *ReconcileArgoCD) reconcileClusterRole(componentName string, policyRules
 
 	if err := verifyInstallationMode(cr, allowed); err != nil {
 		log.Error(err, "error occurred in reconcileClusterRole")
-		return nil, nil
+		return nil, err
 	}
 
 	// if custom ClusterRole mode is enabled then do nothing and return
@@ -362,8 +363,7 @@ func (r *ReconcileArgoCD) reconcileClusterRole(componentName string, policyRules
 
 	// if ClusterRole does not exist then create new, if it does then match required fields
 	existingClusterRole := &v1.ClusterRole{}
-	err = r.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRole.Name}, existingClusterRole)
-	if err != nil {
+	if err := r.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRole.Name}, existingClusterRole); err != nil {
 		if !errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to reconcile the cluster role for the service account associated with %s : %s", componentName, err)
 		}

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -76,11 +76,11 @@ func (r *ReconcileArgoCD) reconcileGrafanaService(cr *argoproj.ArgoCD) error {
 		return err
 	}
 	if svcExists {
-		//nolint:staticcheck
-		if !cr.Spec.Grafana.Enabled {
+		//lint:ignore SA1019 known to be deprecated
+		if !cr.Spec.Grafana.Enabled { //nolint:staticcheck // SA1019: We must test deprecated fields.
 			// Service exists but enabled flag has been set to false, delete the Service
 			argoutil.LogResourceDeletion(log, svc, "grafana is disabled")
-			return r.Client.Delete(context.TODO(), svc)
+			return r.Delete(context.TODO(), svc)
 		}
 		log.Info(grafanaDeprecatedWarning)
 		return nil // Service found, do nothing

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -106,6 +106,7 @@ func (r *ReconcileArgoCD) reconcileServiceAccountPermissions(name string, rules 
 func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoproj.ArgoCD) (*corev1.ServiceAccount, error) {
 	sa := newServiceAccountWithName(name, cr)
 
+	// Attempt to retrieve the ServiceAccount
 	exists := true
 	if err := argoutil.FetchObject(r.Client, cr.Namespace, sa.Name, sa); err != nil {
 		if !errors.IsNotFound(err) {

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -28,19 +28,12 @@ const (
 	illegalSSOConfiguration string = "illegal SSO configuration: "
 )
 
-var (
-	ssoConfigLegalStatus string
-)
-
 // The purpose of reconcileSSO is to try and catch as many illegal configuration edge cases at the highest level (that can lead to conflicts)
 // as possible, that may arise from the operator supporting multiple SSO providers.
 // The operator must support `.spec.sso.dex` fields for dex.
 // The operator must identify edge cases involving partial configurations of specs, spec mismatch with
 // active provider, contradicting configuration etc, and throw the appropriate errors.
-func (r *ReconcileArgoCD) reconcileSSO(cr *argoproj.ArgoCD) error {
-
-	// reset ssoConfigLegalStatus at the beginning of each SSO reconciliation round
-	ssoConfigLegalStatus = ssoLegalUnknown
+func (r *ReconcileArgoCD) reconcileSSO(cr *argoproj.ArgoCD, argocdStatus *argoproj.ArgoCDStatus) error {
 
 	// case 1
 	if cr.Spec.SSO == nil {
@@ -48,105 +41,81 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoproj.ArgoCD) error {
 		return nil
 	}
 
-	if cr.Spec.SSO != nil {
+	// After case 1, cr.Spec.SSO is necessarily non-nil
+
+	// case 2
+	if cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
+		// Relevant SSO settings at play are `.spec.sso.dex` fields
 
 		errMsg := ""
-		var err error
 		isError := false
 
-		// case 2
-		if cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
-			// Relevant SSO settings at play are `.spec.sso.dex` fields
-
-			if cr.Spec.SSO.Dex == nil || (cr.Spec.SSO.Dex != nil && !cr.Spec.SSO.Dex.OpenShiftOAuth && cr.Spec.SSO.Dex.Config == "") {
-				// sso provider specified as dex but no dexconfig supplied. This will cause health probe to fail as per
-				// https://github.com/argoproj-labs/argocd-operator/pull/615 ==> conflict
-				errMsg = "must supply valid dex configuration when requested SSO provider is dex"
-				isError = true
-			} else if cr.Spec.SSO.Keycloak != nil {
-				errMsg = "keycloak configuration is specified even though Dex is enabled. Keycloak support has been deprecated and is no longer available."
-				isError = true
-			}
-
-			if isError {
-				err = errors.New(illegalSSOConfiguration + errMsg)
-				log.Error(err, fmt.Sprintf("Illegal expression of SSO configuration detected for Argo CD %s in namespace %s. %s", cr.Name, cr.Namespace, errMsg))
-				ssoConfigLegalStatus = ssoLegalFailed // set global indicator that SSO config has gone wrong
-				_ = r.reconcileStatusSSO(cr)
-				return err
-			}
+		if cr.Spec.SSO.Dex == nil || (cr.Spec.SSO.Dex != nil && !cr.Spec.SSO.Dex.OpenShiftOAuth && cr.Spec.SSO.Dex.Config == "") {
+			// sso provider specified as dex but no dexconfig supplied. This will cause health probe to fail as per
+			// https://github.com/argoproj-labs/argocd-operator/pull/615 ==> conflict
+			errMsg = "must supply valid dex configuration when requested SSO provider is dex"
+			isError = true
+		} else if cr.Spec.SSO.Keycloak != nil {
+			errMsg = "keycloak configuration is specified even though Dex is enabled. Keycloak support has been deprecated and is no longer available."
+			isError = true
 		}
 
-		// case 3
-		if cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
-			log.Info("Keycloak SSO provider is no longer supported. RBAC scopes configuration is ignored.")
-			ssoConfigLegalStatus = ssoLegalFailed // set global indicator that SSO config has gone wrong
-			return fmt.Errorf("keycloak is set as SSO provider, but keycloak support has been deprecated and is no longer available")
-		}
-
-		// case 4
-		if cr.Spec.SSO.Provider.ToLower() == "" {
-
-			if cr.Spec.SSO.Dex != nil {
-				// `.spec.sso.dex` expressed without specifying SSO provider ==> conflict
-				errMsg = "Cannot specify SSO provider spec without specifying SSO provider type"
-				err = errors.New(illegalSSOConfiguration + errMsg)
-				log.Error(err, fmt.Sprintf("Cannot specify SSO provider spec without specifying SSO provider type for Argo CD %s in namespace %s.", cr.Name, cr.Namespace))
-				ssoConfigLegalStatus = ssoLegalFailed // set global indicator that SSO config has gone wrong
-				_ = r.reconcileStatusSSO(cr)
-				return err
-			}
-		}
-
-		// case 5
-		if cr.Spec.SSO.Provider.ToLower() != argoproj.SSOProviderTypeDex {
-			// `.spec.sso.provider` contains unsupported value
-
-			errMsg = fmt.Sprintf("Unsupported SSO provider type. Supported provider is %s", argoproj.SSOProviderTypeDex)
-			err = errors.New(illegalSSOConfiguration + errMsg)
-			log.Error(err, fmt.Sprintf("Unsupported SSO provider type for Argo CD %s in namespace %s.", cr.Name, cr.Namespace))
-			ssoConfigLegalStatus = ssoLegalFailed // set global indicator that SSO config has gone wrong
-			_ = r.reconcileStatusSSO(cr)
+		if isError {
+			err := errors.New(illegalSSOConfiguration + errMsg)
+			log.Error(err, fmt.Sprintf("Illegal expression of SSO configuration detected for Argo CD %s in namespace %s. %s", cr.Name, cr.Namespace, errMsg))
+			argocdStatus.SSO = "Failed"
 			return err
 		}
 	}
 
+	// case 3
+	if cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
+		log.Info("Keycloak SSO provider is no longer supported. RBAC scopes configuration is ignored.")
+		argocdStatus.SSO = "Failed"
+		return fmt.Errorf("keycloak is set as SSO provider, but keycloak support has been deprecated and is no longer available")
+	}
+
+	// case 4
+	if cr.Spec.SSO.Provider.ToLower() == "" {
+
+		if cr.Spec.SSO.Dex != nil {
+			// `.spec.sso.dex` expressed without specifying SSO provider ==> conflict
+			errMsg := "Cannot specify SSO provider spec without specifying SSO provider type"
+			err := errors.New(illegalSSOConfiguration + errMsg)
+			log.Error(err, fmt.Sprintf("Cannot specify SSO provider spec without specifying SSO provider type for Argo CD %s in namespace %s.", cr.Name, cr.Namespace))
+			argocdStatus.SSO = "Failed"
+			return err
+		}
+	}
+
+	// case 5
+	if cr.Spec.SSO.Provider.ToLower() != argoproj.SSOProviderTypeDex {
+		// `.spec.sso.provider` contains unsupported value
+
+		errMsg := fmt.Sprintf("Unsupported SSO provider type. Supported provider is %s", argoproj.SSOProviderTypeDex)
+		err := errors.New(illegalSSOConfiguration + errMsg)
+		log.Error(err, fmt.Sprintf("Unsupported SSO provider type for Argo CD %s in namespace %s.", cr.Name, cr.Namespace))
+		argocdStatus.SSO = "Failed"
+		return err
+	}
+
 	// control reaching this point means that none of the illegal config combinations were detected. SSO is configured legally
 	// set global indicator that SSO config has been successful
-	ssoConfigLegalStatus = ssoLegalSuccess
 
 	// reconcile resources based on enabled provider
 	// keycloak
 	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
 		log.Info("Keycloak SSO provider is no longer supported. RBAC scopes configuration is ignored.")
+		argocdStatus.SSO = "Unknown"
+		return nil
 		// Keycloak functionality has been removed, skipping reconciliation
 	} else if UseDex(cr) {
 		// dex
 		if err := r.reconcileDexResources(cr); err != nil {
+			argocdStatus.SSO = "Failed"
 			return err
 		}
 	}
 
-	_ = r.reconcileStatusSSO(cr)
-
-	return nil
-}
-
-func (r *ReconcileArgoCD) deleteSSOConfiguration(newCr *argoproj.ArgoCD, oldCr *argoproj.ArgoCD) error {
-
-	log.Info("uninstalling existing SSO configuration")
-
-	if oldCr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeKeycloak {
-		log.Info("Keycloak SSO provider is no longer supported. Existing configuration will be ignored and not reconciled.")
-		// Keycloak support has been removed, skipping any cleanup or reconciliation
-	} else if oldCr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
-		// Trigger reconciliation of Dex resources so they get deleted
-		if err := r.deleteDexResources(newCr); err != nil {
-			log.Error(err, "Unable to reconcile necessary resources for uninstallation of Dex")
-			return fmt.Errorf("unable to reconcile necessary resources for uninstallation of Dex. error: %w", err)
-		}
-	}
-
-	_ = r.reconcileStatusSSO(newCr)
 	return nil
 }

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1268,7 +1268,8 @@ func TestUpdateStatusConditionOfArgoCD_Success(t *testing.T) {
 
 	assert.NoError(t, createNamespace(r, argocd.Namespace, ""))
 	assert.NoError(t, r.Create(ctx, &argocd))
-	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition(""), &argocd, r.Client, log))
+
+	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition(""), &argocd, &argocd.Status, r.Client, log))
 
 	assert.Equal(t, argocd.Status.Conditions[0].Type, argoproj.ArgoCDConditionType)
 	assert.Equal(t, argocd.Status.Conditions[0].Reason, argoproj.ArgoCDConditionReasonSuccess)
@@ -1296,7 +1297,7 @@ func TestUpdateStatusConditionOfArgoCD_Fail(t *testing.T) {
 
 	assert.NoError(t, createNamespace(r, argocd.Namespace, ""))
 	assert.NoError(t, r.Create(ctx, &argocd))
-	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition("some error"), &argocd, r.Client, log))
+	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition("some error"), &argocd, &argocd.Status, r.Client, log))
 
 	assert.Equal(t, argocd.Status.Conditions[0].Type, argoproj.ArgoCDConditionType)
 	assert.Equal(t, argocd.Status.Conditions[0].Reason, argoproj.ArgoCDConditionReasonErrorOccurred)
@@ -1304,7 +1305,7 @@ func TestUpdateStatusConditionOfArgoCD_Fail(t *testing.T) {
 	assert.Equal(t, argocd.Status.Conditions[0].Status, metav1.ConditionFalse)
 
 	// Update error condition
-	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition("some other error"), &argocd, r.Client, log))
+	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition("some other error"), &argocd, &argocd.Status, r.Client, log))
 
 	assert.Equal(t, argocd.Status.Conditions[0].Type, argoproj.ArgoCDConditionType)
 	assert.Equal(t, argocd.Status.Conditions[0].Reason, argoproj.ArgoCDConditionReasonErrorOccurred)
@@ -1312,7 +1313,7 @@ func TestUpdateStatusConditionOfArgoCD_Fail(t *testing.T) {
 	assert.Equal(t, argocd.Status.Conditions[0].Status, metav1.ConditionFalse)
 
 	// Update success condition
-	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition(""), &argocd, r.Client, log))
+	assert.NoError(t, updateStatusConditionOfArgoCD(ctx, createCondition(""), &argocd, &argocd.Status, r.Client, log))
 
 	assert.Equal(t, argocd.Status.Conditions[0].Type, argoproj.ArgoCDConditionType)
 	assert.Equal(t, argocd.Status.Conditions[0].Reason, argoproj.ArgoCDConditionReasonSuccess)

--- a/tests/ginkgo/parallel/1-015_validate_sso_status_test.go
+++ b/tests/ginkgo/parallel/1-015_validate_sso_status_test.go
@@ -77,8 +77,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			})
 
 			By("verifying Argo CD is pending and SSO is failed, because we have not provided configuration details")
-			Eventually(argoCD).Should(argocdFixture.HavePhase("Pending"))
-			Consistently(argoCD, "15s", "1s").Should(argocdFixture.HavePhase("Pending"))
+			Eventually(argoCD).Should(argocdFixture.HavePhase("Failed"))
+			Consistently(argoCD, "15s", "1s").Should(argocdFixture.HavePhase("Failed"))
 			Eventually(argoCD).Should(argocdFixture.HaveSSOStatus("Failed"))
 
 			By("verifying dex is not ready for same reason")
@@ -173,8 +173,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				}
 			})
 
-			By("Argo CD should be Pending/Failed, as this is an invalid configuration")
-			Eventually(argoCD).Should(argocdFixture.HavePhase("Pending"))
+			By("Argo CD should be Failed/Failed, as this is an invalid configuration")
+			Eventually(argoCD).Should(argocdFixture.HavePhase("Failed"))
 			Eventually(argoCD).Should(argocdFixture.HaveSSOStatus("Failed"))
 
 			By("creating a new SSO secret")

--- a/tests/ginkgo/parallel/1-047_validate_impersonation_namespace_scoped_instance_test.go
+++ b/tests/ginkgo/parallel/1-047_validate_impersonation_namespace_scoped_instance_test.go
@@ -171,7 +171,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, guestbookApplication)).To(Succeed())
-			Eventually(guestbookApplication, "2m", "5s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
+			Eventually(guestbookApplication, "4m", "5s").Should(applicationFixture.HaveSyncStatusCode(appv1alpha1.SyncStatusCodeSynced))
 
 			By("creating a new namespace 'guestbook-dev' which is managed by our argo cd instance")
 			guestbookDevNS, cleanupFunc := fixture.CreateManagedNamespaceWithCleanupFunc("guestbook-dev-1-047", argoCD.Namespace)

--- a/tests/ginkgo/parallel/1-048_validate_status_conditions_test.go
+++ b/tests/ginkgo/parallel/1-048_validate_status_conditions_test.go
@@ -64,7 +64,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			By("verifying that the invalid Argo CD CR shows the expected error message")
 
 			Eventually(argoCD, "2m", "5s").Should(
-				And(argocdFixture.HavePhase("Pending"),
+				And(argocdFixture.HavePhase("Failed"),
 					argocdFixture.HaveSSOStatus("Failed"),
 				))
 
@@ -116,7 +116,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("verifying .status.condition goes to invalid with expected error message")
 			Eventually(argoCD, "2m", "5s").Should(
-				And(argocdFixture.HavePhase("Pending"),
+				And(argocdFixture.HavePhase("Failed"),
 					argocdFixture.HaveSSOStatus("Failed"),
 				))
 

--- a/tests/ginkgo/parallel/1-120_verify_argocd_status_consistency_test.go
+++ b/tests/ginkgo/parallel/1-120_verify_argocd_status_consistency_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+
+	Context("1-120_verify_argocd_status_consistency", func() {
+
+		var (
+			k8sClient client.Client
+			ctx       context.Context
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+
+		})
+
+		It("cycle throughs each component of .status.phase, and ensures that enabling/disabling the components will affect the .status.phase as expected.", func() {
+			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+			defer cleanupFunc()
+
+			type componentEnabler struct {
+				// name of the component to be enabled/disabled
+				name string
+				// disable function disables the component via ArgoCD CR (it should not be running after being set)
+				disable func(acd *argov1beta1api.ArgoCD)
+				// enables function enables the component via ArgoCD CR: if shouldFail is true, then an error (for example, a bad image) will be injected into component
+				enable func(acd *argov1beta1api.ArgoCD, shouldFail bool)
+				// verify verifies the component has the expected status
+				verify func(acd *argov1beta1api.ArgoCD, expectedStatus string)
+			}
+
+			enablers := []componentEnabler{
+				{
+					name: "redis",
+					disable: func(acd *argov1beta1api.ArgoCD) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							ac.Spec.Redis = argov1beta1api.ArgoCDRedisSpec{Enabled: ptr.To(false)}
+						})
+					},
+					enable: func(acd *argov1beta1api.ArgoCD, shouldFail bool) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							if shouldFail {
+								ac.Spec.Redis = argov1beta1api.ArgoCDRedisSpec{Enabled: ptr.To(true), Image: "quay.io/argoprojlabs/argocd-operator-does-not-exist:latest"}
+							} else {
+								ac.Spec.Redis = argov1beta1api.ArgoCDRedisSpec{Enabled: ptr.To(true)}
+							}
+						})
+					},
+					verify: func(acd *argov1beta1api.ArgoCD, expectedStatus string) {
+						Eventually(acd, "3m", "5s").Should(argocdFixture.HaveRedisStatus(expectedStatus))
+						Consistently(acd).Should(argocdFixture.HaveRedisStatus(expectedStatus))
+					},
+				},
+				{
+					name: "app-controller",
+					disable: func(acd *argov1beta1api.ArgoCD) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							ac.Spec.Controller = argov1beta1api.ArgoCDApplicationControllerSpec{Enabled: ptr.To(false)}
+						})
+					},
+					enable: func(acd *argov1beta1api.ArgoCD, shouldFail bool) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							if shouldFail {
+								ac.Spec.Controller = argov1beta1api.ArgoCDApplicationControllerSpec{Enabled: ptr.To(true), ExtraCommandArgs: []string{"--fake-param"}}
+							} else {
+								ac.Spec.Controller = argov1beta1api.ArgoCDApplicationControllerSpec{Enabled: ptr.To(true)}
+							}
+						})
+					},
+					verify: func(acd *argov1beta1api.ArgoCD, expectedStatus string) {
+						Eventually(acd, "3m", "5s").Should(argocdFixture.HaveApplicationControllerStatus(expectedStatus))
+						Consistently(acd).Should(argocdFixture.HaveApplicationControllerStatus(expectedStatus))
+					},
+				},
+				{
+					name: "repo-server",
+					disable: func(acd *argov1beta1api.ArgoCD) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							ac.Spec.Repo = argov1beta1api.ArgoCDRepoSpec{Enabled: ptr.To(false)}
+						})
+					},
+					enable: func(acd *argov1beta1api.ArgoCD, shouldFail bool) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							if shouldFail {
+								ac.Spec.Repo = argov1beta1api.ArgoCDRepoSpec{Enabled: ptr.To(true), Image: "quay.io/argoprojlabs/argocd-operator-does-not-exist:latest"}
+							} else {
+								ac.Spec.Repo = argov1beta1api.ArgoCDRepoSpec{Enabled: ptr.To(true)}
+							}
+						})
+					},
+					verify: func(acd *argov1beta1api.ArgoCD, expectedStatus string) {
+						Eventually(acd, "3m", "5s").Should(argocdFixture.HaveRepoStatus(expectedStatus))
+						Consistently(acd).Should(argocdFixture.HaveRepoStatus(expectedStatus))
+					},
+				},
+				{
+					name: "server",
+					disable: func(acd *argov1beta1api.ArgoCD) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							ac.Spec.Server = argov1beta1api.ArgoCDServerSpec{Enabled: ptr.To(false)}
+						})
+					},
+					enable: func(acd *argov1beta1api.ArgoCD, shouldFail bool) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							if shouldFail {
+								ac.Spec.Server = argov1beta1api.ArgoCDServerSpec{Enabled: ptr.To(true), ExtraCommandArgs: []string{"--not-a-real-param"}}
+							} else {
+								ac.Spec.Server = argov1beta1api.ArgoCDServerSpec{Enabled: ptr.To(true)}
+							}
+						})
+					},
+					verify: func(acd *argov1beta1api.ArgoCD, expectedStatus string) {
+						Eventually(acd, "3m", "5s").Should(argocdFixture.HaveServerStatus(expectedStatus))
+						Consistently(acd).Should(argocdFixture.HaveServerStatus(expectedStatus))
+					},
+				},
+				{
+					name: "dex-sso",
+					disable: func(acd *argov1beta1api.ArgoCD) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							ac.Spec.SSO = nil
+						})
+					},
+					enable: func(acd *argov1beta1api.ArgoCD, shouldFail bool) {
+						argocdFixture.Update(acd, func(ac *argov1beta1api.ArgoCD) {
+							if shouldFail {
+								ac.Spec.SSO = &argov1beta1api.ArgoCDSSOSpec{
+									Provider: argov1beta1api.SSOProviderTypeDex,
+									Dex: &argov1beta1api.ArgoCDDexSpec{
+										Config: "hi",
+										Image:  "quay.io/argoprojlabs/argocd-operator-does-not-exist:latest",
+									},
+								}
+							} else {
+								ac.Spec.SSO = &argov1beta1api.ArgoCDSSOSpec{
+									Provider: argov1beta1api.SSOProviderTypeDex,
+									Dex: &argov1beta1api.ArgoCDDexSpec{
+										Config: "hi",
+									},
+								}
+							}
+						})
+					},
+					verify: func(acd *argov1beta1api.ArgoCD, expectedStatus string) {
+						Eventually(acd, "3m", "5s").Should(argocdFixture.HaveSSOStatus(expectedStatus))
+						Consistently(acd).Should(argocdFixture.HaveSSOStatus(expectedStatus))
+					},
+				},
+			}
+
+			By("creating basic Argo CD instance")
+
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: ns.Name},
+				Spec: argov1beta1api.ArgoCDSpec{
+					Controller:     argov1beta1api.ArgoCDApplicationControllerSpec{},
+					ApplicationSet: &argov1beta1api.ArgoCDApplicationSet{},
+					Server:         argov1beta1api.ArgoCDServerSpec{},
+					SSO: &argov1beta1api.ArgoCDSSOSpec{
+						Provider: argov1beta1api.SSOProviderTypeDex,
+						Dex: &argov1beta1api.ArgoCDDexSpec{
+							Config: "hi",
+						},
+					},
+					Repo:  argov1beta1api.ArgoCDRepoSpec{},
+					Redis: argov1beta1api.ArgoCDRedisSpec{},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			for idx, enabler := range enablers {
+				By(fmt.Sprintf("%d) verifying %s ", idx, enabler.name))
+				Expect(argoCD).Should(k8sFixture.ExistByName())
+
+				By("disable " + enabler.name)
+				enabler.disable(argoCD)
+				By("verify 'Unknown' " + enabler.name)
+				enabler.verify(argoCD, "Unknown")
+
+				By("verifying ArgoCD CR has phase Available")
+				Expect(argoCD).Should(argocdFixture.HavePhase("Available"))
+
+				By("enable " + enabler.name + ", setting it to succeed")
+				enabler.enable(argoCD, false)
+				By("verify 'Running' " + enabler.name)
+				enabler.verify(argoCD, "Running")
+				By("verifying ArgoCD CR has phase Available")
+				Expect(argoCD).Should(argocdFixture.HavePhase("Available"))
+
+				By("disable " + enabler.name)
+				enabler.disable(argoCD)
+				By("verify 'Unknown' " + enabler.name)
+				enabler.verify(argoCD, "Unknown")
+				By("verifying ArgoCD CR has phase Available")
+				Expect(argoCD).Should(argocdFixture.HavePhase("Available"))
+
+				By("enable " + enabler.name + ", setting it to fail")
+				enabler.enable(argoCD, true)
+				By("verify 'Pending' " + enabler.name)
+				enabler.verify(argoCD, "Pending")
+				By("verifying ArgoCD CR has phase Pending")
+				Eventually(argoCD).Should(argocdFixture.HavePhase("Pending"))
+
+				By("disable " + enabler.name)
+				enabler.disable(argoCD)
+				By("verify 'Unknown' " + enabler.name)
+				enabler.verify(argoCD, "Unknown")
+				By("verifying ArgoCD CR has phase Available")
+				Eventually(argoCD).Should(argocdFixture.HavePhase("Available"))
+
+			}
+
+		})
+
+	})
+})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
- Primary purpose is to fix this status race condition, which has been causing periodic test failures: 
    - https://github.com/redhat-developer/gitops-operator/issues/909
- The fix modifies how status updating working in the operator: 
    - Functions which wish to modify the ArgoCD CR .status field, are instead passed a pointer to a `ArgoCDStatus` object. Functions should update this status object, not the `ArgoCD` CR status directly. This status object is set on the `ArgoCD` CR on completion of reconciliation.
- This PR:
    - Updates to .status field of `ArgoCD` CR only happen once, from one function (`updateStatusConditionOfArgoCD`), rather than many different functions.
    - Remove some old dex deletion logic which is no longer needed, and added a unit/ test to verify this is true.
        - We previously removed keycloak, which allows us to make this logic much simpler.
    - Some dex errors which were previously ignored, are no longer ignored (and IMHO never should have been).
    - Remove global variable from SSO reconciliation logic
    - Update other misc code, but no changes to the code logic, just adding the above pointers when needed.
    - Added a new E2E test to verify nothing has broken



**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/redhat-developer/gitops-operator/issues/909

**How to test changes / Special notes to the reviewer**:
