### PR TITLE
fix(makefile): Improve performance of make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ gosec: go_sec
 .PHONY: lint
 lint: golangci_lint
 	$(GOLANGCI_LINT) --version
-	GOMAXPROCS=2 $(GOLANGCI_LINT) run --fix --verbose --timeout 300s
+	$(GOLANGCI_LINT) run --fix --verbose --timeout 300s
 
 
 GO_SEC = $(shell pwd)/bin/gosec


### PR DESCRIPTION
**What type of PR is this?**

Same change now done in argo-cd: https://github.com/argoproj/argo-cd/pull/26025

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
/kind enhancement
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

Speedup from 2m40s to 50s

**Have you updated the necessary documentation?**

* [no] Documentation update is required by this PR.
* [n/a] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process by adjusting linting configuration to allow improved parallelism during code quality checks, enabling the build system to utilize available resources more efficiently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->