### PR TITLE
doc: apps-in-any-namespace configuration

### DIFF
--- a/docs/usage/apps-in-any-namespace.md
+++ b/docs/usage/apps-in-any-namespace.md
@@ -11,7 +11,17 @@ Argo CD administrators can define a certain set of namespaces where Application 
 
 ## Using application-namespaces
 
-In order to enable this feature, specify the namespaces where Argo CD should manage applications in the ArgoCD YAML with `spec.sourceNamespaces`. This field also supports wildcards, allowing flexible and dynamic namespace configurations. For example:
+In order to enable this feature, specify the namespaces where Argo CD should manage applications in the ArgoCD YAML with `spec.sourceNamespaces`. 
+This field supports both:
+ - Glob-style wildcards (e.g., `team-*`, `team-frontend`, `app-??`)
+ - Regular expressions (wrapped in forward slashes, e.g., `/^team-(frontend|backend)$/`, `/^team-.*$/`)
+
+The operator resolves these patterns to actual namespaces at reconcile time and passes the expanded, concrete list to the Application controller.
+
+!!! note
+    Regular expression patterns must be wrapped in forward slashes (`/pattern/`) to be treated as regex. Patterns without slashes are treated as glob patterns. For example:
+    - `team-*` - glob pattern (matches team-1, team-2, etc.)
+    - `/^team-[0-9]+$/` - regex pattern (matches team-1, team-2, but not team-frontend)
 
 ## Enable application creation in a specific namespace
 ```yaml
@@ -41,6 +51,21 @@ spec:
 In this example:
 
 - Permissions are granted to namespaces matching the pattern `app-team-*`, such as `app-team-1`, `app-team-2`, etc.
+
+## Enable application creation in namespaces matching regular expressions
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd-regex
+spec:
+  sourceNamespaces:
+    - /^app-team-(frontend|backend)$/   # only frontend or backend
+    - /^app-team-[0-9]+$/               # numeric suffix (app-team-1, app-team-2)
+```
+
+In these examples, permissions are granted only to namespaces that match the provided regex patterns.
 
 ## Enable application creation in all namespaces
 


### PR DESCRIPTION


**What type of PR is this?**
/kind documentation

Updates [docs/usage/apps-in-any-namespace.md](https://github.com/argoproj-labs/argocd-operator/blob/master/docs/usage/apps-in-any-namespace.md#enable-application-creation-in-a-specific-namespace) to make the documentation consistent with how the operator handles spec.sourceNamespaces patterns:
Clarifies pattern types supported by spec.sourceNamespaces:

- Glob-style wildcards (e.g., team-*, app-??)
- Regular expressions when wrapped in /.../ (e.g., /^team-.*$/)

Adds a regex example showing how to allow namespaces via regular expressions (e.g., only specific team namespaces, numeric suffix namespaces), so users know exactly how to configure it and what to expect.


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**
* Documentation has been updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for application namespaces now supports both glob-style wildcards and regular expressions, with clarification on syntax requirements and practical usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->