### PR TITLE
chore: switch PR build back to Go v1.24 until we are ready to move to Go v1.25

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go.mod'
 
       - name: Restore go build cache
         uses: actions/cache@v4
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go.mod'
       - name: GH actions workaround - Kill XSP4 process
         run: |
           sudo pkill mono || true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version-file: 'go.mod'
 
     - name: Build
       run: make build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
       - name: "Ensure code passes 'go-sec' - run 'make gosec' to identify issues"
         run: |
           make gosec

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go.mod'
 
       - name: Restore go build cache
         uses: actions/cache@v4

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,9 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	## Use release-0.22 as the last version that supports Go 1.24 - https://github.com/kubernetes-sigs/controller-runtime/issues/3358
+	## Feel free to update this when we move to Go 1.25+
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22) 
 	$(ENVTEST) use 1.26
 
 


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
- A previous PR bumped the (GitHub action) go version to 1.25 due to envtest dependency update, an easier solution is just to use the 1.24 version of envtest (discussed here https://github.com/kubernetes-sigs/controller-runtime/issues/3358)
- This PR also moves to reading go version directly from go.mod, rather than hardcoding version in GitHub actions
- AFAICT the base image we use for downstream product still does not support 1.25

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
