### PR TITLE
chore(examples): update ArgoCD CR examples to use apiVersion v1beta1

### DIFF
--- a/examples/argocd-autoscale.yaml
+++ b/examples/argocd-autoscale.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-basic.yaml
+++ b/examples/argocd-basic.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-import.yaml
+++ b/examples/argocd-import.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-ingress-openshift.yaml
+++ b/examples/argocd-ingress-openshift.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-ingress.yaml
+++ b/examples/argocd-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-insights.yaml
+++ b/examples/argocd-insights.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-lb.yaml
+++ b/examples/argocd-lb.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-nm.yaml
+++ b/examples/argocd-nm.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-oauth.yaml
+++ b/examples/argocd-oauth.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-openshift-dex.yaml
+++ b/examples/argocd-openshift-dex.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/examples/argocd-resource-customizations.yaml
+++ b/examples/argocd-resource-customizations.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: argocd

--- a/examples/argocd-route.yaml
+++ b/examples/argocd-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

I tried creating an ArgoCD CR using the examples from this project, but I encountered the following error:

```
Warning: ArgoCD v1alpha1 version is deprecated and will be converted to v1beta1 automatically. Moving forward, please use v1beta1 as the ArgoCD API version.
Error from server: error when creating "STDIN": conversion webhook for argoproj.io/v1alpha1, Kind=ArgoCD failed: Post "https://argocd-operator-webhook-service.argocd-operator-system.svc:443/convert?timeout=30s": dial tcp 10.96.18.111:443: connect: connection refused
```
I am using a KinD cluster and ran `make install` followed by `make deploy`. It seems that the webhook isn't working/connecting, which I hope should be fine in most cases. However, since there's no working webhook to upgrade the API for me, the ArgoCD CR isn't being created.

Since the message "Moving forward, please use v1beta1 as the ArgoCD API version." is quite clear, this PR updates the examples to use v1beta1 instead of the existing v1alpha1.

**Have you updated the necessary documentation?**

* [NA] Documentation update is required by this PR.
* [NA] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes # NA

**How to test changes / Special notes to the reviewer**:
Some of the existing examples already use v1beta1, so it's a bit inconsistent to have a mix of versions.