### PR TITLE
fix: Add missing ReadinessProbe to Image Updater Deployment

### DIFF
--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -422,6 +422,18 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, s
 			InitialDelaySeconds: 15,
 			PeriodSeconds:       20,
 		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{
+						IntVal: int32(8081),
+					},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       10,
+		},
 		SecurityContext: argoutil.DefaultSecurityContext(),
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -292,6 +292,18 @@ func TestReconcileImageUpdater_CreateDeployments(t *testing.T) {
 			InitialDelaySeconds: 15,
 			PeriodSeconds:       20,
 		},
+		ReadinessProbe: &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				HTTPGet: &v1.HTTPGetAction{
+					Path: "/readyz",
+					Port: intstr.IntOrString{
+						IntVal: int32(8081),
+					},
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       10,
+		},
 	}}
 
 	if diff := cmp.Diff(want, deployment.Spec.Template.Spec.Containers); diff != "" {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
ReadinessProbe is missing in Image Updater deployment. This pr fixes that. 

**Have you updated the necessary documentation?**

* [no] Documentation update is required by this PR.
* [no] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
[GITOPS-8069](https://issues.redhat.com/browse/GITOPS-8069)

**How to test changes / Special notes to the reviewer**: