### PR TITLE
chore: reduce Node resource pressure of E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ e2e-tests-sequential-ginkgo: ginkgo
 .PHONY: e2e-tests-parallel-ginkgo
 e2e-tests-parallel-ginkgo: ginkgo
 	@echo "Running operator parallel Ginkgo E2E tests..."
-	$(GINKGO_CLI) -p -v -procs=5 --trace --timeout 90m -r ./tests/ginkgo/parallel
+	$(GINKGO_CLI) -p -v -procs=4 --trace --timeout 90m -r ./tests/ginkgo/parallel
 
 
 GINKGO_CLI = $(shell pwd)/bin/ginkgo

--- a/tests/ginkgo/sequential/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
+++ b/tests/ginkgo/sequential/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package parallel
+package sequential
 
 import (
 	"context"
@@ -39,7 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 	Context("1-067_validate_redis_secure_comm_no_autotls_ha", func() {
 
@@ -51,7 +51,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		)
 
 		BeforeEach(func() {
-			fixture.EnsureParallelCleanSlate()
+			fixture.EnsureSequentialCleanSlate()
+			// - Was previously in parallel, moved to sequential due to it requiring a large resource (memory/cpu) commitment for pods
 
 			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
 			ctx = context.Background()


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
- In a few of the other E2E tests, I was seeing failures, and it appeared to be due to evicted pods. This implies that Argo CD resources on the cluster are overwhelming individually nodes (cpu/memory) while the tests are running.
- This PR moves HA test to sequential (since HA test requires a lot of cpu/memory), and slightly reduces how many tests are run in parallel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized E2E test execution by reducing parallel test concurrency to improve resource efficiency.
  * Migrated a resource-intensive test to sequential execution to accommodate higher memory and CPU requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->