### PR TITLE
chore: add E2E test check for available GH runner storage

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -2,24 +2,22 @@ name: Build and test the operator
 on:
   push:
     branches:
-      - 'master'
-      - 'release-*'
-      - 'rhos-*'
+      - "master"
+      - "release-*"
+      - "rhos-*"
   pull_request:
     paths-ignore:
       - "docs/**"
     branches:
-      - 'master'
-      - 'release-*'
-      - 'rhos-*'
+      - "master"
+      - "release-*"
+      - "rhos-*"
 
 jobs:
-
   build-operator:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Create checkout directory
         run: mkdir -p ~/go/src/github.com/argoproj-labs
 
@@ -32,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Restore go build cache
         uses: actions/cache@v4
@@ -48,14 +46,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k3s-version: [ v1.27.1 ]
+        k3s-version: [v1.27.1]
         # k3s-version: [v1.20.2, v1.19.2, v1.18.9, v1.17.11, v1.16.15]
     steps:
       - name: Download kuttl plugin
         env:
-          KUTTL_VERSION: '0.10.0'
-          KUTTL_PLUGIN_SUM: 'ad21c0d2be495a8f6cfc0821e592ae61afd191ebd453156d9b204e2524fceaf2'
-          KUTTL_PLUGIN_FILENAME: 'kubectl-kuttl_0.10.0_linux_x86_64'
+          KUTTL_VERSION: "0.10.0"
+          KUTTL_PLUGIN_SUM: "ad21c0d2be495a8f6cfc0821e592ae61afd191ebd453156d9b204e2524fceaf2"
+          KUTTL_PLUGIN_FILENAME: "kubectl-kuttl_0.10.0_linux_x86_64"
         run: |
           set -x
           echo ${KUTTL_PLUGIN_FILENAME}
@@ -69,6 +67,13 @@ jobs:
           set -x
           curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
           sudo mkdir -p $HOME/.kube && sudo chown -R runner $HOME/.kube
+
+          # preserved for future use:
+          # - limit logs to 4Mi, to avoid overwhelming GitHub's small runner storage (14Gi)
+          # - k3d cluster create --servers 3 --image rancher/k3s:${{ matrix.k3s-version }}-k3s1 --k3s-arg '--kubelet-arg=container-log-max-files=2@server:*' --k3s-arg '--kubelet-arg=container-log-max-size=2Mi@server:*'
+          # - I tried this, to reduce the the amount of GitHub Runner disk space used by k3d. These params did not appear to affect disk space usage.
+
+          # create k3d cluster
           k3d cluster create --servers 3 --image rancher/k3s:${{ matrix.k3s-version }}-k3s1
           kubectl version
           k3d version
@@ -77,7 +82,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
       - name: GH actions workaround - Kill XSP4 process
         run: |
           sudo pkill mono || true

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	## Use release-0.22 as the last version that supports Go 1.24 - https://github.com/kubernetes-sigs/controller-runtime/issues/3358
 	## Feel free to update this when we move to Go 1.25+
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22) 
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22)
 	$(ENVTEST) use 1.26
 
 
@@ -339,7 +339,7 @@ e2e-tests-sequential-ginkgo: ginkgo
 .PHONY: e2e-tests-parallel-ginkgo
 e2e-tests-parallel-ginkgo: ginkgo
 	@echo "Running operator parallel Ginkgo E2E tests..."
-	$(GINKGO_CLI) -p -v -procs=4 --trace --timeout 90m -r ./tests/ginkgo/parallel
+	$(GINKGO_CLI) -p -v -procs=3 --trace --timeout 90m -r ./tests/ginkgo/parallel
 
 
 GINKGO_CLI = $(shell pwd)/bin/ginkgo


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
- When running via GitHub (GH) action, the E2E test environment has only ~14GiB of disk space available.
- As the E2E tests run, and as the K8s cluster persists data, that available storage drops over time.
    - The E2E tests do a good job of cleaning up namespaces, but there appears to be a delay between when the namespace is deleted, and when the disk space becomes available.
- This drop is especially significant during parallel test execution, as multiple Argo CD instances are running/logging at the same time (across 3 k8s nodes)
- When the available disk space drops to 4GiB, the K8s instance will start to arbitrarily evict pods, which causes tests to intermittently fail.
- As a workaround (since we can't increase disk space on the public GH runner env), each parallel test will wait for a minimum of disk space before starting.
 - Before each parallel test, we thus run `df` command and wait for it to tell use that >= 7GB of disk space is available.
     - As above, below 4GB is 'the danger zone', so this provides a decent buffer before we hit that point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a pre-test disk-space validation to ensure sufficient capacity before E2E runs.
  * Reduced parallel E2E test concurrency to lower resource contention.

* **Chores**
  * Standardized CI workflow formatting and environment string quoting.
  * Minor CI workflow spacing/inline comment cleanups and small build config formatting tweaks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->