### PR TITLE
Enforce tokenRef strict Restrictions for ApplicationSet Any-Namespace mode

### DIFF
--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -1069,8 +1069,9 @@ type ArgoCDSpec struct {
 	AggregatedClusterRoles bool `json:"aggregatedClusterRoles,omitempty"`
 
 	// CmdParams specifies command-line parameters for the Argo CD components.
-	// The only keys currently supported for this parameter are:
+	// Keys commonly used with this field include:
 	// - controller.resource.health.persist
+	// - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
 	CmdParams map[string]string `json:"cmdParams,omitempty"`
 
 	// ArgoCDAgent defines configurations for the ArgoCD Agent component.

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -1069,7 +1069,7 @@ type ArgoCDSpec struct {
 	AggregatedClusterRoles bool `json:"aggregatedClusterRoles,omitempty"`
 
 	// CmdParams specifies command-line parameters for the Argo CD components.
-	// Keys commonly used with this field include:
+	// The only keys currently supported for this parameter are:
 	// - controller.resource.health.persist
 	// - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
 	CmdParams map[string]string `json:"cmdParams,omitempty"`

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -12229,7 +12229,7 @@ spec:
                   type: string
                 description: |-
                   CmdParams specifies command-line parameters for the Argo CD components.
-                  Keys commonly used with this field include:
+                  The only keys currently supported for this parameter are:
                   - controller.resource.health.persist
                   - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
                 type: object

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -12229,8 +12229,9 @@ spec:
                   type: string
                 description: |-
                   CmdParams specifies command-line parameters for the Argo CD components.
-                  The only keys currently supported for this parameter are:
+                  Keys commonly used with this field include:
                   - controller.resource.health.persist
+                  - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
                 type: object
               configManagementPlugins:
                 description: 'Deprecated: ConfigManagementPlugins field is no longer

--- a/common/keys.go
+++ b/common/keys.go
@@ -262,6 +262,13 @@ const (
 	// ArgoCDKeyInstallationID is the configuration key for the installation ID.
 	ArgoCDKeyInstallationID = "installationID"
 
+	// ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey is the upstream argocd-cmd-params-cm key.
+	// consumed by ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE.
+	ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey = "applicationsetcontroller.enable.tokenref.strict.mode"
+
+	// ArgoCDApplicationSetControllerTokenRefStrictModeEnvName is the env variable to enable tokenRef strict mode in the ApplicationSet controller.
+	ArgoCDApplicationSetControllerTokenRefStrictModeEnvName = "ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE" // #nosec G101
+
 	// ArgoCDTrackedByOperatorLabel for resources tracked by the operator
 	ArgoCDTrackedByOperatorLabel = "operator.argoproj.io/tracked-by"
 

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -12218,7 +12218,7 @@ spec:
                   type: string
                 description: |-
                   CmdParams specifies command-line parameters for the Argo CD components.
-                  Keys commonly used with this field include:
+                  The only keys currently supported for this parameter are:
                   - controller.resource.health.persist
                   - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
                 type: object

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -12218,8 +12218,9 @@ spec:
                   type: string
                 description: |-
                   CmdParams specifies command-line parameters for the Argo CD components.
-                  The only keys currently supported for this parameter are:
+                  Keys commonly used with this field include:
                   - controller.resource.health.persist
+                  - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
                 type: object
               configManagementPlugins:
                 description: 'Deprecated: ConfigManagementPlugins field is no longer

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -79,9 +79,23 @@ func (r *ReconcileArgoCD) getArgoApplicationSetCommand(cr *argoproj.ArgoCD) ([]s
 
 	// Only allow applicationsets in any namespace for cluster-scoped clusters
 	if argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) {
-		appsetsSourceNamespaces, err := r.getAllowedApplicationSetSourceNamespaces(cr)
+
+		// appset source namespaces should be subset of apps source namespaces
+		appsetsSourceNamespacesExpanded, err := r.getApplicationSetSourceNamespaces(cr)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get ApplicationSet source namespaces: %w", err)
+		}
+		appsNamespaces, err := r.getSourceNamespaces(cr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get apps source namespaces: %w", err)
+		}
+		appsetsSourceNamespaces := []string{}
+		for _, ns := range appsetsSourceNamespacesExpanded {
+			if contains(appsNamespaces, ns) {
+				appsetsSourceNamespaces = append(appsetsSourceNamespaces, ns)
+			} else {
+				log.V(1).Info(fmt.Sprintf("Apps in target sourceNamespace %s is not enabled, thus skipping the namespace in deployment command.", ns))
+			}
 		}
 		if len(appsetsSourceNamespaces) > 0 {
 			cmd = append(cmd, "--applicationset-namespaces", fmt.Sprint(strings.Join(appsetsSourceNamespaces, ",")))
@@ -104,28 +118,6 @@ func (r *ReconcileArgoCD) getArgoApplicationSetCommand(cr *argoproj.ArgoCD) ([]s
 	cmd = appendUniqueArgs(cmd, extraArgs)
 
 	return cmd, nil
-}
-
-// getAllowedApplicationSetSourceNamespaces returns the effective ApplicationSet source namespaces:
-// expanded from .spec.applicationSet.sourceNamespaces and filtered to namespaces allowed by .spec.sourceNamespaces
-func (r *ReconcileArgoCD) getAllowedApplicationSetSourceNamespaces(cr *argoproj.ArgoCD) ([]string, error) {
-	appsetsSourceNamespacesExpanded, err := r.getApplicationSetSourceNamespaces(cr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ApplicationSet source namespaces: %w", err)
-	}
-	appsNamespaces, err := r.getSourceNamespaces(cr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get apps source namespaces: %w", err)
-	}
-	appsetsSourceNamespaces := []string{}
-	for _, ns := range appsetsSourceNamespacesExpanded {
-		if contains(appsNamespaces, ns) {
-			appsetsSourceNamespaces = append(appsetsSourceNamespaces, ns)
-		} else {
-			log.V(1).Info(fmt.Sprintf("sourceNamespace %s is not allowed by Argo CD apps-in-any-namespace configuration, thus skipping it.", ns))
-		}
-	}
-	return appsetsSourceNamespaces, nil
 }
 
 func (r *ReconcileArgoCD) reconcileApplicationSetController(cr *argoproj.ArgoCD) error {
@@ -764,14 +756,26 @@ func (r *ReconcileArgoCD) reconcileApplicationSetSourceNamespacesResources(cr *a
 		return nil
 	}
 
-	// create resources only for appset namespaces that are also allowed by apps-in-any-ns.
-	appsetsSourceNamespaces, err := r.getAllowedApplicationSetSourceNamespaces(cr)
+	// create resources for each appset source namespace
+	appsetsSourceNamespacesExpanded, err := r.getApplicationSetSourceNamespaces(cr)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed getting ApplicationSet source namespaces: %w", err)
 	}
 
-	// create resources for each allowed source namespace
-	for _, sourceNamespace := range appsetsSourceNamespaces {
+	// source ns should be part of app-in-any-ns
+	appsNamespaces, err := r.getSourceNamespaces(cr)
+	if err != nil {
+		return fmt.Errorf("failed to get apps source namespaces: %w", err)
+	}
+
+	// create resources for each appset source namespace (after wildcard expansion)
+	for _, sourceNamespace := range appsetsSourceNamespacesExpanded {
+		// Only process namespaces that are also in apps source namespaces
+		if !contains(appsNamespaces, sourceNamespace) {
+			log.Info(fmt.Sprintf("skipping reconciliation of resources for sourceNamespace %s as Apps in target sourceNamespace is not enabled", sourceNamespace))
+			continue
+		}
+
 		// skip source ns if doesn't exist
 		namespace := &corev1.Namespace{}
 		if err := r.Get(context.TODO(), types.NamespacedName{Name: sourceNamespace}, namespace); err != nil {

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -79,23 +79,9 @@ func (r *ReconcileArgoCD) getArgoApplicationSetCommand(cr *argoproj.ArgoCD) ([]s
 
 	// Only allow applicationsets in any namespace for cluster-scoped clusters
 	if argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) {
-
-		// appset source namespaces should be subset of apps source namespaces
-		appsetsSourceNamespacesExpanded, err := r.getApplicationSetSourceNamespaces(cr)
+		appsetsSourceNamespaces, err := r.getAllowedApplicationSetSourceNamespaces(cr)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get ApplicationSet source namespaces: %w", err)
-		}
-		appsNamespaces, err := r.getSourceNamespaces(cr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get apps source namespaces: %w", err)
-		}
-		appsetsSourceNamespaces := []string{}
-		for _, ns := range appsetsSourceNamespacesExpanded {
-			if contains(appsNamespaces, ns) {
-				appsetsSourceNamespaces = append(appsetsSourceNamespaces, ns)
-			} else {
-				log.V(1).Info(fmt.Sprintf("Apps in target sourceNamespace %s is not enabled, thus skipping the namespace in deployment command.", ns))
-			}
+			return nil, err
 		}
 		if len(appsetsSourceNamespaces) > 0 {
 			cmd = append(cmd, "--applicationset-namespaces", fmt.Sprint(strings.Join(appsetsSourceNamespaces, ",")))
@@ -118,6 +104,28 @@ func (r *ReconcileArgoCD) getArgoApplicationSetCommand(cr *argoproj.ArgoCD) ([]s
 	cmd = appendUniqueArgs(cmd, extraArgs)
 
 	return cmd, nil
+}
+
+// getAllowedApplicationSetSourceNamespaces returns the effective ApplicationSet source namespaces:
+// expanded from .spec.applicationSet.sourceNamespaces and filtered to namespaces allowed by .spec.sourceNamespaces
+func (r *ReconcileArgoCD) getAllowedApplicationSetSourceNamespaces(cr *argoproj.ArgoCD) ([]string, error) {
+	appsetsSourceNamespacesExpanded, err := r.getApplicationSetSourceNamespaces(cr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ApplicationSet source namespaces: %w", err)
+	}
+	appsNamespaces, err := r.getSourceNamespaces(cr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get apps source namespaces: %w", err)
+	}
+	appsetsSourceNamespaces := []string{}
+	for _, ns := range appsetsSourceNamespacesExpanded {
+		if contains(appsNamespaces, ns) {
+			appsetsSourceNamespaces = append(appsetsSourceNamespaces, ns)
+		} else {
+			log.V(1).Info(fmt.Sprintf("sourceNamespace %s is not allowed by Argo CD apps-in-any-namespace configuration, thus skipping it.", ns))
+		}
+	}
+	return appsetsSourceNamespaces, nil
 }
 
 func (r *ReconcileArgoCD) reconcileApplicationSetController(cr *argoproj.ArgoCD) error {
@@ -388,14 +396,28 @@ func identifyDeploymentDifference(x appsv1.Deployment, y appsv1.Deployment) stri
 
 func (r *ReconcileArgoCD) applicationSetContainer(cr *argoproj.ArgoCD, addSCMGitlabVolumeMount bool) (corev1.Container, error) {
 	// Global proxy env vars go first
-	appSetEnv := []corev1.EnvVar{{
-		Name: "NAMESPACE",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "metadata.namespace",
+	appSetEnv := []corev1.EnvVar{
+		{
+			Name: "NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
 			},
 		},
-	}}
+		{
+			Name: common.ArgoCDApplicationSetControllerTokenRefStrictModeEnvName,
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: common.ArgoCDCmdParamsConfigMapName,
+					},
+					Key:      common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey,
+					Optional: boolPtr(true),
+				},
+			},
+		},
+	}
 
 	// Merge ApplicationSet env vars provided by the user
 	// User should be able to override the default NAMESPACE environmental variable
@@ -742,26 +764,14 @@ func (r *ReconcileArgoCD) reconcileApplicationSetSourceNamespacesResources(cr *a
 		return nil
 	}
 
-	// create resources for each appset source namespace
-	appsetsSourceNamespacesExpanded, err := r.getApplicationSetSourceNamespaces(cr)
+	// create resources only for appset namespaces that are also allowed by apps-in-any-ns.
+	appsetsSourceNamespaces, err := r.getAllowedApplicationSetSourceNamespaces(cr)
 	if err != nil {
-		return fmt.Errorf("failed getting ApplicationSet source namespaces: %w", err)
+		return err
 	}
 
-	// source ns should be part of app-in-any-ns
-	appsNamespaces, err := r.getSourceNamespaces(cr)
-	if err != nil {
-		return fmt.Errorf("failed to get apps source namespaces: %w", err)
-	}
-
-	// create resources for each appset source namespace (after wildcard expansion)
-	for _, sourceNamespace := range appsetsSourceNamespacesExpanded {
-		// Only process namespaces that are also in apps source namespaces
-		if !contains(appsNamespaces, sourceNamespace) {
-			log.Info(fmt.Sprintf("skipping reconciliation of resources for sourceNamespace %s as Apps in target sourceNamespace is not enabled", sourceNamespace))
-			continue
-		}
-
+	// create resources for each allowed source namespace
+	for _, sourceNamespace := range appsetsSourceNamespaces {
 		// skip source ns if doesn't exist
 		namespace := &corev1.Namespace{}
 		if err := r.Get(context.TODO(), types.NamespacedName{Name: sourceNamespace}, namespace); err != nil {

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -279,6 +279,18 @@ func TestReconcileApplicationSetProxyConfiguration(t *testing.T) {
 
 	want := []v1.EnvVar{
 		{
+			Name: common.ArgoCDApplicationSetControllerTokenRefStrictModeEnvName,
+			ValueFrom: &v1.EnvVarSource{
+				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: common.ArgoCDCmdParamsConfigMapName,
+					},
+					Key:      common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey,
+					Optional: boolPtr(true),
+				},
+			},
+		},
+		{
 			Name:  "HTTPS_PROXY",
 			Value: "https://example.com",
 		},
@@ -1250,6 +1262,18 @@ func TestArgoCDApplicationSetEnv(t *testing.T) {
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 	defaultEnv := []v1.EnvVar{
+		{
+			Name: common.ArgoCDApplicationSetControllerTokenRefStrictModeEnvName,
+			ValueFrom: &v1.EnvVarSource{
+				ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: common.ArgoCDCmdParamsConfigMapName,
+					},
+					Key:      common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey,
+					Optional: boolPtr(true),
+				},
+			},
+		},
 		{
 			Name: "NAMESPACE",
 			ValueFrom: &v1.EnvVarSource{

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -975,17 +975,17 @@ func (r *ReconcileArgoCD) reconcileArgoCmdParamsConfigMap(cr *argoproj.ArgoCD) e
 	tokenRefStrictModeValue, hasExplicitTokenRefStrictMode := getTokenRefStrictModeCmdParamValue(cr.Spec.CmdParams)
 	if hasExplicitTokenRefStrictMode {
 		cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = tokenRefStrictModeValue
-	}
-
-	// When applicationSet-in-any-namespace is effectively enabled, default tokenRef strict mode so only
-	// Secrets labeled as SCM credentials can be used with tokenRef
-	if argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) && cr.Spec.ApplicationSet != nil {
-		allowedAppSetNS, err := r.getAllowedApplicationSetSourceNamespaces(cr)
-		if err != nil {
-			return err
-		}
-		if len(allowedAppSetNS) > 0 && !hasExplicitTokenRefStrictMode {
-			cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "true"
+	} else {
+		// When applicationSet-in-any-namespace is effectively enabled, default tokenRef strict mode so only
+		// Secrets labeled as SCM credentials can be used with tokenRef
+		if argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) && cr.Spec.ApplicationSet != nil {
+			allowedAppSetNS, err := r.getAllowedApplicationSetSourceNamespaces(cr)
+			if err != nil {
+				return err
+			}
+			if len(allowedAppSetNS) > 0 {
+				cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "true"
+			}
 		}
 	}
 

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -970,6 +970,25 @@ func (r *ReconcileArgoCD) reconcileArgoCmdParamsConfigMap(cr *argoproj.ArgoCD) e
 	const healthPersistKey = "controller.resource.health.persist"
 	cm.Data[healthPersistKey] = "true"
 
+	// TokenRef strict mode uses the upstream argocd-cmd-params-cm key consumed by
+	// ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE.
+	tokenRefStrictModeValue, hasExplicitTokenRefStrictMode := getTokenRefStrictModeCmdParamValue(cr.Spec.CmdParams)
+	if hasExplicitTokenRefStrictMode {
+		cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = tokenRefStrictModeValue
+	}
+
+	// When applicationSet-in-any-namespace is effectively enabled, default tokenRef strict mode so only
+	// Secrets labeled as SCM credentials can be used with tokenRef
+	if argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) && cr.Spec.ApplicationSet != nil {
+		allowedAppSetNS, err := r.getAllowedApplicationSetSourceNamespaces(cr)
+		if err != nil {
+			return err
+		}
+		if len(allowedAppSetNS) > 0 && !hasExplicitTokenRefStrictMode {
+			cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "true"
+		}
+	}
+
 	// Copy user-specified command parameters if any
 	if len(cr.Spec.CmdParams) > 0 {
 		for k, v := range cr.Spec.CmdParams {
@@ -1016,6 +1035,14 @@ func (r *ReconcileArgoCD) reconcileArgoCmdParamsConfigMap(cr *argoproj.ArgoCD) e
 	}
 	argoutil.LogResourceCreation(log, cm)
 	return r.Create(context.TODO(), cm)
+}
+
+func getTokenRefStrictModeCmdParamValue(cmdParams map[string]string) (string, bool) {
+	if len(cmdParams) == 0 {
+		return "", false
+	}
+	val, ok := cmdParams[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey]
+	return val, ok
 }
 
 type filteredResource struct {

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -970,23 +970,21 @@ func (r *ReconcileArgoCD) reconcileArgoCmdParamsConfigMap(cr *argoproj.ArgoCD) e
 	const healthPersistKey = "controller.resource.health.persist"
 	cm.Data[healthPersistKey] = "true"
 
+	// When applicationSet-in-any-namespace is enabled, default tokenRef strict mode so only
+	// Secrets labeled as SCM credentials can be used with tokenRef
+	appsetsSourceNamespaces, err := r.getApplicationSetSourceNamespaces(cr)
+	if err != nil {
+		return err
+	}
+	cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "false"
+	if len(appsetsSourceNamespaces) > 0 {
+		cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "true"
+	}
 	// TokenRef strict mode uses the upstream argocd-cmd-params-cm key consumed by
 	// ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE.
 	tokenRefStrictModeValue, hasExplicitTokenRefStrictMode := getTokenRefStrictModeCmdParamValue(cr.Spec.CmdParams)
 	if hasExplicitTokenRefStrictMode {
 		cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = tokenRefStrictModeValue
-	} else {
-		// When applicationSet-in-any-namespace is effectively enabled, default tokenRef strict mode so only
-		// Secrets labeled as SCM credentials can be used with tokenRef
-		if argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) && cr.Spec.ApplicationSet != nil {
-			allowedAppSetNS, err := r.getAllowedApplicationSetSourceNamespaces(cr)
-			if err != nil {
-				return err
-			}
-			if len(allowedAppSetNS) > 0 {
-				cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "true"
-			}
-		}
 	}
 
 	// Copy user-specified command parameters if any

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -1866,3 +1866,117 @@ func TestReconcileArgoCD_reconcileArgoCmdParamsConfigMap(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileArgoCD_reconcileArgoCmdParamsConfigMap_tokenRefStrictDefault(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	key := common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey
+
+	tests := []struct {
+		name              string
+		clusterScoped     bool
+		applicationSet    *argoproj.ArgoCDApplicationSet
+		sourceNamespaces  []string
+		extraNamespaces   []client.Object
+		cmdParams         map[string]string
+		expectStrictValue string
+	}{
+		{
+			name:          "namespace-scoped instance does not default tokenRef strict mode",
+			clusterScoped: false,
+			applicationSet: &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{"foo"},
+			},
+			sourceNamespaces: []string{"foo"},
+			extraNamespaces: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			},
+			cmdParams:         nil,
+			expectStrictValue: "",
+		},
+		{
+			name:          "cluster-scoped with reconciled appset namespaces defaults strict mode",
+			clusterScoped: true,
+			applicationSet: &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{"foo"},
+			},
+			sourceNamespaces: []string{"foo"},
+			extraNamespaces: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			},
+			cmdParams:         nil,
+			expectStrictValue: "true",
+		},
+		{
+			name:          "cluster-scoped with empty intersection does not default",
+			clusterScoped: true,
+			applicationSet: &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{"foo"},
+				SCMProviders:     []string{"github.com"},
+			},
+			sourceNamespaces: []string{},
+			extraNamespaces: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			},
+			cmdParams:         nil,
+			expectStrictValue: "",
+		},
+		{
+			name:          "user cmdParams sets tokenRef strict mode explicitly",
+			clusterScoped: true,
+			applicationSet: &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{"foo"},
+			},
+			sourceNamespaces: []string{"foo"},
+			extraNamespaces: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			},
+			cmdParams: map[string]string{
+				key: "false",
+			},
+			expectStrictValue: "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.clusterScoped {
+				t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", testNamespace)
+			} else {
+				t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
+			}
+
+			a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+				ac.Spec.ApplicationSet = tt.applicationSet
+				ac.Spec.SourceNamespaces = tt.sourceNamespaces
+				ac.Spec.CmdParams = tt.cmdParams
+			})
+
+			resObjs := []client.Object{a}
+			resObjs = append(resObjs, tt.extraNamespaces...)
+			subresObjs := []client.Object{a}
+			runtimeObjs := []runtime.Object{}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+			err := r.reconcileArgoCmdParamsConfigMap(a)
+			assert.NoError(t, err)
+
+			cm := &corev1.ConfigMap{}
+			err = r.Get(context.TODO(), types.NamespacedName{
+				Name:      common.ArgoCDCmdParamsConfigMapName,
+				Namespace: testNamespace,
+			}, cm)
+			assert.NoError(t, err)
+
+			val, exists := cm.Data[key]
+			if tt.expectStrictValue == "" {
+				assert.False(t, exists, "expected tokenRef strict key absent")
+			} else {
+				assert.True(t, exists)
+				assert.Equal(t, tt.expectStrictValue, val)
+			}
+		})
+	}
+}

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -1874,60 +1874,62 @@ func TestReconcileArgoCD_reconcileArgoCmdParamsConfigMap_tokenRefStrictDefault(t
 
 	tests := []struct {
 		name              string
-		clusterScoped     bool
 		applicationSet    *argoproj.ArgoCDApplicationSet
-		sourceNamespaces  []string
 		extraNamespaces   []client.Object
 		cmdParams         map[string]string
 		expectStrictValue string
 	}{
 		{
-			name:          "namespace-scoped instance does not default tokenRef strict mode",
-			clusterScoped: false,
+			name: "defaults to true when applicationSet source namespace matches a cluster namespace",
 			applicationSet: &argoproj.ArgoCDApplicationSet{
 				SourceNamespaces: []string{"foo"},
 			},
-			sourceNamespaces: []string{"foo"},
 			extraNamespaces: []client.Object{
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			},
-			cmdParams:         nil,
-			expectStrictValue: "",
-		},
-		{
-			name:          "cluster-scoped with reconciled appset namespaces defaults strict mode",
-			clusterScoped: true,
-			applicationSet: &argoproj.ArgoCDApplicationSet{
-				SourceNamespaces: []string{"foo"},
-			},
-			sourceNamespaces: []string{"foo"},
-			extraNamespaces: []client.Object{
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
-			},
-			cmdParams:         nil,
 			expectStrictValue: "true",
 		},
 		{
-			name:          "cluster-scoped with empty intersection does not default",
-			clusterScoped: true,
+			name: "defaults to true when applicationSet source namespace pattern matches a cluster namespace",
 			applicationSet: &argoproj.ArgoCDApplicationSet{
-				SourceNamespaces: []string{"foo"},
-				SCMProviders:     []string{"github.com"},
+				SourceNamespaces: []string{"team-*"},
 			},
-			sourceNamespaces: []string{},
+			extraNamespaces: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
+			},
+			expectStrictValue: "true",
+		},
+		{
+			name: "defaults to false when applicationSet sourceNamespaces is empty",
+			applicationSet: &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{},
+			},
 			extraNamespaces: []client.Object{
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			},
-			cmdParams:         nil,
-			expectStrictValue: "",
+			expectStrictValue: "false",
 		},
 		{
-			name:          "user cmdParams sets tokenRef strict mode explicitly",
-			clusterScoped: true,
+			name:              "defaults to false when applicationSet is nil",
+			applicationSet:    nil,
+			extraNamespaces:   []client.Object{},
+			expectStrictValue: "false",
+		},
+		{
+			name: "defaults to false when applicationSet sourceNamespaces match no cluster namespace",
+			applicationSet: &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{"bar"},
+			},
+			extraNamespaces: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			},
+			expectStrictValue: "false",
+		},
+		{
+			name: "spec.cmdParams false opts out when source namespaces would default to true",
 			applicationSet: &argoproj.ArgoCDApplicationSet{
 				SourceNamespaces: []string{"foo"},
 			},
-			sourceNamespaces: []string{"foo"},
 			extraNamespaces: []client.Object{
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			},
@@ -1936,19 +1938,25 @@ func TestReconcileArgoCD_reconcileArgoCmdParamsConfigMap_tokenRefStrictDefault(t
 			},
 			expectStrictValue: "false",
 		},
+		{
+			name: "spec.cmdParams true overrides when applicationSet sourceNamespaces are empty",
+			applicationSet: &argoproj.ArgoCDApplicationSet{
+				SourceNamespaces: []string{},
+			},
+			extraNamespaces: []client.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			},
+			cmdParams: map[string]string{
+				key: "true",
+			},
+			expectStrictValue: "true",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.clusterScoped {
-				t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", testNamespace)
-			} else {
-				t.Setenv("ARGOCD_CLUSTER_CONFIG_NAMESPACES", "")
-			}
-
 			a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
 				ac.Spec.ApplicationSet = tt.applicationSet
-				ac.Spec.SourceNamespaces = tt.sourceNamespaces
 				ac.Spec.CmdParams = tt.cmdParams
 			})
 
@@ -1971,12 +1979,8 @@ func TestReconcileArgoCD_reconcileArgoCmdParamsConfigMap_tokenRefStrictDefault(t
 			assert.NoError(t, err)
 
 			val, exists := cm.Data[key]
-			if tt.expectStrictValue == "" {
-				assert.False(t, exists, "expected tokenRef strict key absent")
-			} else {
-				assert.True(t, exists)
-				assert.Equal(t, tt.expectStrictValue, val)
-			}
+			assert.True(t, exists, "expected tokenRef strict mode key in argocd-cmd-params-cm")
+			assert.Equal(t, tt.expectStrictValue, val)
 		})
 	}
 }

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
@@ -12229,7 +12229,7 @@ spec:
                   type: string
                 description: |-
                   CmdParams specifies command-line parameters for the Argo CD components.
-                  Keys commonly used with this field include:
+                  The only keys currently supported for this parameter are:
                   - controller.resource.health.persist
                   - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
                 type: object

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
@@ -12229,8 +12229,9 @@ spec:
                   type: string
                 description: |-
                   CmdParams specifies command-line parameters for the Argo CD components.
-                  The only keys currently supported for this parameter are:
+                  Keys commonly used with this field include:
                   - controller.resource.health.persist
+                  - applicationsetcontroller.enable.tokenref.strict.mode — when ApplicationSet-in-any-namespace is active, the operator defaults this to "true"
                 type: object
               configManagementPlugins:
                 description: 'Deprecated: ConfigManagementPlugins field is no longer

--- a/tests/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/tests/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -1327,39 +1327,115 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(appset).Should(k8sFixture.NotExistByName())
 		})
 
-		It("with ApplicationSet-in-any-namespace, enables tokenRef strict mode in cmd-params and corrects drift", func() {
-			By("creating namespaces appset-argocd and appset-target-ns")
+		It("defaults tokenRef strict mode to true when applicationSet sourceNamespaces are configured", func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 
 			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 
-			By("creating Argo CD with apps and appset source namespaces configured")
 			argoCD := &v1beta1.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tokenref-default-example",
+					Name:      "tokenref-strict-true",
 					Namespace: appsetArgocdNS.Name,
 				},
 				Spec: v1beta1.ArgoCDSpec{
-					SourceNamespaces: []string{
-						targetNS.Name,
-					},
 					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
-						SourceNamespaces: []string{
-							targetNS.Name,
-						},
-						SCMProviders: []string{
-							"github.com",
-						},
+						SourceNamespaces: []string{targetNS.Name},
 					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
-			Eventually(argoCD).Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
 
-			By("verifying cmd params configmap defaults tokenRef strict mode to true")
+			cmdParamsCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDCmdParamsConfigMapName,
+					Namespace: argoCD.Namespace,
+				},
+			}
+			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
+		})
+
+		It("defaults tokenRef strict mode to false when applicationSet sourceNamespaces are empty or removed", func() {
+			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			cmdParamsCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDCmdParamsConfigMapName,
+					Namespace: appsetArgocdNS.Name,
+				},
+			}
+
+			By("empty applicationSet.sourceNamespaces on create")
+			argoCDEmpty := &v1beta1.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tokenref-strict-false-empty",
+					Namespace: appsetArgocdNS.Name,
+				},
+				Spec: v1beta1.ArgoCDSpec{
+					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
+						SourceNamespaces: []string{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCDEmpty)).To(Succeed())
+			Eventually(argoCDEmpty, "5m", "5s").Should(argocdFixture.BeAvailable())
+			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+
+			By("removing applicationSet.sourceNamespaces after they were configured")
+			argoCDRemove := &v1beta1.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tokenref-strict-false-removed",
+					Namespace: appsetArgocdNS.Name,
+				},
+				Spec: v1beta1.ArgoCDSpec{
+					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
+						SourceNamespaces: []string{targetNS.Name},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCDRemove)).To(Succeed())
+			Eventually(argoCDRemove, "5m", "5s").Should(argocdFixture.BeAvailable())
+			cmdParamsCMRemove := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDCmdParamsConfigMapName,
+					Namespace: argoCDRemove.Namespace,
+				},
+			}
+			Eventually(cmdParamsCMRemove).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
+
+			argocdFixture.Update(argoCDRemove, func(ac *v1beta1.ArgoCD) {
+				ac.Spec.ApplicationSet.SourceNamespaces = []string{}
+			})
+			Eventually(cmdParamsCMRemove, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+		})
+
+		It("reconciles tokenRef strict mode cmd-params drift when applicationSet sourceNamespaces remain configured", func() {
+			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			argoCD := &v1beta1.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tokenref-strict-drift",
+					Namespace: appsetArgocdNS.Name,
+				},
+				Spec: v1beta1.ArgoCDSpec{
+					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
+						SourceNamespaces: []string{targetNS.Name},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
 			cmdParamsCM := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDCmdParamsConfigMapName,
@@ -1368,53 +1444,22 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
 
-			By("verifying appset deployment consumes strict mode from cmd params configmap")
-			appsetDeployment := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tokenref-default-example-applicationset-controller",
-					Namespace: argoCD.Namespace,
-				},
-			}
-			Eventually(appsetDeployment).Should(k8sFixture.ExistByName())
-			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(appsetDeployment), appsetDeployment); err != nil {
-					GinkgoWriter.Println(err)
-					return false
-				}
-				if len(appsetDeployment.Spec.Template.Spec.Containers) == 0 {
-					return false
-				}
-				for _, env := range appsetDeployment.Spec.Template.Spec.Containers[0].Env {
-					if env.Name != common.ArgoCDApplicationSetControllerTokenRefStrictModeEnvName {
-						continue
-					}
-					if env.ValueFrom == nil || env.ValueFrom.ConfigMapKeyRef == nil {
-						return false
-					}
-					return env.ValueFrom.ConfigMapKeyRef.Name == common.ArgoCDCmdParamsConfigMapName &&
-						env.ValueFrom.ConfigMapKeyRef.Key == common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey
-				}
-				return false
-			}).Should(BeTrue())
-			By("ApplicationSet controller reads strict mode from argocd-cmd-params-cm via ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE")
-
 			configmapFixture.Update(cmdParamsCM, func(cm *corev1.ConfigMap) {
 				cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "false"
 			})
 			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
 
-			By("triggering reconcile by updating ArgoCD and verifying operator overwrites key back to true")
+			By("triggering reconciliation via ArgoCD metadata change")
 			argocdFixture.Update(argoCD, func(ac *v1beta1.ArgoCD) {
-				if ac.Spec.ApplicationSet.Annotations == nil {
-					ac.Spec.ApplicationSet.Annotations = map[string]string{}
+				if ac.Annotations == nil {
+					ac.Annotations = map[string]string{}
 				}
-				ac.Spec.ApplicationSet.Annotations["e2e.argocd-operator/tokenref-strict-drift"] = "true"
+				ac.Annotations["argocds.argoproj.io/e2e-reconcile-touch"] = "1"
 			})
-			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
 		})
 
-		It("spec.cmdParams opts out of default tokenRef strict mode when ApplicationSet-in-any-namespace is active", func() {
-			By("opt-out via spec.cmdParams.applicationsetcontroller.enable.tokenref.strict.mode=false is not overwritten")
+		It("spec.cmdParams overrides tokenRef strict mode default", func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 
@@ -1423,14 +1468,12 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			argoCD := &v1beta1.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tokenref-optout-example",
+					Name:      "tokenref-strict-optout",
 					Namespace: appsetArgocdNS.Name,
 				},
 				Spec: v1beta1.ArgoCDSpec{
-					SourceNamespaces: []string{targetNS.Name},
 					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
 						SourceNamespaces: []string{targetNS.Name},
-						SCMProviders:     []string{"github.com"},
 					},
 					CmdParams: map[string]string{
 						common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey: "false",
@@ -1439,7 +1482,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
-			Eventually(argoCD).Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
 
 			cmdParamsCM := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1449,202 +1491,14 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}
 			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
 
-			By("triggering reconcile and verifying opt-out persists")
+			By("triggering reconcile by updating ArgoCD spec.cmdParams and verifying opt-out persists")
 			argocdFixture.Update(argoCD, func(ac *v1beta1.ArgoCD) {
-				if ac.Spec.ApplicationSet.Annotations == nil {
-					ac.Spec.ApplicationSet.Annotations = map[string]string{}
+				if ac.Spec.CmdParams == nil {
+					ac.Spec.CmdParams = map[string]string{}
 				}
-				ac.Spec.ApplicationSet.Annotations["e2e.argocd-operator/tokenref-strict-optout"] = "true"
+				ac.Spec.CmdParams[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "false"
 			})
 			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
-		})
-
-		It("with tokenRef strict mode enabled SCM tokenRef rejects secrets without scm-creds label", func() {
-			By("Argo CD enforces scm-creds on tokenRef when strict mode is on ")
-			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
-			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
-
-			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
-			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
-
-			fakeSCMURL := fmt.Sprintf("http://fake-scm.%s.svc.cluster.local", targetNS.Name)
-			By("deploying in-cluster HTTP server as a stand-in SCM endpoint")
-			oneReplica := int32(1)
-			fakeSCMDepl := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fake-scm",
-					Namespace: targetNS.Name,
-				},
-				Spec: appsv1.DeploymentSpec{
-					Replicas: &oneReplica,
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"app": "fake-scm"},
-					},
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{"app": "fake-scm"},
-						},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Name:  "fake-scm",
-								Image: "nginx:latest",
-								Ports: []corev1.ContainerPort{{ContainerPort: 80}},
-							}},
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, fakeSCMDepl)).To(Succeed())
-			fakeSCMSvc := &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "fake-scm",
-					Namespace: targetNS.Name,
-				},
-				Spec: corev1.ServiceSpec{
-					Selector: map[string]string{"app": "fake-scm"},
-					Ports:    []corev1.ServicePort{{Port: 80}},
-				},
-			}
-			Expect(k8sClient.Create(ctx, fakeSCMSvc)).To(Succeed())
-			Eventually(fakeSCMDepl, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
-
-			argoCD := &v1beta1.ArgoCD{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tokenref-scm-strict-example",
-					Namespace: appsetArgocdNS.Name,
-				},
-				Spec: v1beta1.ArgoCDSpec{
-					SourceNamespaces: []string{targetNS.Name},
-					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
-						SourceNamespaces: []string{targetNS.Name},
-						SCMProviders:     []string{fakeSCMURL},
-					},
-					CmdParams: map[string]string{
-						common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey: "true",
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
-			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
-			Eventually(argoCD).Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
-
-			tokenSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "platform-scm-token",
-					Namespace: targetNS.Name,
-				},
-				StringData: map[string]string{"token": "e2e-test-token"},
-			}
-			Expect(k8sClient.Create(ctx, tokenSecret)).To(Succeed())
-
-			const scmStrictAppSetName = "tokenref-scm-strict-appset"
-			appSet := &appv1alpha1.ApplicationSet{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: appv1alpha1.SchemeGroupVersion.String(),
-					Kind:       appv1alpha1.ApplicationSetSchemaGroupVersionKind.Kind,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      scmStrictAppSetName,
-					Namespace: targetNS.Name,
-				},
-				Spec: appv1alpha1.ApplicationSetSpec{
-					Generators: []appv1alpha1.ApplicationSetGenerator{
-						{
-							SCMProvider: &appv1alpha1.SCMProviderGenerator{
-								Gitlab: &appv1alpha1.SCMProviderGeneratorGitlab{
-									API:      fakeSCMURL,
-									Group:    "demo",
-									Insecure: true,
-									TokenRef: &appv1alpha1.SecretRef{
-										SecretName: "platform-scm-token",
-										Key:        "token",
-									},
-								},
-							},
-						},
-					},
-					Template: appv1alpha1.ApplicationSetTemplate{
-						ApplicationSetTemplateMeta: appv1alpha1.ApplicationSetTemplateMeta{
-							Name: "placeholder-{{repository}}",
-						},
-						Spec: appv1alpha1.ApplicationSpec{
-							Project: "default",
-							Source: &appv1alpha1.ApplicationSource{
-								RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
-								TargetRevision: "HEAD",
-								Path:           "guestbook",
-							},
-							Destination: appv1alpha1.ApplicationDestination{
-								Server:    "https://kubernetes.default.svc",
-								Namespace: targetNS.Name,
-							},
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, appSet)).To(Succeed())
-
-			getErrorOccurredMessage := func() string {
-				current := &appv1alpha1.ApplicationSet{}
-				if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: targetNS.Name, Name: scmStrictAppSetName}, current); err != nil {
-					GinkgoWriter.Println(err)
-					return ""
-				}
-				for _, cond := range current.Status.Conditions {
-					if cond.Type == appv1alpha1.ApplicationSetConditionErrorOccurred {
-						return cond.Message
-					}
-				}
-				return ""
-			}
-
-			Eventually(func() string { return getErrorOccurredMessage() }, "3m", "5s").
-				Should(And(
-					ContainSubstring(`secret must have label "argocd.argoproj.io/secret-type"="scm-creds"`),
-					ContainSubstring("platform-scm-token"),
-				))
-		})
-
-		It("no default ApplicationSet tokenRef strict mode added for namespace-scoped instances", func() {
-			By("creating namespaces appset-namespace-scoped and appset-target-ns")
-			namespaceScopedArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-namespace-scoped")
-			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
-
-			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
-			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
-
-			By("creating namespace-scoped Argo CD with sourceNamespaces and applicationSet.sourceNamespaces configured")
-			argoCD := &v1beta1.ArgoCD{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "tokenref-ns-scoped",
-					Namespace: namespaceScopedArgocdNS.Name,
-				},
-				Spec: v1beta1.ArgoCDSpec{
-					SourceNamespaces: []string{
-						targetNS.Name,
-					},
-					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
-						SourceNamespaces: []string{
-							targetNS.Name,
-						},
-						SCMProviders: []string{
-							"github.com",
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
-			Eventually(argoCD).Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
-
-			By("verifying cmd params configmap does not default tokenRef strict mode key")
-			cmdParamsCM := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      common.ArgoCDCmdParamsConfigMapName,
-					Namespace: argoCD.Namespace,
-				},
-			}
-			Eventually(cmdParamsCM).Should(k8sFixture.ExistByName())
-			Consistently(cmdParamsCM, "30s", "2s").Should(configmapFixture.NotHaveStringDataKey(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey))
 		})
 
 	})

--- a/tests/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/tests/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -15,6 +15,7 @@ import (
 	appprojectFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/appproject"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
 	clusterroleFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/clusterrole"
+	configmapFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/configmap"
 	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
 	namespaceFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/namespace"
@@ -1324,6 +1325,326 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("Cleaning up the ApplicationSet")
 			Expect(k8sClient.Delete(ctx, appset)).To(Succeed())
 			Eventually(appset).Should(k8sFixture.NotExistByName())
+		})
+
+		It("with ApplicationSet-in-any-namespace, enables tokenRef strict mode in cmd-params and corrects drift", func() {
+			By("creating namespaces appset-argocd and appset-target-ns")
+			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			By("creating Argo CD with apps and appset source namespaces configured")
+			argoCD := &v1beta1.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tokenref-default-example",
+					Namespace: appsetArgocdNS.Name,
+				},
+				Spec: v1beta1.ArgoCDSpec{
+					SourceNamespaces: []string{
+						targetNS.Name,
+					},
+					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
+						SourceNamespaces: []string{
+							targetNS.Name,
+						},
+						SCMProviders: []string{
+							"github.com",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+			Eventually(argoCD).Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
+
+			By("verifying cmd params configmap defaults tokenRef strict mode to true")
+			cmdParamsCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDCmdParamsConfigMapName,
+					Namespace: argoCD.Namespace,
+				},
+			}
+			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
+
+			By("verifying appset deployment consumes strict mode from cmd params configmap")
+			appsetDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tokenref-default-example-applicationset-controller",
+					Namespace: argoCD.Namespace,
+				},
+			}
+			Eventually(appsetDeployment).Should(k8sFixture.ExistByName())
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(appsetDeployment), appsetDeployment); err != nil {
+					GinkgoWriter.Println(err)
+					return false
+				}
+				if len(appsetDeployment.Spec.Template.Spec.Containers) == 0 {
+					return false
+				}
+				for _, env := range appsetDeployment.Spec.Template.Spec.Containers[0].Env {
+					if env.Name != common.ArgoCDApplicationSetControllerTokenRefStrictModeEnvName {
+						continue
+					}
+					if env.ValueFrom == nil || env.ValueFrom.ConfigMapKeyRef == nil {
+						return false
+					}
+					return env.ValueFrom.ConfigMapKeyRef.Name == common.ArgoCDCmdParamsConfigMapName &&
+						env.ValueFrom.ConfigMapKeyRef.Key == common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey
+				}
+				return false
+			}).Should(BeTrue())
+			By("ApplicationSet controller reads strict mode from argocd-cmd-params-cm via ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE")
+
+			configmapFixture.Update(cmdParamsCM, func(cm *corev1.ConfigMap) {
+				cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "false"
+			})
+			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+
+			By("triggering reconcile by updating ArgoCD and verifying operator overwrites key back to true")
+			argocdFixture.Update(argoCD, func(ac *v1beta1.ArgoCD) {
+				if ac.Spec.ApplicationSet.Annotations == nil {
+					ac.Spec.ApplicationSet.Annotations = map[string]string{}
+				}
+				ac.Spec.ApplicationSet.Annotations["e2e.argocd-operator/tokenref-strict-drift"] = "true"
+			})
+			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
+		})
+
+		It("spec.cmdParams opts out of default tokenRef strict mode when ApplicationSet-in-any-namespace is active", func() {
+			By("opt-out via spec.cmdParams.applicationsetcontroller.enable.tokenref.strict.mode=false is not overwritten")
+			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			argoCD := &v1beta1.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tokenref-optout-example",
+					Namespace: appsetArgocdNS.Name,
+				},
+				Spec: v1beta1.ArgoCDSpec{
+					SourceNamespaces: []string{targetNS.Name},
+					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
+						SourceNamespaces: []string{targetNS.Name},
+						SCMProviders:     []string{"github.com"},
+					},
+					CmdParams: map[string]string{
+						common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey: "false",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+			Eventually(argoCD).Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
+
+			cmdParamsCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDCmdParamsConfigMapName,
+					Namespace: argoCD.Namespace,
+				},
+			}
+			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+
+			By("triggering reconcile and verifying opt-out persists")
+			argocdFixture.Update(argoCD, func(ac *v1beta1.ArgoCD) {
+				if ac.Spec.ApplicationSet.Annotations == nil {
+					ac.Spec.ApplicationSet.Annotations = map[string]string{}
+				}
+				ac.Spec.ApplicationSet.Annotations["e2e.argocd-operator/tokenref-strict-optout"] = "true"
+			})
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+		})
+
+		It("with tokenRef strict mode enabled SCM tokenRef rejects secrets without scm-creds label", func() {
+			By("Argo CD enforces scm-creds on tokenRef when strict mode is on ")
+			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			fakeSCMURL := fmt.Sprintf("http://fake-scm.%s.svc.cluster.local", targetNS.Name)
+			By("deploying in-cluster HTTP server as a stand-in SCM endpoint")
+			oneReplica := int32(1)
+			fakeSCMDepl := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake-scm",
+					Namespace: targetNS.Name,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &oneReplica,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "fake-scm"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"app": "fake-scm"},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "fake-scm",
+								Image: "nginx:latest",
+								Ports: []corev1.ContainerPort{{ContainerPort: 80}},
+							}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, fakeSCMDepl)).To(Succeed())
+			fakeSCMSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake-scm",
+					Namespace: targetNS.Name,
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{"app": "fake-scm"},
+					Ports:    []corev1.ServicePort{{Port: 80}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, fakeSCMSvc)).To(Succeed())
+			Eventually(fakeSCMDepl, "3m", "5s").Should(deploymentFixture.HaveReadyReplicas(1))
+
+			argoCD := &v1beta1.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tokenref-scm-strict-example",
+					Namespace: appsetArgocdNS.Name,
+				},
+				Spec: v1beta1.ArgoCDSpec{
+					SourceNamespaces: []string{targetNS.Name},
+					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
+						SourceNamespaces: []string{targetNS.Name},
+						SCMProviders:     []string{fakeSCMURL},
+					},
+					CmdParams: map[string]string{
+						common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey: "true",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+			Eventually(argoCD).Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
+
+			tokenSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "platform-scm-token",
+					Namespace: targetNS.Name,
+				},
+				StringData: map[string]string{"token": "e2e-test-token"},
+			}
+			Expect(k8sClient.Create(ctx, tokenSecret)).To(Succeed())
+
+			const scmStrictAppSetName = "tokenref-scm-strict-appset"
+			appSet := &appv1alpha1.ApplicationSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: appv1alpha1.SchemeGroupVersion.String(),
+					Kind:       appv1alpha1.ApplicationSetSchemaGroupVersionKind.Kind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      scmStrictAppSetName,
+					Namespace: targetNS.Name,
+				},
+				Spec: appv1alpha1.ApplicationSetSpec{
+					Generators: []appv1alpha1.ApplicationSetGenerator{
+						{
+							SCMProvider: &appv1alpha1.SCMProviderGenerator{
+								Gitlab: &appv1alpha1.SCMProviderGeneratorGitlab{
+									API:      fakeSCMURL,
+									Group:    "demo",
+									Insecure: true,
+									TokenRef: &appv1alpha1.SecretRef{
+										SecretName: "platform-scm-token",
+										Key:        "token",
+									},
+								},
+							},
+						},
+					},
+					Template: appv1alpha1.ApplicationSetTemplate{
+						ApplicationSetTemplateMeta: appv1alpha1.ApplicationSetTemplateMeta{
+							Name: "placeholder-{{repository}}",
+						},
+						Spec: appv1alpha1.ApplicationSpec{
+							Project: "default",
+							Source: &appv1alpha1.ApplicationSource{
+								RepoURL:        "https://github.com/argoproj/argocd-example-apps.git",
+								TargetRevision: "HEAD",
+								Path:           "guestbook",
+							},
+							Destination: appv1alpha1.ApplicationDestination{
+								Server:    "https://kubernetes.default.svc",
+								Namespace: targetNS.Name,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, appSet)).To(Succeed())
+
+			getErrorOccurredMessage := func() string {
+				current := &appv1alpha1.ApplicationSet{}
+				if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: targetNS.Name, Name: scmStrictAppSetName}, current); err != nil {
+					GinkgoWriter.Println(err)
+					return ""
+				}
+				for _, cond := range current.Status.Conditions {
+					if cond.Type == appv1alpha1.ApplicationSetConditionErrorOccurred {
+						return cond.Message
+					}
+				}
+				return ""
+			}
+
+			Eventually(func() string { return getErrorOccurredMessage() }, "3m", "5s").
+				Should(And(
+					ContainSubstring(`secret must have label "argocd.argoproj.io/secret-type"="scm-creds"`),
+					ContainSubstring("platform-scm-token"),
+				))
+		})
+
+		It("no default ApplicationSet tokenRef strict mode added for namespace-scoped instances", func() {
+			By("creating namespaces appset-namespace-scoped and appset-target-ns")
+			namespaceScopedArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-namespace-scoped")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			By("creating namespace-scoped Argo CD with sourceNamespaces and applicationSet.sourceNamespaces configured")
+			argoCD := &v1beta1.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tokenref-ns-scoped",
+					Namespace: namespaceScopedArgocdNS.Name,
+				},
+				Spec: v1beta1.ArgoCDSpec{
+					SourceNamespaces: []string{
+						targetNS.Name,
+					},
+					ApplicationSet: &v1beta1.ArgoCDApplicationSet{
+						SourceNamespaces: []string{
+							targetNS.Name,
+						},
+						SCMProviders: []string{
+							"github.com",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+			Eventually(argoCD).Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
+
+			By("verifying cmd params configmap does not default tokenRef strict mode key")
+			cmdParamsCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDCmdParamsConfigMapName,
+					Namespace: argoCD.Namespace,
+				},
+			}
+			Eventually(cmdParamsCM).Should(k8sFixture.ExistByName())
+			Consistently(cmdParamsCM, "30s", "2s").Should(configmapFixture.NotHaveStringDataKey(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey))
 		})
 
 	})


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
/kind enhancement
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
When ApplicationSet is allowed in namespaces beyond the Argo CD namespace, SCM/PR-style generators can use tokenRef to read Secrets there. Without strict mode, unlabeled Secrets can be accepted, which is risky in shared clusters. Argo CD’s tokenRef strict mode limits this to Secrets labeled argocd.argoproj.io/secret-type=scm-creds. The operator should turn that guardrail on by default when that mode is actually in use, with a clear opt-out. See upstream: [ApplicationSet in any namespace – tokenRef restrictions](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Appset-Any-Namespace/#tokenref-restrictions).

What this PR does:
This PR adds automatic defaulting for `applicationsetcontroller.enable.tokenref.strict.mode `in argocd-cmd-params-cm. The operator now always writes this key, setting it to `true` when `spec.applicationSet.sourceNamespaces` expands to at least one namespace in the cluster, and to `false` otherwise. If `spec.cmdParams` explicitly defines the key, that value takes precedence and is preserved across reconciliations.

The ApplicationSet controller consumes this setting through the `ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE` environment variable. To support this, the PR adds `ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey` and `ArgoCDApplicationSetControllerTokenRefStrictModeEnvName `constants to common/keys.go.

The defaulting logic uses `getApplicationSetSourceNamespaces`, which resolves wildcard and regex patterns defined in `spec.applicationSet.sourceNamespaces`. (It does not depend on the cluster-config namespace or on the intersection with spec.sourceNamespaces)

The operator treats the ArgoCD custom resource as the source of truth and automatically corrects any manual changes to this key in `argocd-cmd-params-cm.`

**Have you updated the necessary documentation?**

* [X] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://redhat.atlassian.net/browse/GITOPS-8628

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ApplicationSet tokenRef strict mode now defaults to enabled for cluster-scoped Argo CD when ApplicationSet-in-any-namespace is active; can be opted out via CmdParams. Controller reads this setting from the argocd-cmd-params-cm ConfigMap into its environment.

* **Tests**
  * Added unit and E2E tests for defaulting, opt-out, enforcement, and namespace-scoped behavior.

* **Documentation**
  * CRD/schema docs updated to document the tokenRef strict-mode CmdParam and its defaulting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-operator/pull/2194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->