### PR TITLE
fix: Restore tracking labels on namespaces

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -232,6 +232,10 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 		return reconcile.Result{}, argocd, err
 	}
 
+	if err = r.restoreTrackingLabelOnNamespacesWithResources(argocd); err != nil {
+		return reconcile.Result{}, argocd, err
+	}
+
 	if err = r.setManagedNamespaces(argocd); err != nil {
 		return reconcile.Result{}, argocd, err
 	}


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
