### PR TITLE
fix(api): Drop the trailing `'` from spec display names

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -69,11 +69,11 @@ type ArgoCD struct {
 // ArgoCDApplicationControllerProcessorsSpec defines the options for the ArgoCD Application Controller processors.
 type ArgoCDApplicationControllerProcessorsSpec struct {
 	// Operation is the number of application operation processors.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Operation Processor Count'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:number"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Operation Processor Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:number"}
 	Operation int32 `json:"operation,omitempty"`
 
 	// Status is the number of application status processors.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Status Processor Count'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:number"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Status Processor Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:number"}
 	Status int32 `json:"status,omitempty"`
 }
 
@@ -89,7 +89,7 @@ type ArgoCDApplicationControllerSpec struct {
 	LogFormat string `json:"logFormat,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Application Controller.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// ParallelismLimit defines the limit for parallel kubectl operations
@@ -194,11 +194,11 @@ type ArgoCDDexSpec struct {
 	Image string `json:"image,omitempty"`
 
 	// OpenShiftOAuth enables OpenShift OAuth authentication for the Dex server.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenShift OAuth Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenShift OAuth Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	OpenShiftOAuth bool `json:"openShiftOAuth,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for Dex.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Version is the Dex container image tag.
@@ -224,7 +224,7 @@ type ArgoCDGrafanaSpec struct {
 	Ingress ArgoCDIngressSpec `json:"ingress,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for Grafana.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Route defines the desired state for an OpenShift Route for the Grafana component.
@@ -272,7 +272,7 @@ type ArgoCDIngressSpec struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Enabled will toggle the creation of the Ingress.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
 
 	// IngressClassName for the Ingress resource.
@@ -378,7 +378,7 @@ type ArgoCDRBACSpec struct {
 	// DefaultPolicy is the name of the default role which Argo CD will falls back to, when
 	// authorizing API requests (optional). If omitted or empty, users may be still be able to login,
 	// but will see no apps, projects, etc...
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Policy'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC","urn:alm:descriptor:com.tectonic.ui:text"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Policy",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC","urn:alm:descriptor:com.tectonic.ui:text"}
 	DefaultPolicy *string `json:"defaultPolicy,omitempty"`
 
 	// Policy is CSV containing user-defined RBAC policies and role definitions.
@@ -407,7 +407,7 @@ type ArgoCDRedisSpec struct {
 	Image string `json:"image,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for Redis.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Version is the Redis container image tag.
@@ -444,7 +444,7 @@ type ArgoCDRepoSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for Redis.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// ServiceAccount defines the ServiceAccount user that you would like the Repo server to use
@@ -494,7 +494,7 @@ type ArgoCDRouteSpec struct {
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Enabled will toggle the creation of the OpenShift Route.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Route Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Route Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
 
 	// Path the router watches for, to route traffic for to the service.
@@ -510,7 +510,7 @@ type ArgoCDRouteSpec struct {
 // ArgoCDServerAutoscaleSpec defines the desired state for autoscaling the Argo CD Server component.
 type ArgoCDServerAutoscaleSpec struct {
 	// Enabled will toggle autoscaling support for the Argo CD Server component.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autoscale Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autoscale Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
 
 	// HPA defines the HorizontalPodAutoscaler options for the Argo CD Server component.
@@ -524,7 +524,7 @@ type ArgoCDServerGRPCSpec struct {
 	Host string `json:"host,omitempty"`
 
 	// Ingress defines the desired state for the Argo CD Server GRPC Ingress.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="GRPC Ingress Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="GRPC Ingress Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Ingress ArgoCDIngressSpec `json:"ingress,omitempty"`
 }
 
@@ -560,7 +560,7 @@ type ArgoCDServerSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Argo CD server component.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Route defines the desired state for an OpenShift Route for the Argo CD Server component.
@@ -581,7 +581,7 @@ type ArgoCDServerSpec struct {
 // ArgoCDServerServiceSpec defines the Service options for Argo CD Server component.
 type ArgoCDServerServiceSpec struct {
 	// Type is the ServiceType to use for the Service resource.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Service Type'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:text"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Service Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:text"}
 	Type corev1.ServiceType `json:"type"`
 }
 
@@ -691,7 +691,7 @@ type ArgoCDSpec struct {
 	ApplicationSet *ArgoCDApplicationSet `json:"applicationSet,omitempty"`
 
 	// ApplicationInstanceLabelKey is the key name where Argo CD injects the app name as a tracking label.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Application Instance Label Key'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Application Instance Label Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ApplicationInstanceLabelKey string `json:"applicationInstanceLabelKey,omitempty"`
 
 	// InstallationID uniquely identifies an Argo CD instance in multi-instance clusters.
@@ -699,7 +699,7 @@ type ArgoCDSpec struct {
 	InstallationID string `json:"installationID,omitempty"`
 
 	// Deprecated: ConfigManagementPlugins field is no longer supported. Argo CD now requires plugins to be defined as sidecar containers of repo server component. See '.spec.repo.sidecarContainers'. ConfigManagementPlugins was previously used to specify additional config management plugins.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Management Plugins'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Management Plugins",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ConfigManagementPlugins string `json:"configManagementPlugins,omitempty"`
 
 	// Controller defines the Application Controller options for ArgoCD.
@@ -717,11 +717,11 @@ type ArgoCDSpec struct {
 	ExtraConfig map[string]string `json:"extraConfig,omitempty"`
 
 	// GATrackingID is the google analytics tracking ID to use.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Tracking ID'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Tracking ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	GATrackingID string `json:"gaTrackingID,omitempty"`
 
 	// GAAnonymizeUsers toggles user IDs being hashed before sending to google analytics.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Anonymize Users'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Anonymize Users",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	GAAnonymizeUsers bool `json:"gaAnonymizeUsers,omitempty"`
 
 	// Deprecated: Grafana defines the Grafana server options for ArgoCD.
@@ -731,11 +731,11 @@ type ArgoCDSpec struct {
 	HA ArgoCDHASpec `json:"ha,omitempty"`
 
 	// HelpChatURL is the URL for getting chat help, this will typically be your Slack channel for support.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Help Chat URL'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Help Chat URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	HelpChatURL string `json:"helpChatURL,omitempty"`
 
 	// HelpChatText is the text for getting chat help, defaults to "Chat now!"
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Help Chat Text'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Help Chat Text",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	HelpChatText string `json:"helpChatText,omitempty"`
 
 	// Image is the ArgoCD container image for all ArgoCD components.
@@ -752,7 +752,7 @@ type ArgoCDSpec struct {
 	Import *ArgoCDImportSpec `json:"import,omitempty"`
 
 	// InitialRepositories to configure Argo CD with upon creation of the cluster.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Initial Repositories'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Initial Repositories",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	InitialRepositories string `json:"initialRepositories,omitempty"`
 
 	// InitialSSHKnownHosts defines the SSH known hosts data upon creation of the cluster for connecting Git repositories via SSH.
@@ -762,11 +762,11 @@ type ArgoCDSpec struct {
 	KustomizeBuildOptions string `json:"kustomizeBuildOptions,omitempty"`
 
 	// KustomizeVersions is a listing of configured versions of Kustomize to be made available within ArgoCD.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Kustomize Build Options'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Kustomize Build Options",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	KustomizeVersions []KustomizeVersionSpec `json:"kustomizeVersions,omitempty"`
 
 	// OIDCConfig is the OIDC configuration as an alternative to dex.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OIDC Config'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OIDC Config",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	OIDCConfig string `json:"oidcConfig,omitempty"`
 
 	// Monitoring defines whether workload status monitoring configuration for this instance.
@@ -795,23 +795,23 @@ type ArgoCDSpec struct {
 
 	// Deprecated field. Support dropped in v1beta1 version.
 	// ResourceCustomizations customizes resource behavior. Keys are in the form: group/Kind. Please note that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences, and ResourceActions.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Customizations",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceCustomizations string `json:"resourceCustomizations,omitempty"`
 
 	// ResourceHealthChecks customizes resource health check behavior.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Health Check Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Health Check Customizations",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceHealthChecks []ResourceHealthCheck `json:"resourceHealthChecks,omitempty"`
 
 	// ResourceIgnoreDifferences customizes resource ignore difference behavior.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Ignore Difference Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Ignore Difference Customizations",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceIgnoreDifferences *ResourceIgnoreDifference `json:"resourceIgnoreDifferences,omitempty"`
 
 	// ResourceActions customizes resource action behavior.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Action Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Action Customizations",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceActions []ResourceAction `json:"resourceActions,omitempty"`
 
 	// ResourceExclusions is used to completely ignore entire classes of resource group/kinds.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Exclusions'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Exclusions",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceExclusions string `json:"resourceExclusions,omitempty"`
 
 	// ResourceInclusions is used to only include specific group/kinds in the
@@ -819,7 +819,7 @@ type ArgoCDSpec struct {
 	ResourceInclusions string `json:"resourceInclusions,omitempty"`
 
 	// ResourceTrackingMethod defines how Argo CD should track resources that it manages
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Tracking Method'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Tracking Method",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceTrackingMethod string `json:"resourceTrackingMethod,omitempty"`
 
 	// Server defines the options for the ArgoCD Server component.
@@ -832,7 +832,7 @@ type ArgoCDSpec struct {
 	SSO *ArgoCDSSOSpec `json:"sso,omitempty"`
 
 	// StatusBadgeEnabled toggles application status badge feature.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Status Badge Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Status Badge Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	StatusBadgeEnabled bool `json:"statusBadgeEnabled,omitempty"`
 
 	// TLS defines the TLS options for ArgoCD.
@@ -840,7 +840,7 @@ type ArgoCDSpec struct {
 
 	// UsersAnonymousEnabled toggles anonymous user access.
 	// The anonymous users get default role permissions specified argocd-rbac-cm.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anonymous Users Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anonymous Users Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	UsersAnonymousEnabled bool `json:"usersAnonymousEnabled,omitempty"`
 
 	// Version is the tag to use with the ArgoCD container image for all ArgoCD components.

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -69,11 +69,11 @@ type ArgoCD struct {
 // ArgoCDApplicationControllerProcessorsSpec defines the options for the ArgoCD Application Controller processors.
 type ArgoCDApplicationControllerProcessorsSpec struct {
 	// Operation is the number of application operation processors.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Operation Processor Count'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:number"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Operation Processor Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:number"}
 	Operation int32 `json:"operation,omitempty"`
 
 	// Status is the number of application status processors.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Status Processor Count'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:number"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Status Processor Count",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:number"}
 	Status int32 `json:"status,omitempty"`
 }
 
@@ -93,7 +93,7 @@ type ArgoCDApplicationControllerSpec struct {
 	LogFormat string `json:"logFormat,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Application Controller.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// ParallelismLimit defines the limit for parallel kubectl operations
@@ -255,11 +255,11 @@ type ArgoCDDexSpec struct {
 	Image string `json:"image,omitempty"`
 
 	// OpenShiftOAuth enables OpenShift OAuth authentication for the Dex server.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenShift OAuth Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenShift OAuth Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	OpenShiftOAuth bool `json:"openShiftOAuth,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for Dex.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Version is the Dex container image tag.
@@ -294,7 +294,7 @@ type ArgoCDGrafanaSpec struct {
 	Ingress ArgoCDIngressSpec `json:"ingress,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for Grafana.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Route defines the desired state for an OpenShift Route for the Grafana component.
@@ -354,7 +354,7 @@ type ArgoCDIngressSpec struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// Enabled will toggle the creation of the Ingress.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ingress Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
 
 	// IngressClassName for the Ingress resource.
@@ -460,7 +460,7 @@ type ArgoCDRBACSpec struct {
 	// DefaultPolicy is the name of the default role which Argo CD will falls back to, when
 	// authorizing API requests (optional). If omitted or empty, users may be still be able to login,
 	// but will see no apps, projects, etc...
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Policy'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC","urn:alm:descriptor:com.tectonic.ui:text"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Default Policy",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC","urn:alm:descriptor:com.tectonic.ui:text"}
 	DefaultPolicy *string `json:"defaultPolicy,omitempty"`
 
 	// Policy is CSV containing user-defined RBAC policies and role definitions.
@@ -489,7 +489,7 @@ type ArgoCDRedisSpec struct {
 	Image string `json:"image,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for Redis.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Version is the Redis container image tag.
@@ -540,7 +540,7 @@ type ArgoCDRepoSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for Redis.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// ServiceAccount defines the ServiceAccount user that you would like the Repo server to use
@@ -610,7 +610,7 @@ type ArgoCDRouteSpec struct {
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Enabled will toggle the creation of the OpenShift Route.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Route Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Route Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus","urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
 
 	// Path the router watches for, to route traffic for to the service.
@@ -626,7 +626,7 @@ type ArgoCDRouteSpec struct {
 // ArgoCDServerAutoscaleSpec defines the desired state for autoscaling the Argo CD Server component.
 type ArgoCDServerAutoscaleSpec struct {
 	// Enabled will toggle autoscaling support for the Argo CD Server component.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autoscale Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Autoscale Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Enabled bool `json:"enabled"`
 
 	// HPA defines the HorizontalPodAutoscaler options for the Argo CD Server component.
@@ -640,7 +640,7 @@ type ArgoCDServerGRPCSpec struct {
 	Host string `json:"host,omitempty"`
 
 	// Ingress defines the desired state for the Argo CD Server GRPC Ingress.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="GRPC Ingress Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="GRPC Ingress Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	Ingress ArgoCDIngressSpec `json:"ingress,omitempty"`
 }
 
@@ -679,7 +679,7 @@ type ArgoCDServerSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Resources defines the Compute Resources required by the container for the Argo CD server component.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Requirements",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Route defines the desired state for an OpenShift Route for the Argo CD Server component.
@@ -722,7 +722,7 @@ func (a *ArgoCDServerSpec) IsEnabled() bool {
 // ArgoCDServerServiceSpec defines the Service options for Argo CD Server component.
 type ArgoCDServerServiceSpec struct {
 	// Type is the ServiceType to use for the Service resource.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Service Type'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:text"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Service Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server","urn:alm:descriptor:com.tectonic.ui:text"}
 	Type corev1.ServiceType `json:"type"`
 }
 
@@ -850,7 +850,7 @@ type ArgoCDSpec struct {
 	ApplicationSet *ArgoCDApplicationSet `json:"applicationSet,omitempty"`
 
 	// ApplicationInstanceLabelKey is the key name where Argo CD injects the app name as a tracking label.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Application Instance Label Key'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Application Instance Label Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ApplicationInstanceLabelKey string `json:"applicationInstanceLabelKey,omitempty"`
 
 	// InstallationID uniquely identifies an Argo CD instance in multi-instance clusters.
@@ -858,7 +858,7 @@ type ArgoCDSpec struct {
 	InstallationID string `json:"installationID,omitempty"`
 
 	// Deprecated: ConfigManagementPlugins field is no longer supported. Argo CD now requires plugins to be defined as sidecar containers of repo server component. See '.spec.repo.sidecarContainers'. ConfigManagementPlugins was previously used to specify additional config management plugins.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Management Plugins'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Config Management Plugins",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ConfigManagementPlugins string `json:"configManagementPlugins,omitempty"`
 
 	// Controller defines the Application Controller options for ArgoCD.
@@ -876,11 +876,11 @@ type ArgoCDSpec struct {
 	ExtraConfig map[string]string `json:"extraConfig,omitempty"`
 
 	// GATrackingID is the google analytics tracking ID to use.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Tracking ID'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Tracking ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	GATrackingID string `json:"gaTrackingID,omitempty"`
 
 	// GAAnonymizeUsers toggles user IDs being hashed before sending to google analytics.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Anonymize Users'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Analytics Anonymize Users",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	GAAnonymizeUsers bool `json:"gaAnonymizeUsers,omitempty"`
 
 	// Deprecated: Grafana defines the Grafana server options for ArgoCD.
@@ -890,11 +890,11 @@ type ArgoCDSpec struct {
 	HA ArgoCDHASpec `json:"ha,omitempty"`
 
 	// HelpChatURL is the URL for getting chat help, this will typically be your Slack channel for support.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Help Chat URL'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Help Chat URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	HelpChatURL string `json:"helpChatURL,omitempty"`
 
 	// HelpChatText is the text for getting chat help, defaults to "Chat now!"
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Help Chat Text'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Help Chat Text",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	HelpChatText string `json:"helpChatText,omitempty"`
 
 	// Image is the ArgoCD container image for all ArgoCD components.
@@ -914,7 +914,7 @@ type ArgoCDSpec struct {
 	Import *ArgoCDImportSpec `json:"import,omitempty"`
 
 	// Deprecated: InitialRepositories to configure Argo CD with upon creation of the cluster.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Initial Repositories'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Initial Repositories",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	InitialRepositories string `json:"initialRepositories,omitempty"`
 
 	// InitialSSHKnownHosts defines the SSH known hosts data upon creation of the cluster for connecting Git repositories via SSH.
@@ -924,14 +924,14 @@ type ArgoCDSpec struct {
 	KustomizeBuildOptions string `json:"kustomizeBuildOptions,omitempty"`
 
 	// KustomizeVersions is a listing of configured versions of Kustomize to be made available within ArgoCD.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Kustomize Build Options'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Kustomize Build Options",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	KustomizeVersions []KustomizeVersionSpec `json:"kustomizeVersions,omitempty"`
 
 	// LocalUsers is a listing of local users to be created by the operator for the purpose of issuing ArgoCD API keys.
 	LocalUsers []LocalUserSpec `json:"localUsers,omitempty"`
 
 	// OIDCConfig is the OIDC configuration as an alternative to dex.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OIDC Config'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OIDC Config",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	OIDCConfig string `json:"oidcConfig,omitempty"`
 
 	// Monitoring defines whether workload status monitoring configuration for this instance.
@@ -959,19 +959,19 @@ type ArgoCDSpec struct {
 	RepositoryCredentials string `json:"repositoryCredentials,omitempty"`
 
 	// ResourceHealthChecks customizes resource health check behavior.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Health Check Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Health Check Customizations",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceHealthChecks []ResourceHealthCheck `json:"resourceHealthChecks,omitempty"`
 
 	// ResourceIgnoreDifferences customizes resource ignore difference behavior.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Ignore Difference Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Ignore Difference Customizations",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceIgnoreDifferences *ResourceIgnoreDifference `json:"resourceIgnoreDifferences,omitempty"`
 
 	// ResourceActions customizes resource action behavior.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Action Customizations'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Action Customizations",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceActions []ResourceAction `json:"resourceActions,omitempty"`
 
 	// ResourceExclusions is used to completely ignore entire classes of resource group/kinds.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Exclusions'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Exclusions",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceExclusions string `json:"resourceExclusions,omitempty"`
 
 	// ResourceInclusions is used to only include specific group/kinds in the
@@ -979,7 +979,7 @@ type ArgoCDSpec struct {
 	ResourceInclusions string `json:"resourceInclusions,omitempty"`
 
 	// ResourceTrackingMethod defines how Argo CD should track resources that it manages
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Tracking Method'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Resource Tracking Method",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	ResourceTrackingMethod string `json:"resourceTrackingMethod,omitempty"`
 
 	// Server defines the options for the ArgoCD Server component.
@@ -992,7 +992,7 @@ type ArgoCDSpec struct {
 	SSO *ArgoCDSSOSpec `json:"sso,omitempty"`
 
 	// StatusBadgeEnabled toggles application status badge feature.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Status Badge Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Status Badge Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	StatusBadgeEnabled bool `json:"statusBadgeEnabled,omitempty"`
 
 	// TLS defines the TLS options for ArgoCD.
@@ -1000,7 +1000,7 @@ type ArgoCDSpec struct {
 
 	// UsersAnonymousEnabled toggles anonymous user access.
 	// The anonymous users get default role permissions specified argocd-rbac-cm.
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anonymous Users Enabled'",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Anonymous Users Enabled",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	UsersAnonymousEnabled bool `json:"usersAnonymousEnabled,omitempty"`
 
 	// Version is the tag to use with the ArgoCD container image for all ArgoCD components.

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-01-21T09:23:21Z"
+    createdAt: "2026-01-30T19:24:37Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -424,7 +424,7 @@ spec:
       specDescriptors:
       - description: ApplicationInstanceLabelKey is the key name where Argo CD injects
           the app name as a tracking label.
-        displayName: Application Instance Label Key'
+        displayName: Application Instance Label Key
         path: applicationInstanceLabelKey
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -436,7 +436,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: applicationSet.webhookServer.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -444,7 +444,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: applicationSet.webhookServer.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -455,26 +455,26 @@ spec:
           Argo CD now requires plugins to be defined as sidecar containers of repo
           server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
           was previously used to specify additional config management plugins.'
-        displayName: Config Management Plugins'
+        displayName: Config Management Plugins
         path: configManagementPlugins
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Operation is the number of application operation processors.
-        displayName: Operation Processor Count'
+        displayName: Operation Processor Count
         path: controller.processors.operation
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Status is the number of application status processors.
-        displayName: Status Processor Count'
+        displayName: Status Processor Count
         path: controller.processors.status
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Resources defines the Compute Resources required by the container
           for the Application Controller.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: controller.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
@@ -493,14 +493,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -513,13 +513,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: GAAnonymizeUsers toggles user IDs being hashed before sending
           to google analytics.
-        displayName: Google Analytics Anonymize Users'
+        displayName: Google Analytics Anonymize Users
         path: gaAnonymizeUsers
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: GATrackingID is the google analytics tracking ID to use.
-        displayName: Google Analytics Tracking ID'
+        displayName: Google Analytics Tracking ID
         path: gaTrackingID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -543,7 +543,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: grafana.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -552,13 +552,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Grafana.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: grafana.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: grafana.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -585,14 +585,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: HelpChatText is the text for getting chat help, defaults to "Chat
           now!"
-        displayName: Help Chat Text'
+        displayName: Help Chat Text
         path: helpChatText
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: HelpChatURL is the URL for getting chat help, this will typically
           be your Slack channel for support.
-        displayName: Help Chat URL'
+        displayName: Help Chat URL
         path: helpChatURL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -627,7 +627,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: InitialRepositories to configure Argo CD with upon creation of
           the cluster.
-        displayName: Initial Repositories'
+        displayName: Initial Repositories
         path: initialRepositories
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -641,13 +641,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: KustomizeVersions is a listing of configured versions of Kustomize
           to be made available within ArgoCD.
-        displayName: Kustomize Build Options'
+        displayName: Kustomize Build Options
         path: kustomizeVersions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: OIDCConfig is the OIDC configuration as an alternative to dex.
-        displayName: OIDC Config'
+        displayName: OIDC Config
         path: oidcConfig
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -665,7 +665,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: prometheus.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -673,7 +673,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: prometheus.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -689,7 +689,7 @@ spec:
       - description: DefaultPolicy is the name of the default role which Argo CD will
           falls back to, when authorizing API requests (optional). If omitted or empty,
           users may be still be able to login, but will see no apps, projects, etc...
-        displayName: Default Policy'
+        displayName: Default Policy
         path: rbac.defaultPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC
@@ -719,7 +719,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: redis.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis
@@ -732,13 +732,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: repo.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: ResourceActions customizes resource action behavior.
-        displayName: Resource Action Customizations'
+        displayName: Resource Action Customizations
         path: resourceActions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -747,41 +747,41 @@ spec:
           customizes resource behavior. Keys are in the form: group/Kind. Please note
           that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
           and ResourceActions.'
-        displayName: Resource Customizations'
+        displayName: Resource Customizations
         path: resourceCustomizations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
-        displayName: Resource Exclusions'
+        displayName: Resource Exclusions
         path: resourceExclusions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceHealthChecks customizes resource health check behavior.
-        displayName: Resource Health Check Customizations'
+        displayName: Resource Health Check Customizations
         path: resourceHealthChecks
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceIgnoreDifferences customizes resource ignore difference
           behavior.
-        displayName: Resource Ignore Difference Customizations'
+        displayName: Resource Ignore Difference Customizations
         path: resourceIgnoreDifferences
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceTrackingMethod defines how Argo CD should track resources
           that it manages
-        displayName: Resource Tracking Method'
+        displayName: Resource Tracking Method
         path: resourceTrackingMethod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Enabled will toggle autoscaling support for the Argo CD Server
           component.
-        displayName: Autoscale Enabled'
+        displayName: Autoscale Enabled
         path: server.autoscale.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -794,13 +794,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Ingress defines the desired state for the Argo CD Server GRPC
           Ingress.
-        displayName: GRPC Ingress Enabled'
+        displayName: GRPC Ingress Enabled
         path: server.grpc.ingress
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.grpc.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -814,7 +814,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -829,13 +829,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for the Argo CD server component.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: server.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: server.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -843,7 +843,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Type is the ServiceType to use for the Service resource.
-        displayName: Service Type'
+        displayName: Service Type
         path: server.service.type
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -862,14 +862,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: sso.dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: sso.dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -881,14 +881,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: StatusBadgeEnabled toggles application status badge feature.
-        displayName: Status Badge Enabled'
+        displayName: Status Badge Enabled
         path: statusBadgeEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: UsersAnonymousEnabled toggles anonymous user access. The anonymous
           users get default role permissions specified argocd-rbac-cm.
-        displayName: Anonymous Users Enabled'
+        displayName: Anonymous Users Enabled
         path: usersAnonymousEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
@@ -1052,7 +1052,7 @@ spec:
       specDescriptors:
       - description: ApplicationInstanceLabelKey is the key name where Argo CD injects
           the app name as a tracking label.
-        displayName: Application Instance Label Key'
+        displayName: Application Instance Label Key
         path: applicationInstanceLabelKey
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1064,7 +1064,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: applicationSet.webhookServer.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1072,7 +1072,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: applicationSet.webhookServer.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1083,39 +1083,39 @@ spec:
           Argo CD now requires plugins to be defined as sidecar containers of repo
           server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
           was previously used to specify additional config management plugins.'
-        displayName: Config Management Plugins'
+        displayName: Config Management Plugins
         path: configManagementPlugins
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Operation is the number of application operation processors.
-        displayName: Operation Processor Count'
+        displayName: Operation Processor Count
         path: controller.processors.operation
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Status is the number of application status processors.
-        displayName: Status Processor Count'
+        displayName: Status Processor Count
         path: controller.processors.status
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Resources defines the Compute Resources required by the container
           for the Application Controller.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: controller.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: GAAnonymizeUsers toggles user IDs being hashed before sending
           to google analytics.
-        displayName: Google Analytics Anonymize Users'
+        displayName: Google Analytics Anonymize Users
         path: gaAnonymizeUsers
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: GATrackingID is the google analytics tracking ID to use.
-        displayName: Google Analytics Tracking ID'
+        displayName: Google Analytics Tracking ID
         path: gaTrackingID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1139,7 +1139,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: grafana.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1148,13 +1148,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Grafana.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: grafana.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: grafana.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1181,14 +1181,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: HelpChatText is the text for getting chat help, defaults to "Chat
           now!"
-        displayName: Help Chat Text'
+        displayName: Help Chat Text
         path: helpChatText
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: HelpChatURL is the URL for getting chat help, this will typically
           be your Slack channel for support.
-        displayName: Help Chat URL'
+        displayName: Help Chat URL
         path: helpChatURL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1223,7 +1223,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Deprecated: InitialRepositories to configure Argo CD with upon
           creation of the cluster.'
-        displayName: Initial Repositories'
+        displayName: Initial Repositories
         path: initialRepositories
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1237,13 +1237,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: KustomizeVersions is a listing of configured versions of Kustomize
           to be made available within ArgoCD.
-        displayName: Kustomize Build Options'
+        displayName: Kustomize Build Options
         path: kustomizeVersions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: OIDCConfig is the OIDC configuration as an alternative to dex.
-        displayName: OIDC Config'
+        displayName: OIDC Config
         path: oidcConfig
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1261,7 +1261,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: prometheus.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1269,7 +1269,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: prometheus.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1285,7 +1285,7 @@ spec:
       - description: DefaultPolicy is the name of the default role which Argo CD will
           falls back to, when authorizing API requests (optional). If omitted or empty,
           users may be still be able to login, but will see no apps, projects, etc...
-        displayName: Default Policy'
+        displayName: Default Policy
         path: rbac.defaultPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC
@@ -1315,7 +1315,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: redis.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis
@@ -1328,47 +1328,47 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: repo.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: ResourceActions customizes resource action behavior.
-        displayName: Resource Action Customizations'
+        displayName: Resource Action Customizations
         path: resourceActions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
-        displayName: Resource Exclusions'
+        displayName: Resource Exclusions
         path: resourceExclusions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceHealthChecks customizes resource health check behavior.
-        displayName: Resource Health Check Customizations'
+        displayName: Resource Health Check Customizations
         path: resourceHealthChecks
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceIgnoreDifferences customizes resource ignore difference
           behavior.
-        displayName: Resource Ignore Difference Customizations'
+        displayName: Resource Ignore Difference Customizations
         path: resourceIgnoreDifferences
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceTrackingMethod defines how Argo CD should track resources
           that it manages
-        displayName: Resource Tracking Method'
+        displayName: Resource Tracking Method
         path: resourceTrackingMethod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Enabled will toggle autoscaling support for the Argo CD Server
           component.
-        displayName: Autoscale Enabled'
+        displayName: Autoscale Enabled
         path: server.autoscale.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -1381,13 +1381,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Ingress defines the desired state for the Argo CD Server GRPC
           Ingress.
-        displayName: GRPC Ingress Enabled'
+        displayName: GRPC Ingress Enabled
         path: server.grpc.ingress
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.grpc.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1401,7 +1401,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1416,13 +1416,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for the Argo CD server component.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: server.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: server.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1430,7 +1430,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Type is the ServiceType to use for the Service resource.
-        displayName: Service Type'
+        displayName: Service Type
         path: server.service.type
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -1449,14 +1449,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: sso.dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: sso.dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -1468,14 +1468,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: StatusBadgeEnabled toggles application status badge feature.
-        displayName: Status Badge Enabled'
+        displayName: Status Badge Enabled
         path: statusBadgeEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: UsersAnonymousEnabled toggles anonymous user access. The anonymous
           users get default role permissions specified argocd-rbac-cm.
-        displayName: Anonymous Users Enabled'
+        displayName: Anonymous Users Enabled
         path: usersAnonymousEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch

--- a/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/argocd-operator.clusterserviceversion.yaml
@@ -262,7 +262,7 @@ spec:
       specDescriptors:
       - description: ApplicationInstanceLabelKey is the key name where Argo CD injects
           the app name as a tracking label.
-        displayName: Application Instance Label Key'
+        displayName: Application Instance Label Key
         path: applicationInstanceLabelKey
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -274,7 +274,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: applicationSet.webhookServer.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -282,7 +282,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: applicationSet.webhookServer.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -293,39 +293,39 @@ spec:
           Argo CD now requires plugins to be defined as sidecar containers of repo
           server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
           was previously used to specify additional config management plugins.'
-        displayName: Config Management Plugins'
+        displayName: Config Management Plugins
         path: configManagementPlugins
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Operation is the number of application operation processors.
-        displayName: Operation Processor Count'
+        displayName: Operation Processor Count
         path: controller.processors.operation
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Status is the number of application status processors.
-        displayName: Status Processor Count'
+        displayName: Status Processor Count
         path: controller.processors.status
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Resources defines the Compute Resources required by the container
           for the Application Controller.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: controller.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: GAAnonymizeUsers toggles user IDs being hashed before sending
           to google analytics.
-        displayName: Google Analytics Anonymize Users'
+        displayName: Google Analytics Anonymize Users
         path: gaAnonymizeUsers
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: GATrackingID is the google analytics tracking ID to use.
-        displayName: Google Analytics Tracking ID'
+        displayName: Google Analytics Tracking ID
         path: gaTrackingID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -349,7 +349,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: grafana.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -358,13 +358,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Grafana.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: grafana.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: grafana.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -391,14 +391,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: HelpChatText is the text for getting chat help, defaults to "Chat
           now!"
-        displayName: Help Chat Text'
+        displayName: Help Chat Text
         path: helpChatText
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: HelpChatURL is the URL for getting chat help, this will typically
           be your Slack channel for support.
-        displayName: Help Chat URL'
+        displayName: Help Chat URL
         path: helpChatURL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -433,7 +433,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Deprecated: InitialRepositories to configure Argo CD with upon
           creation of the cluster.'
-        displayName: Initial Repositories'
+        displayName: Initial Repositories
         path: initialRepositories
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -447,13 +447,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: KustomizeVersions is a listing of configured versions of Kustomize
           to be made available within ArgoCD.
-        displayName: Kustomize Build Options'
+        displayName: Kustomize Build Options
         path: kustomizeVersions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: OIDCConfig is the OIDC configuration as an alternative to dex.
-        displayName: OIDC Config'
+        displayName: OIDC Config
         path: oidcConfig
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -471,7 +471,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: prometheus.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -479,7 +479,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: prometheus.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -495,7 +495,7 @@ spec:
       - description: DefaultPolicy is the name of the default role which Argo CD will
           falls back to, when authorizing API requests (optional). If omitted or empty,
           users may be still be able to login, but will see no apps, projects, etc...
-        displayName: Default Policy'
+        displayName: Default Policy
         path: rbac.defaultPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC
@@ -525,7 +525,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: redis.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis
@@ -538,47 +538,47 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: repo.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: ResourceActions customizes resource action behavior.
-        displayName: Resource Action Customizations'
+        displayName: Resource Action Customizations
         path: resourceActions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
-        displayName: Resource Exclusions'
+        displayName: Resource Exclusions
         path: resourceExclusions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceHealthChecks customizes resource health check behavior.
-        displayName: Resource Health Check Customizations'
+        displayName: Resource Health Check Customizations
         path: resourceHealthChecks
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceIgnoreDifferences customizes resource ignore difference
           behavior.
-        displayName: Resource Ignore Difference Customizations'
+        displayName: Resource Ignore Difference Customizations
         path: resourceIgnoreDifferences
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceTrackingMethod defines how Argo CD should track resources
           that it manages
-        displayName: Resource Tracking Method'
+        displayName: Resource Tracking Method
         path: resourceTrackingMethod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Enabled will toggle autoscaling support for the Argo CD Server
           component.
-        displayName: Autoscale Enabled'
+        displayName: Autoscale Enabled
         path: server.autoscale.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -591,13 +591,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Ingress defines the desired state for the Argo CD Server GRPC
           Ingress.
-        displayName: GRPC Ingress Enabled'
+        displayName: GRPC Ingress Enabled
         path: server.grpc.ingress
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.grpc.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -611,7 +611,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -626,13 +626,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for the Argo CD server component.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: server.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: server.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -640,7 +640,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Type is the ServiceType to use for the Service resource.
-        displayName: Service Type'
+        displayName: Service Type
         path: server.service.type
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -659,14 +659,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: sso.dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: sso.dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -678,14 +678,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: StatusBadgeEnabled toggles application status badge feature.
-        displayName: Status Badge Enabled'
+        displayName: Status Badge Enabled
         path: statusBadgeEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: UsersAnonymousEnabled toggles anonymous user access. The anonymous
           users get default role permissions specified argocd-rbac-cm.
-        displayName: Anonymous Users Enabled'
+        displayName: Anonymous Users Enabled
         path: usersAnonymousEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
@@ -849,7 +849,7 @@ spec:
       specDescriptors:
       - description: ApplicationInstanceLabelKey is the key name where Argo CD injects
           the app name as a tracking label.
-        displayName: Application Instance Label Key'
+        displayName: Application Instance Label Key
         path: applicationInstanceLabelKey
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -861,7 +861,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: applicationSet.webhookServer.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -869,7 +869,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: applicationSet.webhookServer.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -880,26 +880,26 @@ spec:
           Argo CD now requires plugins to be defined as sidecar containers of repo
           server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
           was previously used to specify additional config management plugins.'
-        displayName: Config Management Plugins'
+        displayName: Config Management Plugins
         path: configManagementPlugins
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Operation is the number of application operation processors.
-        displayName: Operation Processor Count'
+        displayName: Operation Processor Count
         path: controller.processors.operation
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Status is the number of application status processors.
-        displayName: Status Processor Count'
+        displayName: Status Processor Count
         path: controller.processors.status
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Resources defines the Compute Resources required by the container
           for the Application Controller.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: controller.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
@@ -918,14 +918,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -938,13 +938,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: GAAnonymizeUsers toggles user IDs being hashed before sending
           to google analytics.
-        displayName: Google Analytics Anonymize Users'
+        displayName: Google Analytics Anonymize Users
         path: gaAnonymizeUsers
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: GATrackingID is the google analytics tracking ID to use.
-        displayName: Google Analytics Tracking ID'
+        displayName: Google Analytics Tracking ID
         path: gaTrackingID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -968,7 +968,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: grafana.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -977,13 +977,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Grafana.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: grafana.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: grafana.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1010,14 +1010,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: HelpChatText is the text for getting chat help, defaults to "Chat
           now!"
-        displayName: Help Chat Text'
+        displayName: Help Chat Text
         path: helpChatText
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: HelpChatURL is the URL for getting chat help, this will typically
           be your Slack channel for support.
-        displayName: Help Chat URL'
+        displayName: Help Chat URL
         path: helpChatURL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1052,7 +1052,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: InitialRepositories to configure Argo CD with upon creation of
           the cluster.
-        displayName: Initial Repositories'
+        displayName: Initial Repositories
         path: initialRepositories
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1066,13 +1066,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: KustomizeVersions is a listing of configured versions of Kustomize
           to be made available within ArgoCD.
-        displayName: Kustomize Build Options'
+        displayName: Kustomize Build Options
         path: kustomizeVersions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: OIDCConfig is the OIDC configuration as an alternative to dex.
-        displayName: OIDC Config'
+        displayName: OIDC Config
         path: oidcConfig
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1090,7 +1090,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: prometheus.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1098,7 +1098,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: prometheus.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1114,7 +1114,7 @@ spec:
       - description: DefaultPolicy is the name of the default role which Argo CD will
           falls back to, when authorizing API requests (optional). If omitted or empty,
           users may be still be able to login, but will see no apps, projects, etc...
-        displayName: Default Policy'
+        displayName: Default Policy
         path: rbac.defaultPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC
@@ -1144,7 +1144,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: redis.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis
@@ -1157,13 +1157,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: repo.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: ResourceActions customizes resource action behavior.
-        displayName: Resource Action Customizations'
+        displayName: Resource Action Customizations
         path: resourceActions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1172,41 +1172,41 @@ spec:
           customizes resource behavior. Keys are in the form: group/Kind. Please note
           that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
           and ResourceActions.'
-        displayName: Resource Customizations'
+        displayName: Resource Customizations
         path: resourceCustomizations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
-        displayName: Resource Exclusions'
+        displayName: Resource Exclusions
         path: resourceExclusions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceHealthChecks customizes resource health check behavior.
-        displayName: Resource Health Check Customizations'
+        displayName: Resource Health Check Customizations
         path: resourceHealthChecks
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceIgnoreDifferences customizes resource ignore difference
           behavior.
-        displayName: Resource Ignore Difference Customizations'
+        displayName: Resource Ignore Difference Customizations
         path: resourceIgnoreDifferences
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceTrackingMethod defines how Argo CD should track resources
           that it manages
-        displayName: Resource Tracking Method'
+        displayName: Resource Tracking Method
         path: resourceTrackingMethod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Enabled will toggle autoscaling support for the Argo CD Server
           component.
-        displayName: Autoscale Enabled'
+        displayName: Autoscale Enabled
         path: server.autoscale.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -1219,13 +1219,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Ingress defines the desired state for the Argo CD Server GRPC
           Ingress.
-        displayName: GRPC Ingress Enabled'
+        displayName: GRPC Ingress Enabled
         path: server.grpc.ingress
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.grpc.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1239,7 +1239,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1254,13 +1254,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for the Argo CD server component.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: server.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: server.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1268,7 +1268,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Type is the ServiceType to use for the Service resource.
-        displayName: Service Type'
+        displayName: Service Type
         path: server.service.type
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -1287,14 +1287,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: sso.dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: sso.dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -1306,14 +1306,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: StatusBadgeEnabled toggles application status badge feature.
-        displayName: Status Badge Enabled'
+        displayName: Status Badge Enabled
         path: statusBadgeEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: UsersAnonymousEnabled toggles anonymous user access. The anonymous
           users get default role permissions specified argocd-rbac-cm.
-        displayName: Anonymous Users Enabled'
+        displayName: Anonymous Users Enabled
         path: usersAnonymousEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch

--- a/deploy/olm-catalog/argocd-operator/0.18.0/argocd-operator.v0.18.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.18.0/argocd-operator.v0.18.0.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-01-21T09:23:21Z"
+    createdAt: "2026-01-30T19:24:37Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -424,7 +424,7 @@ spec:
       specDescriptors:
       - description: ApplicationInstanceLabelKey is the key name where Argo CD injects
           the app name as a tracking label.
-        displayName: Application Instance Label Key'
+        displayName: Application Instance Label Key
         path: applicationInstanceLabelKey
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -436,7 +436,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: applicationSet.webhookServer.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -444,7 +444,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: applicationSet.webhookServer.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -455,26 +455,26 @@ spec:
           Argo CD now requires plugins to be defined as sidecar containers of repo
           server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
           was previously used to specify additional config management plugins.'
-        displayName: Config Management Plugins'
+        displayName: Config Management Plugins
         path: configManagementPlugins
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Operation is the number of application operation processors.
-        displayName: Operation Processor Count'
+        displayName: Operation Processor Count
         path: controller.processors.operation
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Status is the number of application status processors.
-        displayName: Status Processor Count'
+        displayName: Status Processor Count
         path: controller.processors.status
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Resources defines the Compute Resources required by the container
           for the Application Controller.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: controller.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
@@ -493,14 +493,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -513,13 +513,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: GAAnonymizeUsers toggles user IDs being hashed before sending
           to google analytics.
-        displayName: Google Analytics Anonymize Users'
+        displayName: Google Analytics Anonymize Users
         path: gaAnonymizeUsers
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: GATrackingID is the google analytics tracking ID to use.
-        displayName: Google Analytics Tracking ID'
+        displayName: Google Analytics Tracking ID
         path: gaTrackingID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -543,7 +543,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: grafana.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -552,13 +552,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Grafana.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: grafana.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: grafana.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -585,14 +585,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: HelpChatText is the text for getting chat help, defaults to "Chat
           now!"
-        displayName: Help Chat Text'
+        displayName: Help Chat Text
         path: helpChatText
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: HelpChatURL is the URL for getting chat help, this will typically
           be your Slack channel for support.
-        displayName: Help Chat URL'
+        displayName: Help Chat URL
         path: helpChatURL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -627,7 +627,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: InitialRepositories to configure Argo CD with upon creation of
           the cluster.
-        displayName: Initial Repositories'
+        displayName: Initial Repositories
         path: initialRepositories
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -641,13 +641,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: KustomizeVersions is a listing of configured versions of Kustomize
           to be made available within ArgoCD.
-        displayName: Kustomize Build Options'
+        displayName: Kustomize Build Options
         path: kustomizeVersions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: OIDCConfig is the OIDC configuration as an alternative to dex.
-        displayName: OIDC Config'
+        displayName: OIDC Config
         path: oidcConfig
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -665,7 +665,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: prometheus.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -673,7 +673,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: prometheus.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -689,7 +689,7 @@ spec:
       - description: DefaultPolicy is the name of the default role which Argo CD will
           falls back to, when authorizing API requests (optional). If omitted or empty,
           users may be still be able to login, but will see no apps, projects, etc...
-        displayName: Default Policy'
+        displayName: Default Policy
         path: rbac.defaultPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC
@@ -719,7 +719,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: redis.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis
@@ -732,13 +732,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: repo.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: ResourceActions customizes resource action behavior.
-        displayName: Resource Action Customizations'
+        displayName: Resource Action Customizations
         path: resourceActions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -747,41 +747,41 @@ spec:
           customizes resource behavior. Keys are in the form: group/Kind. Please note
           that this is being deprecated in favor of ResourceHealthChecks, ResourceIgnoreDifferences,
           and ResourceActions.'
-        displayName: Resource Customizations'
+        displayName: Resource Customizations
         path: resourceCustomizations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
-        displayName: Resource Exclusions'
+        displayName: Resource Exclusions
         path: resourceExclusions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceHealthChecks customizes resource health check behavior.
-        displayName: Resource Health Check Customizations'
+        displayName: Resource Health Check Customizations
         path: resourceHealthChecks
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceIgnoreDifferences customizes resource ignore difference
           behavior.
-        displayName: Resource Ignore Difference Customizations'
+        displayName: Resource Ignore Difference Customizations
         path: resourceIgnoreDifferences
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceTrackingMethod defines how Argo CD should track resources
           that it manages
-        displayName: Resource Tracking Method'
+        displayName: Resource Tracking Method
         path: resourceTrackingMethod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Enabled will toggle autoscaling support for the Argo CD Server
           component.
-        displayName: Autoscale Enabled'
+        displayName: Autoscale Enabled
         path: server.autoscale.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -794,13 +794,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Ingress defines the desired state for the Argo CD Server GRPC
           Ingress.
-        displayName: GRPC Ingress Enabled'
+        displayName: GRPC Ingress Enabled
         path: server.grpc.ingress
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.grpc.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -814,7 +814,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -829,13 +829,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for the Argo CD server component.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: server.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: server.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -843,7 +843,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Type is the ServiceType to use for the Service resource.
-        displayName: Service Type'
+        displayName: Service Type
         path: server.service.type
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -862,14 +862,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: sso.dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: sso.dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -881,14 +881,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: StatusBadgeEnabled toggles application status badge feature.
-        displayName: Status Badge Enabled'
+        displayName: Status Badge Enabled
         path: statusBadgeEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: UsersAnonymousEnabled toggles anonymous user access. The anonymous
           users get default role permissions specified argocd-rbac-cm.
-        displayName: Anonymous Users Enabled'
+        displayName: Anonymous Users Enabled
         path: usersAnonymousEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
@@ -1052,7 +1052,7 @@ spec:
       specDescriptors:
       - description: ApplicationInstanceLabelKey is the key name where Argo CD injects
           the app name as a tracking label.
-        displayName: Application Instance Label Key'
+        displayName: Application Instance Label Key
         path: applicationInstanceLabelKey
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1064,7 +1064,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: applicationSet.webhookServer.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1072,7 +1072,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: applicationSet.webhookServer.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1083,39 +1083,39 @@ spec:
           Argo CD now requires plugins to be defined as sidecar containers of repo
           server component. See ''.spec.repo.sidecarContainers''. ConfigManagementPlugins
           was previously used to specify additional config management plugins.'
-        displayName: Config Management Plugins'
+        displayName: Config Management Plugins
         path: configManagementPlugins
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Operation is the number of application operation processors.
-        displayName: Operation Processor Count'
+        displayName: Operation Processor Count
         path: controller.processors.operation
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Status is the number of application status processors.
-        displayName: Status Processor Count'
+        displayName: Status Processor Count
         path: controller.processors.status
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: Resources defines the Compute Resources required by the container
           for the Application Controller.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: controller.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Controller
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: GAAnonymizeUsers toggles user IDs being hashed before sending
           to google analytics.
-        displayName: Google Analytics Anonymize Users'
+        displayName: Google Analytics Anonymize Users
         path: gaAnonymizeUsers
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: GATrackingID is the google analytics tracking ID to use.
-        displayName: Google Analytics Tracking ID'
+        displayName: Google Analytics Tracking ID
         path: gaTrackingID
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1139,7 +1139,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: grafana.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1148,13 +1148,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Grafana.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: grafana.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: grafana.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1181,14 +1181,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: HelpChatText is the text for getting chat help, defaults to "Chat
           now!"
-        displayName: Help Chat Text'
+        displayName: Help Chat Text
         path: helpChatText
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: HelpChatURL is the URL for getting chat help, this will typically
           be your Slack channel for support.
-        displayName: Help Chat URL'
+        displayName: Help Chat URL
         path: helpChatURL
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1223,7 +1223,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: 'Deprecated: InitialRepositories to configure Argo CD with upon
           creation of the cluster.'
-        displayName: Initial Repositories'
+        displayName: Initial Repositories
         path: initialRepositories
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1237,13 +1237,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: KustomizeVersions is a listing of configured versions of Kustomize
           to be made available within ArgoCD.
-        displayName: Kustomize Build Options'
+        displayName: Kustomize Build Options
         path: kustomizeVersions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: OIDCConfig is the OIDC configuration as an alternative to dex.
-        displayName: OIDC Config'
+        displayName: OIDC Config
         path: oidcConfig
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
@@ -1261,7 +1261,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Prometheus
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: prometheus.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1269,7 +1269,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: prometheus.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1285,7 +1285,7 @@ spec:
       - description: DefaultPolicy is the name of the default role which Argo CD will
           falls back to, when authorizing API requests (optional). If omitted or empty,
           users may be still be able to login, but will see no apps, projects, etc...
-        displayName: Default Policy'
+        displayName: Default Policy
         path: rbac.defaultPolicy
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBAC
@@ -1315,7 +1315,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: redis.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Redis
@@ -1328,47 +1328,47 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Resources defines the Compute Resources required by the container
           for Redis.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: repo.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Repo
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: ResourceActions customizes resource action behavior.
-        displayName: Resource Action Customizations'
+        displayName: Resource Action Customizations
         path: resourceActions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceExclusions is used to completely ignore entire classes
           of resource group/kinds.
-        displayName: Resource Exclusions'
+        displayName: Resource Exclusions
         path: resourceExclusions
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceHealthChecks customizes resource health check behavior.
-        displayName: Resource Health Check Customizations'
+        displayName: Resource Health Check Customizations
         path: resourceHealthChecks
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceIgnoreDifferences customizes resource ignore difference
           behavior.
-        displayName: Resource Ignore Difference Customizations'
+        displayName: Resource Ignore Difference Customizations
         path: resourceIgnoreDifferences
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: ResourceTrackingMethod defines how Argo CD should track resources
           that it manages
-        displayName: Resource Tracking Method'
+        displayName: Resource Tracking Method
         path: resourceTrackingMethod
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: Enabled will toggle autoscaling support for the Argo CD Server
           component.
-        displayName: Autoscale Enabled'
+        displayName: Autoscale Enabled
         path: server.autoscale.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -1381,13 +1381,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Ingress defines the desired state for the Argo CD Server GRPC
           Ingress.
-        displayName: GRPC Ingress Enabled'
+        displayName: GRPC Ingress Enabled
         path: server.grpc.ingress
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.grpc.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1401,7 +1401,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Enabled will toggle the creation of the Ingress.
-        displayName: Ingress Enabled'
+        displayName: Ingress Enabled
         path: server.ingress.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1416,13 +1416,13 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for the Argo CD server component.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: server.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Enabled will toggle the creation of the OpenShift Route.
-        displayName: Route Enabled'
+        displayName: Route Enabled
         path: server.route.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Grafana
@@ -1430,7 +1430,7 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Type is the ServiceType to use for the Service resource.
-        displayName: Service Type'
+        displayName: Service Type
         path: server.service.type
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Server
@@ -1449,14 +1449,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: OpenShiftOAuth enables OpenShift OAuth authentication for the
           Dex server.
-        displayName: OpenShift OAuth Enabled'
+        displayName: OpenShift OAuth Enabled
         path: sso.dex.openShiftOAuth
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Resources defines the Compute Resources required by the container
           for Dex.
-        displayName: Resource Requirements'
+        displayName: Resource Requirements
         path: sso.dex.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
@@ -1468,14 +1468,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Dex
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: StatusBadgeEnabled toggles application status badge feature.
-        displayName: Status Badge Enabled'
+        displayName: Status Badge Enabled
         path: statusBadgeEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
         - urn:alm:descriptor:com.tectonic.ui:advanced
       - description: UsersAnonymousEnabled toggles anonymous user access. The anonymous
           users get default role permissions specified argocd-rbac-cm.
-        displayName: Anonymous Users Enabled'
+        displayName: Anonymous Users Enabled
         path: usersAnonymousEnabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
/kind cleanup 
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

No idea how it got there...

**Have you updated the necessary documentation?**

* [no] Documentation update is required by this PR.
* [no] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display name formatting issues across operator metadata by systematically removing trailing apostrophes from numerous field labels and descriptor entries, ensuring consistent and professional presentation throughout the operator UI and management interfaces.

* **Chores**
  * Updated operator release metadata timestamp.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->