### PR TITLE
[0.16] fix: additional checks for appsets in any namespace field (#1953)

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -94,7 +94,7 @@ jobs:
           go mod download
       - name: Run the operator locally
         env:
-          ARGOCD_CLUSTER_CONFIG_NAMESPACES: argocd-e2e-cluster-config,central-argocd,default-thirtysix,appset-argocd,argocd-test-impersonation
+          ARGOCD_CLUSTER_CONFIG_NAMESPACES: argocd-e2e-cluster-config, argocd-test-impersonation-1-046, argocd-agent-principal-1-051, argocd-agent-agent-1-052, appset-argocd, appset-old-ns, appset-new-ns, central-argocd, default-thirtysix, appset-argocd,argocd-test-impersonation
         run: |
           set -o pipefail
           make install generate fmt vet

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -588,6 +588,10 @@ func TestReconcileApplicationSet_Deployments_Command(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			a := makeTestArgoCD()
+
+			os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", a.Namespace)
+			defer os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+
 			ns1 := v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -805,6 +809,8 @@ func TestReconcileApplicationSet_SourceNamespacesRBACCreation(t *testing.T) {
 
 			a := makeTestArgoCD()
 			allowClusterConfigNamespaces(t, a.Namespace)
+			defer os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+
 			resObjs := []client.Object{a}
 			subresObjs := []client.Object{a}
 			runtimeObjs := []runtime.Object{}
@@ -1278,7 +1284,10 @@ func TestArgoCDApplicationSet_removeUnmanagedApplicationSetSourceNamespaceResour
 	ns1 := "foo"
 	ns2 := "bar"
 	a := makeTestArgoCD()
+
 	allowClusterConfigNamespaces(t, a.Namespace)
+	defer os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+
 	a.Spec = argoproj.ArgoCDSpec{
 		SourceNamespaces: []string{ns1, ns2},
 		ApplicationSet: &argoproj.ArgoCDApplicationSet{
@@ -1350,6 +1359,86 @@ func TestArgoCDApplicationSet_removeUnmanagedApplicationSetSourceNamespaceResour
 	val, found := namespace.Labels[common.ArgoCDApplicationSetManagedByClusterArgoCDLabel]
 	assert.True(t, found)
 	assert.Equal(t, a.Namespace, val)
+}
+
+func TestReconcileApplicationSetSourceNamespacesResources_NonClusterConfigNamespace(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	tests := []struct {
+		name                      string
+		clusterConfigNamespaces   string
+		expectInManagedNamespaces bool
+		expectedManagedNamespaces []string
+	}{
+		{
+			name:                      "ARGOCD_CLUSTER_CONFIG_NAMESPACES contains namespace",
+			clusterConfigNamespaces:   "argocd",
+			expectInManagedNamespaces: true,
+			expectedManagedNamespaces: []string{"foo", "bar"},
+		},
+		{
+			name:                      "ARGOCD_CLUSTER_CONFIG_NAMESPACES does not contain namespace",
+			clusterConfigNamespaces:   "",
+			expectInManagedNamespaces: false,
+			expectedManagedNamespaces: []string{},
+		},
+		{
+			name:                      "ARGOCD_CLUSTER_CONFIG_NAMESPACES contains different namespace",
+			clusterConfigNamespaces:   "different-namespace",
+			expectInManagedNamespaces: false,
+			expectedManagedNamespaces: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			a := makeTestArgoCD()
+			a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{"foo", "bar"},
+			}
+			a.Spec.SourceNamespaces = []string{"foo", "bar"}
+
+			// Set ARGOCD_CLUSTER_CONFIG_NAMESPACES based on test case
+			os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", test.clusterConfigNamespaces)
+			defer os.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+
+			resObjs := []client.Object{a}
+			subresObjs := []client.Object{a}
+			runtimeObjs := []runtime.Object{}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+			// Initialize ManagedApplicationSetSourceNamespaces as empty map
+			r.ManagedApplicationSetSourceNamespaces = make(map[string]string)
+
+			// Create source namespaces so the function can process them
+			for _, ns := range []string{"foo", "bar"} {
+				err := createNamespace(r, ns, "")
+				assert.NoError(t, err)
+			}
+
+			// Verify IsNamespaceClusterConfigNamespace returns expected value
+			if test.expectInManagedNamespaces {
+				assert.True(t, argoutil.IsNamespaceClusterConfigNamespace(a.Namespace))
+			} else {
+				assert.False(t, argoutil.IsNamespaceClusterConfigNamespace(a.Namespace))
+			}
+
+			err := r.reconcileApplicationSetSourceNamespacesResources(a)
+			assert.NoError(t, err)
+
+			// Verify ManagedApplicationSetSourceNamespaces contains expected namespaces
+			if test.expectInManagedNamespaces {
+				assert.Equal(t, len(test.expectedManagedNamespaces), len(r.ManagedApplicationSetSourceNamespaces))
+				for _, ns := range test.expectedManagedNamespaces {
+					assert.Contains(t, r.ManagedApplicationSetSourceNamespaces, ns)
+				}
+			} else {
+				assert.Empty(t, r.ManagedApplicationSetSourceNamespaces)
+			}
+		})
+	}
 }
 
 func TestGetApplicationSetContainerImage(t *testing.T) {

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -76,7 +76,11 @@ type ReconcileArgoCD struct {
 	ManagedNamespaces *corev1.NamespaceList
 	// Stores a list of ApplicationSourceNamespaces as keys
 	ManagedSourceNamespaces map[string]string
-	// Stores a list of ApplicationSetSourceNamespaces as keys
+
+	// Stores a list of ApplicationSetSourceNamespaces as keys (value is not used)
+	// - list of namespaces that currently have the 'common.ArgoCDApplicationSetManagedByClusterArgoCDLabel' label
+	// - items in the list that are NOT mentioned in .spec.applicationset.sourceNamespaces will be cleaned up
+	// - (or if ALL resources in the list will be cleaned up if ArgoCD instance in namespace-scoped)
 	ManagedApplicationSetSourceNamespaces map[string]string
 	// Stores label selector used to reconcile a subset of ArgoCD
 	LabelSelector string

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -174,6 +174,7 @@ func (r *ReconcileArgoCD) namespaceResourceMapper(ctx context.Context, o client.
 	argocds := &argoproj.ArgoCDList{}
 	labels := o.GetLabels()
 	namespaceName := o.GetName()
+	// If the namespace is managed by an Argo CD instance in another namespace, then reconcile that instance
 	if v, ok := labels[common.ArgoCDManagedByLabel]; ok {
 		if err := r.List(context.TODO(), argocds, &client.ListOptions{Namespace: v}); err != nil {
 			return result
@@ -189,6 +190,19 @@ func (r *ReconcileArgoCD) namespaceResourceMapper(ctx context.Context, o client.
 		result = []reconcile.Request{
 			{NamespacedName: namespacedName},
 		}
+
+	} else if v, ok := labels[common.ArgoCDApplicationSetManagedByClusterArgoCDLabel]; ok {
+		// If the namespace is managed by applicationsets in any namespace, by Argo CD in another namespace, then reconcile that namespace's instance
+
+		namespaceContainingArgoCD := v
+		if err := r.List(ctx, argocds, client.InNamespace(namespaceContainingArgoCD)); err != nil {
+			return result
+		}
+		for idx := range argocds.Items {
+			argocd := argocds.Items[idx]
+			result = append(result, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&argocd)})
+		}
+
 	} else {
 		// If the namespace does not have the expected managed-by label,
 		// iterate through each ArgoCD instance to identify if the observed namespace

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -52,6 +52,7 @@ func GenerateUniqueResourceName(argoComponentName string, cr *argoproj.ArgoCD) s
 }
 
 func newClusterRole(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) *v1.ClusterRole {
+
 	return &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        GenerateUniqueResourceName(name, cr),


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:

Backport of https://github.com/argoproj-labs/argocd-operator/pull/1953
