### PR TITLE
fix: Redis pods are taking more time to be running in HA enabled mode

### DIFF
--- a/build/redis/init.sh.tpl
+++ b/build/redis/init.sh.tpl
@@ -23,10 +23,10 @@ set -eu
 sentinel_get_master() {
 set +e
     if [ "$SENTINEL_PORT" -eq 0 ]; then
-        redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}" --tls --cacert /app/config/redis/tls/tls.crt sentinel get-master-addr-by-name "${MASTER_GROUP}" |\
+        timeout 3 redis-cli -h "${SERVICE}" -p "${SENTINEL_TLS_PORT}" --tls --cacert /app/config/redis/tls/tls.crt sentinel get-master-addr-by-name "${MASTER_GROUP}" |\
         grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
     else
-        redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}"  sentinel get-master-addr-by-name "${MASTER_GROUP}" |\
+        timeout 3 redis-cli -h "${SERVICE}" -p "${SENTINEL_PORT}"  sentinel get-master-addr-by-name "${MASTER_GROUP}" |\
         grep -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
     fi
 set -e


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
Reported a significant startup delay, approximately 13 minutes, for HA server zero due to the `config init` container for Redis hanging while attempting to identify the Redis master, a problem stemming from the lack of a connection timeout flag in the current Redis version. To resolve this, proposed and demonstrated a fix involving adding a 3-second `timeout` command before `redis-cli`, which agreed to implement in both the GitOps and Argo CD operators.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-7608
Fixes #?
https://issues.redhat.com/browse/GITOPS-7608
**How to test changes / Special notes to the reviewer**:

- deploy openshift gitops operator on oc cluster with multi node
- edit the default instance of argocd from spec.ha.enabled: false to spec.ha.enabled: true
- verify the time taking for redis related ha proxy pod and ha-server pods 
