### PR TITLE
feat: replace non-expiring Dex SA token with short-lived TokenRequest-based token

### DIFF
--- a/common/defaults.go
+++ b/common/defaults.go
@@ -118,6 +118,12 @@ const (
 	// ArgoCDDefaultDexServiceAccountName is the default Service Account name for the Dex server.
 	ArgoCDDefaultDexServiceAccountName = "argocd-dex-server"
 
+	// ArgoCDDexServerTokenExpirySecs is the Dex SA token lifetime in seconds (1 hour).
+	ArgoCDDexServerTokenExpirySecs = int64(3600)
+
+	// ArgoCDDexServerTokenRenewalThresholdFraction is N in "renew when < 1/N lifetime remains".
+	ArgoCDDexServerTokenRenewalThresholdFraction = 3
+
 	// ArgoCDDefaultDexVersion is the Dex container image tag to use when not specified.
 	ArgoCDDefaultDexVersion = "sha256:b08a58c9731c693b8db02154d7afda798e1888dc76db30d34c4a0d0b8a26d913" // v2.43.0
 

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -121,8 +121,10 @@ const (
 	// ArgoCDDexServerTokenExpirySecs is the Dex SA token lifetime in seconds (1 hour).
 	ArgoCDDexServerTokenExpirySecs = int64(3600)
 
-	// ArgoCDDexServerTokenRenewalThresholdFraction is N in "renew when < 1/N lifetime remains".
-	ArgoCDDexServerTokenRenewalThresholdFraction = 3
+	// ArgoCDDexServerTokenRenewalThresholdPercent (1-99): renew the Dex token when less than this percent
+	// of ArgoCDDexServerTokenExpirySecs remains (default 33 is approximately equivalent to the last third
+	// of a 1h nominal lifetime).
+	ArgoCDDexServerTokenRenewalThresholdPercent int64 = 33
 
 	// ArgoCDDefaultDexVersion is the Dex container image tag to use when not specified.
 	ArgoCDDefaultDexVersion = "sha256:b08a58c9731c693b8db02154d7afda798e1888dc76db30d34c4a0d0b8a26d913" // v2.43.0

--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -97,6 +97,11 @@ type ReconcileArgoCD struct {
 	LocalUsers *LocalUsersInfo
 	// FipsConfigChecker checks if the deployment needs FIPS specific environment variables set.
 	FipsConfigChecker argoutil.FipsConfigChecker
+
+	// dexTokenRequeueAfter stores the duration after which the reconciler should
+	// re-run to renew the Dex OAuth client token before it expires.
+	// Key: ArgoCD namespace, Value: time.Duration
+	dexTokenRequeueAfter sync.Map
 }
 
 var log = logr.Log.WithName("controller_argocd")
@@ -365,7 +370,20 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 		return reconcile.Result{}, argocd, argoCDStatus, err
 	}
 
-	// Return and don't requeue
+	// If Dex is in use, requeue before the token reaches its renewal threshold so
+	// the operator proactively renews it without waiting for an external event.
+	if UseDex(argocd) {
+		if v, ok := r.dexTokenRequeueAfter.Load(argocd.Namespace); ok {
+			if d, ok := v.(time.Duration); ok {
+				return reconcile.Result{RequeueAfter: d}, argocd, argoCDStatus, nil
+			}
+		}
+	} else {
+		// Dex is disabled; remove any stale requeue entry so it does not fire
+		// if Dex is later re-enabled and a fresh duration has not been stored yet.
+		r.dexTokenRequeueAfter.Delete(argocd.Namespace)
+	}
+
 	return reconcile.Result{}, argocd, argoCDStatus, nil
 }
 

--- a/controllers/argocd/argocd_controller_test.go
+++ b/controllers/argocd/argocd_controller_test.go
@@ -101,7 +101,7 @@ func TestReconcileArgoCD_DexWorkloads(t *testing.T) {
 	runtimeObjs := []runtime.Object{}
 	sch := makeTestReconcilerScheme(argoproj.AddToScheme, configv1.Install, routev1.Install)
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
-	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	r := makeTestReconciler(cl, sch, makeTestK8sClientWithTokenReactor("mock-dex-token"))
 
 	assert.NoError(t, createNamespace(r, a.Namespace, ""))
 
@@ -139,10 +139,6 @@ func TestReconcileArgoCD_DexWorkloads(t *testing.T) {
 		assert.True(t, len(objectToVerify.GetOwnerReferences()) > 0)
 	}
 
-	var secretList corev1.SecretList
-	err = r.List(context.TODO(), &secretList, client.InNamespace(a.Namespace))
-	assert.NoError(t, err)
-
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-cm",
@@ -154,16 +150,12 @@ func TestReconcileArgoCD_DexWorkloads(t *testing.T) {
 
 	assert.Equal(t, configMap.Data["dex.config"], a.Spec.SSO.Dex.Config)
 
-	var dexSecret *corev1.Secret
-
-	for idx := range secretList.Items {
-		secret := secretList.Items[idx]
-		if strings.HasPrefix(secret.Name, "argocd-dex-server-token-") {
-			dexSecret = &secret
-			break
-		}
-	}
-	assert.NotNil(t, dexSecret)
+	// Verify the expiring token Secret (Opaque type) was created with the expected fixed name.
+	dexTokenSecret := &corev1.Secret{}
+	expectedTokenSecretName := getDexServerTokenSecretName(a)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: expectedTokenSecretName, Namespace: a.Namespace}, dexTokenSecret)
+	assert.NoError(t, err, "expected dex token secret %q to exist", expectedTokenSecretName)
+	assert.Equal(t, corev1.SecretTypeOpaque, dexTokenSecret.Type)
 
 	err = r.Get(context.TODO(), client.ObjectKeyFromObject(a), a)
 	assert.NoError(t, err)

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -46,18 +47,33 @@ func getDexServerTokenSecretName(cr *argoproj.ArgoCD) string {
 	return argoutil.GetSecretNameWithSuffix(cr, common.ArgoCDDefaultDexServiceAccountName+"-token")
 }
 
+// dexServerTokenRenewalThreshold is how much nominal lifetime may remain before we treat the Dex token
+// as due for renewal (ExpirySecs * ArgoCDDexServerTokenRenewalThresholdPercent / 100).
+func dexServerTokenRenewalThreshold() time.Duration {
+	return time.Duration(common.ArgoCDDexServerTokenExpirySecs*common.ArgoCDDexServerTokenRenewalThresholdPercent/100) * time.Second
+}
+
 // needsDexTokenRenewal returns true when the token is missing, unparseable, or within the renewal window.
 func needsDexTokenRenewal(secret *corev1.Secret) bool {
+	if secret == nil || secret.Data == nil {
+		return true
+	}
+	tokenBytes, ok := secret.Data["token"]
+	if !ok || len(tokenBytes) == 0 {
+		return true
+	}
 	expiryBytes, ok := secret.Data["expiry"]
 	if !ok {
 		return true
 	}
 	expiry, err := time.Parse(time.RFC3339, string(expiryBytes))
 	if err != nil {
+		log.Error(err, "dex token secret has unparseable expiry, renewal needed",
+			"secret", fmt.Sprintf("%s/%s", secret.Namespace, secret.Name),
+			"expiry", string(expiryBytes))
 		return true
 	}
-	renewThreshold := time.Duration(common.ArgoCDDexServerTokenExpirySecs/common.ArgoCDDexServerTokenRenewalThresholdFraction) * time.Second
-	return time.Until(expiry) < renewThreshold
+	return time.Until(expiry) < dexServerTokenRenewalThreshold()
 }
 
 // getDexOAuthClientSecret returns a time-limited Dex OAuth client token via the TokenRequest API.
@@ -80,9 +96,12 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoproj.ArgoCD) (*string,
 		token := string(tokenSecret.Data["token"])
 		// Schedule the next reconcile to run just before the renewal threshold so
 		// the token is proactively renewed without waiting for an external event.
-		if expiry, parseErr := time.Parse(time.RFC3339, string(tokenSecret.Data["expiry"])); parseErr == nil {
-			renewThreshold := time.Duration(common.ArgoCDDexServerTokenExpirySecs/common.ArgoCDDexServerTokenRenewalThresholdFraction) * time.Second
-			if d := time.Until(expiry) - renewThreshold; d > 0 {
+		expiry, parseErr := time.Parse(time.RFC3339, string(tokenSecret.Data["expiry"]))
+		if parseErr != nil {
+			log.Error(parseErr, "dex token secret expiry unparseable when scheduling requeue, returning cached token",
+				"secret", fmt.Sprintf("%s/%s", tokenSecret.Namespace, tokenSecret.Name))
+		} else {
+			if d := time.Until(expiry) - dexServerTokenRenewalThreshold(); d > 0 {
 				r.dexTokenRequeueAfter.Store(cr.Namespace, d)
 			}
 		}
@@ -132,8 +151,7 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoproj.ArgoCD) (*string,
 	}
 
 	// Schedule the next reconcile just before the renewal threshold.
-	renewThreshold := time.Duration(common.ArgoCDDexServerTokenExpirySecs/common.ArgoCDDexServerTokenRenewalThresholdFraction) * time.Second
-	if d := time.Until(tokenRequest.Status.ExpirationTimestamp.Time) - renewThreshold; d > 0 {
+	if d := time.Until(tokenRequest.Status.ExpirationTimestamp.Time) - dexServerTokenRenewalThreshold(); d > 0 {
 		r.dexTokenRequeueAfter.Store(cr.Namespace, d)
 	}
 
@@ -154,6 +172,7 @@ func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) 
 	); err != nil {
 		return err
 	}
+	var deleteErrs []error
 	for i := range secretList.Items {
 		s := &secretList.Items[i]
 		if s.Type != corev1.SecretTypeServiceAccountToken {
@@ -162,24 +181,26 @@ func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) 
 		if s.Annotations[corev1.ServiceAccountNameKey] != dexSAName {
 			continue
 		}
-		if !strings.HasPrefix(s.Name, "argocd-dex-server-token-") {
+
+		if !strings.HasPrefix(s.Name, dexSAName+"-token-") {
 			continue
 		}
 		argoutil.LogResourceDeletion(log, s, "removing legacy Dex service account token secret")
 		if err := r.Delete(context.TODO(), s); err != nil && !apierrors.IsNotFound(err) {
-			return err
+			deleteErrs = append(deleteErrs, fmt.Errorf("delete legacy dex token secret %s/%s: %w", s.Namespace, s.Name, err))
 		}
 	}
 	sa := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, cr)
 	if err := argoutil.FetchObject(r.Client, cr.Namespace, sa.Name, sa); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil
+			return errors.Join(deleteErrs...)
 		}
-		return err
+		return errors.Join(append([]error{err}, deleteErrs...)...)
 	}
 	var filtered []corev1.ObjectReference
 	for _, ref := range sa.Secrets {
-		if strings.Contains(ref.Name, "dex-server-token") {
+		// Legacy auto token refs only (matches delete loop).
+		if strings.HasPrefix(ref.Name, dexSAName+"-token-") {
 			continue
 		}
 		filtered = append(filtered, ref)
@@ -188,10 +209,10 @@ func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) 
 		sa.Secrets = filtered
 		argoutil.LogResourceUpdate(log, sa, "removing legacy token secret references from Dex service account")
 		if err := r.Update(context.TODO(), sa); err != nil {
-			return err
+			return errors.Join(append([]error{err}, deleteErrs...)...)
 		}
 	}
-	return nil
+	return errors.Join(deleteErrs...)
 }
 
 // reconcileDexConfiguration will ensure that Dex is configured properly.

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -2,20 +2,19 @@ package argocd
 
 import (
 	"context"
-	e "errors"
 	"fmt"
 	"reflect"
 	"strings"
-
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 
 	"gopkg.in/yaml.v2"
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -42,71 +41,157 @@ func UseDex(cr *argoproj.ArgoCD) bool {
 	return false
 }
 
-// getDexOAuthClientSecret will return the OAuth client secret for the given ArgoCD.
+// getDexServerTokenSecretName returns the name of the Secret that stores the Dex OAuth client token.
+func getDexServerTokenSecretName(cr *argoproj.ArgoCD) string {
+	return argoutil.GetSecretNameWithSuffix(cr, common.ArgoCDDefaultDexServiceAccountName+"-token")
+}
+
+// needsDexTokenRenewal returns true when the token is missing, unparseable, or within the renewal window.
+func needsDexTokenRenewal(secret *corev1.Secret) bool {
+	expiryBytes, ok := secret.Data["expiry"]
+	if !ok {
+		return true
+	}
+	expiry, err := time.Parse(time.RFC3339, string(expiryBytes))
+	if err != nil {
+		return true
+	}
+	renewThreshold := time.Duration(common.ArgoCDDexServerTokenExpirySecs/common.ArgoCDDexServerTokenRenewalThresholdFraction) * time.Second
+	return time.Until(expiry) < renewThreshold
+}
+
+// getDexOAuthClientSecret returns a time-limited Dex OAuth client token via the TokenRequest API.
 func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoproj.ArgoCD) (*string, error) {
 	sa := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, cr)
 	if err := argoutil.FetchObject(r.Client, cr.Namespace, sa.Name, sa); err != nil {
 		return nil, err
 	}
 
-	// Find the token secret
-	var tokenSecret *corev1.ObjectReference
-	for _, saSecret := range sa.Secrets {
-		if strings.Contains(saSecret.Name, "token") {
-			tokenSecret = &saSecret
-			break
+	tokenSecretName := getDexServerTokenSecretName(cr)
+	tokenSecret := &corev1.Secret{}
+	fetchErr := argoutil.FetchObject(r.Client, cr.Namespace, tokenSecretName, tokenSecret)
+	if fetchErr != nil && !apierrors.IsNotFound(fetchErr) {
+		return nil, fetchErr
+	}
+	secretExists := fetchErr == nil
+
+	// Return the cached token if it is still valid.
+	if secretExists && !needsDexTokenRenewal(tokenSecret) {
+		token := string(tokenSecret.Data["token"])
+		// Schedule the next reconcile to run just before the renewal threshold so
+		// the token is proactively renewed without waiting for an external event.
+		if expiry, parseErr := time.Parse(time.RFC3339, string(tokenSecret.Data["expiry"])); parseErr == nil {
+			renewThreshold := time.Duration(common.ArgoCDDexServerTokenExpirySecs/common.ArgoCDDexServerTokenRenewalThresholdFraction) * time.Second
+			if d := time.Until(expiry) - renewThreshold; d > 0 {
+				r.dexTokenRequeueAfter.Store(cr.Namespace, d)
+			}
 		}
+		return &token, nil
 	}
 
-	if tokenSecret == nil {
-		// This change of creating secret for dex service account,is due to
-		// change of reduction of secret-based service account tokens in k8s
-		// v1.24 so from k8s v1.24 no default secret for service account is
-		// created, but for dex to work we need to provide token of secret used
-		// by dex service account as a oauth token, this change helps to achieve
-		// it, in long run we should see do dex really requires a secret or it
-		// manages to create one using TokenRequest API or may be change how dex
-		// is used or configured by operator
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "argocd-dex-server-token-",
-				Namespace:    cr.Namespace,
-				Annotations: map[string]string{
-					corev1.ServiceAccountNameKey: sa.Name,
-				},
+	// Request a new time-limited token via the TokenRequest API.
+	expirationSeconds := common.ArgoCDDexServerTokenExpirySecs
+	tokenRequest, err := r.K8sClient.CoreV1().ServiceAccounts(cr.Namespace).CreateToken(
+		context.TODO(),
+		sa.Name,
+		&authv1.TokenRequest{
+			Spec: authv1.TokenRequestSpec{
+				ExpirationSeconds: &expirationSeconds,
 			},
-			Type: corev1.SecretTypeServiceAccountToken,
-		}
-		argoutil.AddTrackedByOperatorLabel(&secret.ObjectMeta)
-		argoutil.LogResourceCreation(log, secret)
-		err := r.Create(context.TODO(), secret)
-		if err != nil {
-			return nil, e.New("unable to locate and create ServiceAccount token for OAuth client secret")
-		}
-		err = controllerutil.SetControllerReference(cr, secret, r.Scheme)
-		if err != nil {
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token for dex service account %s: %w", sa.Name, err)
+	}
+
+	expiryStr := tokenRequest.Status.ExpirationTimestamp.UTC().Format(time.RFC3339)
+	tokenData := map[string][]byte{
+		"token":  []byte(tokenRequest.Status.Token),
+		"expiry": []byte(expiryStr),
+	}
+
+	if !secretExists {
+		newSecret := argoutil.NewSecretWithSuffix(cr, common.ArgoCDDefaultDexServiceAccountName+"-token")
+		newSecret.Type = corev1.SecretTypeOpaque
+		newSecret.Data = tokenData
+		argoutil.AddTrackedByOperatorLabel(&newSecret.ObjectMeta)
+		if err := controllerutil.SetControllerReference(cr, newSecret, r.Scheme); err != nil {
 			return nil, err
 		}
-		tokenSecret = &corev1.ObjectReference{
-			Name:      secret.Name,
-			Namespace: cr.Namespace,
+		argoutil.LogResourceCreation(log, newSecret)
+		if err := r.Create(context.TODO(), newSecret); err != nil {
+			return nil, err
 		}
-		sa.Secrets = append(sa.Secrets, *tokenSecret)
-		argoutil.LogResourceUpdate(log, sa, "adding ServiceAccount token for OAuth client secret")
-		err = r.Update(context.TODO(), sa)
-		if err != nil {
-			return nil, e.New("failed to add ServiceAccount token for OAuth client secret")
+	} else {
+		tokenSecret.Data = tokenData
+		argoutil.LogResourceUpdate(log, tokenSecret, "renewing dex OAuth client token")
+		if err := r.Update(context.TODO(), tokenSecret); err != nil {
+			return nil, err
 		}
 	}
 
-	// Fetch the secret to obtain the token
-	secret := argoutil.NewSecretWithName(cr, tokenSecret.Name)
-	if err := argoutil.FetchObject(r.Client, cr.Namespace, secret.Name, secret); err != nil {
-		return nil, err
+	// Schedule the next reconcile just before the renewal threshold.
+	renewThreshold := time.Duration(common.ArgoCDDexServerTokenExpirySecs/common.ArgoCDDexServerTokenRenewalThresholdFraction) * time.Second
+	if d := time.Until(tokenRequest.Status.ExpirationTimestamp.Time) - renewThreshold; d > 0 {
+		r.dexTokenRequeueAfter.Store(cr.Namespace, d)
 	}
 
-	token := string(secret.Data["token"])
+	token := tokenRequest.Status.Token
 	return &token, nil
+}
+
+// reconcileDexLegacySATokenSecrets deletes non-expiring kubernetes.io/service-account-token
+// Secrets for the Dex SA and removes their stale references from the SA.
+func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) error {
+	dexSAName := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, cr).Name
+	secretList := &corev1.SecretList{}
+	if err := r.List(context.TODO(), secretList,
+		client.InNamespace(cr.Namespace),
+		client.MatchingLabels(map[string]string{
+			common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
+		}),
+	); err != nil {
+		return err
+	}
+	for i := range secretList.Items {
+		s := &secretList.Items[i]
+		if s.Type != corev1.SecretTypeServiceAccountToken {
+			continue
+		}
+		if s.Annotations[corev1.ServiceAccountNameKey] != dexSAName {
+			continue
+		}
+		if !strings.HasPrefix(s.Name, "argocd-dex-server-token-") {
+			continue
+		}
+		argoutil.LogResourceDeletion(log, s, "removing legacy Dex service account token secret")
+		if err := r.Delete(context.TODO(), s); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	sa := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, cr)
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, sa.Name, sa); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	var filtered []corev1.ObjectReference
+	for _, ref := range sa.Secrets {
+		if strings.Contains(ref.Name, "dex-server-token") {
+			continue
+		}
+		filtered = append(filtered, ref)
+	}
+	if len(filtered) != len(sa.Secrets) {
+		sa.Secrets = filtered
+		argoutil.LogResourceUpdate(log, sa, "removing legacy token secret references from Dex service account")
+		if err := r.Update(context.TODO(), sa); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // reconcileDexConfiguration will ensure that Dex is configured properly.

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -1099,7 +1099,7 @@ func TestGetOpenShiftDexConfig_OIDCDisabled(t *testing.T) {
 }
 
 func TestNeedsDexTokenRenewal(t *testing.T) {
-	renewThreshold := time.Duration(common.ArgoCDDexServerTokenExpirySecs/common.ArgoCDDexServerTokenRenewalThresholdFraction) * time.Second
+	renewThreshold := dexServerTokenRenewalThreshold()
 
 	tests := []struct {
 		name   string
@@ -1135,8 +1135,29 @@ func TestNeedsDexTokenRenewal(t *testing.T) {
 			name: "outside renewal window - no renewal needed",
 			secret: &corev1.Secret{Data: map[string][]byte{
 				"expiry": []byte(time.Now().Add(renewThreshold + time.Hour).UTC().Format(time.RFC3339)),
+				"token":  []byte("present"),
 			}},
 			want: false,
+		},
+		{
+			name:   "nil secret - needs renewal",
+			secret: nil,
+			want:   true,
+		},
+		{
+			name: "valid expiry but missing token key - needs renewal",
+			secret: &corev1.Secret{Data: map[string][]byte{
+				"expiry": []byte(time.Now().Add(renewThreshold + time.Hour).UTC().Format(time.RFC3339)),
+			}},
+			want: true,
+		},
+		{
+			name: "valid expiry but empty token - needs renewal",
+			secret: &corev1.Secret{Data: map[string][]byte{
+				"expiry": []byte(time.Now().Add(renewThreshold + time.Hour).UTC().Format(time.RFC3339)),
+				"token":  []byte{},
+			}},
+			want: true,
 		},
 	}
 
@@ -1249,7 +1270,7 @@ func TestReconcileArgoCD_reconcileDexLegacySATokenSecrets(t *testing.T) {
 	// Create a legacy kubernetes.io/service-account-token Secret.
 	legacySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "argocd-dex-server-token-abc12",
+			Name:      dexSAName + "-token-abc12",
 			Namespace: a.Namespace,
 			Labels: map[string]string{
 				common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
@@ -1283,7 +1304,7 @@ func TestReconcileArgoCD_reconcileDexLegacySATokenSecrets(t *testing.T) {
 	assert.NoError(t, r.Get(context.TODO(),
 		types.NamespacedName{Name: dexSAName, Namespace: a.Namespace}, updatedSA))
 	for _, ref := range updatedSA.Secrets {
-		assert.False(t, strings.Contains(ref.Name, "dex-server-token"),
+		assert.False(t, strings.HasPrefix(ref.Name, dexSAName+"-token-"),
 			"SA.secrets must not contain legacy token reference %q", ref.Name)
 	}
 }

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -2,7 +2,9 @@ package argocd
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
@@ -1094,4 +1096,233 @@ func TestGetOpenShiftDexConfig_OIDCDisabled(t *testing.T) {
 	updated := &argoproj.ArgoCD{}
 	require.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: "example", Namespace: "default"}, updated))
 	assert.Empty(t, updated.Status.Conditions)
+}
+
+func TestNeedsDexTokenRenewal(t *testing.T) {
+	renewThreshold := time.Duration(common.ArgoCDDexServerTokenExpirySecs/common.ArgoCDDexServerTokenRenewalThresholdFraction) * time.Second
+
+	tests := []struct {
+		name   string
+		secret *corev1.Secret
+		want   bool
+	}{
+		{
+			name:   "no expiry key - needs renewal",
+			secret: &corev1.Secret{Data: map[string][]byte{"token": []byte("t")}},
+			want:   true,
+		},
+		{
+			name:   "unparseable expiry - needs renewal",
+			secret: &corev1.Secret{Data: map[string][]byte{"expiry": []byte("not-a-time")}},
+			want:   true,
+		},
+		{
+			name: "expired token - needs renewal",
+			secret: &corev1.Secret{Data: map[string][]byte{
+				"expiry": []byte(time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)),
+			}},
+			want: true,
+		},
+		{
+			name: "within renewal window - needs renewal",
+			secret: &corev1.Secret{Data: map[string][]byte{
+				// just inside the threshold (renewThreshold - 1s remaining)
+				"expiry": []byte(time.Now().Add(renewThreshold - time.Second).UTC().Format(time.RFC3339)),
+			}},
+			want: true,
+		},
+		{
+			name: "outside renewal window - no renewal needed",
+			secret: &corev1.Secret{Data: map[string][]byte{
+				"expiry": []byte(time.Now().Add(renewThreshold + time.Hour).UTC().Format(time.RFC3339)),
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, needsDexTokenRenewal(tt.secret))
+		})
+	}
+}
+
+func TestReconcileArgoCD_getDexOAuthClientSecret_ReturnsCachedToken(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	const firstToken = "first-token"
+	const secondToken = "second-token"
+
+	a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+		ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
+			Dex:      &argoproj.ArgoCDDexSpec{OpenShiftOAuth: true},
+		}
+	})
+
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, []client.Object{a}, []client.Object{a}, nil)
+
+	// First call uses firstToken reactor.
+	r := makeTestReconciler(cl, sch, makeTestK8sClientWithTokenReactor(firstToken))
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
+	assert.NoError(t, err)
+
+	token1, err := r.getDexOAuthClientSecret(a)
+	assert.NoError(t, err)
+	require.NotNil(t, token1)
+	assert.Equal(t, firstToken, *token1)
+
+	// Swap the K8sClient reactor to return a different token.
+	// The cached Secret is still valid, so the same firstToken must be returned.
+	r.K8sClient = makeTestK8sClientWithTokenReactor(secondToken)
+
+	token2, err := r.getDexOAuthClientSecret(a)
+	assert.NoError(t, err)
+	require.NotNil(t, token2)
+	assert.Equal(t, firstToken, *token2, "cached token should be returned while Secret is still valid")
+}
+
+func TestReconcileArgoCD_getDexOAuthClientSecret_RenewsExpiredToken(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	const expiredToken = "expired-token"
+	const renewedToken = "renewed-token"
+
+	a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+		ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
+			Dex:      &argoproj.ArgoCDDexSpec{OpenShiftOAuth: true},
+		}
+	})
+
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, []client.Object{a}, []client.Object{a}, nil)
+	r := makeTestReconciler(cl, sch, makeTestK8sClientWithTokenReactor(renewedToken))
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
+	assert.NoError(t, err)
+
+	// Create an expired token Secret.
+	expiredSecret := argoutil.NewSecretWithSuffix(a, common.ArgoCDDefaultDexServiceAccountName+"-token")
+	expiredSecret.Type = corev1.SecretTypeOpaque
+	expiredSecret.Data = map[string][]byte{
+		"token":  []byte(expiredToken),
+		"expiry": []byte(time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)), // expired 1h ago
+	}
+	argoutil.AddTrackedByOperatorLabel(&expiredSecret.ObjectMeta)
+	assert.NoError(t, r.Create(context.TODO(), expiredSecret))
+
+	token, err := r.getDexOAuthClientSecret(a)
+	assert.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, renewedToken, *token, "expired token must be replaced by a fresh one")
+
+	// Verify the Secret was updated with the renewed token.
+	updated := &corev1.Secret{}
+	assert.NoError(t, r.Get(context.TODO(),
+		types.NamespacedName{Name: getDexServerTokenSecretName(a), Namespace: a.Namespace},
+		updated))
+	assert.Equal(t, renewedToken, string(updated.Data["token"]))
+}
+
+func TestReconcileArgoCD_reconcileDexLegacySATokenSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+		ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
+			Dex:      &argoproj.ArgoCDDexSpec{OpenShiftOAuth: true},
+		}
+	})
+
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, []client.Object{a}, []client.Object{a}, nil)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+
+	// Create the Dex SA so the function can fetch it.
+	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
+	assert.NoError(t, err)
+
+	dexSAName := a.Name + "-" + common.ArgoCDDefaultDexServiceAccountName
+
+	// Create a legacy kubernetes.io/service-account-token Secret.
+	legacySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-dex-server-token-abc12",
+			Namespace: a.Namespace,
+			Labels: map[string]string{
+				common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
+			},
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: dexSAName,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+	assert.NoError(t, r.Create(context.TODO(), legacySecret))
+
+	// Also add a reference to that Secret in the SA.secrets list.
+	sa := &corev1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(),
+		types.NamespacedName{Name: dexSAName, Namespace: a.Namespace}, sa))
+	sa.Secrets = append(sa.Secrets, corev1.ObjectReference{Name: legacySecret.Name})
+	assert.NoError(t, r.Update(context.TODO(), sa))
+
+	// Run the cleanup.
+	assert.NoError(t, r.reconcileDexLegacySATokenSecrets(a))
+
+	// Legacy Secret must be deleted.
+	deleted := &corev1.Secret{}
+	err = r.Get(context.TODO(),
+		types.NamespacedName{Name: legacySecret.Name, Namespace: a.Namespace}, deleted)
+	assert.True(t, apierrors.IsNotFound(err), "legacy SA token Secret must be deleted")
+
+	// SA.secrets must no longer reference the legacy token.
+	updatedSA := &corev1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(),
+		types.NamespacedName{Name: dexSAName, Namespace: a.Namespace}, updatedSA))
+	for _, ref := range updatedSA.Secrets {
+		assert.False(t, strings.Contains(ref.Name, "dex-server-token"),
+			"SA.secrets must not contain legacy token reference %q", ref.Name)
+	}
+}
+
+func TestReconcileArgoCD_reconcileDexLegacySATokenSecrets_IgnoresUnrelatedSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+		ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
+			Dex:      &argoproj.ArgoCDDexSpec{OpenShiftOAuth: true},
+		}
+	})
+
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, []client.Object{a}, []client.Object{a}, nil)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
+	assert.NoError(t, err)
+
+	// Opaque Secret with a similar name must not be deleted.
+	opaqueSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-dex-server-token-opaque",
+			Namespace: a.Namespace,
+			Labels: map[string]string{
+				common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	assert.NoError(t, r.Create(context.TODO(), opaqueSecret))
+
+	assert.NoError(t, r.reconcileDexLegacySATokenSecrets(a))
+
+	// Opaque Secret must still exist.
+	kept := &corev1.Secret{}
+	assert.NoError(t, r.Get(context.TODO(),
+		types.NamespacedName{Name: opaqueSecret.Name, Namespace: a.Namespace}, kept),
+		"Opaque Secret must not be deleted by legacy cleanup")
 }

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -200,9 +200,11 @@ func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoproj.ArgoCD) error {
 	if cr.Spec.SSO != nil && cr.Spec.SSO.Provider.ToLower() == argoproj.SSOProviderTypeDex {
 		dexOIDCClientSecret, err := r.getDexOAuthClientSecret(cr)
 		if err != nil {
-			return nil
+			return err
 		}
-		secret.Data[common.ArgoCDDexSecretKey] = []byte(*dexOIDCClientSecret)
+		if dexOIDCClientSecret != nil {
+			secret.Data[common.ArgoCDDexSecretKey] = []byte(*dexOIDCClientSecret)
+		}
 	}
 
 	if err := controllerutil.SetControllerReference(cr, secret, r.Scheme); err != nil {
@@ -706,6 +708,10 @@ func (r *ReconcileArgoCD) reconcileRedisTLSSecret(cr *argoproj.ArgoCD, useTLSFor
 // reconcileSecrets will reconcile all ArgoCD Secret resources.
 func (r *ReconcileArgoCD) reconcileSecrets(cr *argoproj.ArgoCD) error {
 	if err := r.reconcileClusterSecrets(cr); err != nil {
+		return err
+	}
+
+	if err := r.reconcileDexLegacySATokenSecrets(cr); err != nil {
 		return err
 	}
 

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -790,7 +790,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 		podSpec.Volumes = getArgoImportVolumes(export)
 	}
 
-	invalidImagePod, err := containsInvalidImage(*cr, *r)
+	invalidImagePod, err := containsInvalidImage(*cr, r)
 	if err != nil {
 		return err
 	} else if invalidImagePod {
@@ -979,7 +979,7 @@ func updateNodePlacementStateful(existing *appsv1.StatefulSet, ss *appsv1.Statef
 
 // Returns true if a StatefulSet has pods in ErrImagePull or ImagePullBackoff state.
 // These pods cannot be restarted automatially due to known kubernetes issue https://github.com/kubernetes/kubernetes/issues/67250
-func containsInvalidImage(cr argoproj.ArgoCD, r ReconcileArgoCD) (bool, error) {
+func containsInvalidImage(cr argoproj.ArgoCD, r *ReconcileArgoCD) (bool, error) {
 
 	podList := &corev1.PodList{}
 	applicationControllerListOption := client.MatchingLabels{common.ArgoCDKeyName: fmt.Sprintf("%s-%s", cr.Name, "application-controller")}

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -739,7 +739,7 @@ func Test_ContainsInvalidImage(t *testing.T) {
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 	// Test that containsInvalidImage returns false if there is nothing wrong with the Pod
-	containsInvalidImageRes, err := containsInvalidImage(*a, *r)
+	containsInvalidImageRes, err := containsInvalidImage(*a, r)
 	assert.NoError(t, err)
 	if containsInvalidImageRes {
 		t.Fatalf("containsInvalidImage failed, got true, expected false")
@@ -751,7 +751,7 @@ func Test_ContainsInvalidImage(t *testing.T) {
 	err = cl.Status().Update(context.Background(), po)
 	assert.NoError(t, err)
 
-	containsInvalidImageRes, err = containsInvalidImage(*a, *r)
+	containsInvalidImageRes, err = containsInvalidImage(*a, r)
 	assert.NoError(t, err)
 	assert.True(t, containsInvalidImageRes)
 

--- a/controllers/argocd/testing.go
+++ b/controllers/argocd/testing.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -26,13 +27,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	testclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -63,6 +67,30 @@ func makeTestReconciler(client client.Client, sch *runtime.Scheme, k8sClient kub
 			tokenRenewalTimers: map[string]*tokenRenewalTimer{},
 		},
 	}
+}
+
+// makeTestK8sClientWithTokenReactor returns a fake Kubernetes client pre-configured
+// with a reactor that responds to TokenRequest sub-resource calls by returning a
+// token whose value is mockToken and whose expiry is ArgoCDDexServerTokenExpirySecs from now.
+func makeTestK8sClientWithTokenReactor(mockToken string) *testclient.Clientset {
+	k8sClient := testclient.NewSimpleClientset()
+	k8sClient.PrependReactor("create", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		if createAction.GetSubresource() != "token" {
+			return false, nil, nil
+		}
+		expiry := metav1.NewTime(time.Now().Add(time.Duration(common.ArgoCDDexServerTokenExpirySecs) * time.Second))
+		return true, &authv1.TokenRequest{
+			Status: authv1.TokenRequestStatus{
+				Token:               mockToken,
+				ExpirationTimestamp: expiry,
+			},
+		}, nil
+	})
+	return k8sClient
 }
 
 func makeTestReconcilerClient(sch *runtime.Scheme, resObjs, subresObjs []client.Object, runtimeObj []runtime.Object) client.Client {

--- a/controllers/argocd/util_test.go
+++ b/controllers/argocd/util_test.go
@@ -1126,9 +1126,13 @@ func generateEncodedPEM(t *testing.T) []byte {
 	return encoded
 }
 
-// TestReconcileArgoCD_reconcileDexOAuthClientSecret This test make sures that if dex is enabled a service account is created with token stored in a secret which is used for oauth
+// TestReconcileArgoCD_reconcileDexOAuthClientSecret verifies that getDexOAuthClientSecret
+// uses the TokenRequest API to obtain a time-limited token and stores it in an Opaque
+// Secret rather than creating a non-expiring kubernetes.io/service-account-token Secret.
 func TestReconcileArgoCD_reconcileDexOAuthClientSecret(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
+	const mockToken = "mock-dex-oauth-token"
+
 	a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
 		ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 			Provider: argoproj.SSOProviderTypeDex,
@@ -1143,22 +1147,42 @@ func TestReconcileArgoCD_reconcileDexOAuthClientSecret(t *testing.T) {
 	runtimeObjs := []runtime.Object{}
 	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
-	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	r := makeTestReconciler(cl, sch, makeTestK8sClientWithTokenReactor(mockToken))
 
 	assert.NoError(t, createNamespace(r, a.Namespace, ""))
 	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
 	assert.NoError(t, err)
-	_, err = r.getDexOAuthClientSecret(a)
+
+	token, err := r.getDexOAuthClientSecret(a)
 	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	assert.Equal(t, mockToken, *token)
+
+	// Verify an Opaque token Secret was created (not a ServiceAccountToken type Secret).
+	expectedSecretName := getDexServerTokenSecretName(a)
+	tokenSecret := &corev1.Secret{}
+	assert.NoError(t, argoutil.FetchObject(r.Client, a.Namespace, expectedSecretName, tokenSecret))
+	assert.Equal(t, corev1.SecretTypeOpaque, tokenSecret.Type)
+	assert.Equal(t, mockToken, string(tokenSecret.Data["token"]))
+	assert.NotEmpty(t, tokenSecret.Data["expiry"])
+	expiry, parseErr := time.Parse(time.RFC3339, string(tokenSecret.Data["expiry"]))
+	assert.NoError(t, parseErr, "expiry must be a valid RFC3339 timestamp")
+	assert.True(t, time.Until(expiry) > 0, "token expiry must be in the future")
+
+	// Verify the SA.Secrets list was NOT modified (no legacy token reference added).
 	sa := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, a)
 	assert.NoError(t, argoutil.FetchObject(r.Client, a.Namespace, sa.Name, sa))
-	tokenExists := false
-	for _, saSecret := range sa.Secrets {
-		if strings.Contains(saSecret.Name, "dex-server-token") {
-			tokenExists = true
+	for _, ref := range sa.Secrets {
+		if strings.Contains(ref.Name, "token") {
+			assert.NotEqual(t, corev1.SecretTypeServiceAccountToken,
+				func() corev1.SecretType {
+					s := &corev1.Secret{}
+					_ = argoutil.FetchObject(r.Client, a.Namespace, ref.Name, s)
+					return s.Type
+				}(),
+				"SA.Secrets must not reference a non-expiring ServiceAccountToken Secret")
 		}
 	}
-	assert.True(t, tokenExists, "Dex is enabled but unable to create oauth client secret")
 }
 
 func TestRetainKubernetesData(t *testing.T) {

--- a/tests/ginkgo/fixture/secret/fixture.go
+++ b/tests/ginkgo/fixture/secret/fixture.go
@@ -53,7 +53,7 @@ func UpdateWithError(obj *corev1.Secret, modify func(*corev1.Secret)) error {
 	return err
 }
 
-// HaveNonEmptyKeyValue returns true if Secret has the given key, and the value of the key is non-empty
+// HaveNonEmptyKeyValue returns true if Secret has the given key, and the value of the key is non-empty.
 func HaveNonEmptyKeyValue(key string) matcher.GomegaMatcher {
 	return fetchSecret(func(sec *corev1.Secret) bool {
 		a, exists := sec.Data[key]
@@ -66,7 +66,18 @@ func HaveNonEmptyKeyValue(key string) matcher.GomegaMatcher {
 
 		return len(a) > 0
 	})
+}
 
+// HaveNonEmptyKey returns true if Secret has the given key and its value is non-empty.
+func HaveNonEmptyKey(key string) matcher.GomegaMatcher {
+	return fetchSecret(func(sec *corev1.Secret) bool {
+		a, exists := sec.Data[key]
+		if !exists {
+			GinkgoWriter.Println("HaveNonEmptyKey - Key:", key, "does not exist")
+			return false
+		}
+		return len(a) > 0
+	})
 }
 
 // HaveStringDataKeyValue returns true if Secret has 'key' field under .data map, and the value of that field is equal to 'value'

--- a/tests/ginkgo/fixture/secret/fixture.go
+++ b/tests/ginkgo/fixture/secret/fixture.go
@@ -53,7 +53,7 @@ func UpdateWithError(obj *corev1.Secret, modify func(*corev1.Secret)) error {
 	return err
 }
 
-// HaveNonEmptyKeyValue returns true if Secret has the given key, and the value of the key is non-empty.
+// HaveNonEmptyKeyValue returns true if Secret has the given key, and the value of the key is non-empty
 func HaveNonEmptyKeyValue(key string) matcher.GomegaMatcher {
 	return fetchSecret(func(sec *corev1.Secret) bool {
 		a, exists := sec.Data[key]
@@ -64,18 +64,6 @@ func HaveNonEmptyKeyValue(key string) matcher.GomegaMatcher {
 
 		GinkgoWriter.Println("HaveNonEmptyKeyValue - Key:", key, " Have:", string(a))
 
-		return len(a) > 0
-	})
-}
-
-// HaveNonEmptyKey returns true if Secret has the given key and its value is non-empty.
-func HaveNonEmptyKey(key string) matcher.GomegaMatcher {
-	return fetchSecret(func(sec *corev1.Secret) bool {
-		a, exists := sec.Data[key]
-		if !exists {
-			GinkgoWriter.Println("HaveNonEmptyKey - Key:", key, "does not exist")
-			return false
-		}
 		return len(a) > 0
 	})
 }

--- a/tests/ginkgo/parallel/1-095_validate_dex_clientsecret_test.go
+++ b/tests/ginkgo/parallel/1-095_validate_dex_clientsecret_test.go
@@ -19,6 +19,7 @@ package parallel
 import (
 	"context"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -30,6 +31,7 @@ import (
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	secretFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/secret"
 	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 )
 
@@ -49,7 +51,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("verifies that Dex serviceaccount token secret is not leaked, and is correctly set in Argo CD argocd-secret Secret", func() {
+		It("verifies that the Dex client secret is sourced from a short-lived TokenRequest token and is correctly set in argocd-secret", func() {
 
 			By("creating simple Argo CD instance with Dex and Openshift OAuth enabled")
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
@@ -76,46 +78,81 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
 			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
 
-			serviceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "example-argocd-argocd-dex-server", Namespace: ns.Name}}
+			dexSAName := "example-argocd-argocd-dex-server"
+			serviceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: dexSAName, Namespace: ns.Name}}
 			Eventually(serviceAccount).Should(k8sFixture.ExistByName())
 
-			argocdCM := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "argocd-cm", Namespace: ns.Name},
-			}
-			Eventually(argocdCM).Should(k8sFixture.ExistByName())
-
-			By("verifying argocd-cm ConfigMap is not leaking oidc dex client secret")
-			dexConfig := argocdCM.Data["dex.config"]
-
-			Expect(dexConfig).To(ContainSubstring("clientSecret: $oidc.dex.clientSecret"), "'$oidc.dex.clientSecret' should be set. Any other value implies that the client secret is exposed via ConfigMap")
-
-			By("validating that the Dex Client Secret was copied from dex serviceaccount token secret in to argocd-secret, by the operator")
-
-			// To verify the behavior we should first get the token secret name of the dex service account.
-
-			var secretName string
-			for _, secretData := range serviceAccount.Secrets {
-
-				if strings.Contains(secretData.Name, "token") {
-					secretName = secretData.Name
+			By("verifying no non-expiring kubernetes.io/service-account-token Secret exists for the Dex SA")
+			secretList := &corev1.SecretList{}
+			Expect(k8sClient.List(ctx, secretList, client.InNamespace(ns.Name))).To(Succeed())
+			for _, s := range secretList.Items {
+				if s.Type == corev1.SecretTypeServiceAccountToken &&
+					strings.HasPrefix(s.Name, "argocd-dex-server-token-") &&
+					s.Annotations[corev1.ServiceAccountNameKey] == dexSAName {
+					Fail("Found a non-expiring kubernetes.io/service-account-token Secret for the Dex SA: " + s.Name)
 				}
 			}
-			Expect(secretName).ToNot(BeEmpty())
 
-			// Extract the clientSecret
-			secretReferencedFromServiceAccount := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: ns.Name}}
-			Eventually(secretReferencedFromServiceAccount).Should(k8sFixture.ExistByName())
-			tokenFromSASecret := secretReferencedFromServiceAccount.Data["token"]
-			Expect(tokenFromSASecret).ToNot(BeEmpty())
+			By("verifying argocd-cm ConfigMap is not leaking oidc dex client secret")
+			argocdCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "argocd-cm", Namespace: ns.Name}}
+			Eventually(argocdCM).Should(k8sFixture.ExistByName())
 
-			// actualClientSecret is the value of the secret in argocd-secret where argocd-operator should copy the secret from
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(argocdCM), argocdCM); err != nil {
+					return false
+				}
+				return strings.Contains(argocdCM.Data["dex.config"], "clientSecret: $oidc.dex.clientSecret")
+			}, "2m", "5s").Should(BeTrue(), "'$oidc.dex.clientSecret' should be set. Any other value implies that the client secret is exposed via ConfigMap")
+
+			By("verifying the Dex SA has no non-expiring kubernetes.io/service-account-token Secrets in its .secrets list")
+			// The operator must clean up legacy SA token Secrets and must not auto-generate new ones.
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount); err != nil {
+					return false
+				}
+				for _, ref := range serviceAccount.Secrets {
+					if strings.Contains(ref.Name, "dex-server-token") {
+						GinkgoWriter.Println("Dex SA still has legacy token Secret reference:", ref.Name)
+						return false
+					}
+				}
+				return true
+			}, "2m", "5s").Should(BeTrue(), "Dex SA .secrets must not reference any legacy non-expiring token Secrets")
+
+			By("verifying the dedicated short-lived Dex token Secret was created by the operator")
+			tokenSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "example-argocd-argocd-dex-server-token", Namespace: ns.Name}}
+			Eventually(tokenSecret, "2m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(tokenSecret).Should(secretFixture.HaveNonEmptyKey("token"))
+			Eventually(tokenSecret).Should(secretFixture.HaveNonEmptyKeyValue("expiry"))
+
+			By("verifying the token expiry is a valid RFC3339 timestamp in the future")
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret); err != nil {
+					return false
+				}
+				expiry, err := time.Parse(time.RFC3339, string(tokenSecret.Data["expiry"]))
+				if err != nil {
+					GinkgoWriter.Println("expiry is not valid RFC3339:", string(tokenSecret.Data["expiry"]), err)
+					return false
+				}
+				GinkgoWriter.Println("token expiry:", expiry.UTC())
+				return time.Until(expiry) > 0
+			}, "2m", "5s").Should(BeTrue(), "Dex token 'expiry' must be a valid RFC3339 timestamp in the future")
+
+			By("validating that the Dex client secret in argocd-secret matches the token in the dedicated token Secret")
 			argocdSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "argocd-secret", Namespace: ns.Name}}
 			Eventually(argocdSecret).Should(k8sFixture.ExistByName())
+			Eventually(argocdSecret).Should(secretFixture.HaveNonEmptyKey("oidc.dex.clientSecret"))
 
-			actualClientSecret := argocdSecret.Data["oidc.dex.clientSecret"]
-
-			Expect(string(actualClientSecret)).To(Equal(string(tokenFromSASecret)), "Dex Client Secret for OIDC is not valid")
-
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret); err != nil {
+					return false
+				}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(argocdSecret), argocdSecret); err != nil {
+					return false
+				}
+				return string(tokenSecret.Data["token"]) == string(argocdSecret.Data["oidc.dex.clientSecret"])
+			}, "2m", "5s").Should(BeTrue(), "Dex client secret in argocd-secret must match the token in the dedicated Dex token Secret")
 		})
 
 	})

--- a/tests/ginkgo/parallel/1-095_validate_dex_clientsecret_test.go
+++ b/tests/ginkgo/parallel/1-095_validate_dex_clientsecret_test.go
@@ -24,16 +24,38 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
 	secretFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/secret"
 	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 )
+
+// newArgoCDForDexOpenShiftOAuthE2E returns the ArgoCD CR.
+func newArgoCDForDexOpenShiftOAuthE2E(namespace string) *argov1beta1api.ArgoCD {
+	return &argov1beta1api.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{Name: "example-argocd", Namespace: namespace},
+		Spec: argov1beta1api.ArgoCDSpec{
+			SSO: &argov1beta1api.ArgoCDSSOSpec{
+				Provider: argov1beta1api.SSOProviderTypeDex,
+				Dex: &argov1beta1api.ArgoCDDexSpec{
+					OpenShiftOAuth: true,
+				},
+			},
+			Server: argov1beta1api.ArgoCDServerSpec{
+				Route: argov1beta1api.ArgoCDRouteSpec{
+					Enabled: true,
+				},
+			},
+		},
+	}
+}
 
 var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
@@ -57,22 +79,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
 			defer cleanupFunc()
 
-			argoCD := &argov1beta1api.ArgoCD{
-				ObjectMeta: metav1.ObjectMeta{Name: "example-argocd", Namespace: ns.Name},
-				Spec: argov1beta1api.ArgoCDSpec{
-					SSO: &argov1beta1api.ArgoCDSSOSpec{
-						Provider: argov1beta1api.SSOProviderTypeDex,
-						Dex: &argov1beta1api.ArgoCDDexSpec{
-							OpenShiftOAuth: true,
-						},
-					},
-					Server: argov1beta1api.ArgoCDServerSpec{
-						Route: argov1beta1api.ArgoCDRouteSpec{
-							Enabled: true,
-						},
-					},
-				},
-			}
+			argoCD := newArgoCDForDexOpenShiftOAuthE2E(ns.Name)
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
 			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
@@ -82,16 +89,21 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			serviceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: dexSAName, Namespace: ns.Name}}
 			Eventually(serviceAccount).Should(k8sFixture.ExistByName())
 
-			By("verifying no non-expiring kubernetes.io/service-account-token Secret exists for the Dex SA")
-			secretList := &corev1.SecretList{}
-			Expect(k8sClient.List(ctx, secretList, client.InNamespace(ns.Name))).To(Succeed())
-			for _, s := range secretList.Items {
-				if s.Type == corev1.SecretTypeServiceAccountToken &&
-					strings.HasPrefix(s.Name, "argocd-dex-server-token-") &&
-					s.Annotations[corev1.ServiceAccountNameKey] == dexSAName {
-					Fail("Found a non-expiring kubernetes.io/service-account-token Secret for the Dex SA: " + s.Name)
+			By("verifying no non-expiring kubernetes.io/service-account-token Secret exists for the Dex SA (absence must hold for a short window, not only at one instant)")
+			Consistently(func() bool {
+				secretList := &corev1.SecretList{}
+				if err := k8sClient.List(ctx, secretList, client.InNamespace(ns.Name)); err != nil {
+					return false
 				}
-			}
+				for _, s := range secretList.Items {
+					if s.Type == corev1.SecretTypeServiceAccountToken &&
+						strings.HasPrefix(s.Name, dexSAName+"-token-") &&
+						s.Annotations[corev1.ServiceAccountNameKey] == dexSAName {
+						return false
+					}
+				}
+				return true
+			}, "20s", "4s").Should(BeTrue(), "no legacy kubernetes.io/service-account-token Secret for the Dex SA should appear while reconciles continue")
 
 			By("verifying argocd-cm ConfigMap is not leaking oidc dex client secret")
 			argocdCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "argocd-cm", Namespace: ns.Name}}
@@ -106,7 +118,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("verifying the Dex SA has no non-expiring kubernetes.io/service-account-token Secrets in its .secrets list")
 			// The operator must clean up legacy SA token Secrets and must not auto-generate new ones.
-			Eventually(func() bool {
+			dexSANoLegacyTokenRefs := func() bool {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount); err != nil {
 					return false
 				}
@@ -117,12 +129,15 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 					}
 				}
 				return true
-			}, "2m", "5s").Should(BeTrue(), "Dex SA .secrets must not reference any legacy non-expiring token Secrets")
+			}
+			Eventually(dexSANoLegacyTokenRefs, "2m", "5s").Should(BeTrue(), "Dex SA .secrets must not reference any legacy non-expiring token Secrets")
+			By("verifying that absence of legacy token Secret references in the Dex SA .secrets list persists")
+			Consistently(dexSANoLegacyTokenRefs, "20s", "4s").Should(BeTrue(), "Dex SA .secrets must keep no legacy non-expiring token Secret references")
 
 			By("verifying the dedicated short-lived Dex token Secret was created by the operator")
 			tokenSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "example-argocd-argocd-dex-server-token", Namespace: ns.Name}}
 			Eventually(tokenSecret, "2m", "5s").Should(k8sFixture.ExistByName())
-			Eventually(tokenSecret).Should(secretFixture.HaveNonEmptyKey("token"))
+			Eventually(tokenSecret).Should(secretFixture.HaveNonEmptyKeyValue("token"))
 			Eventually(tokenSecret).Should(secretFixture.HaveNonEmptyKeyValue("expiry"))
 
 			By("verifying the token expiry is a valid RFC3339 timestamp in the future")
@@ -142,7 +157,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			By("validating that the Dex client secret in argocd-secret matches the token in the dedicated token Secret")
 			argocdSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "argocd-secret", Namespace: ns.Name}}
 			Eventually(argocdSecret).Should(k8sFixture.ExistByName())
-			Eventually(argocdSecret).Should(secretFixture.HaveNonEmptyKey("oidc.dex.clientSecret"))
+			Eventually(argocdSecret).Should(secretFixture.HaveNonEmptyKeyValue("oidc.dex.clientSecret"))
 
 			Eventually(func() bool {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tokenSecret), tokenSecret); err != nil {
@@ -153,6 +168,96 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				}
 				return string(tokenSecret.Data["token"]) == string(argocdSecret.Data["oidc.dex.clientSecret"])
 			}, "2m", "5s").Should(BeTrue(), "Dex client secret in argocd-secret must match the token in the dedicated Dex token Secret")
+		})
+
+		It("verifies the operator deletes legacy non-expiring Dex kubernetes.io/service-account-token Secrets and drops them from the Dex SA", func() {
+
+			By("creating simple Argo CD instance with Dex and Openshift OAuth enabled")
+			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+			defer cleanupFunc()
+
+			argoCD := newArgoCDForDexOpenShiftOAuthE2E(ns.Name)
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			dexSAName := "example-argocd-argocd-dex-server"
+			dexSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: dexSAName, Namespace: ns.Name}}
+			Eventually(dexSA).Should(k8sFixture.ExistByName())
+
+			legacyName := dexSAName + "-token-e2elegacy"
+			By("creating a legacy non-expiring kubernetes.io/service-account-token Secret for the Dex SA (operator-tracked label required for cleanup list)")
+			legacySecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      legacyName,
+					Namespace: ns.Name,
+					Labels: map[string]string{
+						common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
+					},
+					Annotations: map[string]string{
+						corev1.ServiceAccountNameKey: dexSAName,
+					},
+				},
+				Type: corev1.SecretTypeServiceAccountToken,
+			}
+			Expect(k8sClient.Create(ctx, legacySecret)).To(Succeed())
+
+			By("adding the legacy Secret to the Dex SA .secrets list to mimic stale controller state")
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dexSA), dexSA); err != nil {
+					GinkgoWriter.Printf("get Dex SA: %v\n", err)
+					return false
+				}
+				for _, ref := range dexSA.Secrets {
+					if ref.Name == legacyName {
+						return true
+					}
+				}
+				dexSA.Secrets = append(dexSA.Secrets, corev1.ObjectReference{Name: legacyName})
+				if err := k8sClient.Update(ctx, dexSA); err != nil {
+					GinkgoWriter.Printf("update Dex SA with legacy secret ref: %v\n", err)
+					return false
+				}
+				return true
+			}, "2m", "3s").Should(BeTrue(), "Dex SA should list the synthetic legacy token Secret reference")
+
+			By("triggering reconciliation so the operator runs legacy Dex token Secret cleanup (creating the Secret does not enqueue the ArgoCD reconcile)")
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				if ac.Annotations == nil {
+					ac.Annotations = make(map[string]string)
+				}
+				ac.Annotations["test.argocd.argoproj.io/trigger-legacy-dex-token-reconcile"] = time.Now().Format(time.RFC3339Nano)
+			})
+
+			By("waiting for the operator to delete the legacy Secret")
+			legacySecretGone := func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(legacySecret), legacySecret)
+				return apierrors.IsNotFound(err)
+			}
+			Eventually(legacySecretGone, "2m", "5s").Should(BeTrue(), "legacy kubernetes.io/service-account-token Secret must be deleted")
+			By("verifying the legacy Secret stays deleted")
+			Consistently(legacySecretGone, "20s", "4s").Should(BeTrue(), "legacy kubernetes.io/service-account-token Secret must not reappear")
+
+			By("waiting for the Dex SA to no longer reference legacy dex-server-token Secrets")
+			dexSANoLegacyTokenRefs := func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dexSA), dexSA); err != nil {
+					return false
+				}
+				for _, ref := range dexSA.Secrets {
+					if strings.Contains(ref.Name, "dex-server-token") {
+						GinkgoWriter.Println("Dex SA still has legacy token Secret reference:", ref.Name)
+						return false
+					}
+				}
+				return true
+			}
+			Eventually(dexSANoLegacyTokenRefs, "2m", "5s").Should(BeTrue(), "Dex SA .secrets must not reference legacy non-expiring token Secrets")
+			By("verifying that absence of legacy token Secret references in the Dex SA .secrets list persists")
+			Consistently(dexSANoLegacyTokenRefs, "20s", "4s").Should(BeTrue(), "Dex SA .secrets must keep no legacy non-expiring token Secret references")
+
+			By("verifying the Argo CD instance stays healthy after legacy cleanup")
+			Eventually(argoCD, "2m", "5s").Should(argocdFixture.BeAvailable())
 		})
 
 	})


### PR DESCRIPTION
**What type of PR is this?**
<!-- /kind enhancement -->

**What does this PR do / why we need it**:
The openshift-gitops-argocd-dex-server service account previously auto-generated a non-expiring kubernetes.io/service-account-token Secret, which violates OpenShift platform guidelines that no longer auto-generate such tokens. This PR replaces that approach with a short-lived token obtained via the Kubernetes TokenRequest API, stored in a dedicated Opaque Secret, and proactively renewed before expiry. Legacy non-expiring token Secrets are cleaned up automatically on reconcile.

Token lifetime is currently hardcoded to 1 hour (ArgoCDDexServerTokenExpirySecs = 3600) with renewal triggered at the 20-minute mark (1/3 of lifetime). Should we keep 1 hour, or would a different value be preferred? 

PR contains unit and e2e test to verify above

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
JIRA - https://redhat.atlassian.net/browse/GITOPS-9427

**How to test changes / Special notes to the reviewer**:
from argocd-operator 
run make install run

Create an ArgoCD instance with Dex and OpenShift OAuth enabled
   apiVersion: argoproj.io/v1beta1
   kind: ArgoCD
   metadata:
     name: example-argocd
     namespace: <your-namespace>
   spec:
     sso:
       provider: dex
       dex:
         openShiftOAuth: true

Verify no non-expiring SA token Secret was created:
   kubectl get secret example-argocd-argocd-dex-server-token -n <ns> -o jsonpath='{.data.expiry}' | base64 -d

Expected: only example-argocd-argocd-dex-server-token (Opaque type), no kubernetes.io/service-account-token type.

Verify the token Secret has valid token and expiry keys:
   kubectl get secret example-argocd-argocd-dex-server-token -n <ns> -o jsonpath='{.data.expiry}' | base64 -d

Expected: a RFC3339 timestamp ~1 hour in the future.

Verify argocd-cm uses the placeholder, not the raw token:

   kubectl get cm argocd-cm -n <ns> -o jsonpath='{.data.dex\.config}' | grep clientSecret
Expected: clientSecret: $oidc.dex.clientSecret

Verify argocd-secret has the token set
   kubectl get secret argocd-secret -n <ns> -o jsonpath='{.data.oidc\.dex\.clientSecret}' | base64 -d | cut -c1-20

Expected: a JWT token (starts with eyJ), matching the token key in the dedicated Secret.

To check dex sso login 

 kubectl get route example-argocd-server -n <ns> -o jsonpath='{.spec.host}'

Open https://<route-host> in a browser.

On the login page, click "Log in via OpenShift"

Complete the OpenShift login. If you land on the ArgoCD dashboard, Dex successfully used the short-lived token to authenticate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dex OAuth tokens are now short‑lived, stored with expiry, proactively renewed, and scheduled for timely refresh; managed token secrets use deterministic names.

* **Bug Fixes**
  * Cleanup of legacy non‑expiring service‑account token secrets and prevention of legacy token leakage into Argo CD secrets.
  * Improved error propagation during secret reconciliation.

* **Tests**
  * Added/updated tests covering renewal logic, caching, expiry parsing, legacy cleanup, and token secret behavior.

* **Chores**
  * Added configuration defaults and test helpers to support token expiry/renewal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->