### PR TITLE
chore: don't output 'df -k' command string

### DIFF
--- a/tests/ginkgo/fixture/fixture.go
+++ b/tests/ginkgo/fixture/fixture.go
@@ -56,7 +56,7 @@ func WaitForRootPartitionToHaveMinimumDiskSpace() {
 
 	for {
 
-		output, err := osFixture.ExecCommandWithOutputParam(true, "df", "-k")
+		output, err := osFixture.ExecCommandWithOutputParam(false, false, "df", "-k")
 		Expect(err).ToNot(HaveOccurred())
 
 		// Output from 'df' looks like this:
@@ -535,7 +535,7 @@ func OutputDebugOnFail(namespaceParams ...any) {
 
 	for _, namespace := range namespaces {
 
-		kubectlOutput, err := osFixture.ExecCommandWithOutputParam(false, "kubectl", "get", "all", "-n", namespace)
+		kubectlOutput, err := osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "get", "all", "-n", namespace)
 		if err != nil {
 			GinkgoWriter.Println("unable to list", namespace, err, kubectlOutput)
 			continue
@@ -547,7 +547,7 @@ func OutputDebugOnFail(namespaceParams ...any) {
 		GinkgoWriter.Println(kubectlOutput)
 		GinkgoWriter.Println("----------------------------------------------------------------")
 
-		kubectlOutput, err = osFixture.ExecCommandWithOutputParam(false, "kubectl", "get", "deployments", "-n", namespace, "-o", "yaml")
+		kubectlOutput, err = osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "get", "deployments", "-n", namespace, "-o", "yaml")
 		if err != nil {
 			GinkgoWriter.Println("unable to list", namespace, err, kubectlOutput)
 			continue
@@ -559,7 +559,7 @@ func OutputDebugOnFail(namespaceParams ...any) {
 		GinkgoWriter.Println(kubectlOutput)
 		GinkgoWriter.Println("----------------------------------------------------------------")
 
-		kubectlOutput, err = osFixture.ExecCommandWithOutputParam(false, "kubectl", "get", "events", "-n", namespace)
+		kubectlOutput, err = osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "get", "events", "-n", namespace)
 		if err != nil {
 			GinkgoWriter.Println("unable to get events for namespace", err, kubectlOutput)
 		} else {
@@ -572,7 +572,7 @@ func OutputDebugOnFail(namespaceParams ...any) {
 
 	}
 
-	kubectlOutput, err := osFixture.ExecCommandWithOutputParam(false, "kubectl", "get", "argocds", "-A", "-o", "yaml")
+	kubectlOutput, err := osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "get", "argocds", "-A", "-o", "yaml")
 	if err != nil {
 		GinkgoWriter.Println("unable to output all argo cd statuses", err, kubectlOutput)
 	} else {
@@ -653,7 +653,7 @@ func outputPodLog(podSubstring string) {
 	}
 
 	// Extract operator logs
-	kubectlLogOutput, err := osFixture.ExecCommandWithOutputParam(false, "kubectl", "logs", "pod/"+matchingPods[0].Name, "manager", "-n", matchingPods[0].Namespace)
+	kubectlLogOutput, err := osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "logs", "pod/"+matchingPods[0].Name, "manager", "-n", matchingPods[0].Namespace)
 	if err != nil {
 		GinkgoWriter.Println("unable to extract operator logs", err)
 		return

--- a/tests/ginkgo/fixture/os/fixture.go
+++ b/tests/ginkgo/fixture/os/fixture.go
@@ -8,12 +8,15 @@ import (
 )
 
 func ExecCommand(cmdArgs ...string) (string, error) {
-	return ExecCommandWithOutputParam(true, cmdArgs...)
+	return ExecCommandWithOutputParam(true, true, cmdArgs...)
 }
 
 // You probably want to use ExecCommand, unless you need to supress the output of sensitive data (for example, openssl CLI output)
-func ExecCommandWithOutputParam(printOutput bool, cmdArgs ...string) (string, error) {
-	GinkgoWriter.Println("executing command:", cmdArgs)
+func ExecCommandWithOutputParam(printOutput bool, printCommand bool, cmdArgs ...string) (string, error) {
+
+	if printCommand {
+		GinkgoWriter.Println("executing command:", cmdArgs)
+	}
 
 	// #nosec G204
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)

--- a/tests/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
+++ b/tests/ginkgo/parallel/1-066_validate_redis_secure_comm_no_autotls_no_ha_test.go
@@ -113,7 +113,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			err = os.WriteFile(openssl_test_File.Name(), ([]byte)(opensslTestCNFContents), 0666)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = osFixture.ExecCommandWithOutputParam(false, "openssl", "req", "-new", "-x509", "-sha256",
+			_, err = osFixture.ExecCommandWithOutputParam(false, true, "openssl", "req", "-new", "-x509", "-sha256",
 				"-subj", "/C=XX/ST=XX/O=Testing/CN=redis",
 				"-reqexts", "SAN",
 				"-extensions", "SAN",

--- a/tests/ginkgo/parallel/1-073_validate_rhsso_test.go
+++ b/tests/ginkgo/parallel/1-073_validate_rhsso_test.go
@@ -235,7 +235,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			GinkgoWriter.Println("ssoUsername has length", len(ssoUsername), "ssoPass has length", len(ssoPassword), "keycloakRouteHost:", keycloakRouteHost)
 
-			output, err := osFixture.ExecCommandWithOutputParam(false, "curl", "-d", "client_id=admin-cli", "-d", "username="+string(ssoUsername), "-d", "password="+string(ssoPassword), "-d", "grant_type=password", "https://"+keycloakRouteHost+"/auth/realms/master/protocol/openid-connect/token", "-k")
+			output, err := osFixture.ExecCommandWithOutputParam(false, false, "curl", "-d", "client_id=admin-cli", "-d", "username="+string(ssoUsername), "-d", "password="+string(ssoPassword), "-d", "grant_type=password", "https://"+keycloakRouteHost+"/auth/realms/master/protocol/openid-connect/token", "-k")
 			Expect(err).ToNot(HaveOccurred())
 
 			// Extract the JSON part of the output
@@ -251,13 +251,13 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("executing the CURL command to verify the realm and client creation")
 
-			output, err = osFixture.ExecCommandWithOutputParam(false, "curl", "-H", "Content-Type: application/json", "-H", "Authorization: bearer "+accessToken, "https://"+keycloakRouteHost+"/auth/admin/realms/argocd/clients", "-k")
+			output, err = osFixture.ExecCommandWithOutputParam(false, false, "curl", "-H", "Content-Type: application/json", "-H", "Authorization: bearer "+accessToken, "https://"+keycloakRouteHost+"/auth/admin/realms/argocd/clients", "-k")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(output).To(ContainSubstring("\"clientId\":\"argocd\""))
 
 			By("executing the CURL command to verify OpenShift-v4 IdP creation")
 
-			output, err = osFixture.ExecCommandWithOutputParam(false, "curl", "-H", "Content-Type: application/json", "-H", "Authorization: bearer "+accessToken, "https://"+keycloakRouteHost+"/auth/admin/realms/argocd/identity-provider/instances", "-k")
+			output, err = osFixture.ExecCommandWithOutputParam(false, false, "curl", "-H", "Content-Type: application/json", "-H", "Authorization: bearer "+accessToken, "https://"+keycloakRouteHost+"/auth/admin/realms/argocd/identity-provider/instances", "-k")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(output).To(ContainSubstring("openshift-v4"))
 			Expect(output).To(ContainSubstring("\"syncMode\":\"FORCE\""))

--- a/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -487,7 +487,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("Verify principal pod starts successfully by checking logs")
 
 			Eventually(func() bool {
-				logOutput, err := osFixture.ExecCommandWithOutputParam(false, "kubectl", "logs",
+				logOutput, err := osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "logs",
 					"deployment/"+argoCDAgentPrincipalName, "-n", ns.Name, "--tail=200")
 				if err != nil {
 					GinkgoWriter.Println("Error getting logs: ", err)

--- a/tests/ginkgo/sequential/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
+++ b/tests/ginkgo/sequential/1-067_validate_redis_secure_comm_no_autotls_ha_test.go
@@ -135,7 +135,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			err = os.WriteFile(openssl_test_File.Name(), ([]byte)(opensslTestCNFContents), 0666)
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = osFixture.ExecCommandWithOutputParam(false, "openssl", "req", "-new", "-x509", "-sha256",
+			_, err = osFixture.ExecCommandWithOutputParam(false, true, "openssl", "req", "-new", "-x509", "-sha256",
 				"-subj", "/C=XX/ST=XX/O=Testing/CN=redis",
 				"-reqexts", "SAN",
 				"-extensions", "SAN",
@@ -162,7 +162,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectComponentsAreRunning()
 
 			By("extracting the contents of /data/conf/redis.conf and checking it contains expected values")
-			redisConf, err := osFixture.ExecCommandWithOutputParam(false, "kubectl", "exec", "-i", "pod/argocd-redis-ha-server-0", "-n", ns.Name, "-c", "redis", "--", "cat", "/data/conf/redis.conf")
+			redisConf, err := osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "exec", "-i", "pod/argocd-redis-ha-server-0", "-n", ns.Name, "-c", "redis", "--", "cat", "/data/conf/redis.conf")
 			Expect(err).ToNot(HaveOccurred())
 			expectedRedisConfig := []string{
 				"port 0",
@@ -178,7 +178,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 
 			By("extracting the contents of /data/conf/sentinel.conf and checking it contains expected values")
-			sentinelConf, err := osFixture.ExecCommandWithOutputParam(false, "kubectl", "exec", "-i", "pod/argocd-redis-ha-server-0", "-n", ns.Name, "-c", "redis", "--", "cat", "/data/conf/sentinel.conf")
+			sentinelConf, err := osFixture.ExecCommandWithOutputParam(false, true, "kubectl", "exec", "-i", "pod/argocd-redis-ha-server-0", "-n", ns.Name, "-c", "redis", "--", "cat", "/data/conf/sentinel.conf")
 			Expect(err).ToNot(HaveOccurred())
 			expectedSentinelConfig := []string{
 				"port 0",


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
- A previous PR was merged which uses 'df -k' to ensure enough ephemeral storage exists.
- However, the previous PR causes 'executing command: df -k' to be output before each test.
- This text is not required and can be removed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to enhance command execution handling and output management across test utilities.
  * Modified test invocations to use updated function signatures for improved consistency in command execution and output capture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->