### PR TITLE
fix: restore serving-cert annotation when tls termination is reencrypt that was stripped in older versions

### DIFF
--- a/common/annotations.go
+++ b/common/annotations.go
@@ -12,4 +12,8 @@ const (
 	// AnnotationOpenShiftServiceCA is the annotation on services used to
 	// request a TLS certificate from OpenShift's Service CA for AutoTLS
 	AnnotationOpenShiftServiceCA = "service.beta.openshift.io/serving-cert-secret-name"
+
+	// AnnotationOpenShiftOriginatingServiceName is the annotation on secrets used to
+	// identify the service that created the secret.
+	AnnotationOpenShiftOriginatingServiceName = "service.beta.openshift.io/originating-service-name"
 )

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -257,7 +257,8 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoproj.ArgoCD) error {
 		// break users who have already configured a TLS secret for Passthrough.
 		// We continue with Passthrough if we find a TLS secret that was manually configured
 		// by the user and not by the OpenShift Service CA.
-		if cr.Spec.Server.Route.TLS == nil && isTLSSecretFound && !isCreatedByServiceCA(cr.Name, *tlsSecret) {
+		serverServiceName := nameWithSuffix("server", cr)
+		if cr.Spec.Server.Route.TLS == nil && isTLSSecretFound && !isCreatedByServiceCA(serverServiceName, *tlsSecret) {
 			route.Spec.TLS = &routev1.TLSConfig{
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 				Termination:                   routev1.TLSTerminationPassthrough,
@@ -300,11 +301,11 @@ func (r *ReconcileArgoCD) reconcileServerRoute(cr *argoproj.ArgoCD) error {
 }
 
 // isCreatedByServiceCA checks if the secret was created by the OpenShift Service CA
-func isCreatedByServiceCA(crName string, secret corev1.Secret) bool {
-	serviceName := fmt.Sprintf("%s-%s", crName, "server")
+// for the Argo CD server Service ({crName}-server).
+func isCreatedByServiceCA(serviceName string, secret corev1.Secret) bool {
 	serviceAnnFound := false
 	if secret.Annotations != nil {
-		value, ok := secret.Annotations["service.beta.openshift.io/originating-service-name"]
+		value, ok := secret.Annotations[common.AnnotationOpenShiftOriginatingServiceName]
 		if ok && value == serviceName {
 			serviceAnnFound = true
 		}

--- a/controllers/argocd/route_test.go
+++ b/controllers/argocd/route_test.go
@@ -643,7 +643,7 @@ func TestReconcileRouteTLSConfig(t *testing.T) {
 						Name:      common.ArgoCDServerTLSSecretName,
 						Namespace: cr.Namespace,
 						Annotations: map[string]string{
-							"service.beta.openshift.io/originating-service-name": serviceName,
+							common.AnnotationOpenShiftOriginatingServiceName: serviceName,
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -695,7 +695,7 @@ func TestIsCreatedByServiceCA(t *testing.T) {
 			Name:      common.ArgoCDServerTLSSecretName,
 			Namespace: cr.Namespace,
 			Annotations: map[string]string{
-				"service.beta.openshift.io/originating-service-name": serviceName,
+				common.AnnotationOpenShiftOriginatingServiceName: serviceName,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -744,7 +744,7 @@ func TestIsCreatedByServiceCA(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			testSecret := secret.DeepCopy()
 			test.updateSecret(testSecret)
-			assert.Equal(t, test.want, isCreatedByServiceCA(cr.Name, *testSecret))
+			assert.Equal(t, test.want, isCreatedByServiceCA(nameWithSuffix("server", cr), *testSecret))
 		})
 	}
 }

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -410,12 +410,17 @@ func ensureAutoTLSAnnotation(k8sClient client.Client, svc *corev1.Service, secre
 	if autoTLSAnnotationName != "" {
 		val, ok := svc.Annotations[autoTLSAnnotationName]
 		if enabled {
-			// Don't request a TLS certificate from the OpenShift Service CA if the secret already exists.
-			isTLSSecretFound, err := argoutil.IsObjectFound(k8sClient, svc.Namespace, secretName, &corev1.Secret{})
+			tlsSecret := &corev1.Secret{}
+			isTLSSecretFound, err := argoutil.IsObjectFound(k8sClient, svc.Namespace, secretName, tlsSecret)
 			if err != nil {
 				return false, err
 			}
 			if !ok && isTLSSecretFound {
+				if isCreatedByServiceCA(svc.Name, *tlsSecret) {
+					log.Info(fmt.Sprintf("restoring AutoTLS annotation on service %s for OpenShift serving cert secret %s", svc.Name, secretName))
+					svc.Annotations[autoTLSAnnotationName] = autoTLSAnnotationValue
+					return true, nil
+				}
 				log.Info(fmt.Sprintf("skipping AutoTLS on service %s since the TLS secret is already present", svc.Name))
 				return false, nil
 			}

--- a/controllers/argocd/service_test.go
+++ b/controllers/argocd/service_test.go
@@ -94,6 +94,34 @@ func TestEnsureAutoTLSAnnotation(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, needUpdate, false)
 	})
+	t.Run("Restore annotation when TLS secret exists and was created by OpenShift Service CA", func(t *testing.T) {
+		argoutil.SetRouteAPIFound(true)
+		svc := newService(a)
+		svc.Name = "argocd-server"
+		sec := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.ArgoCDServerTLSSecretName,
+				Namespace: svc.Namespace,
+				Annotations: map[string]string{
+					common.AnnotationOpenShiftOriginatingServiceName: svc.Name,
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{Name: svc.Name, Kind: "Service"},
+				},
+			},
+		}
+		err := fakeClient.Create(context.Background(), sec)
+		assert.NoError(t, err)
+		needUpdate, err := ensureAutoTLSAnnotation(fakeClient, svc, sec.Name, true)
+		assert.NoError(t, err)
+		assert.True(t, needUpdate)
+		atls, ok := svc.Annotations[common.AnnotationOpenShiftServiceCA]
+		assert.True(t, ok)
+		assert.Equal(t, sec.Name, atls)
+		needUpdate, err = ensureAutoTLSAnnotation(fakeClient, svc, sec.Name, true)
+		assert.NoError(t, err)
+		assert.False(t, needUpdate)
+	})
 }
 
 func TestReconcileServerService(t *testing.T) {

--- a/tests/ginkgo/fixture/certificate/fixture.go
+++ b/tests/ginkgo/fixture/certificate/fixture.go
@@ -1,0 +1,50 @@
+package cert
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"time"
+)
+
+func GenerateCert() ([]byte, []byte, error) {
+	//Generate a random RSA key
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	//Create a certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Co"},
+			CommonName:   "localhost",
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour * 24),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	//Create a self-signed certificate
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	//PEM encode the certificate
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	//PEM encode the private key
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	return certPem, keyPem, nil
+}

--- a/tests/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
+++ b/tests/ginkgo/parallel/1-125_validate_server_serving_cert_annotation_restore_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+	_ "embed"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	certFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/certificate"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+
+	Context("1-125_validate_server_serving_cert_annotation_restore", func() {
+
+		var (
+			ctx       context.Context
+			k8sClient client.Client
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		It("restores service.beta.openshift.io/serving-cert-secret-name when Route TLS returns from passthrough to default reencrypt", func() {
+
+			fixture.EnsureRunningOnOpenShift()
+
+			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+			defer nsCleanup()
+
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example",
+					Namespace: ns.Name,
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+			Eventually(argoCD, "3m", "5s").Should(argocdFixture.HaveServerStatus("Running"))
+
+			serverSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-server",
+					Namespace: ns.Name,
+				},
+			}
+			Eventually(serverSvc, "3m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(serverSvc, "3m", "5s").Should(
+				k8sFixture.HaveAnnotationWithValue(common.AnnotationOpenShiftServiceCA, common.ArgoCDServerTLSSecretName))
+
+			By("setting Route TLS termination to passthrough so AutoTLS is disabled and the serving-cert annotation is removed")
+
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.Server.Route.TLS = &routev1.TLSConfig{
+					Termination: routev1.TLSTerminationPassthrough,
+				}
+			})
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(serverSvc), serverSvc); err != nil {
+					GinkgoWriter.Println(err)
+					return false
+				}
+				if serverSvc.Annotations == nil {
+					return true
+				}
+				_, present := serverSvc.Annotations[common.AnnotationOpenShiftServiceCA]
+				return !present
+			}, "3m", "5s").Should(BeTrue(), "serving-cert annotation should be removed under passthrough")
+
+			By("clearing Route TLS so the operator defaults to reencrypt again")
+
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.Server.Route.TLS = nil
+			})
+
+			By("verifying the serving-cert annotation is restored")
+			Eventually(serverSvc, "3m", "5s").Should(
+				k8sFixture.HaveAnnotationWithValue(common.AnnotationOpenShiftServiceCA, common.ArgoCDServerTLSSecretName))
+
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+			Eventually(argoCD, "3m", "5s").Should(argocdFixture.HaveServerStatus("Running"))
+
+			By("simulating a stale Service after upgrade: remove serving-cert annotation only")
+
+			k8sFixture.Update(serverSvc, func(obj client.Object) {
+				s := obj.(*corev1.Service)
+				if s.Annotations != nil {
+					delete(s.Annotations, common.AnnotationOpenShiftServiceCA)
+				}
+			})
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(serverSvc), serverSvc); err != nil {
+					GinkgoWriter.Println(err)
+					return false
+				}
+				if serverSvc.Annotations == nil {
+					return true
+				}
+				_, present := serverSvc.Annotations[common.AnnotationOpenShiftServiceCA]
+				return !present
+			}, "1m", "2s").Should(BeTrue())
+
+			By("triggering reconciliation via a no-op ArgoCD metadata change")
+
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				if ac.Annotations == nil {
+					ac.Annotations = map[string]string{}
+				}
+				ac.Annotations["argocds.argoproj.io/e2e-serving-cert-reconcile-touch"] = "1"
+			})
+
+			Eventually(serverSvc, "3m", "5s").Should(
+				k8sFixture.HaveAnnotationWithValue(common.AnnotationOpenShiftServiceCA, common.ArgoCDServerTLSSecretName))
+
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+			Eventually(argoCD, "3m", "5s").Should(argocdFixture.HaveServerStatus("Running"))
+
+		})
+
+		It("does not add serving-cert annotation when argocd-server-tls already exists as a user-managed secret (not Service CA)", func() {
+			certPem, keyPem, err := certFixture.GenerateCert()
+			Expect(err).NotTo(HaveOccurred())
+
+			fixture.EnsureRunningOnOpenShift()
+
+			ns, nsCleanup := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+			defer nsCleanup()
+
+			By("pre-creating argocd-server-tls without OpenShift Service CA annotations or ownerReferences")
+
+			customTLS := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDServerTLSSecretName,
+					Namespace: ns.Name,
+				},
+				Type: corev1.SecretTypeTLS,
+				StringData: map[string]string{
+					"tls.crt": string(certPem),
+					"tls.key": string(keyPem),
+				},
+			}
+			Expect(k8sClient.Create(ctx, customTLS)).To(Succeed())
+
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-argocd",
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					Server: argov1beta1api.ArgoCDServerSpec{
+						Route: argov1beta1api.ArgoCDRouteSpec{
+							TLS: &routev1.TLSConfig{
+								Termination: routev1.TLSTerminationReencrypt,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+			Eventually(argoCD, "3m", "5s").Should(argocdFixture.HaveServerStatus("Running"))
+
+			serverSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-argocd-server",
+					Namespace: ns.Name,
+				},
+			}
+			Eventually(serverSvc, "3m", "5s").Should(k8sFixture.ExistByName())
+
+			By("verifying the server Service never gets the OpenShift serving-cert annotation")
+
+			Consistently(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(serverSvc), serverSvc); err != nil {
+					GinkgoWriter.Println(err)
+					return false
+				}
+				if serverSvc.Annotations == nil {
+					return true
+				}
+				_, present := serverSvc.Annotations[common.AnnotationOpenShiftServiceCA]
+				return !present
+			}, "2m", "5s").Should(BeTrue())
+
+			By("verifying annotation stays absent after an ArgoCD reconcile trigger")
+
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				if ac.Annotations == nil {
+					ac.Annotations = map[string]string{}
+				}
+				ac.Annotations["argocds.argoproj.io/e2e-custom-tls-no-svc-ca-touch"] = "1"
+			})
+
+			Consistently(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(serverSvc), serverSvc); err != nil {
+					GinkgoWriter.Println(err)
+					return false
+				}
+				if serverSvc.Annotations == nil {
+					return true
+				}
+				_, present := serverSvc.Annotations[common.AnnotationOpenShiftServiceCA]
+				return !present
+			}, "2m", "5s").Should(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION

- Restore serving-cert annotation when tls termination is reencrypt that was stripped in older versions
- Added annotation constant and refacttored isCreatedByServiceCA
- Incorporated changes to create certs while test execution
- Moved cert generation file inside fixture folder



---------

**What type of PR is this?**
cherry-pick #2162 


**What does this PR do / why we need it**:
Upgrading the OpenShift GitOps Operator specifically from v1.12.3 to v1.12.4 causes the service.beta.openshift.io/serving-cert-secret-name annotation to be stripped from the Argo CD server Service.

This prevents the Service-CA ClusterOperator from rotating or managing the service certificate. While the console may work initially, it will eventually return an HTTP 503 Service Unavailable error once the certificate expires or the secret is modified. Because this state is persisted in the Service object, the issue remains even if the operator is subsequently upgraded to later versions (e.g., v1.19).
This happens because in v1.12.4, default TLS termination value was set to 'passthrough' that stripped this annotation. The default value was changed back to 'reencrypt' in future versions but the stripped annotation was not added back that resulted in this regression. In this PR it is checked whether the TLS termination is reencrypt or nil (default value is reencrypt). If so then it is further checking if the cert is created by service CA. If yes then we are adding back the annotation.


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
[GITOPS-8784](https://redhat.atlassian.net/browse/GITOPS-8784)
**How to test changes / Special notes to the reviewer**:
