### PR TITLE
chore: increase timeout on test 1-067, plus log namespace events on fail

### DIFF
--- a/tests/ginkgo/fixture/fixture.go
+++ b/tests/ginkgo/fixture/fixture.go
@@ -493,6 +493,17 @@ func OutputDebugOnFail(namespaceParams ...any) {
 		GinkgoWriter.Println(kubectlOutput)
 		GinkgoWriter.Println("----------------------------------------------------------------")
 
+		kubectlOutput, err = osFixture.ExecCommandWithOutputParam(false, "kubectl", "get", "events", "-n", namespace)
+		if err != nil {
+			GinkgoWriter.Println("unable to get events for namespace", err, kubectlOutput)
+		} else {
+			GinkgoWriter.Println("")
+			GinkgoWriter.Println("----------------------------------------------------------------")
+			GinkgoWriter.Println("'kubectl get events -n " + namespace + ":")
+			GinkgoWriter.Println(kubectlOutput)
+			GinkgoWriter.Println("----------------------------------------------------------------")
+		}
+
 	}
 
 	kubectlOutput, err := osFixture.ExecCommandWithOutputParam(false, "kubectl", "get", "argocds", "-A", "-o", "yaml")
@@ -505,6 +516,8 @@ func OutputDebugOnFail(namespaceParams ...any) {
 		GinkgoWriter.Println(kubectlOutput)
 		GinkgoWriter.Println("----------------------------------------------------------------")
 	}
+
+	GinkgoWriter.Println("You can skip this debug output by setting 'SKIP_DEBUG_OUTPUT=true'")
 
 }
 

--- a/tests/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
+++ b/tests/ginkgo/parallel/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
@@ -86,7 +86,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				// In BeAvailable() we wait 15 seconds for ArgoCD CR to be reconciled, this SHOULD be enough time.
 
 				By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
-				Eventually(argoCD, "5m", "10s").Should(argocdFixture.BeAvailable())
+				Eventually(argoCD, "10m", "10s").Should(argocdFixture.BeAvailable())
 
 				deploymentsShouldExist := []string{"argocd-redis-ha-haproxy", "argocd-server", "argocd-repo-server"}
 				for _, depl := range deploymentsShouldExist {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What does this PR do / why we need it**:
- Increase timeout on 1-067: On this step, the Argo CD HA workloads were still in 'init':
```
2025-10-09T19:51:18.9828103Z   ----------------------------------------------------------------
2025-10-09T19:51:18.9828520Z   'kubectl get all -n gitops-e2e-test-f17bdec0-7d99' output:
2025-10-09T19:51:18.9829320Z   NAME                                           READY   STATUS     RESTARTS   AGE
2025-10-09T19:51:18.9830002Z   pod/argocd-application-controller-0            1/1     Running    0          5m9s
2025-10-09T19:51:18.9830570Z   pod/argocd-redis-ha-haproxy-7fc59b5f95-972k5   1/1     Running    0          5m9s
2025-10-09T19:51:18.9831130Z   pod/argocd-redis-ha-haproxy-7fc59b5f95-tl4q4   1/1     Running    0          5m9s
2025-10-09T19:51:18.9831680Z   pod/argocd-redis-ha-haproxy-7fc59b5f95-vlk9c   1/1     Running    0          5m9s
2025-10-09T19:51:18.9832193Z   pod/argocd-redis-ha-server-0                   0/2     Init:0/1   0          5m9s
2025-10-09T19:51:18.9832695Z   pod/argocd-repo-server-7757ddc84c-xphpz        1/1     Running    0          5m9s
2025-10-09T19:51:18.9833221Z   pod/argocd-server-846578f7df-vd6bf             1/1     Running    0          5m9s
2025-10-09T19:51:18.9833496Z 
2025-10-09T19:51:18.9833740Z   NAME                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)              AGE
2025-10-09T19:51:18.9834374Z   service/argocd-metrics               ClusterIP   10.43.7.167     <none>        8082/TCP             5m9s
2025-10-09T19:51:18.9835241Z   service/argocd-redis-ha              ClusterIP   10.43.247.12    <none>        6379/TCP,26379/TCP   5m9s
2025-10-09T19:51:18.9836489Z   service/argocd-redis-ha-announce-0   ClusterIP   10.43.202.163   <none>        6379/TCP,26379/TCP   5m9s
2025-10-09T19:51:18.9837486Z   service/argocd-redis-ha-announce-1   ClusterIP   10.43.173.49    <none>        6379/TCP,26379/TCP   5m9s
2025-10-09T19:51:18.9838659Z   service/argocd-redis-ha-announce-2   ClusterIP   10.43.233.245   <none>        6379/TCP,26379/TCP   5m9s
2025-10-09T19:51:18.9839825Z   service/argocd-redis-ha-haproxy      ClusterIP   10.43.222.187   <none>        6379/TCP             5m9s
2025-10-09T19:51:18.9840804Z   service/argocd-repo-server           ClusterIP   10.43.191.132   <none>        8081/TCP,8084/TCP    5m9s
2025-10-09T19:51:18.9841780Z   service/argocd-server                ClusterIP   10.43.224.182   <none>        80/TCP,443/TCP       5m9s
2025-10-09T19:51:18.9842903Z   service/argocd-server-metrics        ClusterIP   10.43.110.164   <none>        8083/TCP             5m9s
2025-10-09T19:51:18.9843550Z 
2025-10-09T19:51:18.9843860Z   NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
2025-10-09T19:51:18.9844717Z   deployment.apps/argocd-redis-ha-haproxy   3/3     3            3           5m9s
2025-10-09T19:51:18.9845865Z   deployment.apps/argocd-repo-server        1/1     1            1           5m9s
2025-10-09T19:51:18.9846659Z   deployment.apps/argocd-server             1/1     1            1           5m9s
2025-10-09T19:51:18.9847170Z 
2025-10-09T19:51:18.9847473Z   NAME                                                 DESIRED   CURRENT   READY   AGE
2025-10-09T19:51:18.9849088Z   replicaset.apps/argocd-redis-ha-haproxy-7fc59b5f95   3         3         3       5m9s
2025-10-09T19:51:18.9850270Z   replicaset.apps/argocd-repo-server-7757ddc84c        1         1         1       5m9s
2025-10-09T19:51:18.9851329Z   replicaset.apps/argocd-server-846578f7df             1         1         1       5m9s
2025-10-09T19:51:18.9851857Z 
2025-10-09T19:51:18.9852102Z   NAME                                             READY   AGE
2025-10-09T19:51:18.9852772Z   statefulset.apps/argocd-application-controller   1/1     5m9s
2025-10-09T19:51:18.9853513Z   statefulset.apps/argocd-redis-ha-server          0/3     5m9s
```
- If this happens again, we should move this test to sequential (for example, if it's due to scheduling contention on k3d cluster)
- Also added logging for namespace events, on test failure.

