### PR TITLE
[release-0.17] fix: namespace validation for notification (#1955)

### DIFF
--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -224,10 +224,11 @@ func TestReconcileNotifications_Deployments_Command(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
-		name           string
-		argocdSpec     argoproj.ArgoCDSpec
-		expectedCmd    []string
-		notExpectedCmd []string
+		name                  string
+		argocdSpec            argoproj.ArgoCDSpec
+		expectedCmd           []string
+		notExpectedCmd        []string
+		namespaceScopedArgoCD bool
 	}{
 		{
 			name: "Notifications contained in spec.sourceNamespaces",
@@ -264,12 +265,29 @@ func TestReconcileNotifications_Deployments_Command(t *testing.T) {
 			expectedCmd:    []string{},
 			notExpectedCmd: []string{"--application-namespaces", "foo", "--self-service-notification-enabled", "true"},
 		},
+		{
+			name:                  "Namespace scoped Argo CD, no application namespaces arg",
+			namespaceScopedArgoCD: true,
+			argocdSpec: argoproj.ArgoCDSpec{
+				Notifications: argoproj.ArgoCDNotifications{
+					Enabled:          true,
+					SourceNamespaces: []string{"foo"},
+				},
+				SourceNamespaces: []string{"foo"},
+			},
+			expectedCmd:    []string{},
+			notExpectedCmd: []string{"--application-namespaces", "foo", "--self-service-notification-enabled", "true"},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
 			a := makeTestArgoCD()
+			os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
+			if test.namespaceScopedArgoCD {
+				os.Unsetenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES")
+			}
 			ns1 := v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -935,6 +953,7 @@ func TestReconcileNotifications_NotificationsConfigurationInSourceNamespaceWhenD
 		a.Spec.Notifications.SourceNamespaces = []string{sourceNamespace}
 		a.Spec.SourceNamespaces = []string{sourceNamespace}
 	})
+	os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
 
 	resObjs := []client.Object{a}
 	subresObjs := []client.Object{a}

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -102,7 +102,7 @@ func TestReconcileArgoCD_reconcileRole_for_new_namespace(t *testing.T) {
 
 func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD()
+	a := makeTestArgoCDInNamespace("argocd-cluster-role-test")
 
 	resObjs := []client.Object{a}
 	subresObjs := []client.Object{a}

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -565,7 +565,7 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 
 func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD()
+	a := makeTestArgoCDInNamespace("argocd-cluster-permissions-test")
 
 	resObjs := []client.Object{a}
 	subresObjs := []client.Object{a}
@@ -586,7 +586,7 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))
 	assert.Equal(t, string(testSecret.Data["namespaces"]), a.Namespace)
 
-	want := "argocd,someRandomNamespace"
+	want := "argocd-cluster-permissions-test,someRandomNamespace"
 	testSecret.Data["namespaces"] = []byte("someRandomNamespace")
 	err := r.Update(context.TODO(), testSecret)
 	assert.NoError(t, err)
@@ -597,7 +597,7 @@ func Test_ReconcileArgoCD_ClusterPermissionsSecret(t *testing.T) {
 	assert.Equal(t, string(testSecret.Data["namespaces"]), want)
 
 	assert.NoError(t, createNamespace(r, "xyz", a.Namespace))
-	want = "argocd,someRandomNamespace,xyz"
+	want = "argocd-cluster-permissions-test,someRandomNamespace,xyz"
 	// reconcile to check namespace with the label gets added
 	assert.NoError(t, r.reconcileClusterPermissionsSecret(a))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: testSecret.Name, Namespace: testSecret.Namespace}, testSecret))

--- a/controllers/argocd/service_account_test.go
+++ b/controllers/argocd/service_account_test.go
@@ -81,7 +81,7 @@ func TestReconcileArgoCD_reconcileServiceAccountPermissions(t *testing.T) {
 
 func TestReconcileArgoCD_reconcileServiceAccountClusterPermissions(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
-	a := makeTestArgoCD()
+	a := makeTestArgoCDInNamespace("argocd-sa-cluster-permissions-test")
 
 	resObjs := []client.Object{a}
 	subresObjs := []client.Object{a}

--- a/tests/ginkgo/parallel/1-055_validate_notification_controller_test.go
+++ b/tests/ginkgo/parallel/1-055_validate_notification_controller_test.go
@@ -173,5 +173,76 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 		})
 
+		It("ensure that sourceNamespace resources are not created for namespace-scoped instance", func() {
+
+			By("creating test namespaces")
+			fooNs, fooNsCleanupFunc := fixture.CreateNamespaceWithCleanupFunc("foo-src-ns")
+			defer fooNsCleanupFunc()
+
+			By("creating namespace-scoped Argo CD instance with sourceNamespaces")
+			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("1-055-src-ns-test")
+			defer cleanupFunc()
+
+			argocd := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-argocd",
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					Notifications: argov1beta1api.ArgoCDNotifications{
+						Enabled:          true,
+						SourceNamespaces: []string{fooNs.Name},
+					},
+					SourceNamespaces: []string{fooNs.Name},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argocd)).To(Succeed())
+
+			By("verifying Argo CD and notification controller start as expected")
+			Eventually(argocd, "4m", "5s").Should(argocdFixture.HaveNotificationControllerStatus("Running"))
+
+			By("verifying that sourceNamespace cmd args don't exist")
+			depl := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-argocd-notifications-controller",
+					Namespace: ns.Name,
+				},
+			}
+			Eventually(depl).Should(k8sFixture.ExistByName())
+			// TODO: add check to test "--application-namespaces" cmd arg is not present in the notification deployment container args
+
+			By("verifying sourceNamespace rbac resources are not created")
+			clusterRole := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-argocd-1-055-src-ns-test-argocd-notifications-controller",
+					Namespace: ns.Name,
+				},
+			}
+			clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-argocd-1-055-src-ns-test-argocd-notifications-controller",
+					Namespace: ns.Name,
+				},
+			}
+			role := &rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-argocd-1-055-src-ns-test-notifications",
+					Namespace: fooNs.Name,
+				},
+			}
+			roleBinding := &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-argocd-1-055-src-ns-test-notifications",
+					Namespace: fooNs.Name,
+				},
+			}
+
+			Eventually(role).Should(k8sFixture.NotExistByName())
+			Eventually(roleBinding).Should(k8sFixture.NotExistByName())
+			Eventually(clusterRole).Should(k8sFixture.NotExistByName())
+			Eventually(clusterRoleBinding).Should(k8sFixture.NotExistByName())
+
+		})
+
 	})
 })


### PR DESCRIPTION
(cherry picked from commit d498b8a2c6508c19e4d9c0c9779b4d5e4ab5c4f6)


