### PR TITLE
chore: fix docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,6 @@ python:
   install:
     - requirements: docs/requirements.txt
 build:
-  os: "ubuntu-24.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,10 @@
-mkdocs==1.3.0
+mkdocs==1.6.1
+mkdocs-github-admonitions-plugin==0.1.1
 # Strict mode has been disabled in latest versions of mkdocs-material.
 # Thus pointing to the older version of mkdocs-material.
 mkdocs-material==7.1.8
-markdown_include==0.6.0
-pygments==2.15.0
+markdown_include==0.8.1
+pygments==2.19.2
 jinja2==3.1.6
-markdown==3.3.7
-pymdown-extensions==10.16.1
+markdown==3.10
+pymdown-extensions==10.17.1


### PR DESCRIPTION
**What type of PR is this?**

ReadtheDocs builds are currently failing due to dependency conflicts

```
The conflict is caused by:
  | The user requested markdown==3.3.7
  | mkdocs 1.3.0 depends on Markdown>=3.2.1
  | mkdocs-material 7.1.8 depends on markdown>=3.2
  | markdown-include 0.6.0 depends on markdown
  | pymdown-extensions 10.16.1 depends on markdown>=3.6
```

Aligning the versions with upstream Argo CD.

**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configuration for documentation generation.
  * Upgraded documentation packages and tools to newer versions, including improved plugin support for enhanced documentation features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->