### PR TITLE
fix(docs): Fix docs build + code snippets

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -94,12 +94,12 @@ echo "YOUR_SUB_CLAIM_HERE" | base64 -d
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-   name: example-argocd
-   labels:
-      example: rbac-migration
+  name: example-argocd
+  labels:
+    example: rbac-migration
 spec:
-   rbac:
-      policy: |
+  rbac:
+    policy: |
       # Old: g, ChdleGFtcGxlQGFyZ29wcm9qLmlvEgJkZXhfY29ubl9pZA, role:example
       # New: g, example@argoproj.io, role:example
       g, example@argoproj.io, role:example
@@ -119,4 +119,4 @@ references declared on **`spec.webhookSecrets`** in the **ArgoCD** CR (`v1beta1`
 - **If you do not set** `spec.webhookSecrets`, the operator continues to omit declarative webhook management; **`webhook.*` keys already present in `argocd-secret` are left as-is**, including values you patched in manually before this feature existed.
 - **If you set** `spec.webhookSecrets`, the operator syncs the providers you declare into `argocd-secret`. Providers not listed while management is enabled can have their **`webhook.*` keys cleared** on reconcile—see [Configuring webhook secrets](./usage/webhook-secrets.md) for exact semantics.
 
-For migration from manual edits, verification, integrations (External Secrets, Sealed Secrets), and troubleshooting, use the **[Configuring webhook secrets](./usage/webhook-secrets.md)** guide. A runnable example can be found at [https://github.com/argoproj-labs/argocd-operator/blob/master/examples/argocd-webhook-secrets.yaml]().
+For migration from manual edits, verification, integrations (External Secrets, Sealed Secrets), and troubleshooting, use the **[Configuring webhook secrets](./usage/webhook-secrets.md)** guide. A runnable example can be found at <https://github.com/argoproj-labs/argocd-operator/blob/master/examples/argocd-webhook-secrets.yaml>.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -80,36 +80,36 @@ If you're using the Argo CD CLI with Dex authentication, make sure to use the ne
 #### Example Migration Workflow
 
 1. **Identify affected policies:**
-   ```bash
-   kubectl get cm argocd-rbac-cm -n argocd -o=jsonpath='{.data.policy\.csv}'
-   ```
+```bash
+kubectl get cm argocd-rbac-cm -n argocd -o=jsonpath='{.data.policy\.csv}'
+```
 
 2. **Decode sub claims:**
-   ```bash
-   echo "YOUR_SUB_CLAIM_HERE" | base64 -d
-   ```
+```bash
+echo "YOUR_SUB_CLAIM_HERE" | base64 -d
+```
 
 3. **Update policies:**
-   ```yaml
-   apiVersion: argoproj.io/v1beta1
-   kind: ArgoCD
-   metadata:
-     name: example-argocd
-     labels:
-       example: rbac-migration
-   spec:
-     rbac:
-       policy: |
-         # Old: g, ChdleGFtcGxlQGFyZ29wcm9qLmlvEgJkZXhfY29ubl9pZA, role:example
-         # New: g, example@argoproj.io, role:example
-         g, example@argoproj.io, role:example
-   ```
+```yaml
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+   name: example-argocd
+   labels:
+      example: rbac-migration
+spec:
+   rbac:
+      policy: |
+      # Old: g, ChdleGFtcGxlQGFyZ29wcm9qLmlvEgJkZXhfY29ubl9pZA, role:example
+      # New: g, example@argoproj.io, role:example
+      g, example@argoproj.io, role:example
+```
 
 4. **Test authentication:**
-   ```bash
-   argocd login <your-argocd-server> --sso
-   argocd app list
-   ```
+```bash
+argocd login <your-argocd-server> --sso
+argocd app list
+```
 
 ## Declarative webhook secrets (`spec.webhookSecrets`)
 
@@ -119,4 +119,4 @@ references declared on **`spec.webhookSecrets`** in the **ArgoCD** CR (`v1beta1`
 - **If you do not set** `spec.webhookSecrets`, the operator continues to omit declarative webhook management; **`webhook.*` keys already present in `argocd-secret` are left as-is**, including values you patched in manually before this feature existed.
 - **If you set** `spec.webhookSecrets`, the operator syncs the providers you declare into `argocd-secret`. Providers not listed while management is enabled can have their **`webhook.*` keys cleared** on reconcile—see [Configuring webhook secrets](./usage/webhook-secrets.md) for exact semantics.
 
-For migration from manual edits, verification, integrations (External Secrets, Sealed Secrets), and troubleshooting, use the **[Configuring webhook secrets](./usage/webhook-secrets.md)** guide. A runnable example can be found at [`examples/argocd-webhook-secrets.yaml`](../examples/argocd-webhook-secrets.yaml) in this repository ([view on GitHub](https://github.com/argoproj-labs/argocd-operator/blob/master/examples/argocd-webhook-secrets.yaml)).
+For migration from manual edits, verification, integrations (External Secrets, Sealed Secrets), and troubleshooting, use the **[Configuring webhook secrets](./usage/webhook-secrets.md)** guide. A runnable example can be found at [https://github.com/argoproj-labs/argocd-operator/blob/master/examples/argocd-webhook-secrets.yaml]().


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug 
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

- Docs build got broken after https://github.com/argoproj-labs/argocd-operator/pull/2193/changes#diff-0220ca71b6e5d1c80ad9e3dedd642059ed9a26c2a5ae414e46f022d2e688c9a6 (CC @aali309):
```
WARNING -  Doc file 'upgrading.md' contains a link '../examples/argocd-webhook-secrets.yaml', but the target is not found among documentation files.
INFO    -  Doc file 'usage/environment_variables.md' contains an unrecognized relative link 'quay.io/argoproj/argocd', it was left as is.
INFO    -  Doc file 'usage/environment_variables.md' contains an unrecognized relative link 'quay.io/argoprojlabs/argocd-image-updater', it was left as is.
INFO    -  Doc file 'usage/environment_variables.md' contains an unrecognized relative link 'ghcr.io/dexidp/dex', it was left as is.
INFO    -  DeprecationWarning: invalid escape sequence '\s'
             File "/opt/app-root/lib64/python3.11/site-packages/jinja2/lexer.py", line 391, in __next__
               self.current = next(self._iter)
             File "/opt/app-root/lib64/python3.11/site-packages/jinja2/lexer.py", line 654, in wrap
               .decode("unicode-escape")
INFO    -  Doc file 'reference/argocd.md' contains a link '#ingress-options', but there is no such anchor on this page.
INFO    -  Doc file 'reference/argocd.md' contains a link '#initial-repositories', but there is no such anchor on this page.
INFO    -  Doc file 'usage/dex.md' contains a link '#installing--configuring-dex', but there is no such anchor on this page.

Aborted with 1 warnings in strict mode!
make: *** [Makefile:390: serve-docs] Error 1
```
- Some old code snippet thereof were broken: https://argocd-operator.readthedocs.io/en/latest/upgrading/#example-migration-workflow. After:
<img width="791" height="729" alt="image" src="https://github.com/user-attachments/assets/97a7b84b-83e2-4a4e-b118-d36451dbdad1" />


**Have you updated the necessary documentation?**

* [YES] Documentation update is required by this PR.
* [ALSO YES] Documentation has been updated.

**Which issue(s) this PR fixes**:

None

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of the step-by-step migration workflow examples to make inline commands and code snippets clearer and easier to follow.
  * Replaced a relative example link with a direct GitHub URL in the webhook secrets section to make the runnable example easier to access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-operator/pull/2208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->