### PR TITLE
feat: create ServiceMonitors for Principal and Agent components

### DIFF
--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -1646,6 +1646,13 @@ func (r *ReconcileArgoCD) reconcileArgoCDAgent(cr *argoproj.ArgoCD) error {
 		return err
 	}
 
+	if IsPrometheusAPIAvailable() {
+		log.Info("reconciling ArgoCD Agent's Principal metrics ServiceMonitor")
+		if err := argocdagent.ReconcilePrincipalServiceMonitor(r.Client, compName, cr, r.Scheme, cr.Spec.Prometheus.Enabled); err != nil {
+			return err
+		}
+	}
+
 	log.Info("reconciling ArgoCD Agent's Principal redis proxy service")
 	if err := argocdagent.ReconcilePrincipalRedisProxyService(r.Client, compName, cr, r.Scheme); err != nil {
 		return err
@@ -1708,6 +1715,13 @@ func (r *ReconcileArgoCD) reconcileArgoCDAgent(cr *argoproj.ArgoCD) error {
 	log.Info("reconciling ArgoCD Agent's Agent metrics service")
 	if err := agent.ReconcileAgentMetricsService(r.Client, agentCompName, cr, r.Scheme); err != nil {
 		return err
+	}
+
+	if IsPrometheusAPIAvailable() {
+		log.Info("reconciling ArgoCD Agent's Agent metrics ServiceMonitor")
+		if err := agent.ReconcileAgentServiceMonitor(r.Client, agentCompName, cr, r.Scheme, cr.Spec.Prometheus.Enabled); err != nil {
+			return err
+		}
 	}
 
 	log.Info("reconciling ArgoCD Agent's Agent healthz service")

--- a/controllers/argocdagent/agent/servicemonitor.go
+++ b/controllers/argocdagent/agent/servicemonitor.go
@@ -57,7 +57,7 @@ func ReconcileAgentServiceMonitor(client client.Client, compName string, cr *arg
 
 			argoutil.LogResourceUpdate(log, sm, "updating agent ServiceMonitor spec")
 			if err := client.Update(context.TODO(), sm); err != nil {
-				return fmt.Errorf("failed to update agent ServiceMonitor %s: %v", smName, err)
+				return fmt.Errorf("failed to update agent ServiceMonitor %s: %w", smName, err)
 			}
 		}
 		return nil
@@ -75,7 +75,7 @@ func ReconcileAgentServiceMonitor(client client.Client, compName string, cr *arg
 
 	argoutil.LogResourceCreation(log, sm)
 	if err := client.Create(context.TODO(), sm); err != nil {
-		return fmt.Errorf("failed to create agent ServiceMonitor %s: %v", smName, err)
+		return fmt.Errorf("failed to create agent ServiceMonitor %s: %w", smName, err)
 	}
 	return nil
 }

--- a/controllers/argocdagent/agent/servicemonitor.go
+++ b/controllers/argocdagent/agent/servicemonitor.go
@@ -1,0 +1,106 @@
+// Copyright 2026 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
+)
+
+func ReconcileAgentServiceMonitor(client client.Client, compName string, cr *argoproj.ArgoCD, scheme *runtime.Scheme, prometheusEnabled bool) error {
+	smName := generateAgentResourceName(cr.Name, compName) + "-metrics"
+
+	sm := &monitoringv1.ServiceMonitor{}
+	exists, err := argoutil.IsObjectFound(client, cr.Namespace, smName, sm)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if !prometheusEnabled || !hasAgent(cr) || !cr.Spec.ArgoCDAgent.Agent.IsEnabled() {
+			argoutil.LogResourceDeletion(log, sm, "agent ServiceMonitor is being deleted as agent or prometheus is disabled")
+			if err := client.Delete(context.TODO(), sm); err != nil {
+				return fmt.Errorf("failed to delete agent ServiceMonitor %s: %w", smName, err)
+			}
+			return nil
+		}
+
+		expected := buildAgentServiceMonitor(smName, compName, cr)
+		if !reflect.DeepEqual(sm.Spec.Endpoints, expected.Spec.Endpoints) ||
+			!reflect.DeepEqual(sm.Spec.Selector, expected.Spec.Selector) {
+
+			sm.Spec.Endpoints = expected.Spec.Endpoints
+			sm.Spec.Selector = expected.Spec.Selector
+
+			argoutil.LogResourceUpdate(log, sm, "updating agent ServiceMonitor spec")
+			if err := client.Update(context.TODO(), sm); err != nil {
+				return fmt.Errorf("failed to update agent ServiceMonitor %s: %v", smName, err)
+			}
+		}
+		return nil
+	}
+
+	if !prometheusEnabled || !hasAgent(cr) || !cr.Spec.ArgoCDAgent.Agent.IsEnabled() {
+		return nil // Prometheus not enabled or agent disabled, do nothing.
+	}
+
+	sm = buildAgentServiceMonitor(smName, compName, cr)
+
+	if err := controllerutil.SetControllerReference(cr, sm, scheme); err != nil {
+		return fmt.Errorf("failed to set ArgoCD CR %s as owner for ServiceMonitor %s: %w", cr.Name, smName, err)
+	}
+
+	argoutil.LogResourceCreation(log, sm)
+	if err := client.Create(context.TODO(), sm); err != nil {
+		return fmt.Errorf("failed to create agent ServiceMonitor %s: %v", smName, err)
+	}
+	return nil
+}
+
+func buildAgentServiceMonitor(name, compName string, cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
+	lbls := buildLabelsForAgent(cr.Name, compName)
+	lbls[common.ArgoCDKeyRelease] = "prometheus-operator"
+
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cr.Namespace,
+			Labels:    lbls,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					common.ArgoCDKeyName: generateAgentResourceName(cr.Name, compName),
+				},
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: AgentMetricsServicePortName,
+				},
+			},
+		},
+	}
+}

--- a/controllers/argocdagent/agent/servicemonitor_test.go
+++ b/controllers/argocdagent/agent/servicemonitor_test.go
@@ -1,0 +1,301 @@
+// Copyright 2026 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+)
+
+func makeTestReconcilerSchemeWithMonitoring() *runtime.Scheme {
+	s := scheme.Scheme
+	_ = argoproj.AddToScheme(s)
+	_ = monitoringv1.AddToScheme(s)
+	return s
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorDoesNotExist_PrometheusDisabled(t *testing.T) {
+	// Test case: ServiceMonitor doesn't exist, agent is enabled but prometheus is disabled
+	// Expected behavior: Should do nothing
+
+	cr := makeTestArgoCD(withAgentEnabled(true))
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, false)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorDoesNotExist_AgentDisabled(t *testing.T) {
+	// Test case: ServiceMonitor doesn't exist, prometheus is enabled but agent is disabled
+	// Expected behavior: Should do nothing
+
+	cr := makeTestArgoCD(withAgentEnabled(false))
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorDoesNotExist_AgentEnabled(t *testing.T) {
+	// Test case: ServiceMonitor doesn't exist, both agent and prometheus are enabled
+	// Expected behavior: Should create the ServiceMonitor with expected labels, selector, endpoints and owner reference
+
+	cr := makeTestArgoCD(withAgentEnabled(true))
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.NoError(t, err)
+
+	// Verify ServiceMonitor has expected metadata
+	expectedName := generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics"
+	assert.Equal(t, expectedName, sm.Name)
+	assert.Equal(t, cr.Namespace, sm.Namespace)
+
+	expectedLabels := buildLabelsForAgent(cr.Name, testAgentCompName)
+	expectedLabels[common.ArgoCDKeyRelease] = "prometheus-operator"
+	assert.Equal(t, expectedLabels, sm.Labels)
+
+	// Verify ServiceMonitor has expected spec
+	assert.Equal(t, AgentMetricsServicePortName, sm.Spec.Endpoints[0].Port)
+	assert.Equal(t, map[string]string{
+		common.ArgoCDKeyName: generateAgentResourceName(cr.Name, testAgentCompName),
+	}, sm.Spec.Selector.MatchLabels)
+
+	// Verify owner reference is set
+	assert.Len(t, sm.OwnerReferences, 1)
+	assert.Equal(t, cr.Name, sm.OwnerReferences[0].Name)
+	assert.Equal(t, "ArgoCD", sm.OwnerReferences[0].Kind)
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorExists_PrometheusDisabled(t *testing.T) {
+	// Test case: ServiceMonitor exists but prometheus is disabled
+	// Expected behavior: Should delete the ServiceMonitor
+
+	cr := makeTestArgoCD(withAgentEnabled(true))
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+			Namespace: cr.Namespace,
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, false)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorExists_AgentDisabled(t *testing.T) {
+	// Test case: ServiceMonitor exists but agent is disabled
+	// Expected behavior: Should delete the ServiceMonitor
+
+	cr := makeTestArgoCD(withAgentEnabled(false))
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+			Namespace: cr.Namespace,
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorExists_AgentEnabled(t *testing.T) {
+	// Test case: ServiceMonitor exists and both agent and prometheus are enabled
+	// Expected behavior: Should do nothing, keep existing ServiceMonitor
+
+	cr := makeTestArgoCD(withAgentEnabled(true))
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+			Namespace: cr.Namespace,
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.NoError(t, err)
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorExists_AgentEnabled_DifferentSpec(t *testing.T) {
+	// Test case: ServiceMonitor exists with different spec, both agent and prometheus are enabled
+	// Expected behavior: Should update the ServiceMonitor with expected spec
+
+	cr := makeTestArgoCD(withAgentEnabled(true))
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+			Namespace: cr.Namespace,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "wrong-selector",
+				},
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: "wrong-port",
+				},
+			},
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.NoError(t, err)
+
+	// Verify spec was updated to expected values
+	assert.Equal(t, AgentMetricsServicePortName, sm.Spec.Endpoints[0].Port)
+	assert.Equal(t, map[string]string{
+		common.ArgoCDKeyName: generateAgentResourceName(cr.Name, testAgentCompName),
+	}, sm.Spec.Selector.MatchLabels)
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorDoesNotExist_AgentNotSet(t *testing.T) {
+	// Test case: ServiceMonitor doesn't exist and agent spec is not set (nil)
+	// Expected behavior: Should do nothing
+
+	cr := makeTestArgoCD()
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcileAgentServiceMonitor_ServiceMonitorExists_AgentNotSet(t *testing.T) {
+	// Test case: ServiceMonitor exists but agent spec is not set (nil)
+	// Expected behavior: Should delete the ServiceMonitor
+
+	cr := makeTestArgoCD()
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+			Namespace: cr.Namespace,
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcileAgentServiceMonitor(cl, testAgentCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName) + "-metrics",
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}

--- a/controllers/argocdagent/servicemonitor.go
+++ b/controllers/argocdagent/servicemonitor.go
@@ -57,7 +57,7 @@ func ReconcilePrincipalServiceMonitor(client client.Client, compName string, cr 
 
 			argoutil.LogResourceUpdate(log, sm, "updating principal ServiceMonitor spec")
 			if err := client.Update(context.TODO(), sm); err != nil {
-				return fmt.Errorf("failed to update principal ServiceMonitor %s: %v", smName, err)
+				return fmt.Errorf("failed to update principal ServiceMonitor %s: %w", smName, err)
 			}
 		}
 		return nil
@@ -75,7 +75,7 @@ func ReconcilePrincipalServiceMonitor(client client.Client, compName string, cr 
 
 	argoutil.LogResourceCreation(log, sm)
 	if err := client.Create(context.TODO(), sm); err != nil {
-		return fmt.Errorf("failed to create principal ServiceMonitor %s: %v", smName, err)
+		return fmt.Errorf("failed to create principal ServiceMonitor %s: %w", smName, err)
 	}
 	return nil
 }

--- a/controllers/argocdagent/servicemonitor.go
+++ b/controllers/argocdagent/servicemonitor.go
@@ -1,0 +1,106 @@
+// Copyright 2026 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocdagent
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
+)
+
+func ReconcilePrincipalServiceMonitor(client client.Client, compName string, cr *argoproj.ArgoCD, scheme *runtime.Scheme, prometheusEnabled bool) error {
+	smName := generateAgentResourceName(cr.Name, compName+"-metrics")
+
+	sm := &monitoringv1.ServiceMonitor{}
+	exists, err := argoutil.IsObjectFound(client, cr.Namespace, smName, sm)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if !prometheusEnabled || !hasPrincipal(cr) || !cr.Spec.ArgoCDAgent.Principal.IsEnabled() {
+			argoutil.LogResourceDeletion(log, sm, "principal ServiceMonitor is being deleted as principal or prometheus is disabled")
+			if err := client.Delete(context.TODO(), sm); err != nil {
+				return fmt.Errorf("failed to delete principal ServiceMonitor %s: %w", smName, err)
+			}
+			return nil
+		}
+
+		expected := buildPrincipalServiceMonitor(smName, compName, cr)
+		if !reflect.DeepEqual(sm.Spec.Endpoints, expected.Spec.Endpoints) ||
+			!reflect.DeepEqual(sm.Spec.Selector, expected.Spec.Selector) {
+
+			sm.Spec.Endpoints = expected.Spec.Endpoints
+			sm.Spec.Selector = expected.Spec.Selector
+
+			argoutil.LogResourceUpdate(log, sm, "updating principal ServiceMonitor spec")
+			if err := client.Update(context.TODO(), sm); err != nil {
+				return fmt.Errorf("failed to update principal ServiceMonitor %s: %v", smName, err)
+			}
+		}
+		return nil
+	}
+
+	if !prometheusEnabled || !hasPrincipal(cr) || !cr.Spec.ArgoCDAgent.Principal.IsEnabled() {
+		return nil // Prometheus not enabled or principal disabled, do nothing.
+	}
+
+	sm = buildPrincipalServiceMonitor(smName, compName, cr)
+
+	if err := controllerutil.SetControllerReference(cr, sm, scheme); err != nil {
+		return fmt.Errorf("failed to set ArgoCD CR %s as owner for ServiceMonitor %s: %w", cr.Name, smName, err)
+	}
+
+	argoutil.LogResourceCreation(log, sm)
+	if err := client.Create(context.TODO(), sm); err != nil {
+		return fmt.Errorf("failed to create principal ServiceMonitor %s: %v", smName, err)
+	}
+	return nil
+}
+
+func buildPrincipalServiceMonitor(name, compName string, cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
+	lbls := buildLabelsForAgentPrincipal(cr.Name, compName)
+	lbls[common.ArgoCDKeyRelease] = "prometheus-operator"
+
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cr.Namespace,
+			Labels:    lbls,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					common.ArgoCDKeyName: generateAgentResourceName(cr.Name, compName),
+				},
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: PrincipalMetricsServicePortName,
+				},
+			},
+		},
+	}
+}

--- a/controllers/argocdagent/servicemonitor_test.go
+++ b/controllers/argocdagent/servicemonitor_test.go
@@ -1,0 +1,301 @@
+// Copyright 2026 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocdagent
+
+import (
+	"context"
+	"testing"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+)
+
+func makeTestReconcilerSchemeWithMonitoring() *runtime.Scheme {
+	s := scheme.Scheme
+	_ = argoproj.AddToScheme(s)
+	_ = monitoringv1.AddToScheme(s)
+	return s
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorDoesNotExist_PrometheusDisabled(t *testing.T) {
+	// Test case: ServiceMonitor doesn't exist, principal is enabled but prometheus is disabled
+	// Expected behavior: Should do nothing
+
+	cr := makeTestArgoCD(withPrincipalEnabled(true))
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, false)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorDoesNotExist_PrincipalDisabled(t *testing.T) {
+	// Test case: ServiceMonitor doesn't exist, prometheus is enabled but principal is disabled
+	// Expected behavior: Should do nothing
+
+	cr := makeTestArgoCD(withPrincipalEnabled(false))
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorDoesNotExist_PrincipalEnabled(t *testing.T) {
+	// Test case: ServiceMonitor doesn't exist, both principal and prometheus are enabled
+	// Expected behavior: Should create the ServiceMonitor with expected labels, selector, endpoints and owner reference
+
+	cr := makeTestArgoCD(withPrincipalEnabled(true))
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.NoError(t, err)
+
+	// Verify ServiceMonitor has expected metadata
+	expectedName := generateAgentResourceName(cr.Name, testCompName+"-metrics")
+	assert.Equal(t, expectedName, sm.Name)
+	assert.Equal(t, cr.Namespace, sm.Namespace)
+
+	expectedLabels := buildLabelsForAgentPrincipal(cr.Name, testCompName)
+	expectedLabels[common.ArgoCDKeyRelease] = "prometheus-operator"
+	assert.Equal(t, expectedLabels, sm.Labels)
+
+	// Verify ServiceMonitor has expected spec
+	assert.Equal(t, PrincipalMetricsServicePortName, sm.Spec.Endpoints[0].Port)
+	assert.Equal(t, map[string]string{
+		common.ArgoCDKeyName: generateAgentResourceName(cr.Name, testCompName),
+	}, sm.Spec.Selector.MatchLabels)
+
+	// Verify owner reference is set
+	assert.Len(t, sm.OwnerReferences, 1)
+	assert.Equal(t, cr.Name, sm.OwnerReferences[0].Name)
+	assert.Equal(t, "ArgoCD", sm.OwnerReferences[0].Kind)
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorExists_PrometheusDisabled(t *testing.T) {
+	// Test case: ServiceMonitor exists but prometheus is disabled
+	// Expected behavior: Should delete the ServiceMonitor
+
+	cr := makeTestArgoCD(withPrincipalEnabled(true))
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+			Namespace: cr.Namespace,
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, false)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorExists_PrincipalDisabled(t *testing.T) {
+	// Test case: ServiceMonitor exists but principal is disabled
+	// Expected behavior: Should delete the ServiceMonitor
+
+	cr := makeTestArgoCD(withPrincipalEnabled(false))
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+			Namespace: cr.Namespace,
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorExists_PrincipalEnabled(t *testing.T) {
+	// Test case: ServiceMonitor exists and both principal and prometheus are enabled
+	// Expected behavior: Should do nothing, keep existing ServiceMonitor
+
+	cr := makeTestArgoCD(withPrincipalEnabled(true))
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+			Namespace: cr.Namespace,
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.NoError(t, err)
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorExists_PrincipalEnabled_DifferentSpec(t *testing.T) {
+	// Test case: ServiceMonitor exists with different spec, both principal and prometheus are enabled
+	// Expected behavior: Should update the ServiceMonitor with expected spec
+
+	cr := makeTestArgoCD(withPrincipalEnabled(true))
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+			Namespace: cr.Namespace,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "wrong-selector",
+				},
+			},
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: "wrong-port",
+				},
+			},
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.NoError(t, err)
+
+	// Verify spec was updated to expected values
+	assert.Equal(t, PrincipalMetricsServicePortName, sm.Spec.Endpoints[0].Port)
+	assert.Equal(t, map[string]string{
+		common.ArgoCDKeyName: generateAgentResourceName(cr.Name, testCompName),
+	}, sm.Spec.Selector.MatchLabels)
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorDoesNotExist_PrincipalNotSet(t *testing.T) {
+	// Test case: ServiceMonitor doesn't exist and principal spec is not set (nil)
+	// Expected behavior: Should do nothing
+
+	cr := makeTestArgoCD()
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}
+
+func TestReconcilePrincipalServiceMonitor_ServiceMonitorExists_PrincipalNotSet(t *testing.T) {
+	// Test case: ServiceMonitor exists but principal spec is not set (nil)
+	// Expected behavior: Should delete the ServiceMonitor
+
+	cr := makeTestArgoCD()
+
+	existingSM := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+			Namespace: cr.Namespace,
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSM}
+	sch := makeTestReconcilerSchemeWithMonitoring()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	err := ReconcilePrincipalServiceMonitor(cl, testCompName, cr, sch, true)
+	assert.NoError(t, err)
+
+	sm := &monitoringv1.ServiceMonitor{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName+"-metrics"),
+		Namespace: cr.Namespace,
+	}, sm)
+	assert.True(t, errors.IsNotFound(err))
+}

--- a/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -904,6 +905,55 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			})
 
 			Eventually(principalNetworkPolicy).Should(k8sFixture.NotExistByName())
+		})
+
+		It("should create and delete principal ServiceMonitor based on prometheus enabled flag", func() {
+
+			By("Create ArgoCD instance with principal enabled and prometheus enabled")
+
+			argoCD.Spec.Prometheus.Enabled = true
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("Verify expected resources are created for principal pod")
+
+			verifyExpectedResourcesExist(ns)
+
+			By("Verify principal ServiceMonitor is created")
+
+			principalServiceMonitor := &monitoringv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-agent-principal-metrics", argoCDName),
+					Namespace: ns.Name,
+				},
+			}
+			Eventually(principalServiceMonitor, "2m", "2s").Should(k8sFixture.ExistByName())
+
+			By("Disable prometheus and verify ServiceMonitor is deleted")
+
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: argoCDName, Namespace: ns.Name}, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.Prometheus.Enabled = false
+			})
+
+			Eventually(principalServiceMonitor, "2m", "2s").Should(k8sFixture.NotExistByName())
+
+			By("Re-enable prometheus and verify ServiceMonitor is recreated")
+
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: argoCDName, Namespace: ns.Name}, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.Prometheus.Enabled = true
+			})
+
+			Eventually(principalServiceMonitor, "2m", "2s").Should(k8sFixture.ExistByName())
+
+			By("Disable principal and verify ServiceMonitor is deleted")
+
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: argoCDName, Namespace: ns.Name}, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.ArgoCDAgent.Principal.Enabled = ptr.To(false)
+			})
+
+			Eventually(principalServiceMonitor, "2m", "2s").Should(k8sFixture.NotExistByName())
 		})
 	})
 })

--- a/tests/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/tests/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -581,6 +582,55 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: argoCD.Name, Namespace: argoCD.Namespace}, argoCD)
 				return err != nil
 			}, "60s", "2s").Should(BeTrue(), "ArgoCD should be deleted")
+		})
+
+		It("should create and delete agent ServiceMonitor based on prometheus enabled flag", func() {
+
+			By("Create ArgoCD instance with agent enabled and prometheus enabled")
+
+			argoCD.Spec.Prometheus.Enabled = true
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("Verify expected resources are created for agent pod")
+
+			verifyExpectedResourcesExist(ns)
+
+			By("Verify agent ServiceMonitor is created")
+
+			agentServiceMonitor := &monitoringv1.ServiceMonitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-agent-agent-metrics", argoCDName),
+					Namespace: ns.Name,
+				},
+			}
+			Eventually(agentServiceMonitor, "2m", "2s").Should(k8sFixture.ExistByName())
+
+			By("Disable prometheus and verify ServiceMonitor is deleted")
+
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: argoCDName, Namespace: ns.Name}, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.Prometheus.Enabled = false
+			})
+
+			Eventually(agentServiceMonitor, "2m", "2s").Should(k8sFixture.NotExistByName())
+
+			By("Re-enable prometheus and verify ServiceMonitor is recreated")
+
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: argoCDName, Namespace: ns.Name}, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.Prometheus.Enabled = true
+			})
+
+			Eventually(agentServiceMonitor, "2m", "2s").Should(k8sFixture.ExistByName())
+
+			By("Disable agent and verify ServiceMonitor is deleted")
+
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: argoCDName, Namespace: ns.Name}, argoCD)).To(Succeed())
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.ArgoCDAgent.Agent.Enabled = ptr.To(false)
+			})
+
+			Eventually(agentServiceMonitor, "2m", "2s").Should(k8sFixture.NotExistByName())
 		})
 	})
 })


### PR DESCRIPTION
/kind enhancement

This PR is to add ServiceMonitor resource for agent and principal components.

Assisted by: Cursor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic creation, update and deletion of Prometheus ServiceMonitor resources for ArgoCD Agent and Principal metrics, conditional on Prometheus availability and agent/principal enablement.

* **Tests**
  * Added unit and end-to-end tests validating ServiceMonitor lifecycle, label/selector/endpoint correctness, and behavior across enable/disable and absent-spec scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-operator/pull/2182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->