### PR TITLE
fix: Reference of redis secret in principal deployment

### DIFF
--- a/controllers/argocdagent/deployment.go
+++ b/controllers/argocdagent/deployment.go
@@ -376,7 +376,7 @@ func buildPrincipalContainerEnv(cr *argoproj.ArgoCD) []corev1.EnvVar {
 				SecretKeyRef: &corev1.SecretKeySelector{
 					Key: PrincipalRedisPasswordKey,
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: PrincipalRedisSecretname,
+						Name: fmt.Sprintf("%s-%s", cr.Name, PrincipalRedisSecretnameSuffix),
 					},
 					Optional: ptr.To(true),
 				},
@@ -418,7 +418,7 @@ const (
 	EnvArgoCDPrincipalImage                     = "ARGOCD_PRINCIPAL_IMAGE"
 	EnvRedisPassword                            = "REDIS_PASSWORD"
 	PrincipalRedisPasswordKey                   = "admin.password"
-	PrincipalRedisSecretname                    = "argocd-redis-initial-password" // #nosec G101
+	PrincipalRedisSecretnameSuffix              = "redis-initial-password" // #nosec G101
 )
 
 // Logging Configuration

--- a/controllers/argocdagent/deployment_test.go
+++ b/controllers/argocdagent/deployment_test.go
@@ -395,7 +395,8 @@ func TestReconcilePrincipalDeployment_VerifyDeploymentSpec(t *testing.T) {
 		if env.Name == "REDIS_PASSWORD" {
 			assert.NotNil(t, env.ValueFrom, "REDIS_PASSWORD should reference a secret")
 			assert.NotNil(t, env.ValueFrom.SecretKeyRef, "REDIS_PASSWORD should reference a secret key")
-			assert.Equal(t, PrincipalRedisSecretname, env.ValueFrom.SecretKeyRef.Name)
+
+			assert.Equal(t, "argocd-redis-initial-password", env.ValueFrom.SecretKeyRef.Name)
 			assert.Equal(t, "admin.password", env.ValueFrom.SecretKeyRef.Key)
 		} else {
 			// All other environment variables should have direct values, not references


### PR DESCRIPTION
/kind bug

This PR is to fix the reference of redis secret in principal deployment. The redis secret name is hard coded to `argocd-redis-initial-password` but it should be `<ArgoCD instance name>-redis-initial-password`.


