### PR TITLE
fix: Remove dependency on argocd-redis secret

### DIFF
--- a/controllers/argocdagent/deployment.go
+++ b/controllers/argocdagent/deployment.go
@@ -370,7 +370,7 @@ func buildPrincipalContainerEnv(cr *argoproj.ArgoCD) []corev1.EnvVar {
 				SecretKeyRef: &corev1.SecretKeySelector{
 					Key: PrincipalRedisPasswordKey,
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "argocd-redis",
+						Name: PrincipalRedisSecretname,
 					},
 					Optional: ptr.To(true),
 				},
@@ -411,7 +411,8 @@ const (
 	EnvArgoCDPrincipalJwtSecretName             = "ARGOCD_PRINCIPAL_JWT_SECRET_NAME"
 	EnvArgoCDPrincipalImage                     = "ARGOCD_PRINCIPAL_IMAGE"
 	EnvRedisPassword                            = "REDIS_PASSWORD"
-	PrincipalRedisPasswordKey                   = "auth"
+	PrincipalRedisPasswordKey                   = "admin.password"
+	PrincipalRedisSecretname                    = "argocd-redis-initial-password" // #nosec G101
 )
 
 // Logging Configuration

--- a/controllers/argocdagent/deployment_test.go
+++ b/controllers/argocdagent/deployment_test.go
@@ -396,8 +396,8 @@ func TestReconcilePrincipalDeployment_VerifyDeploymentSpec(t *testing.T) {
 		if env.Name == "REDIS_PASSWORD" {
 			assert.NotNil(t, env.ValueFrom, "REDIS_PASSWORD should reference a secret")
 			assert.NotNil(t, env.ValueFrom.SecretKeyRef, "REDIS_PASSWORD should reference a secret key")
-			assert.Equal(t, "argocd-redis", env.ValueFrom.SecretKeyRef.Name)
-			assert.Equal(t, "auth", env.ValueFrom.SecretKeyRef.Key)
+			assert.Equal(t, PrincipalRedisSecretname, env.ValueFrom.SecretKeyRef.Name)
+			assert.Equal(t, "admin.password", env.ValueFrom.SecretKeyRef.Key)
 		} else {
 			// All other environment variables should have direct values, not references
 			assert.Nil(t, env.ValueFrom, "Environment variable %s should have direct value, not reference", env.Name)

--- a/controllers/argocdagent/scripts/create-agent-config.sh
+++ b/controllers/argocdagent/scripts/create-agent-config.sh
@@ -22,9 +22,6 @@ export ARGOCD_AGENT_PRINCIPAL_NAMESPACE=argocd # Should be same as ArgoCD instan
 KUBECTL=$(which kubectl)
 OPENSSL=$(which openssl)
 
-# Create a secret for the redis password
-${KUBECTL} create secret generic argocd-redis -n argocd --from-literal=auth="$(${KUBECTL} get secret argocd-redis-initial-password -n argocd -o jsonpath='{.data.admin\.password}' | base64 -d)"
-
 IPADDR=""
 if test "$IPADDR" = ""; then
        IPADDR=$(kubectl -n ${ARGOCD_AGENT_PRINCIPAL_NAMESPACE} get svc argocd-agent-principal -o jsonpath='{.spec.clusterIP}')

--- a/tests/k8s/1-051_validate_argocd_agent_principal/01-assert.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/01-assert.yaml
@@ -193,7 +193,7 @@ spec:
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
-              key: auth
-              name: argocd-redis
+              key: admin.password
+              name: argocd-redis-initial-password
               optional: true
 

--- a/tests/k8s/1-051_validate_argocd_agent_principal/05-create-agent-secrets.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/05-create-agent-secrets.yaml
@@ -8,7 +8,6 @@ commands:
   - command: kubectl wait --for=condition=progressing --timeout=60s deployment/argocd-agent-principal -n argocd-e2e-cluster-config
   
   # Create the minimal required secrets
-  - command: kubectl create secret generic argocd-redis -n argocd-e2e-cluster-config --from-literal=auth=testpassword
   - command: kubectl create secret generic argocd-agent-jwt -n argocd-e2e-cluster-config --from-literal=jwt.key="dummy-key"
   
   # Generate real TLS certificates using temporary files in current directory


### PR DESCRIPTION
/kind bug 

This PR is to use `argocd-redis-initial-password` secret instead of `argocd-redis` to get redis password  

Fixes https://issues.redhat.com/browse/GITOPS-7837
