### PR TITLE
fix: verify argocd instance matches namespace label on notifications …

### DIFF
--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -883,6 +883,10 @@ func TestNotifications_removeUnmanagedNotificationsSourceNamespaceResources(t *t
 	err = r.reconcileNotificationsSourceNamespacesResources(a)
 	assert.NoError(t, err)
 
+	// populate ManagedNotificationsSourceNamespaces to track managed namespaces
+	err = r.setManagedNotificationsSourceNamespaces(a)
+	assert.NoError(t, err)
+
 	// remove notifications ns
 	a.Spec = argoproj.ArgoCDSpec{
 		SourceNamespaces: []string{ns2},

--- a/tests/ginkgo/parallel/1-055_validate_notification_controller_test.go
+++ b/tests/ginkgo/parallel/1-055_validate_notification_controller_test.go
@@ -18,6 +18,7 @@ package parallel
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -209,7 +210,18 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				},
 			}
 			Eventually(depl).Should(k8sFixture.ExistByName())
-			// TODO: add check to test "--application-namespaces" cmd arg is not present in the notification deployment container args
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(depl), depl)
+				if err != nil {
+					return false
+				}
+				if len(depl.Spec.Template.Spec.Containers) == 0 {
+					return false
+				}
+				cmd := depl.Spec.Template.Spec.Containers[0].Command
+				cmdStr := strings.Join(cmd, " ")
+				return !strings.Contains(cmdStr, "--application-namespaces")
+			}, "2m", "5s").Should(BeTrue())
 
 			By("verifying sourceNamespace rbac resources are not created")
 			clusterRole := &rbacv1.ClusterRole{


### PR DESCRIPTION
…cleanup (#1978)

(cherry picked from commit 8017feaeb59cb9b767b63e24248cf9c5742cd985)

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

 /kind bug 
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
Backport of #1978 
