### PR TITLE
fix: Version override in ArgoCD CR causes operator to use upstream images

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -855,30 +855,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetRoleBinding(cr *argoproj.ArgoCD
 }
 
 func getApplicationSetContainerImage(cr *argoproj.ArgoCD) string {
-
-	defaultImg, defaultTag := false, false
-	img := cr.Spec.ApplicationSet.Image
-	if img == "" {
-		img = cr.Spec.Image
-		if img == "" {
-			img = common.ArgoCDDefaultArgoImage
-			defaultImg = true
-		}
-	}
-
-	tag := cr.Spec.ApplicationSet.Version
-	if tag == "" {
-		tag = cr.Spec.Version
-		if tag == "" {
-			tag = common.ArgoCDDefaultArgoVersion
-			defaultTag = true
-		}
-	}
-
-	// If an env var is specified then use that, but don't override the spec values (if they are present)
-	if e := os.Getenv(common.ArgoCDImageEnvName); e != "" && (defaultTag && defaultImg) {
-		return e
-	}
+	img, tag := GetImageAndTag(common.ArgoCDImageEnvName, cr.Spec.ApplicationSet.Image, cr.Spec.ApplicationSet.Version, cr.Spec.Image, cr.Spec.Version)
 	return argoutil.CombineImageTag(img, tag)
 }
 

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -17,9 +17,12 @@ package argocd
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"hash"
 	"os"
 	"reflect"
 	"sort"
@@ -30,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	"github.com/argoproj/argo-cd/v3/util/glob"
+	"github.com/distribution/reference"
 	"github.com/go-logr/logr"
 
 	"github.com/argoproj-labs/argocd-operator/api/v1alpha1"
@@ -192,22 +196,7 @@ func getArgoApplicationControllerCommand(cr *argoproj.ArgoCD, useTLSForRedis boo
 
 // getArgoContainerImage will return the container image for ArgoCD.
 func getArgoContainerImage(cr *argoproj.ArgoCD) string {
-	defaultTag, defaultImg := false, false
-	img := cr.Spec.Image
-	if img == "" {
-		img = common.ArgoCDDefaultArgoImage
-		defaultImg = true
-	}
-
-	tag := cr.Spec.Version
-	if tag == "" {
-		tag = common.ArgoCDDefaultArgoVersion
-		defaultTag = true
-	}
-	if e := os.Getenv(common.ArgoCDImageEnvName); e != "" && (defaultTag && defaultImg) {
-		return e
-	}
-
+	img, tag := GetImageAndTag(common.ArgoCDImageEnvName, "", "", cr.Spec.Image, cr.Spec.Version)
 	return argoutil.CombineImageTag(img, tag)
 }
 
@@ -225,28 +214,70 @@ func getArgoContainerImage(cr *argoproj.ArgoCD) string {
 // 4. the default is configured in common.ArgoCDDefaultArgoVersion and
 // common.ArgoCDDefaultArgoImage.
 func getRepoServerContainerImage(cr *argoproj.ArgoCD) string {
-	defaultImg, defaultTag := false, false
-	img := cr.Spec.Repo.Image
-	if img == "" {
-		img = cr.Spec.Image
-		if img == "" {
-			img = common.ArgoCDDefaultArgoImage
-			defaultImg = true
+	img, tag := GetImageAndTag(common.ArgoCDImageEnvName, cr.Spec.Repo.Image, cr.Spec.Repo.Version, cr.Spec.Image, cr.Spec.Version)
+	return argoutil.CombineImageTag(img, tag)
+}
+
+// GetImageAndTag determines the image and tag for an ArgoCD component, considering container-level and common-level overrides.
+// Priority order: containerSpec > commonSpec > environment variable > defaults
+// Returns: image, tag
+func GetImageAndTag(envVar, containerSpecImage, containerSpecVersion, commonSpecImage, commonSpecVersion string) (string, string) {
+	// Start with defaults
+	image := common.ArgoCDDefaultArgoImage
+	tag := common.ArgoCDDefaultArgoVersion
+
+	// Check if environment variable is set
+	envVal := os.Getenv(envVar)
+
+	// If no spec values are provided and env var is set, use env var as-is
+	if envVal != "" && containerSpecImage == "" && commonSpecImage == "" &&
+		containerSpecVersion == "" && commonSpecVersion == "" {
+		return envVal, ""
+	}
+
+	// Parse environment variable image if it exists and we need to extract the base image name
+	if envVal != "" {
+		baseImageName, err := extractBaseImageName(envVal)
+		if err != nil {
+			log.Error(err, "Failed to parse environment variable image", "envVal", envVal)
+			return "", ""
+		}
+		if baseImageName != "" {
+			image = baseImageName
 		}
 	}
 
-	tag := cr.Spec.Repo.Version
-	if tag == "" {
-		tag = cr.Spec.Version
-		if tag == "" {
-			tag = common.ArgoCDDefaultArgoVersion
-			defaultTag = true
-		}
+	// Apply spec overrides with container spec taking precedence over common spec
+	image = getPriorityValue(containerSpecImage, commonSpecImage, image)
+	tag = getPriorityValue(containerSpecVersion, commonSpecVersion, tag)
+
+	return image, tag
+}
+
+// extractBaseImageName extracts the base image name from a full image reference (removing tag/digest)
+func extractBaseImageName(imageRef string) (string, error) {
+	// Handle digest format (image@sha256:...)
+	crypto.RegisterHash(crypto.SHA256, func() hash.Hash { return sha256.New() })
+	ref, err := reference.Parse(imageRef)
+	if err != nil {
+		return "", err
 	}
-	if e := os.Getenv(common.ArgoCDImageEnvName); e != "" && (defaultTag && defaultImg) {
-		return e
+	var name string
+	if named, ok := ref.(reference.Named); ok {
+		name = named.Name()
 	}
-	return argoutil.CombineImageTag(img, tag)
+	return name, nil
+}
+
+// getPriorityValue returns the highest priority value from container spec, common spec, or fallback
+func getPriorityValue(containerLevelSpec, commonLevelSpec, fallback string) string {
+	if containerLevelSpec != "" {
+		return containerLevelSpec
+	}
+	if commonLevelSpec != "" {
+		return commonLevelSpec
+	}
+	return fallback
 }
 
 // getArgoRepoResources will return the ResourceRequirements for the Argo CD Repo server container.


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

 /kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
overrides the env variable if present with spec values provided by user
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-7789
Fixes #?

**How to test changes / Special notes to the reviewer**:
configuring Argo CD operator image via environment variable and validate the following scenarios:

No spec.image and no spec.version in the ArgoCD CR → Verify that the ArgoCD resource uses the image specified in the environment variable.

spec.version provided, but no spec.image in the ArgoCD CR → Verify that the ArgoCD resource uses the environment variable image with the user-provided tag.

Both spec.image and spec.version provided in the ArgoCD CR → Verify that the ArgoCD resource uses the user-provided image and version.