### PR TITLE
fix: apply managed-by label for namespaceManagement tenant namespaces…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ e2e: ## Run operator e2e tests
 
 
 start-e2e: install-prometheus-crds ## Start operator for E2E tests (installs required CRDs if needed)
+	ALLOW_NAMESPACE_MANAGEMENT_IN_NAMESPACE_SCOPED_INSTANCES=true \
 	ARGOCD_CLUSTER_CONFIG_NAMESPACES="argocd-e2e-cluster-config, argocd-test-impersonation-1-046, argocd-agent-principal-1-051, argocd-agent-agent-1-052, appset-argocd, appset-old-ns, appset-new-ns, appset-argocd-clusterrole, ns-hosting-principal, ns-hosting-managed-agent, ns-hosting-autonomous-agent" make run
 
 all: test install run e2e ## UnitTest, Run the operator locally and execute e2e tests.

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -339,8 +339,8 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 				return reconcile.Result{}, argocd, argoCDStatus, err
 			}
 
-			// Skip RBAC deletion if the namespace has the "managed-by" label
-			if namespace.Labels[common.ArgoCDManagedByLabel] == nsMgmt.Namespace {
+			// Skip RBAC deletion if the namespace has the "managed-by" label for this Argo CD instance
+			if namespace.Labels[common.ArgoCDManagedByLabel] == argocd.Namespace {
 				log.Info(fmt.Sprintf("Skipping RBAC deletion for namespace %s due to managed-by label", nsMgmt.Namespace))
 				continue
 			}

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -341,7 +341,8 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 
 			// Skip RBAC deletion if the namespace has the "managed-by" label for this Argo CD instance
 			if namespace.Labels[common.ArgoCDManagedByLabel] == argocd.Namespace {
-				log.Info(fmt.Sprintf("Skipping RBAC deletion for namespace %s due to managed-by label", nsMgmt.Namespace))
+				log.Info(fmt.Sprintf("Skipping RBAC deletion for tenant namespace %s: %s=%s matches this Argo CD instance",
+					nsMgmt.Namespace, common.ArgoCDManagedByLabel, argocd.Namespace))
 				continue
 			}
 

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -332,20 +332,6 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 				continue
 			}
 
-			// Check if the namespace has a "managed-by" label
-			namespace := &corev1.Namespace{}
-			if err := r.Get(ctx, types.NamespacedName{Name: nsMgmt.Namespace}, namespace); err != nil {
-				log.Error(err, fmt.Sprintf("unable to fetch namespace %s", nsMgmt.Namespace))
-				return reconcile.Result{}, argocd, argoCDStatus, err
-			}
-
-			// Skip RBAC deletion if the namespace has the "managed-by" label for this Argo CD instance
-			if namespace.Labels[common.ArgoCDManagedByLabel] == argocd.Namespace {
-				log.Info(fmt.Sprintf("Skipping RBAC deletion for tenant namespace %s: %s=%s matches this Argo CD instance",
-					nsMgmt.Namespace, common.ArgoCDManagedByLabel, argocd.Namespace))
-				continue
-			}
-
 			// Remove roles and rolebindings
 			if err := deleteRBACsForNamespace(nsMgmt.Namespace, k8sClient); err != nil {
 				log.Error(err, fmt.Sprintf("Failed to delete RBACs for namespace: %s", nsMgmt.Namespace))

--- a/controllers/argocd/namespaceManagement.go
+++ b/controllers/argocd/namespaceManagement.go
@@ -167,7 +167,8 @@ func (r *ReconcileArgoCD) disableNamespaceManagement(argocd *argoproj.ArgoCD, k8
 
 			// Skip RBAC deletion if the namespace has the "managed-by" label for this Argo CD instance
 			if namespace.Labels[common.ArgoCDManagedByLabel] == argocd.Namespace {
-				log.Info(fmt.Sprintf("Skipping RBAC deletion for namespace %s due to managed-by label", nsName))
+				log.Info(fmt.Sprintf("Skipping RBAC deletion for tenant namespace %s: %s=%s matches this Argo CD instance",
+					nsName, common.ArgoCDManagedByLabel, argocd.Namespace))
 				continue
 			}
 

--- a/controllers/argocd/namespaceManagement.go
+++ b/controllers/argocd/namespaceManagement.go
@@ -66,7 +66,6 @@ func (r *ReconcileArgoCD) reconcileNamespaceManagement(argocd *argoproj.ArgoCD) 
 		} else {
 			message = fmt.Sprintf("Namespace %s is not permitted for management by ArgoCD instance %s based on NamespaceManagement rules", namespace, argocd.Namespace)
 			errorMessages = append(errorMessages, message)
-			statusUpdates = append(statusUpdates, nmStatus{nm: nm, message: message})
 		}
 
 		statusUpdates = append(statusUpdates, nmStatus{nm: nm, message: message})
@@ -166,8 +165,8 @@ func (r *ReconcileArgoCD) disableNamespaceManagement(argocd *argoproj.ArgoCD, k8
 				return err
 			}
 
-			// Skip RBAC deletion if the namespace has the "managed-by" label
-			if namespace.Labels[common.ArgoCDManagedByLabel] == nsName {
+			// Skip RBAC deletion if the namespace has the "managed-by" label for this Argo CD instance
+			if namespace.Labels[common.ArgoCDManagedByLabel] == argocd.Namespace {
 				log.Info(fmt.Sprintf("Skipping RBAC deletion for namespace %s due to managed-by label", nsName))
 				continue
 			}

--- a/controllers/argocd/namespaceManagement.go
+++ b/controllers/argocd/namespaceManagement.go
@@ -9,7 +9,6 @@ import (
 	"github.com/argoproj/argo-cd/v3/util/glob"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
@@ -158,20 +157,6 @@ func (r *ReconcileArgoCD) disableNamespaceManagement(argocd *argoproj.ArgoCD, k8
 		}
 
 		for _, nsName := range matchedNamespaces {
-			// Get namespace object
-			namespace := &corev1.Namespace{}
-			if err := r.Get(ctx, types.NamespacedName{Name: nsName}, namespace); err != nil {
-				log.Error(err, fmt.Sprintf("unable to fetch namespace %s", nsName))
-				return err
-			}
-
-			// Skip RBAC deletion if the namespace has the "managed-by" label for this Argo CD instance
-			if namespace.Labels[common.ArgoCDManagedByLabel] == argocd.Namespace {
-				log.Info(fmt.Sprintf("Skipping RBAC deletion for tenant namespace %s: %s=%s matches this Argo CD instance",
-					nsName, common.ArgoCDManagedByLabel, argocd.Namespace))
-				continue
-			}
-
 			if allowManaged {
 				if err := deleteRBACsForNamespace(nsName, k8sClient); err != nil {
 					log.Error(err, fmt.Sprintf("Failed to delete RBACs for namespace: %s", nsName))

--- a/controllers/argocd/namespaceManagement_test.go
+++ b/controllers/argocd/namespaceManagement_test.go
@@ -200,15 +200,16 @@ func TestHandleFeatureDisable_SkipManagedByLabel(t *testing.T) {
 			Namespace: "ns-managed",
 		},
 		Spec: argoproj.NamespaceManagementSpec{
-			ManagedBy: "argocd",
+			ManagedBy: a.Namespace, // "argocd"
 		},
 	}
 
+	// Label value must be the Argo CD instance namespace (who manages this namespace)
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns-managed",
 			Labels: map[string]string{
-				common.ArgoCDManagedByLabel: "ns-managed",
+				common.ArgoCDManagedByLabel: a.Namespace,
 			},
 		},
 	}
@@ -415,6 +416,60 @@ func TestReconcileNamespaceManagement_ExplicitlyDisallowed(t *testing.T) {
 	err = r.reconcileNamespaceManagement(a)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Namespace deny-ns is not permitted for management by ArgoCD instance argocd based on NamespaceManagement rules")
+}
+
+func TestReconcileNamespaceManagement_AddsManagedByLabel(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.NamespaceManagement = []argoproj.ManagedNamespaces{{
+			Name:           "tenant-ns",
+			AllowManagedBy: true,
+		}}
+	})
+
+	nm := &argoproj.NamespaceManagement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tenant-nm",
+			Namespace: "tenant-ns",
+		},
+		Spec: argoproj.NamespaceManagementSpec{
+			ManagedBy: a.Namespace,
+		},
+	}
+
+	// Tenant namespace must exist so the role reconciler can Get/Update it for the label
+	tenantNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "tenant-ns",
+			Labels: map[string]string{"existing": "label"},
+		},
+	}
+
+	resObjs := []client.Object{a, tenantNS}
+	subresObjs := []client.Object{a, nm, tenantNS}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	err := r.Create(context.Background(), nm)
+	assert.NoError(t, err)
+
+	os.Setenv(common.EnableManagedNamespace, "true")
+	defer os.Unsetenv(common.EnableManagedNamespace)
+
+	err = r.reconcileNamespaceManagement(a)
+	assert.NoError(t, err)
+
+	_, err = r.reconcileRole(common.ArgoCDApplicationControllerComponent, policyRuleForApplicationController(), a)
+	assert.NoError(t, err)
+
+	gotNS := &corev1.Namespace{}
+	err = r.Get(context.Background(), types.NamespacedName{Name: "tenant-ns"}, gotNS)
+	assert.NoError(t, err)
+	assert.Equal(t, a.Namespace, gotNS.Labels[common.ArgoCDManagedByLabel],
+		"tenant namespace should have argocd.argoproj.io/managed-by set to Argo CD instance namespace")
+	assert.Equal(t, "label", gotNS.Labels["existing"], "existing labels should be preserved")
 }
 
 func TestReconcileNamespaceManagement_DeduplicateNamespaces(t *testing.T) {

--- a/controllers/argocd/namespaceManagement_test.go
+++ b/controllers/argocd/namespaceManagement_test.go
@@ -185,7 +185,7 @@ func TestHandleFeatureDisable_NamespaceMatchesPattern_RBACDeleted(t *testing.T) 
 	assert.NoError(t, err)
 }
 
-func TestHandleFeatureDisable_SkipManagedByLabel(t *testing.T) {
+func TestHandleFeatureDisable_DeletesRBACWhenTenantHasManagedByLabel(t *testing.T) {
 	a := makeTestArgoCD()
 	a.Spec.NamespaceManagement = []argoproj.ManagedNamespaces{
 		{
@@ -200,7 +200,7 @@ func TestHandleFeatureDisable_SkipManagedByLabel(t *testing.T) {
 			Namespace: "ns-managed",
 		},
 		Spec: argoproj.NamespaceManagementSpec{
-			ManagedBy: a.Namespace, // "argocd"
+			ManagedBy: a.Namespace,
 		},
 	}
 

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -121,6 +121,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 			ns := &corev1.Namespace{}
 			if err := r.Get(context.TODO(), types.NamespacedName{Name: namespace.Name}, ns); err != nil {
 				log.Error(err, "failed to get namespace for managed-by label", "namespace", namespace.Name)
+				// Continue - namespace might be terminating or temporarily unavailable
 			} else if ns.Labels[common.ArgoCDManagedByLabel] != cr.Namespace {
 				if ns.Labels == nil {
 					ns.Labels = make(map[string]string)
@@ -128,7 +129,7 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 				ns.Labels[common.ArgoCDManagedByLabel] = cr.Namespace
 				argoutil.LogResourceUpdate(log, ns, fmt.Sprintf("adding label '%s=%s'", common.ArgoCDManagedByLabel, cr.Namespace))
 				if err := r.Update(context.TODO(), ns); err != nil {
-					log.Error(err, fmt.Sprintf("failed to add label to namespace [%s]", namespace.Name))
+					return nil, fmt.Errorf("failed to add managed-by label to namespace [%s]: %w", namespace.Name, err)
 				}
 			}
 		}

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -116,6 +116,23 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 			continue
 		}
 
+		// For managed namespaces ensure the managed-by label is set so Argo CD discovers Applications.
+		if cr.Namespace != namespace.Name && name == common.ArgoCDApplicationControllerComponent {
+			ns := &corev1.Namespace{}
+			if err := r.Get(context.TODO(), types.NamespacedName{Name: namespace.Name}, ns); err != nil {
+				log.Error(err, "failed to get namespace for managed-by label", "namespace", namespace.Name)
+			} else if ns.Labels[common.ArgoCDManagedByLabel] != cr.Namespace {
+				if ns.Labels == nil {
+					ns.Labels = make(map[string]string)
+				}
+				ns.Labels[common.ArgoCDManagedByLabel] = cr.Namespace
+				argoutil.LogResourceUpdate(log, ns, fmt.Sprintf("adding label '%s=%s'", common.ArgoCDManagedByLabel, cr.Namespace))
+				if err := r.Update(context.TODO(), ns); err != nil {
+					log.Error(err, fmt.Sprintf("failed to add label to namespace [%s]", namespace.Name))
+				}
+			}
+		}
+
 		// Look for ArgoCD CRs in the managed namespace
 		list := &argoproj.ArgoCDList{}
 		listOption := &client.ListOptions{Namespace: namespace.Name}

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -120,9 +120,15 @@ func (r *ReconcileArgoCD) reconcileRole(name string, policyRules []v1.PolicyRule
 		if cr.Namespace != namespace.Name && name == common.ArgoCDApplicationControllerComponent {
 			ns := &corev1.Namespace{}
 			if err := r.Get(context.TODO(), types.NamespacedName{Name: namespace.Name}, ns); err != nil {
-				log.Error(err, "failed to get namespace for managed-by label", "namespace", namespace.Name)
-				// Continue - namespace might be terminating or temporarily unavailable
-			} else if ns.Labels[common.ArgoCDManagedByLabel] != cr.Namespace {
+				if errors.IsNotFound(err) {
+					continue
+				}
+				return nil, fmt.Errorf("failed to get namespace for managed-by label [%s]: %w", namespace.Name, err)
+			}
+			if ns.DeletionTimestamp != nil {
+				continue
+			}
+			if ns.Labels[common.ArgoCDManagedByLabel] != cr.Namespace {
 				if ns.Labels == nil {
 					ns.Labels = make(map[string]string)
 				}

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -100,6 +100,37 @@ func TestReconcileArgoCD_reconcileRole_for_new_namespace(t *testing.T) {
 	assert.Equal(t, expectedRoleNamespace, redisRoles[0].Namespace)
 }
 
+func TestReconcileRole_AddsManagedByLabelForManagedNamespace(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	tenantNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "tenant-ns",
+			Labels: map[string]string{"keep": "me"},
+		},
+	}
+	resObjs := []client.Object{a, tenantNS}
+	subresObjs := []client.Object{a, tenantNS}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+	// Add tenant namespace to ManagedNamespaces it exists without managed-by label
+	r.ManagedNamespaces.Items = append(r.ManagedNamespaces.Items, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-ns"}})
+
+	_, err := r.reconcileRole(common.ArgoCDApplicationControllerComponent, policyRuleForApplicationController(), a)
+	assert.NoError(t, err)
+
+	gotNS := &corev1.Namespace{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: "tenant-ns"}, gotNS))
+	assert.Equal(t, a.Namespace, gotNS.Labels[common.ArgoCDManagedByLabel],
+		"tenant namespace should have argocd.argoproj.io/managed-by set to Argo CD instance namespace")
+	assert.Equal(t, "me", gotNS.Labels["keep"], "existing labels should be preserved")
+}
+
 func TestReconcileArgoCD_reconcileClusterRole(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCDInNamespace("argocd-cluster-role-test")

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1813,10 +1813,13 @@ func (r *ReconcileArgoCD) handleNamespaceManagementUpdate(oldNSMgmt, newNSMgmt *
 		return false
 	}
 
-	// Skip Update if managed-by label exists on tenant namespace and matches .spec.managedBy
-	if labelVal, labelExists := ns.Labels[common.ArgoCDManagedByLabel]; labelExists && labelVal == oldNSMgmt.Spec.ManagedBy {
-		log.Info(fmt.Sprintf("Namespace %s still managed by same ArgoCD instance via label, skipping update cleanup", oldNSMgmt.Namespace))
-		return false
+	// Skip only when there is no managedBy transition between oldNSMgmt and newNSMgmt
+	if oldNSMgmt.Spec.ManagedBy == newNSMgmt.Spec.ManagedBy {
+		// Skip Update if managed-by label exists on tenant namespace and matches .spec.managedBy
+		if labelVal, labelExists := ns.Labels[common.ArgoCDManagedByLabel]; labelExists && labelVal == oldNSMgmt.Spec.ManagedBy {
+			log.Info(fmt.Sprintf("Namespace %s still managed by same ArgoCD instance via label, skipping update cleanup", oldNSMgmt.Namespace))
+			return false
+		}
 	}
 
 	// If `.spec.managedBy` changes, trigger reconciliation
@@ -1830,17 +1833,6 @@ func (r *ReconcileArgoCD) handleNamespaceManagementUpdate(oldNSMgmt, newNSMgmt *
 }
 
 func (r *ReconcileArgoCD) handleNamespaceManagementDelete(nsMgmt *argoproj.NamespaceManagement, k8sClient kubernetes.Interface) bool {
-	ns := &corev1.Namespace{}
-	if err := r.Get(context.TODO(), types.NamespacedName{Name: nsMgmt.Namespace}, ns); err != nil {
-		return false
-	}
-
-	// Skip cleanup if managed-by label exists on tenant namespace and matches .spec.managedBy
-	if labelVal, labelExists := ns.Labels[common.ArgoCDManagedByLabel]; labelExists && labelVal == nsMgmt.Spec.ManagedBy {
-		log.Info(fmt.Sprintf("Namespace %s still managed by same ArgoCD instance via label, skipping delete cleanup", nsMgmt.Namespace))
-		return false
-	}
-
 	// Retrieve the ArgoCD instance that was managing this namespace
 	argocdNamespace := nsMgmt.Spec.ManagedBy
 	if argocdNamespace == "" {

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1809,11 +1809,11 @@ func (r *ReconcileArgoCD) handleArgoCDNamespaceManagementUpdate(valNew, valOld *
 
 func (r *ReconcileArgoCD) handleNamespaceManagementUpdate(oldNSMgmt, newNSMgmt *argoproj.NamespaceManagement, k8sClient kubernetes.Interface) bool {
 	ns := &corev1.Namespace{}
-	if err := r.Get(context.TODO(), types.NamespacedName{Name: oldNSMgmt.Spec.ManagedBy}, ns); err != nil {
+	if err := r.Get(context.TODO(), types.NamespacedName{Name: oldNSMgmt.Namespace}, ns); err != nil {
 		return false
 	}
 
-	// Skip Update if managed-by label exists and matches .spec.managedBy
+	// Skip Update if managed-by label exists on tenant namespace and matches .spec.managedBy
 	if labelVal, labelExists := ns.Labels[common.ArgoCDManagedByLabel]; labelExists && labelVal == oldNSMgmt.Spec.ManagedBy {
 		log.Info(fmt.Sprintf("Namespace %s still managed by same ArgoCD instance via label, skipping update cleanup", oldNSMgmt.Namespace))
 		return false
@@ -1831,11 +1831,11 @@ func (r *ReconcileArgoCD) handleNamespaceManagementUpdate(oldNSMgmt, newNSMgmt *
 
 func (r *ReconcileArgoCD) handleNamespaceManagementDelete(nsMgmt *argoproj.NamespaceManagement, k8sClient kubernetes.Interface) bool {
 	ns := &corev1.Namespace{}
-	if err := r.Get(context.TODO(), types.NamespacedName{Name: nsMgmt.Spec.ManagedBy}, ns); err != nil {
+	if err := r.Get(context.TODO(), types.NamespacedName{Name: nsMgmt.Namespace}, ns); err != nil {
 		return false
 	}
 
-	// Skip cleanup if managed-by label exists and matches .spec.managedBy
+	// Skip cleanup if managed-by label exists on tenant namespace and matches .spec.managedBy
 	if labelVal, labelExists := ns.Labels[common.ArgoCDManagedByLabel]; labelExists && labelVal == nsMgmt.Spec.ManagedBy {
 		log.Info(fmt.Sprintf("Namespace %s still managed by same ArgoCD instance via label, skipping delete cleanup", nsMgmt.Namespace))
 		return false

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1544,7 +1544,7 @@ func TestNamespaceManagementHandlers(t *testing.T) {
 		}
 
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-			Name: "old",
+			Name: testNamespace,
 		}}
 
 		resObjs := []client.Object{argoCD, ns, oldNSMgmt, newNSMgmt}
@@ -1578,8 +1578,11 @@ func TestNamespaceManagementHandlers(t *testing.T) {
 			Spec:       argoproj.NamespaceManagementSpec{ManagedBy: "argocd"},
 		}
 
-		resObjs := []client.Object{argoCD, nsMgmt}
-		subresObjs := []client.Object{argoCD, nsMgmt}
+		// Tenant namespace (where NM CR lives); no managed-by label so cleanup runs.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+
+		resObjs := []client.Object{argoCD, ns, nsMgmt}
+		subresObjs := []client.Object{argoCD, ns, nsMgmt}
 		runtimeObjs := []runtime.Object{}
 		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
 		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1578,7 +1578,7 @@ func TestNamespaceManagementHandlers(t *testing.T) {
 			Spec:       argoproj.NamespaceManagementSpec{ManagedBy: "argocd"},
 		}
 
-		// Tenant namespace (where NM CR lives); no managed-by label so cleanup runs.
+		// Tenant namespace (where NM CR lives); NamespaceManagement delete runs cleanup regardless of managed-by label.
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
 
 		resObjs := []client.Object{argoCD, ns, nsMgmt}

--- a/tests/ginkgo/parallel/1-012_validate-managed-by-chain_test.go
+++ b/tests/ginkgo/parallel/1-012_validate-managed-by-chain_test.go
@@ -23,71 +23,32 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
-	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	appFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/application"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
-	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
-	namespaceFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/namespace"
 	secretFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/secret"
 	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	controllerManagerName      = "argocd-operator-controller-manager"
-	controllerManagerNamespace = "argocd-operator-system"
-)
-
-func ensureNamespaceManagementEnabledForTest(ctx context.Context, k8sClient client.Client) (cleanup func()) {
-	operatorDeployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      controllerManagerName,
-			Namespace: controllerManagerNamespace,
-		},
-	}
-	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(operatorDeployment), operatorDeployment); err != nil {
-		By("no in-cluster controller-manager Deployment — skipping " + common.EnableManagedNamespace + " patch; test still runs (set env on the operator process when running locally)")
-		return func() {}
-	}
-	By("enabling NamespaceManagement feature")
-	originalEnvValue, _ := deploymentFixture.GetEnv(operatorDeployment, "manager", common.EnableManagedNamespace)
-	deploymentFixture.SetEnv(operatorDeployment, "manager", common.EnableManagedNamespace, "true")
-	Eventually(operatorDeployment, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
-
-	return func() {
-		By("restoring operator EnableManagedNamespace env var")
-		if originalEnvValue != nil {
-			deploymentFixture.SetEnv(operatorDeployment, "manager", common.EnableManagedNamespace, *originalEnvValue)
-		} else {
-			deploymentFixture.RemoveEnv(operatorDeployment, "manager", common.EnableManagedNamespace)
-		}
-		Eventually(operatorDeployment, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
-	}
-}
-
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 	Context("1-012_validate-managed-by-chain", func() {
 
 		var (
-			ctx                     context.Context
-			k8sClient               client.Client
-			cleanupfuncs            []func()
-			nsTest_1_12_custom      *corev1.Namespace
-			nsTest_1_12_custom2     *corev1.Namespace
-			randomNS                *corev1.Namespace
-			nsTest_1_12_nm_argocd   *corev1.Namespace
-			nsTest_1_12_nm_tenant   *corev1.Namespace
-			argoCDWithNamespaceMgmt *argov1beta1api.ArgoCD
+			ctx                 context.Context
+			k8sClient           client.Client
+			cleanupfuncs        []func()
+			nsTest_1_12_custom  *corev1.Namespace
+			nsTest_1_12_custom2 *corev1.Namespace
+			randomNS            *corev1.Namespace
 		)
 
 		BeforeEach(func() {
@@ -103,13 +64,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 					cleanupfunc()
 				}
 			}()
-			var debugParams []any
-			for _, ns := range []*corev1.Namespace{nsTest_1_12_custom, nsTest_1_12_custom2, randomNS, nsTest_1_12_nm_argocd, nsTest_1_12_nm_tenant} {
-				if ns != nil {
-					debugParams = append(debugParams, ns)
-				}
-			}
-			fixture.OutputDebugOnFail(debugParams...)
+
+			fixture.OutputDebugOnFail(nsTest_1_12_custom, nsTest_1_12_custom2, randomNS)
 		})
 
 		It("validates that namespace-scoped Argo CD instance is able to managed other namespaces, including when those namespaces are deleted", func() {
@@ -305,67 +261,6 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Eventually(app2, "4m", "1s").Should(appFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
 			Eventually(app2, "4m", "1s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
 
-		})
-
-		It("validates that with spec.namespaceManagement and a NamespaceManagement CR the operator applies the managed-by label and RBAC to the tenant namespace so Applications are discovered (fix for issue #2039)", func() {
-
-			cleanup := ensureNamespaceManagementEnabledForTest(ctx, k8sClient)
-			defer cleanup()
-
-			By("creating namespace for Argo CD instance")
-			nsTest_1_12_nm_argocd, cleanupFunc1 := fixture.CreateNamespaceWithCleanupFunc("test-1-12-nm-argocd")
-			cleanupfuncs = append(cleanupfuncs, cleanupFunc1)
-
-			By("creating tenant namespace to be managed via NamespaceManagement")
-			nsTest_1_12_nm_tenant, cleanupFunc2 := fixture.CreateNamespaceWithCleanupFunc("test-1-12-nm-tenant")
-			cleanupfuncs = append(cleanupfuncs, cleanupFunc2)
-
-			By("creating namespace-scoped Argo CD with spec.namespaceManagement allowing the tenant namespace")
-			argoCDWithNamespaceMgmt = &argov1beta1api.ArgoCD{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "argocd",
-					Namespace: nsTest_1_12_nm_argocd.Name,
-				},
-				Spec: argov1beta1api.ArgoCDSpec{
-					NamespaceManagement: []argov1beta1api.ManagedNamespaces{
-						{
-							Name:           nsTest_1_12_nm_tenant.Name,
-							AllowManagedBy: true,
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, argoCDWithNamespaceMgmt)).To(Succeed())
-
-			By("creating NamespaceManagement CR in tenant namespace with managedBy set to Argo CD namespace")
-			nm := &argov1beta1api.NamespaceManagement{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tenant-nm",
-					Namespace: nsTest_1_12_nm_tenant.Name,
-				},
-				Spec: argov1beta1api.NamespaceManagementSpec{
-					ManagedBy: nsTest_1_12_nm_argocd.Name,
-				},
-			}
-			Expect(k8sClient.Create(ctx, nm)).To(Succeed())
-
-			By("waiting for Argo CD instance to become available")
-			Eventually(argoCDWithNamespaceMgmt, "5m", "5s").Should(argocdFixture.BeAvailable())
-
-			By("verifying tenant namespace gets argocd.argoproj.io/managed-by label")
-			Eventually(nsTest_1_12_nm_tenant, "2m", "5s").Should(namespaceFixture.HaveLabel(common.ArgoCDManagedByLabel, nsTest_1_12_nm_argocd.Name))
-			Consistently(nsTest_1_12_nm_tenant, "10s", "2s").Should(namespaceFixture.HaveLabel(common.ArgoCDManagedByLabel, nsTest_1_12_nm_argocd.Name))
-
-			By("verifying RBAC is created in tenant namespace")
-			Eventually(&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_tenant.Name}}).Should(k8sFixture.ExistByName())
-			Eventually(&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-application-controller", Namespace: nsTest_1_12_nm_tenant.Name}}).Should(k8sFixture.ExistByName())
-			rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_tenant.Name}}
-			Eventually(rb).Should(k8sFixture.ExistByName())
-			Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
-			Expect(rb.RoleRef.Kind).To(Equal("Role"))
-			Expect(rb.RoleRef.Name).To(Equal("argocd-argocd-server"))
-			Expect(rb.Subjects).To(HaveLen(1))
-			Expect(rb.Subjects[0]).To(Equal(rbacv1.Subject{Kind: "ServiceAccount", Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_argocd.Name}))
 		})
 
 	})

--- a/tests/ginkgo/parallel/1-012_validate-managed-by-chain_test.go
+++ b/tests/ginkgo/parallel/1-012_validate-managed-by-chain_test.go
@@ -48,6 +48,10 @@ const (
 )
 
 func ensureNamespaceManagementEnabledForTest(ctx context.Context, k8sClient client.Client) (cleanup func()) {
+	if fixture.EnvLocalRun() {
+		Skip("Skipping NamespaceManagement deployment patch test for LOCAL_RUN - operator runs locally without an in-cluster Deployment to mutate")
+		return func() {}
+	}
 	operatorDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controllerManagerName,
@@ -55,7 +59,8 @@ func ensureNamespaceManagementEnabledForTest(ctx context.Context, k8sClient clie
 		},
 	}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(operatorDeployment), operatorDeployment); err != nil {
-		By("operator not deployed in cluster ALLOW_NAMESPACE_MANAGEMENT_IN_NAMESPACE_SCOPED_INSTANCES set via start-e2e")
+		Skip("Operator deployment " + controllerManagerNamespace + "/" + controllerManagerName +
+			" not found - test requires in-cluster operator (e.g. make start-e2e) to patch " + common.EnableManagedNamespace + ". Error: " + err.Error())
 		return func() {}
 	}
 	By("enabling NamespaceManagement feature")

--- a/tests/ginkgo/parallel/1-012_validate-managed-by-chain_test.go
+++ b/tests/ginkgo/parallel/1-012_validate-managed-by-chain_test.go
@@ -48,10 +48,6 @@ const (
 )
 
 func ensureNamespaceManagementEnabledForTest(ctx context.Context, k8sClient client.Client) (cleanup func()) {
-	if fixture.EnvLocalRun() {
-		Skip("Skipping NamespaceManagement deployment patch test for LOCAL_RUN - operator runs locally without an in-cluster Deployment to mutate")
-		return func() {}
-	}
 	operatorDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      controllerManagerName,
@@ -59,8 +55,7 @@ func ensureNamespaceManagementEnabledForTest(ctx context.Context, k8sClient clie
 		},
 	}
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(operatorDeployment), operatorDeployment); err != nil {
-		Skip("Operator deployment " + controllerManagerNamespace + "/" + controllerManagerName +
-			" not found - test requires in-cluster operator (e.g. make start-e2e) to patch " + common.EnableManagedNamespace + ". Error: " + err.Error())
+		By("no in-cluster controller-manager Deployment — skipping " + common.EnableManagedNamespace + " patch; test still runs (set env on the operator process when running locally)")
 		return func() {}
 	}
 	By("enabling NamespaceManagement feature")

--- a/tests/ginkgo/parallel/1-012_validate-managed-by-chain_test.go
+++ b/tests/ginkgo/parallel/1-012_validate-managed-by-chain_test.go
@@ -23,32 +23,71 @@ import (
 	"github.com/argoproj/gitops-engine/pkg/health"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	appFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/application"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	namespaceFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/namespace"
 	secretFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/secret"
 	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	controllerManagerName      = "argocd-operator-controller-manager"
+	controllerManagerNamespace = "argocd-operator-system"
+)
+
+func ensureNamespaceManagementEnabledForTest(ctx context.Context, k8sClient client.Client) (cleanup func()) {
+	operatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controllerManagerName,
+			Namespace: controllerManagerNamespace,
+		},
+	}
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(operatorDeployment), operatorDeployment); err != nil {
+		By("operator not deployed in cluster ALLOW_NAMESPACE_MANAGEMENT_IN_NAMESPACE_SCOPED_INSTANCES set via start-e2e")
+		return func() {}
+	}
+	By("enabling NamespaceManagement feature")
+	originalEnvValue, _ := deploymentFixture.GetEnv(operatorDeployment, "manager", common.EnableManagedNamespace)
+	deploymentFixture.SetEnv(operatorDeployment, "manager", common.EnableManagedNamespace, "true")
+	Eventually(operatorDeployment, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+
+	return func() {
+		By("restoring operator EnableManagedNamespace env var")
+		if originalEnvValue != nil {
+			deploymentFixture.SetEnv(operatorDeployment, "manager", common.EnableManagedNamespace, *originalEnvValue)
+		} else {
+			deploymentFixture.RemoveEnv(operatorDeployment, "manager", common.EnableManagedNamespace)
+		}
+		Eventually(operatorDeployment, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+	}
+}
+
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 	Context("1-012_validate-managed-by-chain", func() {
 
 		var (
-			ctx                 context.Context
-			k8sClient           client.Client
-			cleanupfuncs        []func()
-			nsTest_1_12_custom  *corev1.Namespace
-			nsTest_1_12_custom2 *corev1.Namespace
-			randomNS            *corev1.Namespace
+			ctx                     context.Context
+			k8sClient               client.Client
+			cleanupfuncs            []func()
+			nsTest_1_12_custom      *corev1.Namespace
+			nsTest_1_12_custom2     *corev1.Namespace
+			randomNS                *corev1.Namespace
+			nsTest_1_12_nm_argocd   *corev1.Namespace
+			nsTest_1_12_nm_tenant   *corev1.Namespace
+			argoCDWithNamespaceMgmt *argov1beta1api.ArgoCD
 		)
 
 		BeforeEach(func() {
@@ -64,8 +103,13 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 					cleanupfunc()
 				}
 			}()
-
-			fixture.OutputDebugOnFail(nsTest_1_12_custom, nsTest_1_12_custom2, randomNS)
+			var debugParams []any
+			for _, ns := range []*corev1.Namespace{nsTest_1_12_custom, nsTest_1_12_custom2, randomNS, nsTest_1_12_nm_argocd, nsTest_1_12_nm_tenant} {
+				if ns != nil {
+					debugParams = append(debugParams, ns)
+				}
+			}
+			fixture.OutputDebugOnFail(debugParams...)
 		})
 
 		It("validates that namespace-scoped Argo CD instance is able to managed other namespaces, including when those namespaces are deleted", func() {
@@ -261,6 +305,67 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			Eventually(app2, "4m", "1s").Should(appFixture.HaveHealthStatusCode(health.HealthStatusHealthy))
 			Eventually(app2, "4m", "1s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
 
+		})
+
+		It("validates that with spec.namespaceManagement and a NamespaceManagement CR the operator applies the managed-by label and RBAC to the tenant namespace so Applications are discovered (fix for issue #2039)", func() {
+
+			cleanup := ensureNamespaceManagementEnabledForTest(ctx, k8sClient)
+			defer cleanup()
+
+			By("creating namespace for Argo CD instance")
+			nsTest_1_12_nm_argocd, cleanupFunc1 := fixture.CreateNamespaceWithCleanupFunc("test-1-12-nm-argocd")
+			cleanupfuncs = append(cleanupfuncs, cleanupFunc1)
+
+			By("creating tenant namespace to be managed via NamespaceManagement")
+			nsTest_1_12_nm_tenant, cleanupFunc2 := fixture.CreateNamespaceWithCleanupFunc("test-1-12-nm-tenant")
+			cleanupfuncs = append(cleanupfuncs, cleanupFunc2)
+
+			By("creating namespace-scoped Argo CD with spec.namespaceManagement allowing the tenant namespace")
+			argoCDWithNamespaceMgmt = &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd",
+					Namespace: nsTest_1_12_nm_argocd.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					NamespaceManagement: []argov1beta1api.ManagedNamespaces{
+						{
+							Name:           nsTest_1_12_nm_tenant.Name,
+							AllowManagedBy: true,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCDWithNamespaceMgmt)).To(Succeed())
+
+			By("creating NamespaceManagement CR in tenant namespace with managedBy set to Argo CD namespace")
+			nm := &argov1beta1api.NamespaceManagement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tenant-nm",
+					Namespace: nsTest_1_12_nm_tenant.Name,
+				},
+				Spec: argov1beta1api.NamespaceManagementSpec{
+					ManagedBy: nsTest_1_12_nm_argocd.Name,
+				},
+			}
+			Expect(k8sClient.Create(ctx, nm)).To(Succeed())
+
+			By("waiting for Argo CD instance to become available")
+			Eventually(argoCDWithNamespaceMgmt, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			By("verifying tenant namespace gets argocd.argoproj.io/managed-by label")
+			Eventually(nsTest_1_12_nm_tenant, "2m", "5s").Should(namespaceFixture.HaveLabel(common.ArgoCDManagedByLabel, nsTest_1_12_nm_argocd.Name))
+			Consistently(nsTest_1_12_nm_tenant, "10s", "2s").Should(namespaceFixture.HaveLabel(common.ArgoCDManagedByLabel, nsTest_1_12_nm_argocd.Name))
+
+			By("verifying RBAC is created in tenant namespace")
+			Eventually(&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_tenant.Name}}).Should(k8sFixture.ExistByName())
+			Eventually(&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-application-controller", Namespace: nsTest_1_12_nm_tenant.Name}}).Should(k8sFixture.ExistByName())
+			rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_tenant.Name}}
+			Eventually(rb).Should(k8sFixture.ExistByName())
+			Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+			Expect(rb.RoleRef.Kind).To(Equal("Role"))
+			Expect(rb.RoleRef.Name).To(Equal("argocd-argocd-server"))
+			Expect(rb.Subjects).To(HaveLen(1))
+			Expect(rb.Subjects[0]).To(Equal(rbacv1.Subject{Kind: "ServiceAccount", Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_argocd.Name}))
 		})
 
 	})

--- a/tests/ginkgo/sequential/1-012_validate_managed_by_chain_namespace_management_test.go
+++ b/tests/ginkgo/sequential/1-012_validate_managed_by_chain_namespace_management_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sequential
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	namespaceFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/namespace"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	controllerManagerNameForNamespaceManagementTest      = "argocd-operator-controller-manager"
+	controllerManagerNamespaceForNamespaceManagementTest = "argocd-operator-system"
+)
+
+func ensureNamespaceManagementEnabledForTest(ctx context.Context, k8sClient client.Client) (cleanup func()) {
+	operatorDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controllerManagerNameForNamespaceManagementTest,
+			Namespace: controllerManagerNamespaceForNamespaceManagementTest,
+		},
+	}
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(operatorDeployment), operatorDeployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			By("no in-cluster controller-manager Deployment - skipping " + common.EnableManagedNamespace + " patch; test still runs (set env on the operator process when running locally)")
+			return func() {}
+		}
+		Expect(err).NotTo(HaveOccurred(), "failed to read controller-manager Deployment")
+	}
+	By("enabling NamespaceManagement feature")
+	originalEnvValue, _ := deploymentFixture.GetEnv(operatorDeployment, "manager", common.EnableManagedNamespace)
+	deploymentFixture.SetEnv(operatorDeployment, "manager", common.EnableManagedNamespace, "true")
+	Eventually(operatorDeployment, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+
+	return func() {
+		By("restoring operator EnableManagedNamespace env var")
+		if originalEnvValue != nil {
+			deploymentFixture.SetEnv(operatorDeployment, "manager", common.EnableManagedNamespace, *originalEnvValue)
+		} else {
+			deploymentFixture.RemoveEnv(operatorDeployment, "manager", common.EnableManagedNamespace)
+		}
+		Eventually(operatorDeployment, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+	}
+}
+
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
+	Context("1-012_validate_managed_by_chain_namespace_management", func() {
+		var (
+			ctx                   context.Context
+			k8sClient             client.Client
+			cleanupfuncs          []func()
+			nsTest_1_12_nm_argocd *corev1.Namespace
+			nsTest_1_12_nm_tenant *corev1.Namespace
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureSequentialCleanSlate()
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+			cleanupfuncs = make([]func(), 0)
+		})
+
+		AfterEach(func() {
+			defer func() {
+				for _, cleanupfunc := range cleanupfuncs {
+					cleanupfunc()
+				}
+			}()
+			var debugParams []any
+			for _, ns := range []*corev1.Namespace{nsTest_1_12_nm_argocd, nsTest_1_12_nm_tenant} {
+				if ns != nil {
+					debugParams = append(debugParams, ns)
+				}
+			}
+			fixture.OutputDebugOnFail(debugParams...)
+		})
+
+		It("validates that with spec.namespaceManagement and a NamespaceManagement CR the operator applies the managed-by label and RBAC to the tenant namespace so Applications are discovered (fix for issue #2039)", func() {
+			cleanup := ensureNamespaceManagementEnabledForTest(ctx, k8sClient)
+			defer cleanup()
+
+			By("creating namespace for Argo CD instance")
+			nsTest_1_12_nm_argocd, cleanupFunc1 := fixture.CreateNamespaceWithCleanupFunc("test-1-12-nm-argocd")
+			cleanupfuncs = append(cleanupfuncs, cleanupFunc1)
+
+			By("creating tenant namespace to be managed via NamespaceManagement")
+			nsTest_1_12_nm_tenant, cleanupFunc2 := fixture.CreateNamespaceWithCleanupFunc("test-1-12-nm-tenant")
+			cleanupfuncs = append(cleanupfuncs, cleanupFunc2)
+
+			By("creating namespace-scoped Argo CD with spec.namespaceManagement allowing the tenant namespace")
+			argoCDWithNamespaceMgmt := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "argocd",
+					Namespace: nsTest_1_12_nm_argocd.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					NamespaceManagement: []argov1beta1api.ManagedNamespaces{
+						{
+							Name:           nsTest_1_12_nm_tenant.Name,
+							AllowManagedBy: true,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCDWithNamespaceMgmt)).To(Succeed())
+
+			By("creating NamespaceManagement CR in tenant namespace with managedBy set to Argo CD namespace")
+			nm := &argov1beta1api.NamespaceManagement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tenant-nm",
+					Namespace: nsTest_1_12_nm_tenant.Name,
+				},
+				Spec: argov1beta1api.NamespaceManagementSpec{
+					ManagedBy: nsTest_1_12_nm_argocd.Name,
+				},
+			}
+			Expect(k8sClient.Create(ctx, nm)).To(Succeed())
+
+			By("waiting for Argo CD instance to become available")
+			Eventually(argoCDWithNamespaceMgmt, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			By("verifying tenant namespace gets argocd.argoproj.io/managed-by label")
+			Eventually(nsTest_1_12_nm_tenant, "2m", "5s").Should(namespaceFixture.HaveLabel(common.ArgoCDManagedByLabel, nsTest_1_12_nm_argocd.Name))
+			Consistently(nsTest_1_12_nm_tenant, "10s", "2s").Should(namespaceFixture.HaveLabel(common.ArgoCDManagedByLabel, nsTest_1_12_nm_argocd.Name))
+
+			By("verifying RBAC is created in tenant namespace")
+			Eventually(&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_tenant.Name}}).Should(k8sFixture.ExistByName())
+			Eventually(&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-application-controller", Namespace: nsTest_1_12_nm_tenant.Name}}).Should(k8sFixture.ExistByName())
+			rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_tenant.Name}}
+			Eventually(rb).Should(k8sFixture.ExistByName())
+			Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
+			Expect(rb.RoleRef.Kind).To(Equal("Role"))
+			Expect(rb.RoleRef.Name).To(Equal("argocd-argocd-server"))
+			Expect(rb.Subjects).To(HaveLen(1))
+			Expect(rb.Subjects[0]).To(Equal(rbacv1.Subject{Kind: "ServiceAccount", Name: "argocd-argocd-server", Namespace: nsTest_1_12_nm_argocd.Name}))
+		})
+	})
+})


### PR DESCRIPTION
… and fix related bugs (#2039)

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
Namespace-scoped Argo CD with spec.namespaceManagement was not labeling the tenant namespace with argocd.argoproj.io/managed-by, so Applications in that namespace were not discovered. This PR fixes that by applying the managed-by label from the role controller when reconciling the application-controller role for managed namespaces
Changes  include related fixes (single status update in NamespaceManagement, correct namespace in RBAC skip logic), unit and E2E testing

**Which issue(s) this PR fixes**:

Fixes #2039?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator now ensures tenant namespaces get the Argo CD managed-by label when applicable, preserving existing labels.

* **Bug Fixes**
  * RBAC/cleanup skipping now consistently detects managed namespaces by comparing to the Argo CD instance namespace.

* **Tests**
  * Expanded unit and e2e tests covering managed-by labeling, RBAC/Role and RoleBinding creation, and cleanup behavior.

* **Chores**
  * E2E start command exports an env var to enable namespace-management in namespace-scoped runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->