### PR TITLE
fix: dex copyutil initcontainer update of dex deployment

### DIFF
--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -445,6 +445,14 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoproj.ArgoCD) error {
 			existing.Spec.Template.Spec.Containers[0].VolumeMounts = deploy.Spec.Template.Spec.Containers[0].VolumeMounts
 			changes = append(changes, "container volume mounts")
 		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].VolumeMounts, existing.Spec.Template.Spec.InitContainers[0].VolumeMounts) {
+			existing.Spec.Template.Spec.InitContainers[0].VolumeMounts = deploy.Spec.Template.Spec.InitContainers[0].VolumeMounts
+			changes = append(changes, "init container volume mounts")
+		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.InitContainers[0].Resources, existing.Spec.Template.Spec.InitContainers[0].Resources) {
+			existing.Spec.Template.Spec.InitContainers[0].Resources = deploy.Spec.Template.Spec.InitContainers[0].Resources
+			changes = append(changes, "init container resources")
+		}
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Volumes, existing.Spec.Template.Spec.Volumes) {
 			existing.Spec.Template.Spec.Volumes = deploy.Spec.Template.Spec.Volumes
 			changes = append(changes, "volumes")

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -680,6 +680,149 @@ func TestReconcileArgoCD_reconcileDexDeployment_withUpdate(t *testing.T) {
 	}
 }
 
+func TestReconcileArgoCD_reconcileDexDeployment_updatesInitContainerFields(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	// staleDeployment simulates a Dex Deployment created by an old operator version (e.g., v1.13)
+	// that only has the "static-files" volumeMount in the copyutil initContainer and no dexconfig volume.
+	staleDeployment := func(namespace string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "argocd-dex-server",
+				Namespace: namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/name": "argocd-dex-server",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app.kubernetes.io/name": "argocd-dex-server",
+						},
+					},
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Name: "copyutil",
+								// Old state: only static-files, dexconfig mount is absent
+								VolumeMounts: []corev1.VolumeMount{
+									{Name: "static-files", MountPath: "/shared"},
+								},
+								Resources: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{
+										corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+									},
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resourcev1.MustParse("15m"),
+										corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							{Name: "dex"},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name:         "static-files",
+								VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                 string
+		argoCD               *argoproj.ArgoCD
+		wantInitVolumeMounts []corev1.VolumeMount
+		wantInitResources    corev1.ResourceRequirements
+	}{
+		{
+			name: "reconciler adds missing dexconfig volumeMount to copyutil initContainer on upgrade",
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+				}
+			}),
+			wantInitVolumeMounts: []corev1.VolumeMount{
+				{Name: "static-files", MountPath: "/shared"},
+				{Name: "dexconfig", MountPath: "/tmp"},
+			},
+			wantInitResources: corev1.ResourceRequirements{},
+		},
+		{
+			name: "reconciler updates stale resources in copyutil initContainer on upgrade",
+			argoCD: makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+				cr.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
+						Resources: &corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+								corev1.ResourceCPU:    resourcev1.MustParse("250m"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resourcev1.MustParse("256Mi"),
+								corev1.ResourceCPU:    resourcev1.MustParse("500m"),
+							},
+						},
+					},
+				}
+			}),
+			wantInitVolumeMounts: []corev1.VolumeMount{
+				{Name: "static-files", MountPath: "/shared"},
+				{Name: "dexconfig", MountPath: "/tmp"},
+			},
+			wantInitResources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resourcev1.MustParse("128Mi"),
+					corev1.ResourceCPU:    resourcev1.MustParse("250m"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resourcev1.MustParse("256Mi"),
+					corev1.ResourceCPU:    resourcev1.MustParse("500m"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			existingDeploy := staleDeployment(test.argoCD.Namespace)
+			resObjs := []client.Object{test.argoCD, existingDeploy}
+			subresObjs := []client.Object{test.argoCD}
+			runtimeObjs := []runtime.Object{}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+			assert.NoError(t, r.reconcileDexDeployment(test.argoCD))
+
+			deployment := &appsv1.Deployment{}
+			assert.NoError(t, r.Get(
+				context.TODO(),
+				types.NamespacedName{
+					Name:      "argocd-dex-server",
+					Namespace: test.argoCD.Namespace,
+				},
+				deployment))
+
+			assert.Equal(t, test.wantInitVolumeMounts,
+				deployment.Spec.Template.Spec.InitContainers[0].VolumeMounts,
+				"copyutil initContainer VolumeMounts should be updated by reconciler")
+			assert.Equal(t, test.wantInitResources,
+				deployment.Spec.Template.Spec.InitContainers[0].Resources,
+				"copyutil initContainer Resources should be updated by reconciler")
+		})
+	}
+}
+
 // When Dex is enabled dex service should be created, when disabled the Dex service should be removed
 func TestReconcileArgoCD_reconcileDexService_removes_dex_when_disabled(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))


### PR DESCRIPTION
**What type of PR is this?**
<!-- /kind bug -->

**What does this PR do / why we need it**:
The reconcileDexDeployment reconciliation logic was not updating two fields of the copyutil initContainer when an existing Dex Deployment was found:

- initContainers[copyutil].volumeMounts — the dexconfig volume mount (mountPath: /tmp)
- initContainers[copyutil].resources — resource limits and requests on the copyutil initContainer were not reconciled when changed

Added unit test

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
JIRA  -  https://redhat.atlassian.net/browse/GITOPS-9549

**How to test changes / Special notes to the reviewer**:
<img width="586" height="458" alt="Screenshot 2026-04-16 at 11 12 12 AM" src="https://github.com/user-attachments/assets/e2053f27-0110-40db-9d98-96b300655e67" />
<img width="424" height="151" alt="Screenshot 2026-04-16 at 11 14 15 AM" src="https://github.com/user-attachments/assets/1be20687-6d47-4bd9-895a-a7310be08db0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dex deployment now properly synchronizes init container configuration, including volume mounts and resource allocations, to ensure consistency with desired specifications during reconciliation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->