### PR TITLE
chore: update to latest released argocd-agent version v0.6.0

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -288,10 +288,10 @@ vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOf
 	ArgoCDCmdParamsConfigMapName = "argocd-cmd-params-cm"
 
 	// ArgoCDAgentPrincipalDefaultImageName is the default image name for the ArgoCD agent's principal component.
-	ArgoCDAgentPrincipalDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.5.2"
+	ArgoCDAgentPrincipalDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.6.0"
 
 	// ArgoCDAgentAgentDefaultImageName is the default image name for the ArgoCD agent's agent component.
-	ArgoCDAgentAgentDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.5.2"
+	ArgoCDAgentAgentDefaultImageName = "quay.io/argoprojlabs/argocd-agent:v0.6.0"
 
 	// ArgoCDImageUpdaterControllerComponent is the name of the Image Updater controller control plane component
 	ArgoCDImageUpdaterControllerComponent = "argocd-image-updater-controller"

--- a/controllers/argocdagent/example/argocd-agent.yaml
+++ b/controllers/argocdagent/example/argocd-agent.yaml
@@ -20,7 +20,7 @@ spec:
       # Log format (text or json)
       logFormat: "text"
       # Container image for the ArgoCD Agent
-      image: "quay.io/argoprojlabs/argocd-agent:v0.3.2"
+      image: "quay.io/argoprojlabs/argocd-agent:v0.6.0"
       # Environment variables for the Agent component
       env:
         - name: GRPC_GO_LOG_VERBOSITY_LEVEL
@@ -29,7 +29,7 @@ spec:
           value: "info"
         - name: GODEBUG
           value: "http2debug=2"
-      
+
       # Client configuration for the Agent component
       client:
         # Address of the principal server to connect to
@@ -45,7 +45,7 @@ spec:
         enableCompression: false
         # Keep-alive interval for pings to the principal
         keepAliveInterval: "30s"
-      
+
       # TLS configuration for the agent
       tls:
         # Secret containing the agent client TLS certificate
@@ -54,7 +54,7 @@ spec:
         rootCASecretName: "argocd-agent-ca"
         # Skip TLS certificate validation (insecure, for development only)
         insecure: false
-      
+
       # Redis configuration for caching and state management
       redis:
         # Redis server address

--- a/controllers/argocdagent/example/argocd-principal.yaml
+++ b/controllers/argocdagent/example/argocd-principal.yaml
@@ -6,13 +6,13 @@ spec:
   # Disable the main controller since we're using the agent
   controller:
     enabled: false
-  
+
   # ArgoCD Agent configuration
   argoCDAgent:
     principal:
       # Enable the Principal component
       enabled: true
-      
+
       # Authentication method - mTLS with certificate common name extraction
       auth: "mtls:CN=([^,]+)"
       # Log level for the Principal component
@@ -20,7 +20,7 @@ spec:
       # Log format (text or json)
       logFormat: "text"
       # Container image for the ArgoCD Agent
-      image: "quay.io/argoprojlabs/argocd-agent:v0.3.2"
+      image: "quay.io/argoprojlabs/argocd-agent:v0.6.0"
       # Environment variables for the Principal component
       env:
         - name: GRPC_GO_LOG_VERBOSITY_LEVEL
@@ -29,24 +29,24 @@ spec:
           value: "info"
         - name: GODEBUG
           value: "http2debug=2"
-      
+
       # Server configuration for the Principal component
       server:
         # Enable WebSocket for real-time event streaming
         enableWebSocket: true
         # Minimum interval between keep-alive messages
         keepAliveMinInterval: "30s"
-        
+
         # Service configuration for the Principal component
         service:
           # ServiceType for the Principal service (ClusterIP, NodePort, LoadBalancer)
           type: ClusterIP
-        
+
         # Route configuration for OpenShift Route (optional)
         route:
           # Enable OpenShift Route creation
           enabled: false
-      
+
       # Namespace management configuration
       namespace:
         # List of namespaces the principal can watch and manage
@@ -60,21 +60,21 @@ spec:
         namespaceCreateLabels:
           - "environment=agent"
           - "managed-by=argocd-agent"
-      
+
       # Resource proxy configuration for external resource access
       resourceProxy:
         # Secret containing proxy TLS certificate and key
         secretName: "argocd-agent-proxy-tls"
         # Secret containing proxy CA certificate
         caSecretName: "argocd-agent-proxy-ca"
-      
+
       # Redis configuration for caching and state management
       redis:
         # Redis server address
         serverAddress: "redis:6379"
         # Compression type for Redis data
         compressionType: "gzip"
-      
+
       # TLS configuration for secure communication
       tls:
         # Secret containing TLS certificate and key
@@ -83,14 +83,14 @@ spec:
         rootCASecretName: "argocd-agent-ca"
         # Allow automatic certificate generation if not provided
         insecureGenerate: true
-      
+
       # JWT configuration for token-based authentication
       jwt:
         # Allow insecure JWT key generation
         insecureGenerate: true
         # Secret containing JWT signing key
         secretName: "argocd-agent-jwt"
-  
+
   # Source namespaces for ArgoCD applications
   sourceNamespaces:
     - "agent-managed"

--- a/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -393,7 +393,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			By("Create ArgoCD instance")
 
-			argoCD.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.0"
+			argoCD.Spec.ArgoCDAgent.Principal.Image = common.ArgoCDAgentPrincipalDefaultImageName
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
 			By("Verify expected resources are created for principal pod")
@@ -404,7 +404,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			container := deploymentFixture.GetTemplateSpecContainerByName(argoCDAgentPrincipalName, *principalDeployment)
 			Expect(container).ToNot(BeNil())
-			Expect(container.Image).To(Equal("quay.io/argoprojlabs/argocd-agent:v0.5.0"))
+			Expect(container.Image).To(Equal(common.ArgoCDAgentPrincipalDefaultImageName))
 
 			By("Verify environment variables are set correctly")
 

--- a/tests/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/tests/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -370,7 +370,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			By("Create ArgoCD instance")
 
-			argoCD.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.0"
+			argoCD.Spec.ArgoCDAgent.Agent.Image = common.ArgoCDAgentAgentDefaultImageName
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
 			By("Verify expected resources are created for agent pod")
@@ -381,7 +381,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			container := deploymentFixture.GetTemplateSpecContainerByName(argoCDAgentAgentName, *agentDeployment)
 			Expect(container).ToNot(BeNil())
-			Expect(container.Image).To(Equal("quay.io/argoprojlabs/argocd-agent:v0.5.0"))
+			Expect(container.Image).To(Equal(common.ArgoCDAgentAgentDefaultImageName))
 
 			By("Verify environment variables are set correctly")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind chore

**What does this PR do / why we need it**:
- Update to image latest argocd-agent version (v0.6.0)
- I've verified there were no significant manifest changes in argocd-agent that we need to echo in argocd-operator logic,

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ArgoCD Agent component images to version 0.6.0.
  * Extended ArgoCD Principal configuration to support an additional source namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->