### PR TITLE
fix: redis ha proxy rolling update pod in pending state

### DIFF
--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -664,7 +664,12 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS b
 // reconcileRedisHAProxyDeployment will ensure the Deployment resource is present for the Redis HA Proxy component.
 func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) error {
 	deploy := newDeploymentWithSuffix("redis-ha-haproxy", "redis", cr)
-
+	deploy.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxSurge: &intstr.IntOrString{IntVal: 0},
+		},
+	}
 	var redisEnv = append(proxyEnvVars(), corev1.EnvVar{
 		Name: "AUTH",
 		ValueFrom: &corev1.EnvVarSource{
@@ -951,6 +956,14 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) e
 				explanation += ", "
 			}
 			explanation += "pod security context"
+			changed = true
+		}
+		if !reflect.DeepEqual(deploy.Spec.Strategy, existing.Spec.Strategy) {
+			existing.Spec.Strategy = deploy.Spec.Strategy
+			if changed {
+				explanation += ", "
+			}
+			explanation += "deployment strategy"
 			changed = true
 		}
 		if changed {

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -874,7 +874,7 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy_with_resources(t *testing
 	}
 	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Resources, testResources)
 	assert.Equal(t, deployment.Spec.Template.Spec.InitContainers[0].Resources, testResources)
-
+	assert.Equal(t, deployment.Spec.Strategy.RollingUpdate.MaxSurge, &intstr.IntOrString{IntVal: 0})
 	// test resource is Updated on reconciliation
 	newResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -899,6 +899,7 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy_with_resources(t *testing
 
 	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Resources, newResources)
 	assert.Equal(t, deployment.Spec.Template.Spec.InitContainers[0].Resources, newResources)
+	assert.Equal(t, deployment.Spec.Strategy.RollingUpdate.MaxSurge, &intstr.IntOrString{IntVal: 0})
 }
 func TestReconcileArgoCD_reconcileRedisHAProxyDeployment_ModifyContainerSpec(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.6
 require (
 	github.com/argoproj/argo-cd/v3 v3.1.5
 	github.com/cert-manager/cert-manager v1.14.4
+	github.com/distribution/reference v0.6.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo v1.16.5
@@ -110,7 +111,6 @@ require (
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
We now explicitly set the maxSurge value to 0 during deployment creation. By default, Kubernetes uses a 25% surge, which causes one HA pod to remain in a pending state during rolling updates on clusters with only three worker nodes due to the combination of rolling update strategy constraints and pod affinity rules.
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-8033
Fixes #?
https://issues.redhat.com/browse/GITOPS-8033
**How to test changes / Special notes to the reviewer**:
Here’s a cleaner and more structured version:
Testing Steps:

Create a 3-worker-node cluster.
Install the GitOps Operator.
Edit the default ArgoCD instance and set spec.ha.enabled from false to true.
Wait for the Redis HA proxy and server pods to become running and stable.
Trigger a rolling update by modifying a configuration value (e.g., change imagePullPolicy from IfNotPresent to Always).
Verify that all 3 redis-ha-haproxy replicas roll out successfully without any pods remaining in a Pending state.