### PR TITLE
feat: default Image Updater to namespace scope

### DIFF
--- a/bundle/manifests/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/bundle/manifests/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -14,7 +14,20 @@ spec:
     singular: imageupdater
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.applicationsMatched
+      name: Apps
+      type: integer
+    - jsonPath: .status.imagesManaged
+      name: Images
+      type: integer
+    - jsonPath: .status.lastCheckedAt
+      name: Last Checked
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ImageUpdater is the Schema for the imageupdaters API
@@ -306,6 +319,25 @@ spec:
                                 Branch to commit updates to.
                                 Required if write-back method is Git and this is not specified at the spec level.
                               type: string
+                            pullRequest:
+                              description: |-
+                                PullRequest configures creation of pull requests when writing back image updates to Git.
+                                When set, the controller opens a PR instead of pushing to the branch.
+                                If not specified write back config method is `git`.
+                              properties:
+                                github:
+                                  description: GitHub configures PR creation via the
+                                    GitHub API.
+                                  type: object
+                                gitlab:
+                                  description: GitLab configures MR creation via the
+                                    GitLab API.
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: Exactly one of github or gitlab must be set
+                                rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab)
+                                  ? 1 : 0) == 1'
                             repository:
                               description: |-
                                 Repository URL to commit changes to.
@@ -390,14 +422,6 @@ spec:
                       This acts as the default if not overridden at a more specific level.
                     type: string
                 type: object
-              namespace:
-                description: |-
-                  Namespace indicates the target namespace of the applications.
-
-                  Deprecated: This field is deprecated and will be removed in a future release.
-                  The controller now uses the ImageUpdater CR's namespace (metadata.namespace)
-                  to determine which namespace to search for applications. This field is ignored.
-                type: string
               writeBackConfig:
                 description: |-
                   WriteBackConfig provides global default settings for how and where to write back image updates.
@@ -413,6 +437,25 @@ spec:
                           Branch to commit updates to.
                           Required if write-back method is Git and this is not specified at the spec level.
                         type: string
+                      pullRequest:
+                        description: |-
+                          PullRequest configures creation of pull requests when writing back image updates to Git.
+                          When set, the controller opens a PR instead of pushing to the branch.
+                          If not specified write back config method is `git`.
+                        properties:
+                          github:
+                            description: GitHub configures PR creation via the GitHub
+                              API.
+                            type: object
+                          gitlab:
+                            description: GitLab configures MR creation via the GitLab
+                              API.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Exactly one of github or gitlab must be set
+                          rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab) ?
+                            1 : 0) == 1'
                       repository:
                         description: |-
                           Repository URL to commit changes to.
@@ -444,7 +487,15 @@ spec:
           status:
             description: ImageUpdaterStatus defines the observed state of ImageUpdater
             properties:
+              applicationsMatched:
+                description: ApplicationsMatched is the number of Argo CD applications
+                  matched by this CR's selectors.
+                format: int32
+                minimum: 0
+                type: integer
               conditions:
+                description: Conditions represent the latest available observations
+                  of the resource's state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -500,48 +551,73 @@ spec:
                   - type
                   type: object
                 type: array
-              imageStatus:
-                description: ImageStatus indicates the detailed status for the list
-                  of managed images
-                items:
-                  description: ImageStatus contains information for an image:version
-                    and its update status in hosting applications
-                  properties:
-                    applications:
-                      description: Applications contains a list of applications and
-                        when the image was last updated therein
-                      items:
-                        description: ImageApplicationLastUpdated contains information
-                          for an application and when the image was last updated therein
-                        properties:
-                          appName:
-                            description: AppName indicates and namespace and the application
-                              name
-                            type: string
-                          lastUpdatedAt:
-                            description: LastUpdatedAt indicates when the image in
-                              this application was last updated
-                            format: date-time
-                            type: string
-                        required:
-                        - appName
-                        type: object
-                      type: array
-                    name:
-                      description: Name indicates the image name
-                      type: string
-                    version:
-                      description: Version indicates the image version
-                      type: string
-                  required:
-                  - name
-                  - version
-                  type: object
-                type: array
-              reconciledAt:
-                description: LastUpdatedAt indicates when the image updater last ran
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              imagesManaged:
+                description: ImagesManaged is the number of images that were eligible
+                  for update checking.
+                format: int32
+                minimum: 0
+                type: integer
+              lastCheckedAt:
+                description: LastCheckedAt indicates when the controller last checked
+                  for image updates.
                 format: date-time
                 type: string
+              lastUpdatedAt:
+                description: LastUpdatedAt indicates when the controller last performed
+                  an image update.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                minimum: 0
+                type: integer
+              recentUpdates:
+                description: RecentUpdates contains the list of image updates performed
+                  during the last update cycle.
+                items:
+                  description: RecentUpdate records a single image update performed
+                    during the last update.
+                  properties:
+                    alias:
+                      description: Alias is the alias of the image configuration that
+                        was updated.
+                      type: string
+                    applicationsUpdated:
+                      description: ApplicationsUpdated is the number of applications
+                        in which this image was updated.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    image:
+                      description: Image is the full image reference.
+                      type: string
+                    message:
+                      description: Message provides a human-readable description of
+                        the update action.
+                      type: string
+                    newVersion:
+                      description: NewVersion is the new tag or digest the image was
+                        updated to.
+                      type: string
+                    updatedAt:
+                      description: UpdatedAt is the timestamp when the update was
+                        applied.
+                      format: date-time
+                      type: string
+                  required:
+                  - alias
+                  - applicationsUpdated
+                  - image
+                  - newVersion
+                  - updatedAt
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             type: object
         type: object
     served: true

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-04-10T16:59:38Z"
+    createdAt: "2026-04-22T19:10:17Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -14,7 +14,20 @@ spec:
     singular: imageupdater
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.applicationsMatched
+      name: Apps
+      type: integer
+    - jsonPath: .status.imagesManaged
+      name: Images
+      type: integer
+    - jsonPath: .status.lastCheckedAt
+      name: Last Checked
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ImageUpdater is the Schema for the imageupdaters API
@@ -306,6 +319,25 @@ spec:
                                 Branch to commit updates to.
                                 Required if write-back method is Git and this is not specified at the spec level.
                               type: string
+                            pullRequest:
+                              description: |-
+                                PullRequest configures creation of pull requests when writing back image updates to Git.
+                                When set, the controller opens a PR instead of pushing to the branch.
+                                If not specified write back config method is `git`.
+                              properties:
+                                github:
+                                  description: GitHub configures PR creation via the
+                                    GitHub API.
+                                  type: object
+                                gitlab:
+                                  description: GitLab configures MR creation via the
+                                    GitLab API.
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: Exactly one of github or gitlab must be set
+                                rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab)
+                                  ? 1 : 0) == 1'
                             repository:
                               description: |-
                                 Repository URL to commit changes to.
@@ -390,14 +422,6 @@ spec:
                       This acts as the default if not overridden at a more specific level.
                     type: string
                 type: object
-              namespace:
-                description: |-
-                  Namespace indicates the target namespace of the applications.
-
-                  Deprecated: This field is deprecated and will be removed in a future release.
-                  The controller now uses the ImageUpdater CR's namespace (metadata.namespace)
-                  to determine which namespace to search for applications. This field is ignored.
-                type: string
               writeBackConfig:
                 description: |-
                   WriteBackConfig provides global default settings for how and where to write back image updates.
@@ -413,6 +437,25 @@ spec:
                           Branch to commit updates to.
                           Required if write-back method is Git and this is not specified at the spec level.
                         type: string
+                      pullRequest:
+                        description: |-
+                          PullRequest configures creation of pull requests when writing back image updates to Git.
+                          When set, the controller opens a PR instead of pushing to the branch.
+                          If not specified write back config method is `git`.
+                        properties:
+                          github:
+                            description: GitHub configures PR creation via the GitHub
+                              API.
+                            type: object
+                          gitlab:
+                            description: GitLab configures MR creation via the GitLab
+                              API.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Exactly one of github or gitlab must be set
+                          rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab) ?
+                            1 : 0) == 1'
                       repository:
                         description: |-
                           Repository URL to commit changes to.
@@ -444,7 +487,15 @@ spec:
           status:
             description: ImageUpdaterStatus defines the observed state of ImageUpdater
             properties:
+              applicationsMatched:
+                description: ApplicationsMatched is the number of Argo CD applications
+                  matched by this CR's selectors.
+                format: int32
+                minimum: 0
+                type: integer
               conditions:
+                description: Conditions represent the latest available observations
+                  of the resource's state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -500,48 +551,73 @@ spec:
                   - type
                   type: object
                 type: array
-              imageStatus:
-                description: ImageStatus indicates the detailed status for the list
-                  of managed images
-                items:
-                  description: ImageStatus contains information for an image:version
-                    and its update status in hosting applications
-                  properties:
-                    applications:
-                      description: Applications contains a list of applications and
-                        when the image was last updated therein
-                      items:
-                        description: ImageApplicationLastUpdated contains information
-                          for an application and when the image was last updated therein
-                        properties:
-                          appName:
-                            description: AppName indicates and namespace and the application
-                              name
-                            type: string
-                          lastUpdatedAt:
-                            description: LastUpdatedAt indicates when the image in
-                              this application was last updated
-                            format: date-time
-                            type: string
-                        required:
-                        - appName
-                        type: object
-                      type: array
-                    name:
-                      description: Name indicates the image name
-                      type: string
-                    version:
-                      description: Version indicates the image version
-                      type: string
-                  required:
-                  - name
-                  - version
-                  type: object
-                type: array
-              reconciledAt:
-                description: LastUpdatedAt indicates when the image updater last ran
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              imagesManaged:
+                description: ImagesManaged is the number of images that were eligible
+                  for update checking.
+                format: int32
+                minimum: 0
+                type: integer
+              lastCheckedAt:
+                description: LastCheckedAt indicates when the controller last checked
+                  for image updates.
                 format: date-time
                 type: string
+              lastUpdatedAt:
+                description: LastUpdatedAt indicates when the controller last performed
+                  an image update.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                minimum: 0
+                type: integer
+              recentUpdates:
+                description: RecentUpdates contains the list of image updates performed
+                  during the last update cycle.
+                items:
+                  description: RecentUpdate records a single image update performed
+                    during the last update.
+                  properties:
+                    alias:
+                      description: Alias is the alias of the image configuration that
+                        was updated.
+                      type: string
+                    applicationsUpdated:
+                      description: ApplicationsUpdated is the number of applications
+                        in which this image was updated.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    image:
+                      description: Image is the full image reference.
+                      type: string
+                    message:
+                      description: Message provides a human-readable description of
+                        the update action.
+                      type: string
+                    newVersion:
+                      description: NewVersion is the new tag or digest the image was
+                        updated to.
+                      type: string
+                    updatedAt:
+                      description: UpdatedAt is the timestamp when the update was
+                        applied.
+                      format: date-time
+                      type: string
+                  required:
+                  - alias
+                  - applicationsUpdated
+                  - image
+                  - newVersion
+                  - updatedAt
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             type: object
         type: object
     served: true

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,39 +38,107 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterController(cr *argoproj.ArgoCD) e
 }
 
 func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.ArgoCD) error {
-	log.Info("reconciling image updater service account")
+	log.Info("reconciling Image Updater service account")
 	sa, err := r.reconcileImageUpdaterServiceAccount(cr)
 	if err != nil {
 		return err
 	}
 
-	log.Info("reconciling image updater role")
-	role, err := r.reconcileImageUpdaterRole(cr)
-	if err != nil {
-		return err
-	}
-
-	log.Info("reconciling image updater cluster role")
-	clusterRole, err := r.reconcileImageUpdaterClusterRole(cr)
-	if err != nil {
-		return err
-	}
-
-	if sa != nil && role != nil {
-		log.Info("reconciling image updater role binding")
-		if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
-			return err
+	// Determine the watch scope from IMAGE_UPDATER_WATCH_NAMESPACES before creating roles,
+	// because the required role set depends on the mode.
+	// Three modes are supported:
+	//   - Not set or empty: namespace-scoped (Option 1). Controller watches only its own namespace.
+	//     Single role with all rules in cr.Namespace (base + manager rules combined).
+	//   - "*": cluster-scoped (Option 3). Controller watches all namespaces.
+	//     Base role in cr.Namespace + ClusterRole with manager rules. Requires cluster-config namespace.
+	//   - "ns1,ns2,...": watches specific namespaces.
+	//     Base role in cr.Namespace + manager Role in each listed namespace.
+	watchNamespaces := ""
+	for _, env := range cr.Spec.ImageUpdater.Env {
+		if env.Name == "IMAGE_UPDATER_WATCH_NAMESPACES" {
+			watchNamespaces = strings.TrimSpace(env.Value)
+			break
 		}
 	}
 
-	if sa != nil && clusterRole != nil {
-		log.Info("reconciling image updater cluster role binding")
-		if err := r.reconcileImageUpdaterClusterRoleBinding(cr, clusterRole, sa); err != nil {
+	switch watchNamespaces {
+	case "*":
+		if !argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) {
+			return fmt.Errorf("IMAGE_UPDATER_WATCH_NAMESPACES=\"*\" can only be configured in cluster scope")
+		}
+		// Base role (configmaps, secrets, leases, events) in cr.Namespace.
+		log.Info("reconciling Image Updater role")
+		role, err := r.reconcileImageUpdaterRole(cr, policyRuleForRoleForImageUpdaterController())
+		if err != nil {
 			return err
+		}
+		if sa != nil && role != nil {
+			log.Info("reconciling Image Updater role binding")
+			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
+				return err
+			}
+		}
+		// ClusterRole for cluster-wide manager rules (imageupdaters, applications, events).
+		log.Info("using cluster-scoped installation for Image Updater")
+		log.Info("reconciling Image Updater cluster role")
+		clusterRole, err := r.reconcileImageUpdaterClusterRole(cr)
+		if err != nil {
+			return err
+		}
+		if sa != nil && clusterRole != nil {
+			log.Info("reconciling Image Updater cluster role binding")
+			if err := r.reconcileImageUpdaterClusterRoleBinding(cr, clusterRole, sa); err != nil {
+				return err
+			}
+		}
+	case "":
+		// Namespace-scoped: both base and manager rules apply to cr.Namespace, so combine them into a single role.
+		log.Info("using namespace-scoped installation for Image Updater", "namespace", cr.Namespace)
+		log.Info("reconciling Image Updater role", "namespace", cr.Namespace)
+		allRules := append(policyRuleForRoleForImageUpdaterController(), policyRuleForRoleManagerRoleForImageUpdaterController()...)
+		role, err := r.reconcileImageUpdaterRole(cr, allRules)
+		if err != nil {
+			return err
+		}
+		if sa != nil && role != nil {
+			log.Info("reconciling Image Updater role binding", "namespace", cr.Namespace)
+			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
+				return err
+			}
+		}
+	default:
+		// Comma-separated list: base role in cr.Namespace + manager Role in each listed namespace.
+		log.Info("reconciling Image Updater role")
+		role, err := r.reconcileImageUpdaterRole(cr, policyRuleForRoleForImageUpdaterController())
+		if err != nil {
+			return err
+		}
+		if sa != nil && role != nil {
+			log.Info("reconciling Image Updater role binding")
+			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
+				return err
+			}
+		}
+		for _, ns := range strings.Split(watchNamespaces, ",") {
+			ns = strings.TrimSpace(ns)
+			if ns == "" {
+				continue
+			}
+			log.Info("reconciling Image Updater manager role", "namespace", ns)
+			nsRole, err := r.reconcileImageUpdaterRoleForNamespace(ns, cr, policyRuleForRoleManagerRoleForImageUpdaterController())
+			if err != nil {
+				return err
+			}
+			if sa != nil && nsRole != nil {
+				log.Info("reconciling Image Updater manager role binding", "namespace", ns)
+				if err := r.reconcileImageUpdaterRoleBindingForNamespace(ns, cr, nsRole, sa); err != nil {
+					return err
+				}
+			}
 		}
 	}
 
-	log.Info("reconciling image updater secret")
+	log.Info("reconciling Image Updater secret")
 	if err := r.reconcileImageUpdaterSecret(cr); err != nil {
 		return err
 	}
@@ -90,14 +159,14 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 	}
 
 	for _, cm := range imageUpdaterConfigMaps {
-		log.Info("reconciling image updater configmap")
+		log.Info("reconciling Image Updater configmap", "name", cm.Name)
 		if err := r.reconcileImageUpdaterConfigMap(cr, cm); err != nil {
 			return err
 		}
 	}
 
 	if sa != nil {
-		log.Info("reconciling image updater deployment")
+		log.Info("reconciling Image Updater deployment")
 		if err := r.reconcileImageUpdaterDeployment(cr, sa); err != nil {
 			return err
 		}
@@ -132,37 +201,72 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerDisabled(cr *argoproj.A
 		clusterRole.Name = clusterRoleName
 	}
 
-	log.Info("deleting image updater deployment")
+	log.Info("deleting Image Updater deployment")
 	if err := r.reconcileImageUpdaterDeployment(cr, sa); err != nil {
 		return err
 	}
 
-	log.Info("deleting image updater role binding")
+	log.Info("deleting Image Updater role binding")
 	if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
 		return err
 	}
 
-	log.Info("deleting image updater cluster role binding")
+	log.Info("deleting Image Updater cluster role binding")
 	if err := r.reconcileImageUpdaterClusterRoleBinding(cr, clusterRole, sa); err != nil {
 		return err
 	}
 
-	log.Info("deleting image updater service account")
+	log.Info("deleting Image Updater service account")
 	if _, err := r.reconcileImageUpdaterServiceAccount(cr); err != nil {
 		return err
 	}
 
-	log.Info("deleting image updater role")
-	if _, err := r.reconcileImageUpdaterRole(cr); err != nil {
+	// reconcileImageUpdaterRole deletes the role in cr.Namespace, which covers both the
+	// base role (Option 1/3) and the manager role (Option 1) since they share the same name.
+	log.Info("deleting Image Updater role")
+	if _, err := r.reconcileImageUpdaterRole(cr, policyRuleForRoleForImageUpdaterController()); err != nil {
 		return err
 	}
 
-	log.Info("deleting image updater cluster role")
+	log.Info("deleting Image Updater cluster role")
 	if _, err := r.reconcileImageUpdaterClusterRole(cr); err != nil {
 		return err
 	}
 
-	log.Info("deleting image updater secret")
+	// For a comma-separated IMAGE_UPDATER_WATCH_NAMESPACES, manager roles were created in
+	// each listed namespace. Delete them here. Option 1 ("") is handled above (same role name
+	// in cr.Namespace); Option 3 ("*") used a ClusterRole, also handled above.
+	watchNamespaces := ""
+	for _, env := range cr.Spec.ImageUpdater.Env {
+		if env.Name == "IMAGE_UPDATER_WATCH_NAMESPACES" {
+			watchNamespaces = strings.TrimSpace(env.Value)
+			break
+		}
+	}
+	if watchNamespaces != "" && watchNamespaces != "*" {
+		for _, ns := range strings.Split(watchNamespaces, ",") {
+			ns = strings.TrimSpace(ns)
+			if ns == "" {
+				continue
+			}
+			log.Info("deleting Image Updater manager role", "namespace", ns)
+			nsRole, err := r.reconcileImageUpdaterRoleForNamespace(ns, cr, policyRuleForRoleManagerRoleForImageUpdaterController())
+			if err != nil {
+				return err
+			}
+			if nsRole == nil {
+				// Role was not found — fetch a stub so the RoleBinding deletion can proceed.
+				nsRole = &rbacv1.Role{}
+				nsRole.Name = getRoleNameForApplicationSourceNamespaces(ns, cr)
+			}
+			log.Info("deleting Image Updater manager role binding", "namespace", ns)
+			if err := r.reconcileImageUpdaterRoleBindingForNamespace(ns, cr, nsRole, sa); err != nil {
+				return err
+			}
+		}
+	}
+
+	log.Info("deleting Image Updater secret")
 	if err := r.reconcileImageUpdaterSecret(cr); err != nil {
 		return err
 	}
@@ -183,7 +287,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerDisabled(cr *argoproj.A
 	}
 
 	for _, cm := range imageUpdaterConfigMaps {
-		log.Info(fmt.Sprintf("deleting image updater configmap %s", cm.Name))
+		log.Info("deleting Image Updater configmap", "name", cm.Name)
 		if err := r.reconcileImageUpdaterConfigMap(cr, cm); err != nil {
 			return err
 		}
@@ -227,8 +331,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterServiceAccount(cr *argoproj.ArgoC
 	return sa, nil
 }
 
-func (r *ReconcileArgoCD) reconcileImageUpdaterRole(cr *argoproj.ArgoCD) (*rbacv1.Role, error) {
-	policyRules := policyRuleForRoleForImageUpdaterController()
+func (r *ReconcileArgoCD) reconcileImageUpdaterRole(cr *argoproj.ArgoCD, policyRules []rbacv1.PolicyRule) (*rbacv1.Role, error) {
 	desiredRole := newRole(common.ArgoCDImageUpdaterControllerComponent, policyRules, cr)
 	role, err := r.reconcileRoleHelper(cr, desiredRole)
 	if err != nil {
@@ -241,7 +344,6 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRole(cr *argoproj.ArgoCD) (*rbacv
 }
 
 func (r *ReconcileArgoCD) reconcileImageUpdaterRoleBinding(cr *argoproj.ArgoCD, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
-
 	desiredRoleBinding := newRoleBindingWithname(common.ArgoCDImageUpdaterControllerComponent, cr)
 	desiredRoleBinding.RoleRef = rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
@@ -259,8 +361,39 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRoleBinding(cr *argoproj.ArgoCD, 
 	return r.reconcileRoleBindingHelper(cr, desiredRoleBinding)
 }
 
+func (r *ReconcileArgoCD) reconcileImageUpdaterRoleForNamespace(namespace string, cr *argoproj.ArgoCD, policyRules []rbacv1.PolicyRule) (*rbacv1.Role, error) {
+	desiredRole := newRoleForApplicationSourceNamespaces(namespace, policyRules, cr)
+	role, err := r.reconcileRoleHelper(cr, desiredRole)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		return nil, nil
+	}
+	return role.(*rbacv1.Role), nil
+}
+
+func (r *ReconcileArgoCD) reconcileImageUpdaterRoleBindingForNamespace(namespace string, cr *argoproj.ArgoCD, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
+	desiredRoleBinding := newRoleBindingForSupportNamespaces(cr, namespace)
+	desiredRoleBinding.RoleRef = rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "Role",
+		Name:     role.Name,
+	}
+	// The ServiceAccount lives in cr.Namespace; specify its namespace explicitly
+	// because the RoleBinding is in a different namespace.
+	desiredRoleBinding.Subjects = []rbacv1.Subject{
+		{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+	}
+	return r.reconcileRoleBindingHelper(cr, desiredRoleBinding)
+}
+
 func (r *ReconcileArgoCD) reconcileImageUpdaterClusterRole(cr *argoproj.ArgoCD) (*rbacv1.ClusterRole, error) {
-	policyRules := policyRuleForClusterRoleForImageUpdaterController()
+	policyRules := policyRuleForRoleManagerRoleForImageUpdaterController()
 	desiredClusterRole := newClusterRole(common.ArgoCDImageUpdaterControllerComponent, policyRules, cr)
 	clusterRole, err := r.reconcileRoleHelper(cr, desiredClusterRole)
 	if err != nil {
@@ -475,6 +608,9 @@ func (r *ReconcileArgoCD) reconcileRoleHelper(cr *argoproj.ArgoCD, desiredRole c
 
 	switch r := desiredRole.(type) {
 	case *rbacv1.Role:
+		if ns := desiredRole.GetNamespace(); ns != "" {
+			namespace = ns
+		}
 	case *rbacv1.ClusterRole:
 		namespace = ""
 	default:
@@ -491,8 +627,10 @@ func (r *ReconcileArgoCD) reconcileRoleHelper(cr *argoproj.ArgoCD, desiredRole c
 			return nil, nil
 		}
 
-		// role does not exist but should, so it should be created
-		if _, ok := desiredRole.(*rbacv1.Role); ok {
+		// role does not exist but should, so it should be created.
+		// Owner references are only set for objects in the same namespace as cr;
+		// cross-namespace owner references are forbidden by Kubernetes.
+		if _, ok := desiredRole.(*rbacv1.Role); ok && desiredRole.GetNamespace() == cr.Namespace {
 			if err := controllerutil.SetControllerReference(cr, desiredRole, r.Scheme); err != nil {
 				return nil, err
 			}
@@ -516,7 +654,7 @@ func (r *ReconcileArgoCD) reconcileRoleHelper(cr *argoproj.ArgoCD, desiredRole c
 	existingRules := getRulesFromRole(existingRole)
 	if !reflect.DeepEqual(existingRules, desiredRules) {
 		setRulesOnRole(existingRole, desiredRules)
-		if _, ok := existingRole.(*rbacv1.Role); ok {
+		if _, ok := existingRole.(*rbacv1.Role); ok && existingRole.GetNamespace() == cr.Namespace {
 			if err := controllerutil.SetControllerReference(cr, existingRole, r.Scheme); err != nil {
 				return nil, err
 			}
@@ -559,6 +697,8 @@ func (r *ReconcileArgoCD) reconcileRoleBindingHelper(cr *argoproj.ArgoCD, desire
 	namespace := cr.Namespace
 	if _, ok := desiredRoleBinding.(*rbacv1.ClusterRoleBinding); ok {
 		namespace = ""
+	} else if ns := desiredRoleBinding.GetNamespace(); ns != "" {
+		namespace = ns
 	}
 
 	// fetch existing rolebinding by name
@@ -572,8 +712,10 @@ func (r *ReconcileArgoCD) reconcileRoleBindingHelper(cr *argoproj.ArgoCD, desire
 			return nil
 		}
 
-		// roleBinding does not exist but should, so it should be created
-		if _, ok := desiredRoleBinding.(*rbacv1.RoleBinding); ok {
+		// roleBinding does not exist but should, so it should be created.
+		// Owner references are only set for objects in the same namespace as cr;
+		// cross-namespace owner references are forbidden by Kubernetes.
+		if _, ok := desiredRoleBinding.(*rbacv1.RoleBinding); ok && desiredRoleBinding.GetNamespace() == cr.Namespace {
 			if err := controllerutil.SetControllerReference(cr, desiredRoleBinding, r.Scheme); err != nil {
 				return err
 			}
@@ -597,7 +739,7 @@ func (r *ReconcileArgoCD) reconcileRoleBindingHelper(cr *argoproj.ArgoCD, desire
 		}
 	} else if !reflect.DeepEqual(getSubjectsFromRoleBinding(existingRoleBinding), getSubjectsFromRoleBinding(desiredRoleBinding)) {
 		setSubjectsOnRoleBinding(existingRoleBinding, getSubjectsFromRoleBinding(desiredRoleBinding))
-		if _, ok := existingRoleBinding.(*rbacv1.RoleBinding); ok {
+		if _, ok := existingRoleBinding.(*rbacv1.RoleBinding); ok && existingRoleBinding.GetNamespace() == cr.Namespace {
 			if err := controllerutil.SetControllerReference(cr, existingRoleBinding, r.Scheme); err != nil {
 				return err
 			}

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -24,10 +24,15 @@ import (
 
 const (
 	DefaultImageUpdaterImage      = "quay.io/argoprojlabs/argocd-image-updater"
-	DefaultImageUpdaterTag        = "v1.1.1"
+	DefaultImageUpdaterTag        = "latest" //TODO: temporary keeps it as latest until v1.2 releases
 	ArgocdImageUpdaterConfigCM    = "argocd-image-updater-config"
 	ArgocdImageUpdaterSSHConfigCM = "argocd-image-updater-ssh-config"
 	ArgocdImageUpdaterSecret      = "argocd-image-updater-secret" // #nosec G101
+
+	// imageUpdaterManagedNamespaceLabel is applied to every Role and RoleBinding that the
+	// operator creates in a per-namespace watch scope. It allows the operator to list and
+	// prune stale objects when IMAGE_UPDATER_WATCH_NAMESPACES changes between reconciles.
+	imageUpdaterManagedNamespaceLabel = "argocd.argoproj.io/image-updater-managed-namespace"
 )
 
 func (r *ReconcileArgoCD) reconcileImageUpdaterController(cr *argoproj.ArgoCD) error {
@@ -58,6 +63,14 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 		if env.Name == "IMAGE_UPDATER_WATCH_NAMESPACES" {
 			watchNamespaces = strings.TrimSpace(env.Value)
 			break
+		}
+	}
+
+	// When the mode is not cluster-scoped, remove any ClusterRole/ClusterRoleBinding that may
+	// have been created by a previous reconcile cycle when watchNamespaces was "*".
+	if watchNamespaces != "*" {
+		if err := r.deleteImageUpdaterClusterRBAC(cr); err != nil {
+			return err
 		}
 	}
 
@@ -136,6 +149,19 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 				}
 			}
 		}
+	}
+
+	// Remove per-namespace Roles/RoleBindings for namespaces no longer in the watch list.
+	desiredNamespaces := map[string]struct{}{}
+	if watchNamespaces != "" && watchNamespaces != "*" {
+		for _, ns := range strings.Split(watchNamespaces, ",") {
+			if ns = strings.TrimSpace(ns); ns != "" {
+				desiredNamespaces[ns] = struct{}{}
+			}
+		}
+	}
+	if err := r.pruneImageUpdaterNamespaceRBAC(cr, desiredNamespaces); err != nil {
+		return err
 	}
 
 	log.Info("reconciling Image Updater secret")
@@ -233,37 +259,11 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerDisabled(cr *argoproj.A
 		return err
 	}
 
-	// For a comma-separated IMAGE_UPDATER_WATCH_NAMESPACES, manager roles were created in
-	// each listed namespace. Delete them here. Option 1 ("") is handled above (same role name
-	// in cr.Namespace); Option 3 ("*") used a ClusterRole, also handled above.
-	watchNamespaces := ""
-	for _, env := range cr.Spec.ImageUpdater.Env {
-		if env.Name == "IMAGE_UPDATER_WATCH_NAMESPACES" {
-			watchNamespaces = strings.TrimSpace(env.Value)
-			break
-		}
-	}
-	if watchNamespaces != "" && watchNamespaces != "*" {
-		for _, ns := range strings.Split(watchNamespaces, ",") {
-			ns = strings.TrimSpace(ns)
-			if ns == "" {
-				continue
-			}
-			log.Info("deleting Image Updater manager role", "namespace", ns)
-			nsRole, err := r.reconcileImageUpdaterRoleForNamespace(ns, cr, policyRuleForRoleManagerRoleForImageUpdaterController())
-			if err != nil {
-				return err
-			}
-			if nsRole == nil {
-				// Role was not found — fetch a stub so the RoleBinding deletion can proceed.
-				nsRole = &rbacv1.Role{}
-				nsRole.Name = getRoleNameForApplicationSourceNamespaces(ns, cr)
-			}
-			log.Info("deleting Image Updater manager role binding", "namespace", ns)
-			if err := r.reconcileImageUpdaterRoleBindingForNamespace(ns, cr, nsRole, sa); err != nil {
-				return err
-			}
-		}
+	// Delete all per-namespace Roles/RoleBindings previously created for any watch-namespace list.
+	// pruneImageUpdaterNamespaceRBAC with an empty desired set removes everything it finds by label.
+	log.Info("deleting Image Updater namespace roles and role bindings")
+	if err := r.pruneImageUpdaterNamespaceRBAC(cr, map[string]struct{}{}); err != nil {
+		return err
 	}
 
 	log.Info("deleting Image Updater secret")
@@ -363,6 +363,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRoleBinding(cr *argoproj.ArgoCD, 
 
 func (r *ReconcileArgoCD) reconcileImageUpdaterRoleForNamespace(namespace string, cr *argoproj.ArgoCD, policyRules []rbacv1.PolicyRule) (*rbacv1.Role, error) {
 	desiredRole := newRoleForApplicationSourceNamespaces(namespace, policyRules, cr)
+	desiredRole.Labels[imageUpdaterManagedNamespaceLabel] = "true"
 	role, err := r.reconcileRoleHelper(cr, desiredRole)
 	if err != nil {
 		return nil, err
@@ -375,6 +376,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRoleForNamespace(namespace string
 
 func (r *ReconcileArgoCD) reconcileImageUpdaterRoleBindingForNamespace(namespace string, cr *argoproj.ArgoCD, role *rbacv1.Role, sa *corev1.ServiceAccount) error {
 	desiredRoleBinding := newRoleBindingForSupportNamespaces(cr, namespace)
+	desiredRoleBinding.Labels[imageUpdaterManagedNamespaceLabel] = "true"
 	desiredRoleBinding.RoleRef = rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
 		Kind:     "Role",
@@ -390,6 +392,55 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRoleBindingForNamespace(namespace
 		},
 	}
 	return r.reconcileRoleBindingHelper(cr, desiredRoleBinding)
+}
+
+// pruneImageUpdaterNamespaceRBAC removes per-namespace Image Updater Roles and RoleBindings
+// whose namespace is not present in desiredNamespaces. Pass an empty map to remove all of them
+// (used when Image Updater is disabled). Only objects carrying imageUpdaterManagedNamespaceLabel
+// are considered, so no other operator-managed RBAC is touched.
+func (r *ReconcileArgoCD) pruneImageUpdaterNamespaceRBAC(cr *argoproj.ArgoCD, desiredNamespaces map[string]struct{}) error {
+	matchLabels := client.MatchingLabels{
+		common.ArgoCDKeyName:              cr.Name,
+		imageUpdaterManagedNamespaceLabel: "true",
+	}
+
+	// pruneManaged lists objects of the given type and deletes those whose namespace is not
+	// in desiredNamespaces. getItems is called after List, so it always sees the populated slice.
+	pruneManaged := func(list client.ObjectList, getItems func() []client.Object) error {
+		if err := r.Client.List(context.TODO(), list, matchLabels); err != nil {
+			return fmt.Errorf("failed to list %T: %w", list, err)
+		}
+		for _, obj := range getItems() {
+			if _, ok := desiredNamespaces[obj.GetNamespace()]; ok {
+				continue
+			}
+			argoutil.LogResourceDeletion(log, obj, "namespace removed from IMAGE_UPDATER_WATCH_NAMESPACES")
+			if err := r.Client.Delete(context.TODO(), obj); err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+		}
+		return nil
+	}
+
+	roleList := &rbacv1.RoleList{}
+	if err := pruneManaged(roleList, func() []client.Object {
+		objs := make([]client.Object, len(roleList.Items))
+		for i := range roleList.Items {
+			objs[i] = &roleList.Items[i]
+		}
+		return objs
+	}); err != nil {
+		return err
+	}
+
+	rbList := &rbacv1.RoleBindingList{}
+	return pruneManaged(rbList, func() []client.Object {
+		objs := make([]client.Object, len(rbList.Items))
+		for i := range rbList.Items {
+			objs[i] = &rbList.Items[i]
+		}
+		return objs
+	})
 }
 
 func (r *ReconcileArgoCD) reconcileImageUpdaterClusterRole(cr *argoproj.ArgoCD) (*rbacv1.ClusterRole, error) {
@@ -423,6 +474,28 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterClusterRoleBinding(cr *argoproj.A
 	}
 
 	return r.reconcileRoleBindingHelper(cr, desiredClusterRoleBinding)
+}
+
+// deleteImageUpdaterClusterRBAC deletes the Image Updater ClusterRole and ClusterRoleBinding
+// if they exist. It is called when the watch scope is no longer cluster-wide ("*"), so that
+// resources from a previous reconcile cycle do not remain stale on the cluster.
+func (r *ReconcileArgoCD) deleteImageUpdaterClusterRBAC(cr *argoproj.ArgoCD) error {
+	name := GenerateUniqueResourceName(common.ArgoCDImageUpdaterControllerComponent, cr)
+
+	for _, obj := range []client.Object{&rbacv1.ClusterRole{}, &rbacv1.ClusterRoleBinding{}} {
+		if err := argoutil.FetchObject(r.Client, "", name, obj); err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		} else {
+			argoutil.LogResourceDeletion(log, obj, "IMAGE_UPDATER_WATCH_NAMESPACES is no longer \"*\"")
+			if err := r.Delete(context.TODO(), obj); err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // reconcileImageUpdaterSecret only creates/deletes the argocd-image-updater-secret based on whether image updater is enabled/disabled in the CR

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -407,7 +407,7 @@ func (r *ReconcileArgoCD) pruneImageUpdaterNamespaceRBAC(cr *argoproj.ArgoCD, de
 	// pruneManaged lists objects of the given type and deletes those whose namespace is not
 	// in desiredNamespaces. getItems is called after List, so it always sees the populated slice.
 	pruneManaged := func(list client.ObjectList, getItems func() []client.Object) error {
-		if err := r.Client.List(context.TODO(), list, matchLabels); err != nil {
+		if err := r.List(context.TODO(), list, matchLabels); err != nil {
 			return fmt.Errorf("failed to list %T: %w", list, err)
 		}
 		for _, obj := range getItems() {
@@ -415,7 +415,7 @@ func (r *ReconcileArgoCD) pruneImageUpdaterNamespaceRBAC(cr *argoproj.ArgoCD, de
 				continue
 			}
 			argoutil.LogResourceDeletion(log, obj, "namespace removed from IMAGE_UPDATER_WATCH_NAMESPACES")
-			if err := r.Client.Delete(context.TODO(), obj); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(context.TODO(), obj); err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -38,8 +38,9 @@ func TestReconcileImageUpdater_CreateRoles(t *testing.T) {
 	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	desiredPolicyRules := policyRuleForRoleForImageUpdaterController()
 
-	_, err := r.reconcileImageUpdaterRole(a)
+	_, err := r.reconcileImageUpdaterRole(a, desiredPolicyRules)
 	assert.NoError(t, err)
 
 	testRole := &rbacv1.Role{}
@@ -48,12 +49,10 @@ func TestReconcileImageUpdater_CreateRoles(t *testing.T) {
 		Namespace: a.Namespace,
 	}, testRole))
 
-	desiredPolicyRules := policyRuleForRoleForImageUpdaterController()
-
 	assert.Equal(t, desiredPolicyRules, testRole.Rules)
 
 	a.Spec.ImageUpdater.Enabled = false
-	_, err = r.reconcileImageUpdaterRole(a)
+	_, err = r.reconcileImageUpdaterRole(a, desiredPolicyRules)
 	assert.NoError(t, err)
 
 	err = r.Get(context.TODO(), types.NamespacedName{
@@ -84,7 +83,7 @@ func TestReconcileImageUpdater_CreateClusterRoles(t *testing.T) {
 		Name: GenerateUniqueResourceName(common.ArgoCDImageUpdaterControllerComponent, a),
 	}, testRole))
 
-	desiredPolicyRules := policyRuleForClusterRoleForImageUpdaterController()
+	desiredPolicyRules := policyRuleForRoleManagerRoleForImageUpdaterController()
 
 	assert.Equal(t, desiredPolicyRules, testRole.Rules)
 
@@ -473,6 +472,197 @@ func TestReconcileImageUpdater_CreateConfigMap(t *testing.T) {
 	configMap := &v1.ConfigMap{}
 	err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-image-updater-config", Namespace: a.Namespace}, configMap)
 	assertNotFound(t, err)
+}
+
+func TestReconcileImageUpdater_RoleForNamespace(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	const targetNS = "target-ns"
+
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	desiredPolicyRules := policyRuleForRoleManagerRoleForImageUpdaterController()
+	_, err := r.reconcileImageUpdaterRoleForNamespace(targetNS, a, desiredPolicyRules)
+	assert.NoError(t, err)
+
+	testRole := &rbacv1.Role{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      getRoleNameForApplicationSourceNamespaces(targetNS, a),
+		Namespace: targetNS,
+	}, testRole))
+
+	assert.Equal(t, targetNS, testRole.Namespace)
+	assert.Equal(t, desiredPolicyRules, testRole.Rules)
+
+	a.Spec.ImageUpdater.Enabled = false
+	_, err = r.reconcileImageUpdaterRoleForNamespace(targetNS, a, desiredPolicyRules)
+	assert.NoError(t, err)
+
+	err = r.Get(context.TODO(), types.NamespacedName{
+		Name:      getRoleNameForApplicationSourceNamespaces(targetNS, a),
+		Namespace: targetNS,
+	}, testRole)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileImageUpdater_RoleBindingForNamespace(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	const targetNS = "target-ns"
+
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{
+		Name:      getRoleNameForApplicationSourceNamespaces(targetNS, a),
+		Namespace: targetNS,
+	}}
+	sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name:      "sa-name",
+		Namespace: a.Namespace,
+	}}
+
+	err := r.reconcileImageUpdaterRoleBindingForNamespace(targetNS, a, role, sa)
+	assert.NoError(t, err)
+
+	rb := &rbacv1.RoleBinding{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      getRoleBindingNameForSourceNamespaces(a.Name, targetNS),
+		Namespace: targetNS,
+	}, rb))
+
+	// RoleBinding must be in targetNS, not cr.Namespace
+	assert.Equal(t, targetNS, rb.Namespace)
+	assert.Equal(t, role.Name, rb.RoleRef.Name)
+	assert.Equal(t, sa.Name, rb.Subjects[0].Name)
+	// Subject namespace must be explicit because SA is in a different namespace
+	assert.Equal(t, a.Namespace, rb.Subjects[0].Namespace)
+
+	a.Spec.ImageUpdater.Enabled = false
+	err = r.reconcileImageUpdaterRoleBindingForNamespace(targetNS, a, role, sa)
+	assert.NoError(t, err)
+
+	err = r.Get(context.TODO(), types.NamespacedName{
+		Name:      getRoleBindingNameForSourceNamespaces(a.Name, targetNS),
+		Namespace: targetNS,
+	}, rb)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	tests := []struct {
+		name               string
+		watchNamespacesEnv string // raw value set in the env var; empty string means env var not set
+		expectClusterRole  bool
+		// namespaces where a manager role is expected (testNamespace = combined role in own ns)
+		expectManagerRoleInNS []string
+	}{
+		{
+			name:                  "namespace-scoped: env var not set",
+			watchNamespacesEnv:    "",
+			expectClusterRole:     false,
+			expectManagerRoleInNS: []string{testNamespace},
+		},
+		{
+			name:                  "namespace-scoped: env var set to whitespace",
+			watchNamespacesEnv:    "  ",
+			expectClusterRole:     false,
+			expectManagerRoleInNS: []string{testNamespace},
+		},
+		{
+			name:                  "comma-separated: two namespaces",
+			watchNamespacesEnv:    "ns1,ns2",
+			expectClusterRole:     false,
+			expectManagerRoleInNS: []string{"ns1", "ns2"},
+		},
+		{
+			name:                  "comma-separated: single namespace",
+			watchNamespacesEnv:    "ns1",
+			expectClusterRole:     false,
+			expectManagerRoleInNS: []string{"ns1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envVars := []v1.EnvVar{}
+			if tt.watchNamespacesEnv != "" {
+				envVars = append(envVars, v1.EnvVar{
+					Name:  "IMAGE_UPDATER_WATCH_NAMESPACES",
+					Value: tt.watchNamespacesEnv,
+				})
+			}
+
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+				a.Spec.ImageUpdater.Enabled = true
+				a.Spec.ImageUpdater.Env = envVars
+			})
+
+			resObjs := []client.Object{a}
+			subresObjs := []client.Object{a}
+			runtimeObjs := []runtime.Object{}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+			assert.NoError(t, r.reconcileImageUpdaterControllerEnabled(a))
+
+			for _, ns := range tt.expectManagerRoleInNS {
+				if ns == testNamespace {
+					// Namespace-scoped: base + manager rules are merged into a single role.
+					role := &rbacv1.Role{}
+					assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+						Name:      generateResourceName(common.ArgoCDImageUpdaterControllerComponent, a),
+						Namespace: ns,
+					}, role), "expected combined role in namespace %s", ns)
+					assert.NotEmpty(t, role.Rules)
+				} else {
+					// Comma-separated: manager role in the listed namespace.
+					role := &rbacv1.Role{}
+					assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+						Name:      getRoleNameForApplicationSourceNamespaces(ns, a),
+						Namespace: ns,
+					}, role), "expected manager role in namespace %s", ns)
+					assert.Equal(t, policyRuleForRoleManagerRoleForImageUpdaterController(), role.Rules)
+
+					rb := &rbacv1.RoleBinding{}
+					assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+						Name:      getRoleBindingNameForSourceNamespaces(a.Name, ns),
+						Namespace: ns,
+					}, rb), "expected manager role binding in namespace %s", ns)
+					assert.Equal(t, role.Name, rb.RoleRef.Name)
+					assert.Equal(t, a.Namespace, rb.Subjects[0].Namespace)
+				}
+			}
+
+			clusterRole := &rbacv1.ClusterRole{}
+			clusterRoleErr := r.Get(context.TODO(), types.NamespacedName{
+				Name: GenerateUniqueResourceName(common.ArgoCDImageUpdaterControllerComponent, a),
+			}, clusterRole)
+			if tt.expectClusterRole {
+				assert.NoError(t, clusterRoleErr)
+			} else {
+				assert.True(t, errors.IsNotFound(clusterRoleErr))
+			}
+		})
+	}
 }
 
 func TestReconcileImageUpdater_testEnvVars(t *testing.T) {

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -474,6 +474,58 @@ func TestReconcileImageUpdater_CreateConfigMap(t *testing.T) {
 	assertNotFound(t, err)
 }
 
+func TestDeleteImageUpdaterClusterRBAC(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	clusterRBACName := GenerateUniqueResourceName(common.ArgoCDImageUpdaterControllerComponent, a)
+
+	t.Run("no-op when ClusterRole and ClusterRoleBinding do not exist", func(t *testing.T) {
+		assert.NoError(t, r.deleteImageUpdaterClusterRBAC(a))
+	})
+
+	t.Run("deletes existing ClusterRole and ClusterRoleBinding", func(t *testing.T) {
+		// Pre-create the ClusterRole and ClusterRoleBinding the same way the enabled reconciler would.
+		clusterRole, err := r.reconcileImageUpdaterClusterRole(a)
+		assert.NoError(t, err)
+		assert.NotNil(t, clusterRole)
+
+		if clusterRole != nil {
+			assert.NoError(t, r.reconcileImageUpdaterClusterRoleBinding(a, clusterRole, &v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: a.Namespace},
+			}))
+		}
+
+		// Verify they exist before deletion.
+		assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: clusterRBACName}, &rbacv1.ClusterRole{}))
+		assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: clusterRBACName}, &rbacv1.ClusterRoleBinding{}))
+
+		// Delete.
+		assert.NoError(t, r.deleteImageUpdaterClusterRBAC(a))
+
+		// Verify they are gone.
+		err = r.Get(context.TODO(), types.NamespacedName{Name: clusterRBACName}, &rbacv1.ClusterRole{})
+		assert.True(t, errors.IsNotFound(err))
+
+		err = r.Get(context.TODO(), types.NamespacedName{Name: clusterRBACName}, &rbacv1.ClusterRoleBinding{})
+		assert.True(t, errors.IsNotFound(err))
+	})
+
+	t.Run("idempotent: second call is a no-op after deletion", func(t *testing.T) {
+		assert.NoError(t, r.deleteImageUpdaterClusterRBAC(a))
+	})
+}
+
 func TestReconcileImageUpdater_RoleForNamespace(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	const targetNS = "target-ns"
@@ -731,4 +783,148 @@ func TestReconcileImageUpdater_testEnvVars(t *testing.T) {
 	if diff := cmp.Diff(envMap, deployment.Spec.Template.Spec.Containers[0].Env); diff != "" {
 		t.Fatalf("operator failed to override the manual changes to image updater controller:\n%s", diff)
 	}
+}
+
+func TestPruneImageUpdaterNamespaceRBAC(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	rules := policyRuleForRoleManagerRoleForImageUpdaterController()
+	sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: a.Namespace}}
+
+	// Create roles and bindings in ns1, ns2, ns3.
+	for _, ns := range []string{"ns1", "ns2", "ns3"} {
+		role, err := r.reconcileImageUpdaterRoleForNamespace(ns, a, rules)
+		assert.NoError(t, err)
+		assert.NotNil(t, role)
+		assert.NoError(t, r.reconcileImageUpdaterRoleBindingForNamespace(ns, a, role, sa))
+	}
+
+	// Verify label is present on the created role.
+	roleNs1 := &rbacv1.Role{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      getRoleNameForApplicationSourceNamespaces("ns1", a),
+		Namespace: "ns1",
+	}, roleNs1))
+	assert.Equal(t, "true", roleNs1.Labels[imageUpdaterManagedNamespaceLabel])
+
+	t.Run("prune removes roles not in the desired set", func(t *testing.T) {
+		// Keep only ns1; ns2 and ns3 should be pruned.
+		desired := map[string]struct{}{"ns1": {}}
+		assert.NoError(t, r.pruneImageUpdaterNamespaceRBAC(a, desired))
+
+		// ns1 must still exist.
+		assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+			Name:      getRoleNameForApplicationSourceNamespaces("ns1", a),
+			Namespace: "ns1",
+		}, &rbacv1.Role{}))
+		assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+			Name:      getRoleBindingNameForSourceNamespaces(a.Name, "ns1"),
+			Namespace: "ns1",
+		}, &rbacv1.RoleBinding{}))
+
+		// ns2 and ns3 must be gone.
+		for _, ns := range []string{"ns2", "ns3"} {
+			err := r.Get(context.TODO(), types.NamespacedName{
+				Name:      getRoleNameForApplicationSourceNamespaces(ns, a),
+				Namespace: ns,
+			}, &rbacv1.Role{})
+			assert.True(t, errors.IsNotFound(err), "expected role in %s to be deleted", ns)
+
+			err = r.Get(context.TODO(), types.NamespacedName{
+				Name:      getRoleBindingNameForSourceNamespaces(a.Name, ns),
+				Namespace: ns,
+			}, &rbacv1.RoleBinding{})
+			assert.True(t, errors.IsNotFound(err), "expected role binding in %s to be deleted", ns)
+		}
+	})
+
+	t.Run("prune with empty set removes all remaining namespace RBAC", func(t *testing.T) {
+		assert.NoError(t, r.pruneImageUpdaterNamespaceRBAC(a, map[string]struct{}{}))
+
+		err := r.Get(context.TODO(), types.NamespacedName{
+			Name:      getRoleNameForApplicationSourceNamespaces("ns1", a),
+			Namespace: "ns1",
+		}, &rbacv1.Role{})
+		assert.True(t, errors.IsNotFound(err))
+
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      getRoleBindingNameForSourceNamespaces(a.Name, "ns1"),
+			Namespace: "ns1",
+		}, &rbacv1.RoleBinding{})
+		assert.True(t, errors.IsNotFound(err))
+	})
+
+	t.Run("prune is idempotent on empty cluster", func(t *testing.T) {
+		assert.NoError(t, r.pruneImageUpdaterNamespaceRBAC(a, map[string]struct{}{}))
+	})
+}
+
+// TestReconcileImageUpdaterControllerEnabled_PrunesStaleNamespaceRBAC verifies that when the
+// watch-namespace list shrinks, the operator removes roles and bindings for the dropped namespaces
+// without touching the remaining ones.
+func TestReconcileImageUpdaterControllerEnabled_PrunesStaleNamespaceRBAC(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	// Start with ns1 and ns2 in the watch list.
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+		a.Spec.ImageUpdater.Env = []v1.EnvVar{
+			{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "ns1,ns2"},
+		}
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	// First reconcile: both namespaces get roles.
+	assert.NoError(t, r.reconcileImageUpdaterControllerEnabled(a))
+
+	for _, ns := range []string{"ns1", "ns2"} {
+		assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+			Name:      getRoleNameForApplicationSourceNamespaces(ns, a),
+			Namespace: ns,
+		}, &rbacv1.Role{}), "expected role in %s after first reconcile", ns)
+	}
+
+	// Shrink to ns1 only.
+	a.Spec.ImageUpdater.Env = []v1.EnvVar{
+		{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "ns1"},
+	}
+
+	// Second reconcile: ns2 role and binding should be pruned.
+	assert.NoError(t, r.reconcileImageUpdaterControllerEnabled(a))
+
+	// ns1 still exists.
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      getRoleNameForApplicationSourceNamespaces("ns1", a),
+		Namespace: "ns1",
+	}, &rbacv1.Role{}))
+
+	// ns2 is gone.
+	err := r.Get(context.TODO(), types.NamespacedName{
+		Name:      getRoleNameForApplicationSourceNamespaces("ns2", a),
+		Namespace: "ns2",
+	}, &rbacv1.Role{})
+	assert.True(t, errors.IsNotFound(err), "stale role in ns2 should have been pruned")
+
+	err = r.Get(context.TODO(), types.NamespacedName{
+		Name:      getRoleBindingNameForSourceNamespaces(a.Name, "ns2"),
+		Namespace: "ns2",
+	}, &rbacv1.RoleBinding{})
+	assert.True(t, errors.IsNotFound(err), "stale role binding in ns2 should have been pruned")
 }

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -624,6 +624,7 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 		watchNamespacesEnv string // raw value set in the env var; empty string means env var not set
 		// clusterConfigNS, when non-empty, is set as ARGOCD_CLUSTER_CONFIG_NAMESPACES for the subtest
 		clusterConfigNS   string
+		expectError       bool // reconcile must return an error
 		expectClusterRole bool
 		expectClusterRB   bool
 		// namespaces where a manager role is expected (testNamespace = combined role in own ns)
@@ -661,6 +662,13 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 			expectClusterRB:       true,
 			expectManagerRoleInNS: []string{},
 		},
+		{
+			// IMAGE_UPDATER_WATCH_NAMESPACES="*" without the ArgoCD instance being in a
+			// cluster-config namespace must be rejected to prevent privilege escalation.
+			name:               "cluster-scoped: * rejected when not a cluster-config namespace",
+			watchNamespacesEnv: "*",
+			expectError:        true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -689,7 +697,12 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-			assert.NoError(t, r.reconcileImageUpdaterControllerEnabled(a))
+			err := r.reconcileImageUpdaterControllerEnabled(a)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
 
 			for _, ns := range tt.expectManagerRoleInNS {
 				if ns == testNamespace {

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -622,7 +622,10 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 	tests := []struct {
 		name               string
 		watchNamespacesEnv string // raw value set in the env var; empty string means env var not set
-		expectClusterRole  bool
+		// clusterConfigNS, when non-empty, is set as ARGOCD_CLUSTER_CONFIG_NAMESPACES for the subtest
+		clusterConfigNS   string
+		expectClusterRole bool
+		expectClusterRB   bool
 		// namespaces where a manager role is expected (testNamespace = combined role in own ns)
 		expectManagerRoleInNS []string
 	}{
@@ -650,10 +653,22 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 			expectClusterRole:     false,
 			expectManagerRoleInNS: []string{"ns1"},
 		},
+		{
+			name:                  "cluster-scoped: watch namespaces set to *",
+			watchNamespacesEnv:    "*",
+			clusterConfigNS:       testNamespace,
+			expectClusterRole:     true,
+			expectClusterRB:       true,
+			expectManagerRoleInNS: []string{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.clusterConfigNS != "" {
+				t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", tt.clusterConfigNS)
+			}
+
 			envVars := []v1.EnvVar{}
 			if tt.watchNamespacesEnv != "" {
 				envVars = append(envVars, v1.EnvVar{
@@ -704,14 +719,20 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 				}
 			}
 
-			clusterRole := &rbacv1.ClusterRole{}
-			clusterRoleErr := r.Get(context.TODO(), types.NamespacedName{
-				Name: GenerateUniqueResourceName(common.ArgoCDImageUpdaterControllerComponent, a),
-			}, clusterRole)
+			clusterRBACName := GenerateUniqueResourceName(common.ArgoCDImageUpdaterControllerComponent, a)
+
+			clusterRoleErr := r.Get(context.TODO(), types.NamespacedName{Name: clusterRBACName}, &rbacv1.ClusterRole{})
 			if tt.expectClusterRole {
-				assert.NoError(t, clusterRoleErr)
+				assert.NoError(t, clusterRoleErr, "expected ClusterRole to exist")
 			} else {
-				assert.True(t, errors.IsNotFound(clusterRoleErr))
+				assert.True(t, errors.IsNotFound(clusterRoleErr), "expected ClusterRole to be absent")
+			}
+
+			clusterRBErr := r.Get(context.TODO(), types.NamespacedName{Name: clusterRBACName}, &rbacv1.ClusterRoleBinding{})
+			if tt.expectClusterRB {
+				assert.NoError(t, clusterRBErr, "expected ClusterRoleBinding to exist")
+			} else {
+				assert.True(t, errors.IsNotFound(clusterRBErr), "expected ClusterRoleBinding to be absent")
 			}
 		})
 	}

--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -713,7 +713,7 @@ func policyRuleForRoleForImageUpdaterController() []v1.PolicyRule {
 	}
 }
 
-func policyRuleForClusterRoleForImageUpdaterController() []v1.PolicyRule {
+func policyRuleForRoleManagerRoleForImageUpdaterController() []v1.PolicyRule {
 	return []v1.PolicyRule{
 		{
 			APIGroups: []string{

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argocd-image-updater.argoproj.io_imageupdaters.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argocd-image-updater.argoproj.io_imageupdaters.yaml
@@ -14,7 +14,20 @@ spec:
     singular: imageupdater
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.applicationsMatched
+      name: Apps
+      type: integer
+    - jsonPath: .status.imagesManaged
+      name: Images
+      type: integer
+    - jsonPath: .status.lastCheckedAt
+      name: Last Checked
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ImageUpdater is the Schema for the imageupdaters API
@@ -306,6 +319,25 @@ spec:
                                 Branch to commit updates to.
                                 Required if write-back method is Git and this is not specified at the spec level.
                               type: string
+                            pullRequest:
+                              description: |-
+                                PullRequest configures creation of pull requests when writing back image updates to Git.
+                                When set, the controller opens a PR instead of pushing to the branch.
+                                If not specified write back config method is `git`.
+                              properties:
+                                github:
+                                  description: GitHub configures PR creation via the
+                                    GitHub API.
+                                  type: object
+                                gitlab:
+                                  description: GitLab configures MR creation via the
+                                    GitLab API.
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                              - message: Exactly one of github or gitlab must be set
+                                rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab)
+                                  ? 1 : 0) == 1'
                             repository:
                               description: |-
                                 Repository URL to commit changes to.
@@ -390,14 +422,6 @@ spec:
                       This acts as the default if not overridden at a more specific level.
                     type: string
                 type: object
-              namespace:
-                description: |-
-                  Namespace indicates the target namespace of the applications.
-
-                  Deprecated: This field is deprecated and will be removed in a future release.
-                  The controller now uses the ImageUpdater CR's namespace (metadata.namespace)
-                  to determine which namespace to search for applications. This field is ignored.
-                type: string
               writeBackConfig:
                 description: |-
                   WriteBackConfig provides global default settings for how and where to write back image updates.
@@ -413,6 +437,25 @@ spec:
                           Branch to commit updates to.
                           Required if write-back method is Git and this is not specified at the spec level.
                         type: string
+                      pullRequest:
+                        description: |-
+                          PullRequest configures creation of pull requests when writing back image updates to Git.
+                          When set, the controller opens a PR instead of pushing to the branch.
+                          If not specified write back config method is `git`.
+                        properties:
+                          github:
+                            description: GitHub configures PR creation via the GitHub
+                              API.
+                            type: object
+                          gitlab:
+                            description: GitLab configures MR creation via the GitLab
+                              API.
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Exactly one of github or gitlab must be set
+                          rule: '(has(self.github) ? 1 : 0) + (has(self.gitlab) ?
+                            1 : 0) == 1'
                       repository:
                         description: |-
                           Repository URL to commit changes to.
@@ -444,7 +487,15 @@ spec:
           status:
             description: ImageUpdaterStatus defines the observed state of ImageUpdater
             properties:
+              applicationsMatched:
+                description: ApplicationsMatched is the number of Argo CD applications
+                  matched by this CR's selectors.
+                format: int32
+                minimum: 0
+                type: integer
               conditions:
+                description: Conditions represent the latest available observations
+                  of the resource's state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -500,48 +551,73 @@ spec:
                   - type
                   type: object
                 type: array
-              imageStatus:
-                description: ImageStatus indicates the detailed status for the list
-                  of managed images
-                items:
-                  description: ImageStatus contains information for an image:version
-                    and its update status in hosting applications
-                  properties:
-                    applications:
-                      description: Applications contains a list of applications and
-                        when the image was last updated therein
-                      items:
-                        description: ImageApplicationLastUpdated contains information
-                          for an application and when the image was last updated therein
-                        properties:
-                          appName:
-                            description: AppName indicates and namespace and the application
-                              name
-                            type: string
-                          lastUpdatedAt:
-                            description: LastUpdatedAt indicates when the image in
-                              this application was last updated
-                            format: date-time
-                            type: string
-                        required:
-                        - appName
-                        type: object
-                      type: array
-                    name:
-                      description: Name indicates the image name
-                      type: string
-                    version:
-                      description: Version indicates the image version
-                      type: string
-                  required:
-                  - name
-                  - version
-                  type: object
-                type: array
-              reconciledAt:
-                description: LastUpdatedAt indicates when the image updater last ran
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              imagesManaged:
+                description: ImagesManaged is the number of images that were eligible
+                  for update checking.
+                format: int32
+                minimum: 0
+                type: integer
+              lastCheckedAt:
+                description: LastCheckedAt indicates when the controller last checked
+                  for image updates.
                 format: date-time
                 type: string
+              lastUpdatedAt:
+                description: LastUpdatedAt indicates when the controller last performed
+                  an image update.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                minimum: 0
+                type: integer
+              recentUpdates:
+                description: RecentUpdates contains the list of image updates performed
+                  during the last update cycle.
+                items:
+                  description: RecentUpdate records a single image update performed
+                    during the last update.
+                  properties:
+                    alias:
+                      description: Alias is the alias of the image configuration that
+                        was updated.
+                      type: string
+                    applicationsUpdated:
+                      description: ApplicationsUpdated is the number of applications
+                        in which this image was updated.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    image:
+                      description: Image is the full image reference.
+                      type: string
+                    message:
+                      description: Message provides a human-readable description of
+                        the update action.
+                      type: string
+                    newVersion:
+                      description: NewVersion is the new tag or digest the image was
+                        updated to.
+                      type: string
+                    updatedAt:
+                      description: UpdatedAt is the timestamp when the update was
+                        applied.
+                      format: date-time
+                      type: string
+                  required:
+                  - alias
+                  - applicationsUpdated
+                  - image
+                  - newVersion
+                  - updatedAt
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             type: object
         type: object
     served: true

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argocd-operator.v0.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argocd-operator.v0.19.0.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-04-10T16:59:38Z"
+    createdAt: "2026-04-22T19:10:17Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/docs/usage/image-updater.md
+++ b/docs/usage/image-updater.md
@@ -28,7 +28,7 @@ The operator supports two installation modes:
 
 The controller runs in the same namespace as the Argo CD instance and watches only that namespace. This is the default behavior when `IMAGE_UPDATER_WATCH_NAMESPACES` is not set or is empty.
 
-If you use Argo CD's [Applications in any namespace](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/) feature and have `Application` resources in additional namespaces, you can specify a comma-separated list of namespaces to watch:
+If you use Argo CD's [Applications in any namespace](https://argocd-operator.readthedocs.io/en/latest/usage/apps-in-any-namespace/) feature and have `Application` resources in additional namespaces, you can specify a comma-separated list of namespaces to watch:
 
 ``` yaml
 spec:

--- a/docs/usage/image-updater.md
+++ b/docs/usage/image-updater.md
@@ -18,14 +18,70 @@ spec:
 
 Users may also specify advanced configuration such as the resource requirements or environment variables for the image updater controller. The full list of available settings can be found in the [API spec](../reference/argocd.md#image-updater-controller-options).
 
-Image Updater is disabled by default. Enabling image updater results in the operator creating the following resources on the cluster:
+### Watch scope
 
-*  `<argocd-instance-name>-argocd-image-updater-controller` deployment
-*  `<argocd-instance-name>-argocd-image-updater-controller` serviceAccount
-*  `<argocd-instance-name>-argocd-image-updater-controller` role
-*  `<argocd-instance-name>-argocd-image-updater-controller` roleBinding
-*  `<argocd-instance-name>-default-argocd-image-updater-controller` clusterRole
-*  `<argocd-instance-name>-default-argocd-image-updater-controller` clusterRoleBinding
+The Image Updater controller's watch scope determines which namespaces it monitors for `ImageUpdater` CRs and Argo CD `Applications`. It is controlled by the `IMAGE_UPDATER_WATCH_NAMESPACES` environment variable, set via `.spec.imageUpdater.env`.
+
+The operator supports two installation modes:
+
+#### Install into the Argo CD namespace (recommended, default)
+
+The controller runs in the same namespace as the Argo CD instance and watches only that namespace. This is the default behavior when `IMAGE_UPDATER_WATCH_NAMESPACES` is not set or is empty.
+
+If you use Argo CD's [Applications in any namespace](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/) feature and have `Application` resources in additional namespaces, you can specify a comma-separated list of namespaces to watch:
+
+``` yaml
+spec:
+  imageUpdater:
+    enabled: true
+    env:
+      - name: IMAGE_UPDATER_WATCH_NAMESPACES
+        value: "app-ns1,app-ns2"
+```
+
+The operator will create a `Role` and `RoleBinding` in each listed namespace so the controller can access resources there.
+
+#### Cluster-scoped installation
+
+For environments where the controller must watch `ImageUpdater` CRs in all namespaces, set `IMAGE_UPDATER_WATCH_NAMESPACES` to `"*"`:
+
+``` yaml
+spec:
+  imageUpdater:
+    enabled: true
+    env:
+      - name: IMAGE_UPDATER_WATCH_NAMESPACES
+        value: "*"
+```
+
+This mode requires the ArgoCD instance to be installed in a cluster configuration namespace. The operator will create a `ClusterRole` and `ClusterRoleBinding` instead of namespace-scoped RBAC.
+
+!!! note
+    Installing Image Updater into a namespace separate from the Argo CD namespace (upstream Option 2) is **not supported** by this operator. Refer to the [upstream documentation](https://argocd-image-updater.readthedocs.io/) for details on that installation pattern.
+
+### Resources created
+
+The resources created depend on the selected watch scope:
+
+**namespace-scoped (default or comma-separated namespaces):**
+
+*  `<instance-name>-argocd-image-updater-controller` deployment
+*  `<instance-name>-argocd-image-updater-controller` serviceAccount
+*  `<instance-name>-argocd-image-updater-controller` role (in the ArgoCD namespace)
+*  `<instance-name>-argocd-image-updater-controller` roleBinding (in the ArgoCD namespace)
+*  `<instance-name>_<namespace>` role + roleBinding (one per extra namespace, when a comma-separated list is provided)
+*  `argocd-image-updater-config` configmap
+*  `argocd-image-updater-ssh-config` configmap
+*  `argocd-image-updater-secret` secret
+
+**cluster-scoped (`IMAGE_UPDATER_WATCH_NAMESPACES="*"`):**
+
+*  `<instance-name>-argocd-image-updater-controller` deployment
+*  `<instance-name>-argocd-image-updater-controller` serviceAccount
+*  `<instance-name>-argocd-image-updater-controller` role (in the ArgoCD namespace)
+*  `<instance-name>-argocd-image-updater-controller` roleBinding (in the ArgoCD namespace)
+*  `<instance-name>-<instance-namespace>-argocd-image-updater-controller` clusterRole
+*  `<instance-name>-<instance-namespace>-argocd-image-updater-controller` clusterRoleBinding
 *  `argocd-image-updater-config` configmap
 *  `argocd-image-updater-ssh-config` configmap
 *  `argocd-image-updater-secret` secret
@@ -33,7 +89,6 @@ Image Updater is disabled by default. Enabling image updater results in the oper
 The operator creates the `argocd-image-updater-config` and `argocd-image-updater-ssh-config` configmaps that are editable to users, and will not be reconciled/overwritten by the operator. The `argocd-image-updater-secret` is an empty secret that can be used to configure credentials for the supported image updater services.
 
 Instructions for appropriate configuration of these resources can be found within [upstream documentation](https://argocd-image-updater.readthedocs.io/).
-
 
 ## Uninstallation
 

--- a/examples/argocd-image-updater.yaml
+++ b/examples/argocd-image-updater.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: example-argocd
+  name: example-image-updater
   labels:
     example: image-updater
 spec:


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
- Added IMAGE_UPDATER_WATCH_NAMESPACES to select watched namespaces for Image Updater: pod-own namespace (default), comma-separated list, or "*" for cluster-wide.
- [config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml](https://github.com/argoproj-labs/argocd-operator/pull/2172/files/dd10b3d4c588facae4220f8495ec0cbb55ab97f7#diff-98156056110bebdbb4e9d5e80ac1167d34427269b4a369d19e22a9d90105949a) was updated from upstream (via `make get-image-updater-crd`) and bundles multiple upstream API changes:

Removal of spec.namespace (namespace-scope related)
New status fields (applicationsMatched, imagesManaged, lastCheckedAt, lastUpdatedAt, observedGeneration, recentUpdates) and corresponding printer columns
Changes to pullRequest configuration in writeBackConfig

**Have you updated the necessary documentation?**
yes
* [*] Documentation update is required by this PR.
* [*] Documentation has been updated.

**Which issue(s) this PR fixes**:
GITOPS-9394

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-request write-back support for Git (GitHub or GitLab) with validation enforcing exactly one.
  * IMAGE_UPDATER_WATCH_NAMESPACES for flexible RBAC scoping (namespace, multiple, or cluster).
  * Expanded status and printer columns showing Ready state, apps/images counts, last-checked/updated times, observed generation, and recent updates.
  * Default image tag changed to "latest".

* **Chores**
  * Removed deprecated spec.namespace from ImageUpdater API.
  * Replaced old imageStatus/reconciledAt with consolidated recentUpdates/status fields.
  * Example manifest resource name updated.

* **Documentation**
  * Usage guide updated with watch-namespaces and mode-specific RBAC behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->