### PR TITLE
remove default: true for network-policy enabled field

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -697,7 +697,6 @@ type ArgoCDNetworkPolicySpec struct {
 	// Enabled defines whether NetworkPolicy resources should be created for this Argo CD instance.
 	// When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
 	// When disabled, the operator will remove any previously-created NetworkPolicies.
-	// +kubebuilder:default=true
 	Enabled *bool `json:"enabled,omitempty"`
 }
 

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -873,7 +873,6 @@ type ArgoCDNetworkPolicySpec struct {
 	// Enabled defines whether NetworkPolicy resources are created for this Argo CD instance.
 	// When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
 	// When disabled, the operator will remove any previously-created NetworkPolicies.
-	// +kubebuilder:default=true
 	Enabled *bool `json:"enabled,omitempty"`
 }
 

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-05-14T13:39:20Z"
+    createdAt: "2026-05-18T06:38:06Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -1905,7 +1905,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources should be created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
@@ -18304,7 +18303,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources are created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -1894,7 +1894,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources should be created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
@@ -18293,7 +18292,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources are created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argocd-operator.v0.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argocd-operator.v0.19.0.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-05-14T13:39:20Z"
+    createdAt: "2026-05-18T06:38:06Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
@@ -1905,7 +1905,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources should be created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.
@@ -18304,7 +18303,6 @@ spec:
                   NetworkPolicy resources for this Argo CD instance.
                 properties:
                   enabled:
-                    default: true
                     description: |-
                       Enabled defines whether NetworkPolicy resources are created for this Argo CD instance.
                       When enabled, the operator will reconcile NetworkPolicies for Argo CD components.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What does this PR do / why we need it**:
Setting field spec.NetworkPolicy.enabled field to true using `// +kubebuilder:default=true`, Go code defaults to enabled when field is absent. CRD schema default is redundant, it forces API server to materialize the field on every admission, creating the oscillation even if the change doesnt affect state of Argo-CD instance.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes https://github.com/argoproj-labs/argocd-operator/issues/2197

**How to test changes / Special notes to the reviewer**:

```
# create kind cluster and run argocd-operator 
kind create cluster 

make install run

# create argocd namespace and argocd instance
kubectl create namespace argocd
kubectl apply -f - <<'EOF'
apiVersion: argoproj.io/v1beta1
kind: ArgoCD
metadata:
  name: argocd
  namespace: argocd
spec:
  networkPolicy:
    enabled: true
EOF

#Watch generation counter

watch -n1 "kubectl get argocd argocd -n argocd -o jsonpath='{.metadata.generation}'"

# Simulate external controller (the key part)
# This script mimics patterns-operator doing full spec replacement — stripping networkPolicy field on every loop:

while true; do
  # Get current spec, strip networkPolicy field, do full Update
  kubectl get argocd argocd -n argocd -o json | \
  jq 'del(.spec.networkPolicy)' | \
  kubectl apply -f -
  sleep 1
done

check if generation is incremented
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Changes**
  * NetworkPolicy is no longer automatically enabled by default. Users must explicitly configure this setting to activate NetworkPolicy resource creation for Argo CD instances.

* **Documentation**
  * Enhanced descriptions for NetworkPolicy configuration behavior and resource management details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-operator/pull/2198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->