### PR TITLE
Added command check when namespace-scoped Argo CD instance in testing

### DIFF
--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -914,7 +914,7 @@ func (r *ReconcileArgoCD) setManagedNotificationsSourceNamespaces(cr *argoproj.A
 	return nil
 }
 
-// removeUnmanagedNotificationsSourceNamespaceResources cleansup resources from NotificationsSourceNamespaces if namespace is not managed by argocd instance.
+// removeUnmanagedNotificationsSourceNamespaceResources cleanup resources from NotificationsSourceNamespaces if namespace is not managed by argocd instance.
 // ManagedNotificationsSourceNamespaces var keeps track of namespaces with notifications resources.
 func (r *ReconcileArgoCD) removeUnmanagedNotificationsSourceNamespaceResources(cr *argoproj.ArgoCD) error {
 


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
 /kind enhancement 
<!-- /kind documentation -->
<!-- /kind code-refactoring -->

**What does this PR do / why we need it**:
Added Controller command check at ginkgo testing of notifications in any namespace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened validation tests for notification controller deployments to assert the absence of an unintended command flag, with robust polling/timeouts.

* **Style**
  * Minor comment grammar correction in notification controller code (non-functional).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->