### PR TITLE
fix: Redis server address is hard coded for principal deployment

### DIFF
--- a/controllers/argocdagent/deployment.go
+++ b/controllers/argocdagent/deployment.go
@@ -503,7 +503,7 @@ func getPrincipalRedisServerAddress(cr *argoproj.ArgoCD) string {
 	if hasRedis(cr) && cr.Spec.ArgoCDAgent.Principal.Redis.ServerAddress != "" {
 		return cr.Spec.ArgoCDAgent.Principal.Redis.ServerAddress
 	}
-	return "argocd-redis:6379"
+	return fmt.Sprintf("%s-%s:%d", cr.Name, "redis", common.ArgoCDDefaultRedisPort)
 }
 
 func getPrincipalRedisCompressionType(cr *argoproj.ArgoCD) string {


### PR DESCRIPTION
/kind bug

This PR is to fix principal deployment configs where default redis server address is hard coded to "argocd-redis", but when ArgoCD is deployed in different namespace then redis service name would be changed and this will cause issue in principal as it will be looking for a wrong address.


Fixes https://issues.redhat.com/browse/GITOPS-7790

