### PR TITLE
fix: Align image updater role binding code

### DIFF
--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -251,9 +251,8 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRoleBinding(cr *argoproj.ArgoCD, 
 
 	desiredRoleBinding.Subjects = []rbacv1.Subject{
 		{
-			Kind:      rbacv1.ServiceAccountKind,
-			Name:      sa.Name,
-			Namespace: sa.Namespace,
+			Kind: rbacv1.ServiceAccountKind,
+			Name: sa.Name,
 		},
 	}
 

--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -714,6 +714,16 @@ func policyRuleForRoleForImageUpdaterController() []v1.PolicyRule {
 				"watch",
 			},
 		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"events",
+			},
+			Verbs: []string{
+				"create",
+				"patch",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
This fix aligns Image Updater with their upstream version.
- `namespace` is not a part of subjects in `RoleBinding`: https://github.com/argoproj-labs/argocd-image-updater/blob/master/config/rbac/argocd-image-updater-rolebinding.yaml
- `events` are part of the `Role`: https://github.com/argoproj-labs/argocd-image-updater/blob/6d40f3fcca0321a8751df4f0f2ce8486e4637118/config/rbac/leader_election_role.yaml#L34

**Have you updated the necessary documentation?**

* [no] Documentation update is required by this PR.
* [no] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-8160

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated role binding configuration for the image updater component to streamline namespace handling.
  * Expanded permissions for the image updater component to create and patch events, enhancing operational capabilities and visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->