### PR TITLE
chore: add e2e tests for agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ e2e: ## Run operator e2e tests
 
 
 start-e2e:
-	ARGOCD_CLUSTER_CONFIG_NAMESPACES="argocd-e2e-cluster-config, argocd-test-impersonation-1-046, argocd-agent-principal-1-051, argocd-agent-agent-1-052, appset-argocd, appset-old-ns, appset-new-ns" make run
+	ARGOCD_CLUSTER_CONFIG_NAMESPACES="argocd-e2e-cluster-config, argocd-test-impersonation-1-046, argocd-agent-principal-1-051, argocd-agent-agent-1-052, appset-argocd, appset-old-ns, appset-new-ns, ns-hosting-principal, ns-hosting-managed-agent, ns-hosting-autonomous-agent" make run
 
 all: test install run e2e ## UnitTest, Run the operator locally and execute e2e tests.
 

--- a/api/v1alpha1/argocd_conversion_test.go
+++ b/api/v1alpha1/argocd_conversion_test.go
@@ -689,7 +689,7 @@ func TestAlphaToBetaConversion(t *testing.T) {
 						Client: &AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
-							Mode:                   "managed",
+							Mode:                   string(v1beta1.AgentModeManaged),
 						},
 					},
 				}
@@ -703,7 +703,7 @@ func TestAlphaToBetaConversion(t *testing.T) {
 						Client: &v1beta1.AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
-							Mode:                   "managed",
+							Mode:                   string(v1beta1.AgentModeManaged),
 						},
 					},
 				}
@@ -726,7 +726,7 @@ func TestAlphaToBetaConversion(t *testing.T) {
 						Client: &AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
-							Mode:                   "managed",
+							Mode:                   string(v1beta1.AgentModeManaged),
 							EnableWebSocket:        &enableWebSocket,
 							EnableCompression:      &enableCompression,
 							KeepAliveInterval:      "30s",
@@ -757,7 +757,7 @@ func TestAlphaToBetaConversion(t *testing.T) {
 						Client: &v1beta1.AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
-							Mode:                   "managed",
+							Mode:                   string(v1beta1.AgentModeManaged),
 							EnableWebSocket:        &enableWebSocket,
 							EnableCompression:      &enableCompression,
 							KeepAliveInterval:      "30s",
@@ -1065,7 +1065,7 @@ func TestBetaToAlphaConversion(t *testing.T) {
 						Client: &v1beta1.AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
-							Mode:                   "managed",
+							Mode:                   string(v1beta1.AgentModeManaged),
 						},
 					},
 				}
@@ -1079,7 +1079,7 @@ func TestBetaToAlphaConversion(t *testing.T) {
 						Client: &AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
-							Mode:                   "managed",
+							Mode:                   string(v1beta1.AgentModeManaged),
 						},
 					},
 				}
@@ -1105,7 +1105,7 @@ func TestBetaToAlphaConversion(t *testing.T) {
 						Client: &v1beta1.AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
-							Mode:                   "managed",
+							Mode:                   string(v1beta1.AgentModeManaged),
 							EnableWebSocket:        &enableWebSocket,
 							EnableCompression:      &enableCompression,
 							KeepAliveInterval:      "30s",
@@ -1139,7 +1139,7 @@ func TestBetaToAlphaConversion(t *testing.T) {
 						Client: &AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
-							Mode:                   "managed",
+							Mode:                   string(v1beta1.AgentModeManaged),
 							EnableWebSocket:        &enableWebSocket,
 							EnableCompression:      &enableCompression,
 							KeepAliveInterval:      "30s",

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -1019,6 +1019,28 @@ type WebhookServerSpec struct {
 	Route ArgoCDRouteSpec `json:"route,omitempty"`
 }
 
+// AgentMode is a type which represents possible agent modes
+type AgentMode string
+
+// Possible agent modes
+const (
+	// AgentModeManaged indicates that the agent is in managed mode
+	AgentModeManaged AgentMode = "managed"
+	// AgentModeAutonomous indicates that the agent is in autonomous mode
+	AgentModeAutonomous AgentMode = "autonomous"
+)
+
+// AgentComponentType is a type which represents possible agent component types
+type AgentComponentType string
+
+// Possible agent component types
+const (
+	// AgentComponentTypePrincipal indicates the component type is principal
+	AgentComponentTypePrincipal AgentComponentType = "principal"
+	// AgentComponentTypeAgent indicates the component type is agent
+	AgentComponentTypeAgent AgentComponentType = "agent"
+)
+
 type ArgoCDAgentSpec struct {
 
 	// Principal defines configurations for the Principal component of Argo CD Agent.

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -1177,6 +1177,28 @@ type WebhookServerSpec struct {
 	Route ArgoCDRouteSpec `json:"route,omitempty"`
 }
 
+// AgentMode is a type which represents possible agent modes
+type AgentMode string
+
+// Possible agent modes
+const (
+	// AgentModeManaged indicates that the agent is in managed mode
+	AgentModeManaged AgentMode = "managed"
+	// AgentModeAutonomous indicates that the agent is in autonomous mode
+	AgentModeAutonomous AgentMode = "autonomous"
+)
+
+// AgentComponentType is a type which represents possible agent component types
+type AgentComponentType string
+
+// Possible agent component types
+const (
+	// AgentComponentTypePrincipal indicates the component type is principal
+	AgentComponentTypePrincipal AgentComponentType = "principal"
+	// AgentComponentTypeAgent indicates the component type is agent
+	AgentComponentTypeAgent AgentComponentType = "agent"
+)
+
 type ArgoCDAgentSpec struct {
 
 	// Principal defines configurations for the Principal component of Argo CD Agent.

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -288,10 +288,10 @@ vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOf
 	ArgoCDCmdParamsConfigMapName = "argocd-cmd-params-cm"
 
 	// ArgoCDAgentPrincipalDefaultImageName is the default image name for the ArgoCD agent's principal component.
-	ArgoCDAgentPrincipalDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.3.2"
+	ArgoCDAgentPrincipalDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.5.2"
 
 	// ArgoCDAgentAgentDefaultImageName is the default image name for the ArgoCD agent's agent component.
-	ArgoCDAgentAgentDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.3.2"
+	ArgoCDAgentAgentDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.5.2"
 
 	// ArgoCDImageUpdaterControllerComponent is the name of the Image Updater controller control plane component
 	ArgoCDImageUpdaterControllerComponent = "argocd-image-updater-controller"

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1846,7 +1846,7 @@ func (r *ReconcileArgoCD) reconcileArgoCDAgent(cr *argoproj.ArgoCD) error {
 	}
 
 	log.Info("reconciling ArgoCD Agent's Principal resources")
-	compName := "principal"
+	compName := string(argoproj.AgentComponentTypePrincipal)
 	var sa *corev1.ServiceAccount
 	var err error
 
@@ -1911,7 +1911,7 @@ func (r *ReconcileArgoCD) reconcileArgoCDAgent(cr *argoproj.ArgoCD) error {
 	}
 
 	log.Info("reconciling ArgoCD Agent's Agent resources")
-	agentCompName := "agent"
+	agentCompName := string(argoproj.AgentComponentTypeAgent)
 
 	log.Info("reconciling ArgoCD Agent's Agent service account")
 	var agentSa *corev1.ServiceAccount

--- a/controllers/argocdagent/agent/deployment.go
+++ b/controllers/argocdagent/agent/deployment.go
@@ -429,7 +429,7 @@ func getAgentMode(cr *argoproj.ArgoCD) string {
 	if hasClient(cr) && cr.Spec.ArgoCDAgent.Agent.Client.Mode != "" {
 		return cr.Spec.ArgoCDAgent.Agent.Client.Mode
 	}
-	return "managed"
+	return string(argoproj.AgentModeManaged)
 }
 
 func getAgentCreds(cr *argoproj.ArgoCD) string {

--- a/tests/ginkgo/fixture/agent/fixture.go
+++ b/tests/ginkgo/fixture/agent/fixture.go
@@ -1,0 +1,565 @@
+package argocdagentprincipal
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	osFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/os"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+type PrincipalResources struct {
+	PrincipalNamespaceName   string
+	ArgoCDAgentPrincipalName string
+	ArgoCDName               string
+	ServiceAccount           *corev1.ServiceAccount
+	Role                     *rbacv1.Role
+	RoleBinding              *rbacv1.RoleBinding
+	ClusterRole              *rbacv1.ClusterRole
+	ClusterRoleBinding       *rbacv1.ClusterRoleBinding
+	PrincipalDeployment      *appsv1.Deployment
+	PrincipalRoute           *routev1.Route
+	ServicesToDelete         []string
+}
+
+type PrincipalSecretsConfig struct {
+	PrincipalNamespaceName      string
+	PrincipalServiceName        string
+	ResourceProxyServiceName    string
+	JWTSecretName               string
+	PrincipalTLSSecretName      string
+	RootCASecretName            string
+	ResourceProxyTLSSecretName  string
+	AdditionalPrincipalSANs     []string
+	AdditionalResourceProxySANs []string
+}
+
+type AgentSecretsConfig struct {
+	AgentNamespace            *corev1.Namespace
+	PrincipalNamespaceName    string
+	PrincipalRootCASecretName string
+	AgentRootCASecretName     string
+	ClientTLSSecretName       string
+	ClientCommonName          string
+	ClientDNSNames            []string
+}
+
+type ClusterRegistrationSecretConfig struct {
+	PrincipalNamespaceName    string
+	AgentNamespaceName        string
+	AgentName                 string
+	ResourceProxyServiceName  string
+	ResourceProxyPort         int32
+	PrincipalRootCASecretName string
+	AgentTLSSecretName        string
+	Server                    string
+}
+
+type AgentSecretNames struct {
+	JWTSecretName                  string
+	PrincipalTLSSecretName         string
+	RootCASecretName               string
+	ResourceProxyTLSSecretName     string
+	RedisInitialPasswordSecretName string
+}
+
+type VerifyExpectedResourcesExistParams struct {
+	Namespace                *corev1.Namespace
+	ArgoCDAgentPrincipalName string
+	ArgoCDName               string
+	ServiceAccount           *corev1.ServiceAccount
+	Role                     *rbacv1.Role
+	RoleBinding              *rbacv1.RoleBinding
+	ClusterRole              *rbacv1.ClusterRole
+	ClusterRoleBinding       *rbacv1.ClusterRoleBinding
+	PrincipalDeployment      *appsv1.Deployment
+	PrincipalRoute           *routev1.Route
+	SecretNames              AgentSecretNames
+	ServiceNames             []string
+	DeploymentNames          []string
+	ExpectRoute              *bool
+}
+
+func VerifyResourcesDeleted(resources PrincipalResources) {
+
+	By("verifying resources are deleted for principal pod")
+
+	Eventually(resources.ServiceAccount).Should(k8sFixture.NotExistByName())
+	Eventually(resources.Role).Should(k8sFixture.NotExistByName())
+	Eventually(resources.RoleBinding).Should(k8sFixture.NotExistByName())
+	Eventually(resources.ClusterRole).Should(k8sFixture.NotExistByName())
+	Eventually(resources.ClusterRoleBinding).Should(k8sFixture.NotExistByName())
+	Eventually(resources.PrincipalDeployment).Should(k8sFixture.NotExistByName())
+
+	for _, serviceName := range resources.ServicesToDelete {
+		if serviceName == "" {
+			continue
+		}
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: resources.PrincipalNamespaceName,
+			},
+		}
+		Eventually(service).Should(k8sFixture.NotExistByName())
+	}
+
+	if fixture.RunningOnOpenShift() {
+		Eventually(resources.PrincipalRoute).Should(k8sFixture.NotExistByName())
+	}
+}
+
+func CreateRequiredSecrets(cfg PrincipalSecretsConfig) {
+	k8sClient, _ := utils.GetE2ETestKubeClient()
+	ctx := context.Background()
+
+	By("creating required secrets for principal pod")
+
+	jwtKey := generateJWTSigningKey()
+	jwtSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.JWTSecretName,
+			Namespace: cfg.PrincipalNamespaceName,
+		},
+		Data: map[string][]byte{
+			"jwt.key": jwtKey,
+		},
+	}
+	Expect(k8sClient.Create(ctx, jwtSecret)).To(Succeed())
+
+	caKey, caCert, caCertPEM := generateCertificateAuthority()
+	caKeyPEM := encodePrivateKeyToPEM(caKey)
+
+	caSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.RootCASecretName,
+			Namespace: cfg.PrincipalNamespaceName,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": caCertPEM,
+			"tls.key": caKeyPEM,
+			"ca.crt":  caCertPEM,
+		},
+	}
+	Expect(k8sClient.Create(ctx, caSecret)).To(Succeed())
+
+	principalDNS, principalIPs := aggregateSANs(cfg.PrincipalNamespaceName, cfg.PrincipalServiceName, cfg.AdditionalPrincipalSANs)
+	principalCertPEM, principalKeyPEM := issueCertificate(caCert, caKey, certificateRequest{
+		CommonName:  cfg.PrincipalServiceName,
+		DNSNames:    principalDNS,
+		IPAddresses: principalIPs,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	createTLSSecret(ctx, k8sClient, cfg.PrincipalNamespaceName, cfg.PrincipalTLSSecretName, principalCertPEM, principalKeyPEM, caCertPEM)
+
+	resourceProxyDNS, resourceProxyIPs := aggregateSANs(cfg.PrincipalNamespaceName, cfg.ResourceProxyServiceName, cfg.AdditionalResourceProxySANs)
+	resourceProxyCertPEM, resourceProxyKeyPEM := issueCertificate(caCert, caKey, certificateRequest{
+		CommonName:  cfg.ResourceProxyServiceName,
+		DNSNames:    resourceProxyDNS,
+		IPAddresses: resourceProxyIPs,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	createTLSSecret(ctx, k8sClient, cfg.PrincipalNamespaceName, cfg.ResourceProxyTLSSecretName, resourceProxyCertPEM, resourceProxyKeyPEM, caCertPEM)
+}
+
+func CreateRequiredAgentSecrets(cfg AgentSecretsConfig) {
+	k8sClient, _ := utils.GetE2ETestKubeClient()
+	ctx := context.Background()
+
+	agentRootCASecretName := cfg.AgentRootCASecretName
+	if agentRootCASecretName == "" {
+		agentRootCASecretName = cfg.PrincipalRootCASecretName
+	}
+
+	var principalCASecret corev1.Secret
+	Expect(k8sClient.Get(ctx, types.NamespacedName{
+		Name:      cfg.PrincipalRootCASecretName,
+		Namespace: cfg.PrincipalNamespaceName,
+	}, &principalCASecret)).To(Succeed())
+
+	caCertPEM := principalCASecret.Data["tls.crt"]
+	Expect(caCertPEM).ToNot(BeEmpty(), "CA certificate must be present in principal namespace secret")
+	caKeyPEM := principalCASecret.Data["tls.key"]
+	Expect(caKeyPEM).ToNot(BeEmpty(), "CA private key must be present in principal namespace secret")
+
+	caCert := parseCertificate(caCertPEM)
+	caKey := parsePrivateKey(caKeyPEM)
+
+	clientDNS, clientIPs := aggregateClientSANs(cfg.ClientDNSNames)
+	clientCertPEM, clientKeyPEM := issueCertificate(caCert, caKey, certificateRequest{
+		CommonName:  cfg.ClientCommonName,
+		DNSNames:    clientDNS,
+		IPAddresses: clientIPs,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+
+	createTLSSecret(ctx, k8sClient, cfg.AgentNamespace.Name, cfg.ClientTLSSecretName, clientCertPEM, clientKeyPEM, caCertPEM)
+
+	// Propagate CA certificate without private key to the agent namespace
+	propagatedCASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentRootCASecretName,
+			Namespace: cfg.AgentNamespace.Name,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"tls.crt": caCertPEM,
+			"ca.crt":  caCertPEM,
+		},
+	}
+	Expect(k8sClient.Create(ctx, propagatedCASecret)).To(Succeed())
+}
+
+func CreateClusterRegistrationSecret(cfg ClusterRegistrationSecretConfig) {
+	k8sClient, _ := utils.GetE2ETestKubeClient()
+	ctx := context.Background()
+
+	server := cfg.Server
+	if server == "" {
+		port := cfg.ResourceProxyPort
+		if port == 0 {
+			port = 9090
+		}
+		host := fmt.Sprintf("%s.%s.svc", cfg.ResourceProxyServiceName, cfg.PrincipalNamespaceName)
+		server = fmt.Sprintf("https://%s:%d?agentName=%s", host, port, cfg.AgentName)
+	}
+
+	var caSecret corev1.Secret
+	Expect(k8sClient.Get(ctx, types.NamespacedName{
+		Name:      cfg.PrincipalRootCASecretName,
+		Namespace: cfg.PrincipalNamespaceName,
+	}, &caSecret)).To(Succeed())
+
+	caData := caSecret.Data["ca.crt"]
+	if len(caData) == 0 {
+		caData = caSecret.Data["tls.crt"]
+	}
+	Expect(caData).ToNot(BeEmpty(), "CA certificate missing from principal root secret")
+
+	var agentTLSSecret corev1.Secret
+	Expect(k8sClient.Get(ctx, types.NamespacedName{
+		Name:      cfg.AgentTLSSecretName,
+		Namespace: cfg.AgentNamespaceName,
+	}, &agentTLSSecret)).To(Succeed())
+
+	clientCert := agentTLSSecret.Data["tls.crt"]
+	Expect(clientCert).ToNot(BeEmpty(), "agent TLS certificate missing")
+	clientKey := agentTLSSecret.Data["tls.key"]
+	Expect(clientKey).ToNot(BeEmpty(), "agent TLS private key missing")
+
+	configPayload, err := json.Marshal(map[string]any{
+		"tlsClientConfig": map[string]any{
+			"insecure": false,
+			"certData": base64.StdEncoding.EncodeToString(clientCert),
+			"keyData":  base64.StdEncoding.EncodeToString(clientKey),
+			"caData":   base64.StdEncoding.EncodeToString(caData),
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("cluster-%s", cfg.AgentName),
+			Namespace: cfg.PrincipalNamespaceName,
+			Labels: map[string]string{
+				common.ArgoCDSecretTypeLabel:               "cluster",
+				"argocd-agent.argoproj-labs.io/agent-name": cfg.AgentName,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"name":   []byte(cfg.AgentName),
+			"server": []byte(server),
+			"config": configPayload,
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+}
+
+func VerifyExpectedResourcesExist(params VerifyExpectedResourcesExistParams) {
+	shouldExpectRoute := true
+	if params.ExpectRoute != nil {
+		shouldExpectRoute = *params.ExpectRoute
+	}
+
+	By("verifying expected resources exist")
+
+	if params.SecretNames.RedisInitialPasswordSecretName != "" {
+		Eventually(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      params.SecretNames.RedisInitialPasswordSecretName,
+				Namespace: params.Namespace.Name,
+			},
+		}, "30s", "2s").Should(k8sFixture.ExistByName())
+	}
+
+	Eventually(params.ServiceAccount).Should(k8sFixture.ExistByName())
+	Eventually(params.Role).Should(k8sFixture.ExistByName())
+	Eventually(params.RoleBinding).Should(k8sFixture.ExistByName())
+	Eventually(params.ClusterRole).Should(k8sFixture.ExistByName())
+	Eventually(params.ClusterRoleBinding).Should(k8sFixture.ExistByName())
+
+	for _, serviceName := range params.ServiceNames {
+		if serviceName == "" {
+			continue
+		}
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: params.Namespace.Name,
+			},
+		}
+		Eventually(service).Should(k8sFixture.ExistByName(), "Service '%s' should exist in namespace '%s'", serviceName, params.Namespace.Name)
+
+		if serviceName != params.ArgoCDAgentPrincipalName {
+			Expect(string(service.Spec.Type)).To(Equal("ClusterIP"), "Service '%s' should have ClusterIP type", serviceName)
+		}
+	}
+
+	if shouldExpectRoute && fixture.RunningOnOpenShift() {
+		Eventually(params.PrincipalRoute).Should(k8sFixture.ExistByName())
+	}
+
+	for _, deploymentName := range params.DeploymentNames {
+		if deploymentName == "" {
+			continue
+		}
+		depl := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentName,
+				Namespace: params.Namespace.Name,
+			},
+		}
+		Eventually(depl).Should(k8sFixture.ExistByName(), "Deployment '%s' should exist in namespace '%s'", deploymentName, params.Namespace.Name)
+	}
+
+	Eventually(params.PrincipalDeployment).Should(k8sFixture.ExistByName())
+	Eventually(params.PrincipalDeployment).Should(k8sFixture.HaveLabelWithValue("app.kubernetes.io/component", string(argov1beta1api.AgentComponentTypePrincipal)))
+	Eventually(params.PrincipalDeployment).Should(k8sFixture.HaveLabelWithValue("app.kubernetes.io/managed-by", params.ArgoCDName))
+	Eventually(params.PrincipalDeployment).Should(k8sFixture.HaveLabelWithValue("app.kubernetes.io/name", params.ArgoCDAgentPrincipalName))
+	Eventually(params.PrincipalDeployment).Should(k8sFixture.HaveLabelWithValue("app.kubernetes.io/part-of", "argocd-agent"))
+}
+
+func VerifyLogs(deploymentName, namespace string, requiredMessages []string) {
+	Eventually(func() bool {
+		logOutput, err := osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "logs",
+			"deployment/"+deploymentName, "-n", namespace, "--tail=200")
+		if err != nil {
+			GinkgoWriter.Println("Error getting agent logs: ", err)
+			return false
+		}
+
+		for _, msg := range requiredMessages {
+			if !strings.Contains(logOutput, msg) {
+				GinkgoWriter.Println("Expected agent log not found:", msg)
+				return false
+			}
+		}
+		return true
+	}, "120s", "5s").Should(BeTrue(), "Agent should process cluster cache updates")
+}
+
+type certificateRequest struct {
+	CommonName  string
+	DNSNames    []string
+	IPAddresses []net.IP
+	ExtKeyUsage []x509.ExtKeyUsage
+}
+
+func generateCertificateAuthority() (*rsa.PrivateKey, *x509.Certificate, []byte) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).ToNot(HaveOccurred())
+
+	template := x509.Certificate{
+		SerialNumber:          randomSerialNumber(),
+		Subject:               pkix.Name{CommonName: "argocd-agent-ca"},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	Expect(err).ToNot(HaveOccurred())
+
+	cert, err := x509.ParseCertificate(certDER)
+	Expect(err).ToNot(HaveOccurred())
+
+	return privateKey, cert, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+}
+
+func issueCertificate(caCert *x509.Certificate, caKey *rsa.PrivateKey, req certificateRequest) ([]byte, []byte) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).ToNot(HaveOccurred())
+
+	template := x509.Certificate{
+		SerialNumber: randomSerialNumber(),
+		Subject: pkix.Name{
+			CommonName: req.CommonName,
+		},
+		NotBefore:   time.Now().Add(-1 * time.Hour),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: req.ExtKeyUsage,
+		DNSNames:    req.DNSNames,
+		IPAddresses: req.IPAddresses,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, caCert, &key.PublicKey, caKey)
+	Expect(err).ToNot(HaveOccurred())
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := encodePrivateKeyToPEM(key)
+
+	return certPEM, keyPEM
+}
+
+func createTLSSecret(ctx context.Context, k8sClient client.Client, namespace, secretName string, certPEM, keyPEM, caCertPEM []byte) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": certPEM,
+			"tls.key": keyPEM,
+			"ca.crt":  caCertPEM,
+		},
+	}
+	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+}
+
+func generateJWTSigningKey() []byte {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	Expect(err).ToNot(HaveOccurred())
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	Expect(err).ToNot(HaveOccurred())
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+}
+
+func encodePrivateKeyToPEM(key *rsa.PrivateKey) []byte {
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	Expect(err).ToNot(HaveOccurred())
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+}
+
+func parseCertificate(certPEM []byte) *x509.Certificate {
+	block, _ := pem.Decode(certPEM)
+	Expect(block).ToNot(BeNil(), "invalid certificate data")
+	cert, err := x509.ParseCertificate(block.Bytes)
+	Expect(err).ToNot(HaveOccurred())
+	return cert
+}
+
+func parsePrivateKey(keyPEM []byte) *rsa.PrivateKey {
+	block, _ := pem.Decode(keyPEM)
+	Expect(block).ToNot(BeNil(), "invalid private key data")
+	parsedKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	Expect(err).ToNot(HaveOccurred())
+
+	privateKey, ok := parsedKey.(*rsa.PrivateKey)
+	Expect(ok).To(BeTrue(), "private key is not RSA")
+	return privateKey
+}
+
+func randomSerialNumber() *big.Int {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	Expect(err).ToNot(HaveOccurred())
+	return serialNumber
+}
+
+func aggregateSANs(namespace, serviceName string, additional []string) ([]string, []net.IP) {
+	defaults := buildDefaultSANs(serviceName, namespace)
+	return aggregateSANLists(defaults, additional)
+}
+
+func aggregateClientSANs(additional []string) ([]string, []net.IP) {
+	return aggregateSANLists(nil, additional)
+}
+
+func aggregateSANLists(defaults, additional []string) ([]string, []net.IP) {
+	dnsSet := map[string]struct{}{}
+	ipSet := map[string]struct{}{}
+	var dnsNames []string
+	var ipAddresses []net.IP
+
+	addEntry := func(entry string) {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			return
+		}
+		if ip := net.ParseIP(entry); ip != nil {
+			key := ip.String()
+			if _, found := ipSet[key]; !found {
+				ipSet[key] = struct{}{}
+				ipAddresses = append(ipAddresses, ip)
+			}
+			return
+		}
+		if _, found := dnsSet[entry]; !found {
+			dnsSet[entry] = struct{}{}
+			dnsNames = append(dnsNames, entry)
+		}
+	}
+
+	for _, entry := range defaults {
+		addEntry(entry)
+	}
+	for _, entry := range additional {
+		addEntry(entry)
+	}
+
+	sort.Strings(dnsNames)
+	sort.Slice(ipAddresses, func(i, j int) bool {
+		return bytes.Compare(ipAddresses[i], ipAddresses[j]) < 0
+	})
+
+	return dnsNames, ipAddresses
+}
+
+func buildDefaultSANs(serviceName, namespace string) []string {
+	if serviceName == "" || namespace == "" {
+		return nil
+	}
+	return []string{
+		serviceName,
+		fmt.Sprintf("%s.%s", serviceName, namespace),
+		fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace),
+	}
+}

--- a/tests/ginkgo/fixture/fixture.go
+++ b/tests/ginkgo/fixture/fixture.go
@@ -248,6 +248,37 @@ func CreateManagedNamespaceWithCleanupFunc(name string, managedByNamespace strin
 	return ns, nsDeletionFunc(ns)
 }
 
+// Create a namespace 'name' that is managed by a cluster-scoped ArgoCD instance, via managed-by-cluster-argocd label.
+func CreateClusterScopedManagedNamespace(name string, managedByArgoCDInstance string) *corev1.Namespace {
+	k8sClient, _ := utils.GetE2ETestKubeClient()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+
+	// If the Namespace already exists, delete it first
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(ns), ns); err == nil {
+		// Namespace exists, so delete it first
+		Expect(deleteNamespaceAndVerify(context.Background(), ns.Name, k8sClient)).To(Succeed())
+	}
+
+	ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: name,
+		Labels: map[string]string{
+			E2ETestLabelsKey: E2ETestLabelsValue,
+			"argocd.argoproj.io/managed-by-cluster-argocd": managedByArgoCDInstance,
+		},
+	}}
+
+	Expect(k8sClient.Create(context.Background(), ns)).To(Succeed())
+
+	return ns
+
+}
+
+func CreateClusterScopedManagedNamespaceWithCleanupFunc(name string, managedByArgoCDInstance string) (*corev1.Namespace, func()) {
+	ns := CreateClusterScopedManagedNamespace(name, managedByArgoCDInstance)
+	return ns, nsDeletionFunc(ns)
+}
+
 // nsDeletionFunc is a convenience function that returns a function that deletes a namespace. This is used for Namespace cleanup by other functions.
 func nsDeletionFunc(ns *corev1.Namespace) func() {
 

--- a/tests/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
+++ b/tests/ginkgo/sequential/1-053_validate_argocd_agent_principal_connected_test.go
@@ -1,0 +1,612 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sequential
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argocdv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/health"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	agentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/agent"
+	appFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/application"
+	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+/*
+### Namespace Hierarchy for this test:
+
+Test Cluster (Has a Hub and two Spokes (Managed and Autonomous) simulated)
+│
+├─ 🏛️ Hub Cluster
+│   ├─ Namespace: ns-hosting-principal
+│   │   ├─ ArgoCD: argocd-hub (Principal enabled)
+│   │   ├─ Deployment: argocd-hub-agent-principal
+│   │   ├─ Service: argocd-hub-agent-principal (Type LoadBalancer)
+│   │   ├─ Secrets: TLS, JWT, CA, Cluster registration secrets
+│   │   └─ AppProject: agent-app-project ("Source of truth" for managed agent, delivered to agent by principal)
+│   │
+│   ├─ Namespace: managed-cluster-in-hub (Logical representation of managed cluster in hub)
+│   │   └─ Application: app-managed ("Source of truth" for managed agent, delivered to agent by principal)
+│   │
+│   │
+│   └─ Namespace: autonomous-cluster-in-hub (Logical representation of autonomous cluster in hub)
+|       └─ Application: app-autonomous ("Source of truth" is autonomous agent, delivered to principal by agent)
+│
+├─ 🔵 Managed Spoke Cluster
+│   ├─ Namespace: ns-hosting-managed-agent
+│   │   ├─ ArgoCD: argocd-spoke (Agent enabled, Managed mode)
+│   │   ├─ Deployment: argocd-spoke-agent-agent
+│   │   ├─ Secrets: Client TLS, CA
+|   |   └─ Application: app-managed ("Source of truth" is principal, but Reconciled and deployed in spoke by agent)
+│   │
+│   └─ Namespace: ns-hosting-app-in-managed-cluster
+│       └─ Pod/Service/Route: spring-petclinic (Application resources deployed by agent in spoke)
+│
+└─ 🔵 Autonomous Spoke Cluster
+    ├─ Namespace: ns-hosting-autonomous-agent
+    │   ├─ ArgoCD: argocd-spoke (Agent enabled, Autonomous mode)
+    │   ├─ Deployment: argocd-spoke-agent-agent
+    │   ├─ Secrets: Client TLS, CA
+    │   ├─ AppProject: agent-app-project ("Source of truth" is autonomous agent, delivered to principal by agent)
+    │   └─ Application: app-autonomous ("Source of truth" is autonomous agent, delivered to principal by agent, Reconciled and deployed in spoke by agent)
+    │
+    └─ Namespace: ns-hosting-app-in-autonomous-cluster
+        └─ Pod/Service/Route: spring-petclinic (Application resources deployed by agent in spoke)
+*/
+
+const (
+	// ArgoCD instance names
+	argoCDAgentInstanceNamePrincipal = "argocd-hub"
+	argoCDAgentInstanceNameAgent     = "argocd-spoke"
+
+	// Agent and Principal deployment names
+	deploymentNameAgentPrincipal = "argocd-hub-agent-principal"
+	deploymentNameAgent          = "argocd-spoke-agent-agent"
+
+	// Names given to clusters in hub
+	managedAgentClusterName    = "managed-cluster-in-hub"
+	autonomousAgentClusterName = "autonomous-cluster-in-hub"
+
+	// Application names
+	applicationNameManagedAgent    = "app-managed"
+	applicationNameAutonomousAgent = "app-autonomous"
+
+	// AppProject names
+	agentAppProjectName = "agent-app-project"
+
+	// Namespaces hosting the principal and agent deployments
+	namespaceAgentPrincipal  = "ns-hosting-principal"
+	namespaceManagedAgent    = "ns-hosting-managed-agent"
+	namespaceAutonomousAgent = "ns-hosting-autonomous-agent"
+
+	// Namespaces hosting application resources in managed and autonomous clusters
+	managedAgentApplicationNamespace    = "ns-hosting-app-in-managed-cluster"
+	autonomousAgentApplicationNamespace = "ns-hosting-app-in-autonomous-cluster"
+
+	// Secret names
+	agentJWTSecretName              = "argocd-agent-jwt"
+	agentPrincipalTLSSecretName     = "argocd-agent-principal-tls"
+	agentRootCASecretName           = "argocd-agent-ca"
+	agentClientTLSSecretName        = "argocd-agent-client-tls"
+	agentResourceProxyTLSSecretName = "argocd-agent-resource-proxy-tls"
+)
+
+var (
+	principalStartupLogs = []string{
+		"Starting metrics server",
+		"Redis proxy started",
+		"Application informer synced and ready",
+		"AppProject informer synced and ready",
+		"Resource proxy started",
+		"Namespace informer synced and ready",
+		"Starting healthz server",
+	}
+
+	agentStartupLogs = []string{
+		"Starting metrics server",
+		"Starting healthz server",
+		"Authentication successful",
+		"Connected to argocd-agent",
+		"Starting event writer",
+		"Starting to send events to event stream",
+		"Starting to receive events from event stream",
+	}
+)
+
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
+	Context("1-053_validate_argocd_agent_principal_connected_test", func() {
+		var (
+			k8sClient                         client.Client
+			ctx                               context.Context
+			cleanupFuncs                      []func()
+			registerCleanup                   func(func())
+			clusterRolePrincipal              *rbacv1.ClusterRole
+			clusterRoleBindingPrincipal       *rbacv1.ClusterRoleBinding
+			clusterRoleManagedAgent           *rbacv1.ClusterRole
+			clusterRoleBindingManagedAgent    *rbacv1.ClusterRoleBinding
+			clusterRoleAutonomousAgent        *rbacv1.ClusterRole
+			clusterRoleBindingAutonomousAgent *rbacv1.ClusterRoleBinding
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureSequentialCleanSlate()
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+			cleanupFuncs = nil
+			registerCleanup = func(fn func()) {
+				if fn != nil {
+					cleanupFuncs = append(cleanupFuncs, fn)
+				}
+			}
+
+			clusterRolePrincipal = &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s-agent-principal", argoCDAgentInstanceNamePrincipal, namespaceAgentPrincipal),
+				},
+			}
+			clusterRoleBindingPrincipal = &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s-agent-principal", argoCDAgentInstanceNamePrincipal, namespaceAgentPrincipal),
+				},
+			}
+
+			clusterRoleManagedAgent = &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s-agent-agent", argoCDAgentInstanceNameAgent, namespaceManagedAgent),
+				},
+			}
+			clusterRoleBindingManagedAgent = &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s-agent-agent", argoCDAgentInstanceNameAgent, namespaceManagedAgent),
+				},
+			}
+
+			clusterRoleAutonomousAgent = &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s-agent-agent", argoCDAgentInstanceNameAgent, namespaceAutonomousAgent),
+				},
+			}
+			clusterRoleBindingAutonomousAgent = &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s-agent-agent", argoCDAgentInstanceNameAgent, namespaceAutonomousAgent),
+				},
+			}
+
+			// Create required namespaces and cleanup functions
+			_, cleanupFuncClusterManaged := fixture.CreateNamespaceWithCleanupFunc(managedAgentClusterName)
+			registerCleanup(cleanupFuncClusterManaged)
+
+			_, cleanupFuncClusterAutonomous := fixture.CreateNamespaceWithCleanupFunc(autonomousAgentClusterName)
+			registerCleanup(cleanupFuncClusterAutonomous)
+
+			_, cleanupFuncManagedApplication := fixture.CreateClusterScopedManagedNamespaceWithCleanupFunc(managedAgentApplicationNamespace, argoCDAgentInstanceNameAgent)
+			registerCleanup(cleanupFuncManagedApplication)
+
+			_, cleanupFuncAutonomousApplication := fixture.CreateClusterScopedManagedNamespaceWithCleanupFunc(autonomousAgentApplicationNamespace, argoCDAgentInstanceNameAgent)
+			registerCleanup(cleanupFuncAutonomousApplication)
+		})
+
+		// This function checks principal logs to verify it has connected to both agents.
+		validatePrincipalAndAgentConnection := func() {
+			By("Verify principal is connected to the both agents")
+
+			agentFixture.VerifyLogs(deploymentNameAgentPrincipal, namespaceAgentPrincipal, []string{
+				fmt.Sprintf("Mapped cluster %s to agent %s", managedAgentClusterName, managedAgentClusterName),
+				fmt.Sprintf("Mapped cluster %s to agent %s", autonomousAgentClusterName, autonomousAgentClusterName),
+				fmt.Sprintf("Updated connection status to 'Successful' in Cluster: '%s' mapped with Agent: '%s'", managedAgentClusterName, managedAgentClusterName),
+				fmt.Sprintf("Updated connection status to 'Successful' in Cluster: '%s' mapped with Agent: '%s'", autonomousAgentClusterName, autonomousAgentClusterName),
+				"Processing clusterCacheInfoUpdate event",
+				"Updated cluster cache stats in cluster.",
+			})
+		}
+
+		// This function deploys an application and verifies it is healthy and synced.
+		deployAndValidateApplication := func(application *argocdv1alpha1.Application) {
+
+			By("Deploy application: " + application.Name + " in namespace: " + application.Namespace)
+			Expect(k8sClient.Create(ctx, application)).To(Succeed())
+
+			By("Verify application: " + application.Name + " in namespace: " + application.Namespace + " is healthy and synced")
+			Eventually(application, "180s", "5s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced), "Application should be synced")
+			Eventually(application, "180s", "5s").Should(appFixture.HaveHealthStatusCode(health.HealthStatusHealthy), "Application should be healthy")
+		}
+
+		// This test verifies that:
+		// 1. A cluster-scoped ArgoCD instance with principal component enabled and a cluster-scoped ArgoCD instance
+		// with agent component enabled are deployed in both "managed" and "autonomous" modes.
+		// 2. Each agent successfully connects to the principal.
+		// 3. Applications can be deployed in both modes, and are verified to be healthy and in sync.
+		// This validates the core connectivity and basic workflow of agent-principal architecture, including RBAC, connection, and application propagation.
+		It("Should deploy ArgoCD principal and agent instances in both modes and verify they are working as expected", func() {
+
+			By("Deploy principal and verify it starts successfully")
+			deployPrincipal(ctx, k8sClient, registerCleanup)
+
+			By("Deploy managed agent and verify it starts successfully")
+			deployAgent(ctx, k8sClient, registerCleanup, argov1beta1api.AgentModeManaged)
+
+			By("Deploy autonomous agent and verify it starts successfully")
+			deployAgent(ctx, k8sClient, registerCleanup, argov1beta1api.AgentModeAutonomous)
+
+			By("Validate both agents are connected to the principal")
+			validatePrincipalAndAgentConnection()
+
+			By("Create AppProject for managed agent in " + namespaceAgentPrincipal)
+			Expect(k8sClient.Create(ctx, buildAppProjectResource(namespaceAgentPrincipal, argov1beta1api.AgentModeManaged))).To(Succeed())
+
+			By("Create AppProject for autonomous agent in " + namespaceAutonomousAgent)
+			Expect(k8sClient.Create(ctx, buildAppProjectResource(namespaceAutonomousAgent, argov1beta1api.AgentModeAutonomous))).To(Succeed())
+
+			By("Deploy application for managed mode")
+			deployAndValidateApplication(buildApplicationResource(applicationNameManagedAgent,
+				managedAgentClusterName, managedAgentClusterName, argoCDAgentInstanceNameAgent, argov1beta1api.AgentModeManaged))
+
+			By("Deploy application for autonomous mode")
+			deployAndValidateApplication(buildApplicationResource(applicationNameAutonomousAgent,
+				namespaceAutonomousAgent, autonomousAgentClusterName, argoCDAgentInstanceNameAgent, argov1beta1api.AgentModeAutonomous))
+		})
+
+		AfterEach(func() {
+			By("Cleanup cluster-scoped resources")
+			_ = k8sClient.Delete(ctx, clusterRolePrincipal)
+			_ = k8sClient.Delete(ctx, clusterRoleBindingPrincipal)
+
+			_ = k8sClient.Delete(ctx, clusterRoleManagedAgent)
+			_ = k8sClient.Delete(ctx, clusterRoleBindingManagedAgent)
+
+			_ = k8sClient.Delete(ctx, clusterRoleAutonomousAgent)
+			_ = k8sClient.Delete(ctx, clusterRoleBindingAutonomousAgent)
+
+			By("Cleanup namespaces created in this test")
+			for i := len(cleanupFuncs) - 1; i >= 0; i-- {
+				cleanupFuncs[i]()
+			}
+		})
+
+	})
+})
+
+// This function deploys the principal ArgoCD instance and waits for it to be ready.
+// It creates the required secrets for the principal and verifies that the principal deployment is in Ready state.
+// It also verifies that the principal logs contain the expected messages.
+func deployPrincipal(ctx context.Context, k8sClient client.Client, registerCleanup func(func())) {
+	GinkgoHelper()
+
+	nsPrincipal, cleanup := fixture.CreateNamespaceWithCleanupFunc(namespaceAgentPrincipal)
+	registerCleanup(cleanup)
+
+	By("Create ArgoCD instance with principal component enabled")
+
+	argoCDInstance := buildArgoCDResource(argoCDAgentInstanceNamePrincipal, argov1beta1api.AgentComponentTypePrincipal, "", nsPrincipal)
+	waitForLoadBalancer := true
+	if !fixture.RunningOnOpenShift() {
+		argoCDInstance.Spec.ArgoCDAgent.Principal.Server.Service.Type = corev1.ServiceTypeClusterIP
+		waitForLoadBalancer = false
+	}
+
+	Expect(k8sClient.Create(ctx, argoCDInstance)).To(Succeed())
+
+	By("Wait for principal service to be ready and use LoadBalancer hostname/IP when available")
+
+	additionalSANs := []string{}
+	if waitForLoadBalancer {
+		principalService := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentNameAgentPrincipal,
+				Namespace: nsPrincipal.Name,
+			},
+		}
+
+		err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+			if pollErr := k8sClient.Get(ctx, client.ObjectKeyFromObject(principalService), principalService); pollErr != nil {
+				return false, nil
+			}
+
+			for _, ingress := range principalService.Status.LoadBalancer.Ingress {
+				switch {
+				case ingress.Hostname != "":
+					additionalSANs = append(additionalSANs, ingress.Hostname)
+					return true, nil
+				case ingress.IP != "":
+					additionalSANs = append(additionalSANs, ingress.IP)
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		if err != nil {
+			GinkgoWriter.Println("LoadBalancer ingress not available, proceeding without external SANs:", err)
+		}
+	} else {
+		GinkgoWriter.Println("Cluster does not support LoadBalancer services; using in-cluster service DNS SANs only")
+	}
+
+	By("Create required secrets for principal")
+
+	agentFixture.CreateRequiredSecrets(agentFixture.PrincipalSecretsConfig{
+		PrincipalNamespaceName:     namespaceAgentPrincipal,
+		PrincipalServiceName:       deploymentNameAgentPrincipal,
+		ResourceProxyServiceName:   fmt.Sprintf("%s-agent-principal-resource-proxy", argoCDAgentInstanceNamePrincipal),
+		JWTSecretName:              agentJWTSecretName,
+		PrincipalTLSSecretName:     agentPrincipalTLSSecretName,
+		RootCASecretName:           agentRootCASecretName,
+		ResourceProxyTLSSecretName: agentResourceProxyTLSSecretName,
+		AdditionalPrincipalSANs:    additionalSANs,
+	})
+
+	By("Verify that principal deployment is in Ready state")
+
+	Eventually(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      deploymentNameAgentPrincipal,
+		Namespace: nsPrincipal.Name}}, "120s", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+
+	By("Verify principal logs contain expected messages")
+
+	agentFixture.VerifyLogs(deploymentNameAgentPrincipal, nsPrincipal.Name, principalStartupLogs)
+}
+
+// This function deploys the agent ArgoCD instance and waits for it to be ready.
+// It creates the required secrets for the agent and verifies that the agent deployment is in Ready state.
+// It also verifies that the agent logs contain the expected messages.
+func deployAgent(ctx context.Context, k8sClient client.Client, registerCleanup func(func()), agentMode argov1beta1api.AgentMode) {
+	GinkgoHelper()
+
+	var (
+		nsAgent   *corev1.Namespace
+		agentName string
+	)
+
+	if agentMode == argov1beta1api.AgentModeManaged {
+		var cleanup func()
+		nsAgent, cleanup = fixture.CreateNamespaceWithCleanupFunc(namespaceManagedAgent)
+		registerCleanup(cleanup)
+		agentName = managedAgentClusterName
+	} else {
+		var cleanup func()
+		nsAgent, cleanup = fixture.CreateNamespaceWithCleanupFunc(namespaceAutonomousAgent)
+		registerCleanup(cleanup)
+		agentName = autonomousAgentClusterName
+	}
+
+	By("Create required secrets for " + string(agentMode) + " agent")
+
+	agentFixture.CreateRequiredAgentSecrets(agentFixture.AgentSecretsConfig{
+		AgentNamespace:            nsAgent,
+		PrincipalNamespaceName:    namespaceAgentPrincipal,
+		PrincipalRootCASecretName: agentRootCASecretName,
+		AgentRootCASecretName:     agentRootCASecretName,
+		ClientTLSSecretName:       agentClientTLSSecretName,
+		ClientCommonName:          agentName,
+	})
+
+	By("Create cluster registration secret for " + string(agentMode) + " agent")
+
+	agentFixture.CreateClusterRegistrationSecret(agentFixture.ClusterRegistrationSecretConfig{
+		PrincipalNamespaceName:    namespaceAgentPrincipal,
+		AgentNamespaceName:        nsAgent.Name,
+		AgentName:                 agentName,
+		ResourceProxyServiceName:  fmt.Sprintf("%s-agent-principal-resource-proxy", argoCDAgentInstanceNamePrincipal),
+		ResourceProxyPort:         9090,
+		PrincipalRootCASecretName: agentRootCASecretName,
+		AgentTLSSecretName:        agentClientTLSSecretName,
+	})
+
+	By("Deploy " + string(agentMode) + " agent ArgoCD instance")
+
+	argoCDInstanceAgent := buildArgoCDResource(argoCDAgentInstanceNameAgent, argov1beta1api.AgentComponentTypeAgent, agentMode, nsAgent)
+	// Set the principal server address
+	argoCDInstanceAgent.Spec.ArgoCDAgent.Agent.Client.PrincipalServerAddress = fmt.Sprintf("%s.%s.svc", deploymentNameAgentPrincipal, namespaceAgentPrincipal)
+	Expect(k8sClient.Create(ctx, argoCDInstanceAgent)).To(Succeed())
+
+	By("Verifying " + string(agentMode) + " agent deployment is in Ready state")
+
+	Eventually(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deploymentNameAgent, Namespace: nsAgent.Name}}, "120s", "5s").
+		Should(deploymentFixture.HaveReadyReplicas(1))
+
+	By("Verifying " + string(agentMode) + " agent logs contain expected messages")
+
+	agentFixture.VerifyLogs(deploymentNameAgent, nsAgent.Name, agentStartupLogs)
+}
+
+// This function builds the ArgoCD instance for the principal or agent based on the component name.
+func buildArgoCDResource(argoCDName string, componentType argov1beta1api.AgentComponentType,
+	agentMode argov1beta1api.AgentMode, ns *corev1.Namespace) *argov1beta1api.ArgoCD {
+
+	argoCD := &argov1beta1api.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      argoCDName,
+			Namespace: ns.Name,
+		},
+	}
+
+	// Principal configurations
+	if componentType == argov1beta1api.AgentComponentTypePrincipal {
+		argoCD.Spec = argov1beta1api.ArgoCDSpec{
+			Controller: argov1beta1api.ArgoCDApplicationControllerSpec{
+				Enabled: ptr.To(false),
+			},
+			ArgoCDAgent: &argov1beta1api.ArgoCDAgentSpec{
+				Principal: &argov1beta1api.PrincipalSpec{
+					Enabled:  ptr.To(true),
+					Auth:     "mtls:CN=([^,]+)",
+					LogLevel: "info",
+					Image:    common.ArgoCDAgentPrincipalDefaultImageName,
+					Namespace: &argov1beta1api.PrincipalNamespaceSpec{
+						AllowedNamespaces: []string{
+							managedAgentClusterName,
+							autonomousAgentClusterName,
+						},
+					},
+					TLS: &argov1beta1api.PrincipalTLSSpec{
+						InsecureGenerate: ptr.To(false),
+					},
+					JWT: &argov1beta1api.PrincipalJWTSpec{
+						InsecureGenerate: ptr.To(false),
+					},
+					Server: &argov1beta1api.PrincipalServerSpec{
+						KeepAliveMinInterval: "30s",
+						Route: argov1beta1api.ArgoCDAgentPrincipalRouteSpec{
+							Enabled: ptr.To(false),
+						},
+						Service: argov1beta1api.ArgoCDAgentPrincipalServiceSpec{
+							Type: corev1.ServiceTypeLoadBalancer,
+						},
+					},
+				},
+				Agent: &argov1beta1api.AgentSpec{
+					Enabled: ptr.To(false),
+				},
+			},
+			SourceNamespaces: []string{
+				managedAgentClusterName,
+				autonomousAgentClusterName,
+			},
+		}
+	} else {
+		// Agent configurations
+		argoCD.Spec = argov1beta1api.ArgoCDSpec{
+			Server: argov1beta1api.ArgoCDServerSpec{
+				Enabled: ptr.To(false),
+			},
+			ArgoCDAgent: &argov1beta1api.ArgoCDAgentSpec{
+				Principal: &argov1beta1api.PrincipalSpec{
+					Enabled: ptr.To(false),
+				},
+				Agent: &argov1beta1api.AgentSpec{
+					Enabled:  ptr.To(true),
+					Creds:    "mtls:any",
+					LogLevel: "info",
+					Image:    common.ArgoCDAgentAgentDefaultImageName,
+					Client: &argov1beta1api.AgentClientSpec{
+						PrincipalServerAddress: "", // will be set in the test
+						PrincipalServerPort:    "443",
+						KeepAliveInterval:      "50s",
+						Mode:                   string(agentMode),
+					},
+					Redis: &argov1beta1api.AgentRedisSpec{
+						ServerAddress: fmt.Sprintf("%s-%s:%d", argoCDAgentInstanceNameAgent, "redis", common.ArgoCDDefaultRedisPort),
+					},
+					TLS: &argov1beta1api.AgentTLSSpec{
+						SecretName:       agentClientTLSSecretName,
+						RootCASecretName: agentRootCASecretName,
+						Insecure:         ptr.To(false),
+					},
+				},
+			},
+		}
+	}
+
+	return argoCD
+}
+
+// This function builds the AppProject resource for the managed or autonomous agent.
+func buildAppProjectResource(nsName string, agentMode argov1beta1api.AgentMode) *argocdv1alpha1.AppProject {
+	appProject := &argocdv1alpha1.AppProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentAppProjectName,
+			Namespace: nsName,
+		},
+		Spec: argocdv1alpha1.AppProjectSpec{
+			ClusterResourceWhitelist: []metav1.GroupKind{{
+				Group: "*",
+				Kind:  "*",
+			}},
+			SourceRepos: []string{"*"},
+		},
+	}
+
+	if agentMode == argov1beta1api.AgentModeManaged {
+		appProject.Spec.SourceNamespaces = []string{
+			managedAgentClusterName,
+			autonomousAgentClusterName,
+		}
+		appProject.Spec.Destinations = []argocdv1alpha1.ApplicationDestination{{
+			Name:      managedAgentClusterName,
+			Namespace: managedAgentApplicationNamespace,
+			Server:    "*",
+		}}
+	} else {
+		appProject.Spec.Destinations = []argocdv1alpha1.ApplicationDestination{{
+			Namespace: autonomousAgentApplicationNamespace,
+			Server:    "*",
+		}}
+	}
+	return appProject
+}
+
+// This function builds the Application resource for the managed or autonomous agent.
+func buildApplicationResource(applicationName, nsName, agentName, argocdInstanceName string,
+	agentMode argov1beta1api.AgentMode) *argocdv1alpha1.Application {
+
+	application := &argocdv1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      applicationName,
+			Namespace: nsName,
+		},
+		Spec: argocdv1alpha1.ApplicationSpec{
+			Project: agentAppProjectName,
+			Source: &argocdv1alpha1.ApplicationSource{
+				RepoURL:        "https://github.com/argoproj/argocd-example-apps",
+				TargetRevision: "HEAD",
+				Path:           "guestbook",
+			},
+			SyncPolicy: &argocdv1alpha1.SyncPolicy{
+				Automated: &argocdv1alpha1.SyncPolicyAutomated{
+					Prune:    true,
+					SelfHeal: true,
+				},
+				ManagedNamespaceMetadata: &argocdv1alpha1.ManagedNamespaceMetadata{
+					Labels: map[string]string{
+						"argocd.argoproj.io/managed-by": argocdInstanceName,
+					},
+				},
+			},
+		},
+	}
+
+	// Set the destination based on the agent mode
+	if agentMode == argov1beta1api.AgentModeManaged {
+		application.Spec.Destination = argocdv1alpha1.ApplicationDestination{
+			Name:      agentName,
+			Namespace: managedAgentApplicationNamespace,
+		}
+	} else {
+		application.Spec.Destination = argocdv1alpha1.ApplicationDestination{
+			Server:    "https://kubernetes.default.svc",
+			Namespace: autonomousAgentApplicationNamespace,
+		}
+	}
+	return application
+}

--- a/tests/k8s/1-051_validate_argocd_agent_principal/01-install.yaml
+++ b/tests/k8s/1-051_validate_argocd_agent_principal/01-install.yaml
@@ -10,7 +10,7 @@ spec:
       enabled: true
       auth: "mtls:CN=([^,]+)"
       logLevel: "info"
-      image: "quay.io/jparsai/argocd-agent:test"  # specify a custom image
+      image: "quay.io/argoprojlabs/argocd-agent:v0.5.0"  # specify a custom image
       server:
         keepAliveMinInterval: 30s
       namespace:


### PR DESCRIPTION
/kind chore

**What type of PR is this?**
This PR is to improve the E2E tests of ArgoCD Agent in operator. The current E2E tests only check if principal and agent resources are created, but they dont check if they are in Ready state or agent and principal are able to connect and deploy/sync applications according agent's to installation mode. 
This PR introducing logic in E2E to do these:
- Deploy principal via ArgoCD CR in CI cluster.
- Deploy managed and autonomous agents via ArgoCD CR in same CI cluster, because we have just one cluster in CI checks, hence we are deploying principal and both agents together.
- Isolate principal, managed and autonomous agents in different namespaces to simulate multi cluster environment.
- Ensure principal is connected to both agents and required secrets, certificates are also isolated in different namespaces.
- Deploy ArgoCD application for both managed and autonomous modes.
- Ensure applications are synced and healthy for both agents. 


Here is how namespaces are used for principal/agent resource isolation to simulate hub and 2 spokes in same cluster. 

```

Test Cluster (Has a Hub and two Spokes (Managed and Autonomous) simulated)
│
├─ 🏛️ Hub Cluster
│   ├─ Namespace: ns-hosting-principal
│   │   ├─ ArgoCD: argocd-hub (Principal enabled)
│   │   ├─ Deployment: argocd-hub-agent-principal
│   │   ├─ Service: argocd-hub-agent-principal (Type LoadBalancer)
│   │   ├─ Secrets: TLS, JWT, CA, Cluster registration secrets
│   │   └─ AppProject: agent-app-project ("Source of truth" for managed agent, delivered to agent by principal)
│   │
│   ├─ Namespace: managed-cluster-in-hub (Logical representation of managed cluster in hub)
│   │   └─ Application: app-managed ("Source of truth" for managed agent, delivered to agent by principal)
│   │
│   └─ Namespace: autonomous-cluster-in-hub (Logical representation of autonomous cluster in hub)
|       └─ Application: app-autonomous ("Source of truth" is autonomous agent, delivered to principal by agent)
│
├─ 🔵 Managed Spoke Cluster
│   ├─ Namespace: ns-hosting-managed-agent
│   │   ├─ ArgoCD: argocd-spoke (Agent enabled, Managed mode)
│   │   ├─ Deployment: argocd-spoke-agent-agent
│   │   ├─ Secrets: Client TLS, CA
|   |   └─ Application: app-managed ("Source of truth" is principal, but Reconciled and deployed in spoke by agent)
│   │
│   └─ Namespace: ns-hosting-app-in-managed-cluster
│       └─ Pod/Service/Route: spring-petclinic (Application resources deployed by agent in spoke)
│
└─ 🔵 Autonomous Spoke Cluster
    ├─ Namespace: ns-hosting-autonomous-agent
    │   ├─ ArgoCD: argocd-spoke (Agent enabled, Autonomous mode)
    │   ├─ Deployment: argocd-spoke-agent-agent
    │   ├─ Secrets: Client TLS, CA
    │   ├─ AppProject: agent-app-project ("Source of truth" is autonomous agent, delivered to principal by agent)
    │   └─ Application: app-autonomous ("Source of truth" is autonomous agent, delivered to principal by agent, Reconciled and deployed in spoke by agent)
    │
    └─ Namespace: ns-hosting-app-in-autonomous-cluster
        └─ Pod/Service/Route: spring-petclinic (Application resources deployed by agent in spoke)

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ArgoCD Agent container images to v0.5.2
  * Added three cluster hosting namespaces to e2e configuration
  * Introduced typed constants for agent modes and component types for consistency

* **Tests**
  * Expanded E2E test coverage and fixtures for agent ↔ principal connectivity in managed and autonomous modes
  * Added structured test helpers to centralize secret, TLS, resource lifecycle, and verification logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->