### PR TITLE
test(e2e): stabilize tokenRef strict mode cmd-params tests

### DIFF
--- a/tests/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/tests/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -1346,7 +1346,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
-			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
 
 			cmdParamsCM := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1354,25 +1353,14 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					Namespace: argoCD.Namespace,
 				},
 			}
-			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
 		})
 
-		It("defaults tokenRef strict mode to false when applicationSet sourceNamespaces are empty or removed", func() {
+		It("defaults tokenRef strict mode to false when applicationSet sourceNamespaces are empty on create", func() {
 			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
 			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
 
-			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
-			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
-
-			cmdParamsCM := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      common.ArgoCDCmdParamsConfigMapName,
-					Namespace: appsetArgocdNS.Name,
-				},
-			}
-
-			By("empty applicationSet.sourceNamespaces on create")
-			argoCDEmpty := &v1beta1.ArgoCD{
+			argoCD := &v1beta1.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tokenref-strict-false-empty",
 					Namespace: appsetArgocdNS.Name,
@@ -1383,12 +1371,25 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, argoCDEmpty)).To(Succeed())
-			Eventually(argoCDEmpty, "5m", "5s").Should(argocdFixture.BeAvailable())
-			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
-			By("removing applicationSet.sourceNamespaces after they were configured")
-			argoCDRemove := &v1beta1.ArgoCD{
+			cmdParamsCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      common.ArgoCDCmdParamsConfigMapName,
+					Namespace: argoCD.Namespace,
+				},
+			}
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+		})
+
+		It("defaults tokenRef strict mode to false when applicationSet sourceNamespaces are removed", func() {
+			appsetArgocdNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-argocd")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			targetNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appset-target-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanupFunc)
+
+			argoCD := &v1beta1.ArgoCD{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "tokenref-strict-false-removed",
 					Namespace: appsetArgocdNS.Name,
@@ -1399,20 +1400,20 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, argoCDRemove)).To(Succeed())
-			Eventually(argoCDRemove, "5m", "5s").Should(argocdFixture.BeAvailable())
-			cmdParamsCMRemove := &corev1.ConfigMap{
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			cmdParamsCM := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      common.ArgoCDCmdParamsConfigMapName,
-					Namespace: argoCDRemove.Namespace,
+					Namespace: argoCD.Namespace,
 				},
 			}
-			Eventually(cmdParamsCMRemove).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
 
-			argocdFixture.Update(argoCDRemove, func(ac *v1beta1.ArgoCD) {
+			argocdFixture.Update(argoCD, func(ac *v1beta1.ArgoCD) {
 				ac.Spec.ApplicationSet.SourceNamespaces = []string{}
 			})
-			Eventually(cmdParamsCMRemove, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
 		})
 
 		It("reconciles tokenRef strict mode cmd-params drift when applicationSet sourceNamespaces remain configured", func() {
@@ -1434,7 +1435,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
-			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
 
 			cmdParamsCM := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1442,12 +1442,12 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					Namespace: argoCD.Namespace,
 				},
 			}
-			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "true"))
 
 			configmapFixture.Update(cmdParamsCM, func(cm *corev1.ConfigMap) {
 				cm.Data[common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey] = "false"
 			})
-			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
 
 			By("triggering reconciliation via ArgoCD metadata change")
 			argocdFixture.Update(argoCD, func(ac *v1beta1.ArgoCD) {
@@ -1481,7 +1481,6 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
-			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
 
 			cmdParamsCM := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1489,7 +1488,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					Namespace: argoCD.Namespace,
 				},
 			}
-			Eventually(cmdParamsCM).Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
+			Eventually(cmdParamsCM, "3m", "5s").Should(configmapFixture.HaveStringDataKeyValue(common.ArgoCDApplicationSetControllerTokenRefStrictModeCmdParamKey, "false"))
 
 			By("triggering reconcile by updating ArgoCD spec.cmdParams and verifying opt-out persists")
 			argocdFixture.Update(argoCD, func(ac *v1beta1.ArgoCD) {


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
/kind failing-test
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
The test defaults tokenRef strict mode to false when applicationSet sourceNamespaces are empty or removed was flaky in CI. It created two ArgoCD instances in the same namespace, which both reconcile the same argocd-cmd-params-cm. That caused reconciliation contention and doubled cluster load. The second instance often never reached Available (e.g. argocd-server in CrashLoopBackOff), so the test timed out on BeAvailable() even though cmd-params logic was correct.

fix: Split the scenario into two tests: empty on create and removed after configure, with one ArgoCD per namespace (same coverage, no shared ConfigMap fight). Align all five tokenRef strict mode tests to assert argocd-cmd-params-cm via Eventually(..., "3m", "5s") instead of BeAvailable(). Cmd-params are reconciled before the instance is fully healthy; waiting for Available is unnecessary for these assertions, slower, and more fragile under load. Other 1-037 tests still use BeAvailable() where they depend on a running instance (RBAC, deployments, etc.).

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test coverage for ApplicationSet controller strict mode configuration behavior with separated test cases evaluating different sourceNamespaces scenarios, improved ConfigMap assertion timing strategies using consistent timing expectations, and refined test execution patterns to ensure reliable validation of strict mode defaults and state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/argoproj-labs/argocd-operator/pull/2210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->