### PR TITLE
fix: additional checks for appsets in any namespace field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ e2e: ## Run operator e2e tests
 
 
 start-e2e:
-	ARGOCD_CLUSTER_CONFIG_NAMESPACES="argocd-e2e-cluster-config, argocd-test-impersonation-1-046, argocd-agent-principal-1-051, argocd-agent-agent-1-052" make run
+	ARGOCD_CLUSTER_CONFIG_NAMESPACES="argocd-e2e-cluster-config, argocd-test-impersonation-1-046, argocd-agent-principal-1-051, argocd-agent-agent-1-052, appset-argocd, appset-old-ns, appset-new-ns" make run
 
 all: test install run e2e ## UnitTest, Run the operator locally and execute e2e tests.
 

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -66,32 +66,36 @@ func (r *ReconcileArgoCD) getArgoApplicationSetCommand(cr *argoproj.ArgoCD) []st
 		cmd = append(cmd, ApplicationSetGitlabSCMTlsCertPath)
 	}
 
-	// appset source namespaces should be subset of apps source namespaces
-	appsetsSourceNamespaces := []string{}
-	appsNamespaces, err := r.getSourceNamespaces(cr)
-	if err == nil {
-		for _, ns := range cr.Spec.ApplicationSet.SourceNamespaces {
-			if contains(appsNamespaces, ns) {
-				appsetsSourceNamespaces = append(appsetsSourceNamespaces, ns)
-			} else {
-				log.V(1).Info(fmt.Sprintf("Apps in target sourceNamespace %s is not enabled, thus skipping the namespace in deployment command.", ns))
+	// Only allow applicationsets in any namespace for cluster-scoped clusters
+	if argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) {
+
+		// appset source namespaces should be subset of apps source namespaces
+		appsetsSourceNamespaces := []string{}
+		appsNamespaces, err := r.getSourceNamespaces(cr)
+		if err == nil {
+			for _, ns := range cr.Spec.ApplicationSet.SourceNamespaces {
+				if contains(appsNamespaces, ns) {
+					appsetsSourceNamespaces = append(appsetsSourceNamespaces, ns)
+				} else {
+					log.V(1).Info(fmt.Sprintf("Apps in target sourceNamespace %s is not enabled, thus skipping the namespace in deployment command.", ns))
+				}
 			}
 		}
-	}
 
-	if len(appsetsSourceNamespaces) > 0 {
-		cmd = append(cmd, "--applicationset-namespaces", fmt.Sprint(strings.Join(appsetsSourceNamespaces, ",")))
+		if len(appsetsSourceNamespaces) > 0 {
+			cmd = append(cmd, "--applicationset-namespaces", fmt.Sprint(strings.Join(appsetsSourceNamespaces, ",")))
+		}
+
+		// appset in any ns is enabled and no scmProviders allow list is specified,
+		// disables scm & PR generators to prevent potential security issues
+		// https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Appset-Any-Namespace/#scm-providers-secrets-consideration
+		if len(appsetsSourceNamespaces) > 0 && (len(cr.Spec.ApplicationSet.SCMProviders) <= 0) {
+			cmd = append(cmd, "--enable-scm-providers=false")
+		}
 	}
 
 	if len(cr.Spec.ApplicationSet.SCMProviders) > 0 {
 		cmd = append(cmd, "--allowed-scm-providers", fmt.Sprint(strings.Join(cr.Spec.ApplicationSet.SCMProviders, ",")))
-	}
-
-	// appset in any ns is enabled and no scmProviders allow list is specified,
-	// disables scm & PR generators to prevent potential security issues
-	// https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Appset-Any-Namespace/#scm-providers-secrets-consideration
-	if len(appsetsSourceNamespaces) > 0 && (len(cr.Spec.ApplicationSet.SCMProviders) <= 0) {
-		cmd = append(cmd, "--enable-scm-providers=false")
 	}
 
 	// ApplicationSet command arguments provided by the user
@@ -638,6 +642,16 @@ func (r *ReconcileArgoCD) reconcileApplicationSetSourceNamespacesResources(cr *a
 		return nil
 	}
 
+	// Only allow applicationsets in any namespace for cluster-scoped clusters
+	if !argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) {
+
+		if len(cr.Spec.ApplicationSet.SourceNamespaces) > 0 {
+			log.Error(nil, ".spec.applicationSet.sourceNamespaces should not be specified for namespace-scoped Argo CD instances. If you wish to use applicationset sourceNamespaces feature, convert the Argo CD instance to a cluster-scoped instance.")
+		}
+
+		return nil
+	}
+
 	// create resources for each appset source namespace
 	for _, sourceNamespace := range cr.Spec.ApplicationSet.SourceNamespaces {
 
@@ -928,28 +942,40 @@ func getResourceNameForApplicationSetSourceNamespaces(cr *argoproj.ArgoCD) strin
 // ManagedApplicationSetSourceNamespaces var keeps track of namespaces with appset resources.
 func (r *ReconcileArgoCD) removeUnmanagedApplicationSetSourceNamespaceResources(cr *argoproj.ArgoCD) error {
 
-	for ns := range r.ManagedApplicationSetSourceNamespaces {
+	// For each namespace the ArgoCDApplicationSetManagedByClusterArgoCDLabel label.
+	for appsetsInAnyNamespaceLabelledNS := range r.ManagedApplicationSetSourceNamespaces {
+
 		managedNamespace := false
-		if cr.Spec.ApplicationSet != nil && cr.GetDeletionTimestamp() == nil {
-			appsNamespaces, err := r.getSourceNamespaces(cr)
-			if err != nil {
-				return err
-			}
-			for _, namespace := range cr.Spec.ApplicationSet.SourceNamespaces {
-				// appset ns should be part of apps ns
-				if namespace == ns && contains(appsNamespaces, namespace) {
-					managedNamespace = true
-					break
+
+		// Ensure the feature is enabled only for cluster-scoped ArgoCD instances:
+		// - If the ArgoCD instance is namespace scoped, then ALL resources should be cleaned up
+		if argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) {
+
+			if cr.Spec.ApplicationSet != nil && cr.GetDeletionTimestamp() == nil {
+
+				// namespace is valid if it's mentioend in cr.Spec.ApplicationSet.SourceNamespaces AND cr.Spec.SourceNamespaces
+				//
+				appsNamespaces, err := r.getSourceNamespaces(cr)
+				if err != nil {
+					return err
+				}
+				for _, namespace := range cr.Spec.ApplicationSet.SourceNamespaces {
+					// appset ns should be part of apps ns
+					if namespace == appsetsInAnyNamespaceLabelledNS && contains(appsNamespaces, namespace) {
+						managedNamespace = true
+						break
+					}
 				}
 			}
 		}
 
+		// If the namespace was previously managed, but no longer is, delete the resources from it and remove the label
 		if !managedNamespace {
-			if err := r.cleanupUnmanagedApplicationSetSourceNamespaceResources(cr, ns); err != nil {
-				log.Error(err, fmt.Sprintf("error cleaning up applicationset resources for namespace %s", ns))
+			if err := r.cleanupUnmanagedApplicationSetSourceNamespaceResources(cr, appsetsInAnyNamespaceLabelledNS); err != nil {
+				log.Error(err, fmt.Sprintf("error cleaning up applicationset resources for namespace %s", appsetsInAnyNamespaceLabelledNS))
 				continue
 			}
-			delete(r.ManagedApplicationSetSourceNamespaces, ns)
+			delete(r.ManagedApplicationSetSourceNamespaces, appsetsInAnyNamespaceLabelledNS)
 		}
 	}
 	return nil

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -588,6 +588,10 @@ func TestReconcileApplicationSet_Deployments_Command(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			a := makeTestArgoCD()
+
+			os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
+			defer os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+
 			ns1 := v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -805,6 +809,8 @@ func TestReconcileApplicationSet_SourceNamespacesRBACCreation(t *testing.T) {
 
 			a := makeTestArgoCD()
 			allowClusterConfigNamespaces(t, a.Namespace)
+			defer os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+
 			resObjs := []client.Object{a}
 			subresObjs := []client.Object{a}
 			runtimeObjs := []runtime.Object{}
@@ -1331,7 +1337,10 @@ func TestArgoCDApplicationSet_removeUnmanagedApplicationSetSourceNamespaceResour
 	ns1 := "foo"
 	ns2 := "bar"
 	a := makeTestArgoCD()
+
 	allowClusterConfigNamespaces(t, a.Namespace)
+	defer os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+
 	a.Spec = argoproj.ArgoCDSpec{
 		SourceNamespaces: []string{ns1, ns2},
 		ApplicationSet: &argoproj.ArgoCDApplicationSet{
@@ -1403,6 +1412,86 @@ func TestArgoCDApplicationSet_removeUnmanagedApplicationSetSourceNamespaceResour
 	val, found := namespace.Labels[common.ArgoCDApplicationSetManagedByClusterArgoCDLabel]
 	assert.True(t, found)
 	assert.Equal(t, a.Namespace, val)
+}
+
+func TestReconcileApplicationSetSourceNamespacesResources_NonClusterConfigNamespace(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	tests := []struct {
+		name                      string
+		clusterConfigNamespaces   string
+		expectInManagedNamespaces bool
+		expectedManagedNamespaces []string
+	}{
+		{
+			name:                      "ARGOCD_CLUSTER_CONFIG_NAMESPACES contains namespace",
+			clusterConfigNamespaces:   "argocd",
+			expectInManagedNamespaces: true,
+			expectedManagedNamespaces: []string{"foo", "bar"},
+		},
+		{
+			name:                      "ARGOCD_CLUSTER_CONFIG_NAMESPACES does not contain namespace",
+			clusterConfigNamespaces:   "",
+			expectInManagedNamespaces: false,
+			expectedManagedNamespaces: []string{},
+		},
+		{
+			name:                      "ARGOCD_CLUSTER_CONFIG_NAMESPACES contains different namespace",
+			clusterConfigNamespaces:   "different-namespace",
+			expectInManagedNamespaces: false,
+			expectedManagedNamespaces: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := makeTestArgoCD()
+			a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{"foo", "bar"},
+			}
+			a.Spec.SourceNamespaces = []string{"foo", "bar"}
+
+			// Set ARGOCD_CLUSTER_CONFIG_NAMESPACES based on test case
+			os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", test.clusterConfigNamespaces)
+			defer os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+
+			resObjs := []client.Object{a}
+			subresObjs := []client.Object{a}
+			runtimeObjs := []runtime.Object{}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+			// Initialize ManagedApplicationSetSourceNamespaces as empty map
+			r.ManagedApplicationSetSourceNamespaces = make(map[string]string)
+
+			// Create source namespaces so the function can process them
+			for _, ns := range []string{"foo", "bar"} {
+				err := createNamespace(r, ns, "")
+				assert.NoError(t, err)
+			}
+
+			// Verify IsNamespaceClusterConfigNamespace returns expected value
+			if test.expectInManagedNamespaces {
+				assert.True(t, argoutil.IsNamespaceClusterConfigNamespace(a.Namespace))
+			} else {
+				assert.False(t, argoutil.IsNamespaceClusterConfigNamespace(a.Namespace))
+			}
+
+			err := r.reconcileApplicationSetSourceNamespacesResources(a)
+			assert.NoError(t, err)
+
+			// Verify ManagedApplicationSetSourceNamespaces contains expected namespaces
+			if test.expectInManagedNamespaces {
+				assert.Equal(t, len(test.expectedManagedNamespaces), len(r.ManagedApplicationSetSourceNamespaces))
+				for _, ns := range test.expectedManagedNamespaces {
+					assert.Contains(t, r.ManagedApplicationSetSourceNamespaces, ns)
+				}
+			} else {
+				assert.Empty(t, r.ManagedApplicationSetSourceNamespaces)
+			}
+		})
+	}
 }
 
 func TestGetApplicationSetContainerImage(t *testing.T) {

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -76,7 +76,11 @@ type ReconcileArgoCD struct {
 	ManagedNamespaces *corev1.NamespaceList
 	// Stores a list of ApplicationSourceNamespaces as keys
 	ManagedSourceNamespaces map[string]string
-	// Stores a list of ApplicationSetSourceNamespaces as keys
+
+	// Stores a list of ApplicationSetSourceNamespaces as keys (value is not used)
+	// - list of namespaces that currently have the 'common.ArgoCDApplicationSetManagedByClusterArgoCDLabel' label
+	// - items in the list that are NOT mentioned in .spec.applicationset.sourceNamespaces will be cleaned up
+	// - (or if ALL resources in the list will be cleaned up if ArgoCD instance in namespace-scoped)
 	ManagedApplicationSetSourceNamespaces map[string]string
 
 	// Stores a list of NotificationsSourceNamespaces as keys

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -174,6 +174,7 @@ func (r *ReconcileArgoCD) namespaceResourceMapper(ctx context.Context, o client.
 	argocds := &argoproj.ArgoCDList{}
 	labels := o.GetLabels()
 	namespaceName := o.GetName()
+	// If the namespace is managed by an Argo CD instance in another namespace, then reconcile that instance
 	if v, ok := labels[common.ArgoCDManagedByLabel]; ok {
 		if err := r.List(context.TODO(), argocds, &client.ListOptions{Namespace: v}); err != nil {
 			return result
@@ -189,6 +190,19 @@ func (r *ReconcileArgoCD) namespaceResourceMapper(ctx context.Context, o client.
 		result = []reconcile.Request{
 			{NamespacedName: namespacedName},
 		}
+
+	} else if v, ok := labels[common.ArgoCDApplicationSetManagedByClusterArgoCDLabel]; ok {
+		// If the namespace is managed by applicationsets in any namespace, by Argo CD in another namespace, then reconcile that namespace's instance
+
+		namespaceContainingArgoCD := v
+		if err := r.List(ctx, argocds, client.InNamespace(namespaceContainingArgoCD)); err != nil {
+			return result
+		}
+		for idx := range argocds.Items {
+			argocd := argocds.Items[idx]
+			result = append(result, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&argocd)})
+		}
+
 	} else {
 		// If the namespace does not have the expected managed-by label,
 		// iterate through each ArgoCD instance to identify if the observed namespace

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -52,6 +52,7 @@ func GenerateUniqueResourceName(argoComponentName string, cr *argoproj.ArgoCD) s
 }
 
 func newClusterRole(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) *v1.ClusterRole {
+
 	return &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        GenerateUniqueResourceName(name, cr),

--- a/tests/ginkgo/fixture/k8s/fixture.go
+++ b/tests/ginkgo/fixture/k8s/fixture.go
@@ -91,6 +91,8 @@ func NotHaveLabelWithValue(key string, value string) matcher.GomegaMatcher {
 			return true
 		}
 
+		GinkgoWriter.Println("NotHaveLabelWithValue: not expected: ", key, "/", value, ". actual:", labels[key])
+
 		return labels[key] != value
 
 	}, BeTrue())


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
* Additional checks for appsets in any namespace field

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cluster-scoped ApplicationSet namespace configuration with automatic resource management
  * Automatic cleanup of managed ApplicationSet resources when source namespaces change

* **Improvements**
  * Enhanced ApplicationSet source namespace reconciliation and resource lifecycle management
  * Improved RBAC resource cleanup logic for ApplicationSet configurations

* **Tests**
  * Expanded test coverage for cluster-scoped ApplicationSet namespace handling and resource cleanup scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->