### PR TITLE
fix: limit StatefulSet names to 52 chars and abbreviate application-controller to prevent label limit errors

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -1045,9 +1045,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetService(cr *argoproj.ArgoCD) er
 
 // Returns the name of the role/rolebinding for the source namespaces for applicationset-controller in the format of "argocdName-argocdNamespace-applicationset"
 func getResourceNameForApplicationSetSourceNamespaces(cr *argoproj.ArgoCD) string {
-	// For source namespace resources, we need namespace to ensure uniqueness across cluster
-	namespacedName := fmt.Sprintf("%s-%s", argoutil.TruncateCRName(cr.Name), cr.Namespace)
-	return argoutil.TruncateWithHash(fmt.Sprintf("%s-applicationset", namespacedName), 63)
+	return fmt.Sprintf("%s-%s-applicationset", cr.Name, cr.Namespace)
 }
 
 // removeUnmanagedApplicationSetSourceNamespaceResources cleansup resources from ApplicationSetSourceNamespaces if namespace is not managed by argocd instance.

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -1045,7 +1045,9 @@ func (r *ReconcileArgoCD) reconcileApplicationSetService(cr *argoproj.ArgoCD) er
 
 // Returns the name of the role/rolebinding for the source namespaces for applicationset-controller in the format of "argocdName-argocdNamespace-applicationset"
 func getResourceNameForApplicationSetSourceNamespaces(cr *argoproj.ArgoCD) string {
-	return fmt.Sprintf("%s-%s-applicationset", cr.Name, cr.Namespace)
+	// For source namespace resources, we need namespace to ensure uniqueness across cluster
+	namespacedName := fmt.Sprintf("%s-%s", argoutil.TruncateCRName(cr.Name), cr.Namespace)
+	return argoutil.TruncateWithHash(fmt.Sprintf("%s-applicationset", namespacedName), 63)
 }
 
 // removeUnmanagedApplicationSetSourceNamespaceResources cleansup resources from ApplicationSetSourceNamespaces if namespace is not managed by argocd instance.

--- a/controllers/argocd/deployment.go
+++ b/controllers/argocd/deployment.go
@@ -463,7 +463,7 @@ func (r *ReconcileArgoCD) reconcileRedisDeployment(cr *argoproj.ArgoCD, useTLS b
 		},
 	}}
 
-	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, "argocd-redis")
+	deploy.Spec.Template.Spec.ServiceAccountName = getServiceAccountName(cr.Name, common.ArgoCDRedisComponent)
 	deploy.Spec.Template.Spec.Volumes = []corev1.Volume{
 		{
 			Name: common.ArgoCDRedisServerTLSSecretName,
@@ -751,7 +751,7 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) e
 	}
 	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
 
-	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, "argocd-redis-ha")
+	deploy.Spec.Template.Spec.ServiceAccountName = getServiceAccountName(cr.Name, common.ArgoCDRedisHAComponent)
 
 	version, err := getClusterVersion(r.Client)
 	if err != nil {
@@ -828,6 +828,10 @@ func (r *ReconcileArgoCD) reconcileRedisHAProxyDeployment(cr *argoproj.ArgoCD) e
 		if !reflect.DeepEqual(deploy.Spec.Replicas, existing.Spec.Replicas) {
 			existing.Spec.Replicas = deploy.Spec.Replicas
 			changes = append(changes, "replicas")
+		}
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.ServiceAccountName, existing.Spec.Template.Spec.ServiceAccountName) {
+			existing.Spec.Template.Spec.ServiceAccountName = deploy.Spec.Template.Spec.ServiceAccountName
+			changes = append(changes, "serviceAccountName")
 		}
 		if len(changes) > 0 {
 			argoutil.LogResourceUpdate(log, existing, "updating", strings.Join(changes, ", "))
@@ -933,7 +937,7 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		SecurityContext: argoutil.DefaultSecurityContext(),
 		VolumeMounts:    serverVolumeMounts,
 	}}
-	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, "argocd-server")
+	deploy.Spec.Template.Spec.ServiceAccountName = getServiceAccountName(cr.Name, common.ArgoCDServerComponent)
 
 	serverVolumes := []corev1.Volume{
 		{
@@ -1154,6 +1158,11 @@ func (r *ReconcileArgoCD) reconcileServerDeployment(cr *argoproj.ArgoCD, useTLSF
 		if !reflect.DeepEqual(deploy.Spec.Template.Labels, existing.Spec.Template.Labels) {
 			existing.Spec.Template.Labels = deploy.Spec.Template.Labels
 			changes = append(changes, "labels")
+		}
+
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.ServiceAccountName, existing.Spec.Template.Spec.ServiceAccountName) {
+			existing.Spec.Template.Spec.ServiceAccountName = deploy.Spec.Template.Spec.ServiceAccountName
+			changes = append(changes, "serviceAccountName")
 		}
 
 		if len(changes) > 0 {

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -480,7 +480,7 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoproj.ArgoCD) error {
 		VolumeMounts:    dexVolumeMounts,
 	}}
 
-	deploy.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDDefaultDexServiceAccountName)
+	deploy.Spec.Template.Spec.ServiceAccountName = getServiceAccountName(cr.Name, common.ArgoCDDefaultDexServiceAccountName)
 	deploy.Spec.Template.Spec.Volumes = dexVolumes
 
 	existing := newDeploymentWithSuffix("dex-server", "dex-server", cr)
@@ -573,6 +573,11 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoproj.ArgoCD) error {
 		if !reflect.DeepEqual(deploy.Spec.Template.Spec.Volumes, existing.Spec.Template.Spec.Volumes) {
 			existing.Spec.Template.Spec.Volumes = deploy.Spec.Template.Spec.Volumes
 			changes = append(changes, "volumes")
+		}
+
+		if !reflect.DeepEqual(deploy.Spec.Template.Spec.ServiceAccountName, existing.Spec.Template.Spec.ServiceAccountName) {
+			existing.Spec.Template.Spec.ServiceAccountName = deploy.Spec.Template.Spec.ServiceAccountName
+			changes = append(changes, "serviceAccountName")
 		}
 
 		if len(changes) > 0 {

--- a/controllers/argocd/dexUtil.go
+++ b/controllers/argocd/dexUtil.go
@@ -62,7 +62,7 @@ func (r *ReconcileArgoCD) getDexOAuthRedirectURI(cr *argoproj.ArgoCD) (string, e
 
 // getDexOAuthClientID will return the OAuth client ID for the given ArgoCD.
 func getDexOAuthClientID(cr *argoproj.ArgoCD) string {
-	return fmt.Sprintf("system:serviceaccount:%s:%s", cr.Namespace, fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDDefaultDexServiceAccountName))
+	return fmt.Sprintf("system:serviceaccount:%s:%s", cr.Namespace, getServiceAccountName(cr.Name, common.ArgoCDDefaultDexServiceAccountName))
 }
 
 // getDexResources will return the ResourceRequirements for the Dex container.

--- a/controllers/argocd/ingress.go
+++ b/controllers/argocd/ingress.go
@@ -16,7 +16,6 @@ package argocd
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -63,7 +62,7 @@ func newIngressWithName(name string, cr *argoproj.ArgoCD) *networkingv1.Ingress 
 
 // newIngressWithSuffix returns a new Ingress with the given name suffix for the ArgoCD.
 func newIngressWithSuffix(suffix string, cr *argoproj.ArgoCD) *networkingv1.Ingress {
-	return newIngressWithName(fmt.Sprintf("%s-%s", cr.Name, suffix), cr)
+	return newIngressWithName(nameWithSuffix(suffix, cr), cr)
 }
 
 // reconcileIngresses will ensure that all ArgoCD Ingress resources are present.

--- a/controllers/argocd/networkpolicies.go
+++ b/controllers/argocd/networkpolicies.go
@@ -373,7 +373,7 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": nameWithSuffix("application-controller", cr),
+									"app.kubernetes.io/name": applicationControllerResourceName(cr),
 								},
 							},
 						},
@@ -514,7 +514,7 @@ func (r *ReconcileArgoCD) ReconcileRedisHANetworkPolicy(cr *argoproj.ArgoCD) err
 						{
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": nameWithSuffix("application-controller", cr),
+									"app.kubernetes.io/name": applicationControllerResourceName(cr),
 								},
 							},
 						},
@@ -807,7 +807,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDApplicationControllerNetworkPolicy(cr *
 	desired.Spec = networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"app.kubernetes.io/name": nameWithSuffix("application-controller", cr),
+				"app.kubernetes.io/name": applicationControllerResourceName(cr),
 			},
 		},
 		PolicyTypes: []networkingv1.PolicyType{
@@ -914,7 +914,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDRepoServerNetworkPolicy(cr *argoproj.Ar
 					{
 						PodSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								"app.kubernetes.io/name": nameWithSuffix("application-controller", cr),
+								"app.kubernetes.io/name": applicationControllerResourceName(cr),
 							},
 						},
 					},

--- a/controllers/argocd/networkpolicies.go
+++ b/controllers/argocd/networkpolicies.go
@@ -90,12 +90,12 @@ func (r *ReconcileArgoCD) ReconcileNetworkPolicies(cr *argoproj.ArgoCD) error {
 
 func (r *ReconcileArgoCD) deleteArgoCDNetworkPolicies(cr *argoproj.ArgoCD) error {
 	names := []string{
-		fmt.Sprintf("%s-%s", cr.Name, ArgoCDNotificationsControllerNetworkPolicy),
-		fmt.Sprintf("%s-%s", cr.Name, ArgoCDDexServerNetworkPolicy),
-		fmt.Sprintf("%s-%s", cr.Name, ArgoCDApplicationSetControllerNetworkPolicy),
-		fmt.Sprintf("%s-%s", cr.Name, ArgoCDServerNetworkPolicy),
-		fmt.Sprintf("%s-%s", cr.Name, ArgoCDApplicationControllerNetworkPolicy),
-		fmt.Sprintf("%s-%s", cr.Name, ArgoCDRepoServerNetworkPolicy),
+		nameWithSuffix(ArgoCDNotificationsControllerNetworkPolicy, cr),
+		nameWithSuffix(ArgoCDDexServerNetworkPolicy, cr),
+		nameWithSuffix(ArgoCDApplicationSetControllerNetworkPolicy, cr),
+		nameWithSuffix(ArgoCDServerNetworkPolicy, cr),
+		nameWithSuffix(ArgoCDApplicationControllerNetworkPolicy, cr),
+		nameWithSuffix(ArgoCDRepoServerNetworkPolicy, cr),
 	}
 
 	for _, name := range names {
@@ -178,7 +178,7 @@ func (r *ReconcileArgoCD) ReconcileDexServerNetworkPolicy(cr *argoproj.ArgoCD) e
 
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, ArgoCDDexServerNetworkPolicy),
+			Name:      nameWithSuffix(ArgoCDDexServerNetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 	}
@@ -283,7 +283,7 @@ func (r *ReconcileArgoCD) ReconcileApplicationSetControllerNetworkPolicy(cr *arg
 
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, ArgoCDApplicationSetControllerNetworkPolicy),
+			Name:      nameWithSuffix(ArgoCDApplicationSetControllerNetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 	}
@@ -355,7 +355,7 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 
 	networkPolicy := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, RedisNetworkPolicy),
+			Name:      nameWithSuffix(RedisNetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
@@ -426,7 +426,7 @@ func (r *ReconcileArgoCD) ReconcileRedisNetworkPolicy(cr *argoproj.ArgoCD) error
 	// Check if the network policy already exists
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, RedisNetworkPolicy),
+			Name:      nameWithSuffix(RedisNetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 	}
@@ -496,7 +496,7 @@ func (r *ReconcileArgoCD) ReconcileRedisHANetworkPolicy(cr *argoproj.ArgoCD) err
 
 	networkPolicy := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, RedisHANetworkPolicy),
+			Name:      nameWithSuffix(RedisHANetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
@@ -551,7 +551,7 @@ func (r *ReconcileArgoCD) ReconcileRedisHANetworkPolicy(cr *argoproj.ArgoCD) err
 	// Check if the network policy already exists
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, RedisHANetworkPolicy),
+			Name:      nameWithSuffix(RedisHANetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 	}
@@ -651,7 +651,7 @@ func (r *ReconcileArgoCD) ReconcileNotificationsControllerNetworkPolicy(cr *argo
 
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, ArgoCDNotificationsControllerNetworkPolicy),
+			Name:      nameWithSuffix(ArgoCDNotificationsControllerNetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 	}
@@ -739,7 +739,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDServerNetworkPolicy(cr *argoproj.ArgoCD
 
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, ArgoCDServerNetworkPolicy),
+			Name:      nameWithSuffix(ArgoCDServerNetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 	}
@@ -833,7 +833,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDApplicationControllerNetworkPolicy(cr *
 	// Check if the network policy already exists
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, ArgoCDApplicationControllerNetworkPolicy),
+			Name:      nameWithSuffix(ArgoCDApplicationControllerNetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 	}
@@ -975,7 +975,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDRepoServerNetworkPolicy(cr *argoproj.Ar
 	// Check if the network policy already exists
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, ArgoCDRepoServerNetworkPolicy),
+			Name:      nameWithSuffix(ArgoCDRepoServerNetworkPolicy, cr),
 			Namespace: cr.Namespace,
 		},
 	}
@@ -1038,7 +1038,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDRepoServerNetworkPolicy(cr *argoproj.Ar
 func returnNetworkPolicyHeaders(cr *argoproj.ArgoCD, NetworkPolicyName string) *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", cr.Name, NetworkPolicyName),
+			Name:      nameWithSuffix(NetworkPolicyName, cr),
 			Namespace: cr.Namespace,
 			Labels:    argoutil.LabelsForCluster(cr),
 		},

--- a/controllers/argocd/networkpolicies_test.go
+++ b/controllers/argocd/networkpolicies_test.go
@@ -126,7 +126,7 @@ func TestRedisNetworkPolicy(t *testing.T) {
 
 	// Check if the network policy has the correct ingress rules
 	assert.Equal(t, 3, len(np.Spec.Ingress[0].From))
-	assert.Equal(t, "argocd-application-controller", np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app.kubernetes.io/name"])
+	assert.Equal(t, applicationControllerResourceName(a), np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app.kubernetes.io/name"])
 	assert.Equal(t, "argocd-repo-server", np.Spec.Ingress[0].From[1].PodSelector.MatchLabels["app.kubernetes.io/name"])
 	assert.Equal(t, "argocd-server", np.Spec.Ingress[0].From[2].PodSelector.MatchLabels["app.kubernetes.io/name"])
 	assert.Equal(t, 1, len(np.Spec.Ingress[0].Ports))
@@ -153,7 +153,7 @@ func TestRedisHANetworkPolicy(t *testing.T) {
 
 	// Check if the network policy has the correct ingress rules
 	assert.Equal(t, 3, len(np.Spec.Ingress[0].From))
-	assert.Equal(t, "argocd-application-controller", np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app.kubernetes.io/name"])
+	assert.Equal(t, applicationControllerResourceName(a), np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app.kubernetes.io/name"])
 	assert.Equal(t, "argocd-repo-server", np.Spec.Ingress[0].From[1].PodSelector.MatchLabels["app.kubernetes.io/name"])
 	assert.Equal(t, "argocd-server", np.Spec.Ingress[0].From[2].PodSelector.MatchLabels["app.kubernetes.io/name"])
 	assert.Equal(t, 2, len(np.Spec.Ingress[0].Ports))
@@ -420,7 +420,7 @@ func TestArgoCDApplicationControllerNetworkPolicy(t *testing.T) {
 	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDApplicationControllerNetworkPolicy), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
-	assert.Equal(t, nameWithSuffix("application-controller", a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
+	assert.Equal(t, applicationControllerResourceName(a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
 	assert.Equal(t, networkingv1.PolicyTypeIngress, np.Spec.PolicyTypes[0])
 
 	assert.Equal(t, 1, len(np.Spec.Ingress))
@@ -456,7 +456,7 @@ func TestArgoCDRepoServerNetworkPolicy(t *testing.T) {
 		}
 	}
 	assert.ElementsMatch(t, []string{
-		nameWithSuffix("application-controller", a),
+		applicationControllerResourceName(a),
 		nameWithSuffix("server", a),
 		nameWithSuffix("notifications-controller", a),
 		"argocd-applicationset-controller",

--- a/controllers/argocd/networkpolicies_test.go
+++ b/controllers/argocd/networkpolicies_test.go
@@ -2,7 +2,6 @@ package argocd
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,12 +56,12 @@ func TestReconcileNetworkPolicies_DisabledDeletesExisting(t *testing.T) {
 	assert.NoError(t, err)
 
 	nps := []string{
-		fmt.Sprintf("%s-%s", a.Name, ArgoCDNotificationsControllerNetworkPolicy),
-		fmt.Sprintf("%s-%s", a.Name, ArgoCDDexServerNetworkPolicy),
-		fmt.Sprintf("%s-%s", a.Name, ArgoCDApplicationSetControllerNetworkPolicy),
-		fmt.Sprintf("%s-%s", a.Name, ArgoCDServerNetworkPolicy),
-		fmt.Sprintf("%s-%s", a.Name, ArgoCDApplicationControllerNetworkPolicy),
-		fmt.Sprintf("%s-%s", a.Name, ArgoCDRepoServerNetworkPolicy),
+		nameWithSuffix(ArgoCDNotificationsControllerNetworkPolicy, a),
+		nameWithSuffix(ArgoCDDexServerNetworkPolicy, a),
+		nameWithSuffix(ArgoCDApplicationSetControllerNetworkPolicy, a),
+		nameWithSuffix(ArgoCDServerNetworkPolicy, a),
+		nameWithSuffix(ArgoCDApplicationControllerNetworkPolicy, a),
+		nameWithSuffix(ArgoCDRepoServerNetworkPolicy, a),
 	}
 	for _, name := range nps {
 		np := &networkingv1.NetworkPolicy{}
@@ -89,7 +88,7 @@ func TestReconcileNetworkPolicies_RecreatesDeletedNetworkPolicy(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Delete one policy manually (simulate kubectl delete)
-	name := fmt.Sprintf("%s-%s", a.Name, ArgoCDRepoServerNetworkPolicy)
+	name := nameWithSuffix(ArgoCDRepoServerNetworkPolicy, a)
 	toDelete := &networkingv1.NetworkPolicy{}
 	err = r.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: a.Namespace}, toDelete)
 	assert.NoError(t, err)
@@ -115,11 +114,11 @@ func TestRedisNetworkPolicy(t *testing.T) {
 
 	// Check if the network policy was created
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, RedisNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(RedisNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	// Check if the network policy has the correct pod selector
-	assert.Equal(t, fmt.Sprintf("%s-%s", a.Name, "redis"), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
+	assert.Equal(t, nameWithSuffix("redis", a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
 
 	// Check if the network policy has the correct policy types
 	assert.Equal(t, networkingv1.PolicyTypeIngress, np.Spec.PolicyTypes[0])
@@ -142,11 +141,11 @@ func TestRedisHANetworkPolicy(t *testing.T) {
 
 	// Check if the network policy was created
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, RedisHANetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(RedisHANetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	// Check if the network policy has the correct pod selector
-	assert.Equal(t, fmt.Sprintf("%s-%s", a.Name, "redis-ha-haproxy"), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
+	assert.Equal(t, nameWithSuffix("redis-ha-haproxy", a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
 
 	// Check if the network policy has the correct policy types
 	assert.Equal(t, networkingv1.PolicyTypeIngress, np.Spec.PolicyTypes[0])
@@ -174,7 +173,7 @@ func TestRedisNetworkPolicyWithLongName(t *testing.T) {
 
 	// Check if the network policy was created
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, RedisNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(RedisNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	// Verify that the pod selector uses the truncated name with preserved suffix
@@ -198,7 +197,7 @@ func TestRedisHANetworkPolicyWithLongName(t *testing.T) {
 
 	// Check if the network policy was created
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, RedisHANetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(RedisHANetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	// Verify that the pod selector uses the truncated name with preserved suffix
@@ -218,11 +217,11 @@ func TestNotificationsControllerNetworkPolicy(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDNotificationsControllerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDNotificationsControllerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	// Check if the network policy has the correct pod selector
-	assert.Equal(t, fmt.Sprintf("%s-%s", a.Name, "notifications-controller"), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
+	assert.Equal(t, nameWithSuffix("notifications-controller", a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
 
 	// Check if the network policy has the correct policy types
 	assert.Equal(t, networkingv1.PolicyTypeIngress, np.Spec.PolicyTypes[0])
@@ -249,7 +248,7 @@ func TestNotificationsControllerNetworkPolicyWithLongName(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDNotificationsControllerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDNotificationsControllerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	// Verify that the pod selector uses the truncated name with preserved suffix
@@ -270,11 +269,11 @@ func TestDexServerNetworkPolicy(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDDexServerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDDexServerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	// podSelector: dex-server
-	assert.Equal(t, fmt.Sprintf("%s-%s", a.Name, "dex-server"), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
+	assert.Equal(t, nameWithSuffix("dex-server", a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
 
 	// ingress: (1) from argocd-server on 5556/5557, (2) from any namespace on 5558
 	assert.Equal(t, networkingv1.PolicyTypeIngress, np.Spec.PolicyTypes[0])
@@ -283,7 +282,7 @@ func TestDexServerNetworkPolicy(t *testing.T) {
 	// Rule 1: from argocd-server
 	assert.Equal(t, 1, len(np.Spec.Ingress[0].From))
 	assert.NotNil(t, np.Spec.Ingress[0].From[0].PodSelector)
-	assert.Equal(t, fmt.Sprintf("%s-%s", a.Name, "server"), np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app.kubernetes.io/name"])
+	assert.Equal(t, nameWithSuffix("server", a), np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app.kubernetes.io/name"])
 	assert.Equal(t, 2, len(np.Spec.Ingress[0].Ports))
 	assert.Equal(t, intstr.FromInt(common.ArgoCDDefaultDexHTTPPort), *np.Spec.Ingress[0].Ports[0].Port)
 	assert.Equal(t, intstr.FromInt(common.ArgoCDDefaultDexGRPCPort), *np.Spec.Ingress[0].Ports[1].Port)
@@ -314,7 +313,7 @@ func TestDexServerNetworkPolicyDisabledDeletesExisting(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDDexServerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDDexServerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.Error(t, err)
 }
 
@@ -332,7 +331,7 @@ func TestDexServerNetworkPolicyWithLongName(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDDexServerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDDexServerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	expectedSelector := nameWithSuffix("dex-server", a)
@@ -351,7 +350,7 @@ func TestApplicationSetControllerNetworkPolicy(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDApplicationSetControllerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDApplicationSetControllerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	// podSelector: argocd-applicationset-controller
@@ -385,7 +384,7 @@ func TestApplicationSetControllerNetworkPolicyDisabledDeletesExisting(t *testing
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDApplicationSetControllerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDApplicationSetControllerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.Error(t, err)
 }
 
@@ -397,7 +396,7 @@ func TestArgoCDServerNetworkPolicy(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDServerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDServerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	assert.Equal(t, nameWithSuffix("server", a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
@@ -417,7 +416,7 @@ func TestArgoCDApplicationControllerNetworkPolicy(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDApplicationControllerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDApplicationControllerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	assert.Equal(t, applicationControllerResourceName(a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
@@ -439,7 +438,7 @@ func TestArgoCDRepoServerNetworkPolicy(t *testing.T) {
 	assert.NoError(t, err)
 
 	np := &networkingv1.NetworkPolicy{}
-	err = r.Get(context.TODO(), client.ObjectKey{Name: fmt.Sprintf("%s-%s", a.Name, ArgoCDRepoServerNetworkPolicy), Namespace: a.Namespace}, np)
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(ArgoCDRepoServerNetworkPolicy, a), Namespace: a.Namespace}, np)
 	assert.NoError(t, err)
 
 	assert.Equal(t, nameWithSuffix("repo-server", a), np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"])
@@ -479,7 +478,7 @@ func TestArgoCDRepoServerNetworkPolicyUpdatesExisting(t *testing.T) {
 	// Create an existing NP with wrong spec
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, ArgoCDRepoServerNetworkPolicy),
+			Name:      nameWithSuffix(ArgoCDRepoServerNetworkPolicy, a),
 			Namespace: a.Namespace,
 		},
 		Spec: networkingv1.NetworkPolicySpec{

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -153,12 +153,12 @@ func (r *ReconcileArgoCD) deleteNotificationsResources(cr *argoproj.ArgoCD) erro
 	sa := &corev1.ServiceAccount{}
 	role := &rbacv1.Role{}
 
-	if err := argoutil.FetchObject(r.Client, cr.Namespace, fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDNotificationsControllerComponent), sa); err != nil {
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, nameWithSuffix(common.ArgoCDNotificationsControllerComponent, cr), sa); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	}
-	if err := argoutil.FetchObject(r.Client, cr.Namespace, fmt.Sprintf("%s-%s", cr.Name, common.ArgoCDNotificationsControllerComponent), role); err != nil {
+	if err := argoutil.FetchObject(r.Client, cr.Namespace, nameWithSuffix(common.ArgoCDNotificationsControllerComponent, cr), role); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -606,9 +606,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsServiceMonitor(cr *argoproj.Argo
 		return nil
 	}
 
-	name := fmt.Sprintf("%s-%s", cr.Name, "notifications-controller-metrics")
-	// Resource names must not exceed 63 characters
-	name = argoutil.TruncateWithHash(name, 63)
+	name := nameWithSuffix("notifications-controller-metrics", cr)
 	serviceMonitor := newServiceMonitorWithName(name, cr)
 	smExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, serviceMonitor.Name, serviceMonitor)
 	if err != nil {
@@ -890,7 +888,9 @@ func getNotificationsResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements 
 
 // Returns the name of the role/rolebinding for the source namespaces for notifications-controller in the format of "argocdName-argocdNamespace-notifications"
 func getResourceNameForNotificationsSourceNamespaces(cr *argoproj.ArgoCD) string {
-	return fmt.Sprintf("%s-%s-notifications", cr.Name, cr.Namespace)
+	// For source namespace resources, we need namespace to ensure uniqueness across cluster
+	namespacedName := fmt.Sprintf("%s-%s", argoutil.TruncateCRName(cr.Name), cr.Namespace)
+	return argoutil.TruncateWithHash(fmt.Sprintf("%s-notifications", namespacedName), 63)
 }
 
 // setManagedNotificationSourceNamespaces populates ManagedNotificationsSourceNamespaces var with namespaces

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -888,9 +888,7 @@ func getNotificationsResources(cr *argoproj.ArgoCD) corev1.ResourceRequirements 
 
 // Returns the name of the role/rolebinding for the source namespaces for notifications-controller in the format of "argocdName-argocdNamespace-notifications"
 func getResourceNameForNotificationsSourceNamespaces(cr *argoproj.ArgoCD) string {
-	// For source namespace resources, we need namespace to ensure uniqueness across cluster
-	namespacedName := fmt.Sprintf("%s-%s", argoutil.TruncateCRName(cr.Name), cr.Namespace)
-	return argoutil.TruncateWithHash(fmt.Sprintf("%s-notifications", namespacedName), 63)
+	return fmt.Sprintf("%s-%s-notifications", cr.Name, cr.Namespace)
 }
 
 // setManagedNotificationSourceNamespaces populates ManagedNotificationsSourceNamespaces var with namespaces

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -607,6 +607,8 @@ func (r *ReconcileArgoCD) reconcileNotificationsServiceMonitor(cr *argoproj.Argo
 	}
 
 	name := fmt.Sprintf("%s-%s", cr.Name, "notifications-controller-metrics")
+	// Resource names must not exceed 63 characters
+	name = argoutil.TruncateWithHash(name, 63)
 	serviceMonitor := newServiceMonitorWithName(name, cr)
 	smExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, serviceMonitor.Name, serviceMonitor)
 	if err != nil {

--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -563,6 +563,42 @@ func TestReconcileNotifications_ServiceMonitorWithMetrics(t *testing.T) {
 	assert.Equal(t, monitoringv1.Duration("30s"), testServiceMonitor.Spec.Endpoints[0].ScrapeTimeout)
 }
 
+func TestReconcileNotifications_ServiceMonitorWithLongName(t *testing.T) {
+	// Test that ServiceMonitor names are truncated to 63 characters
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Name = "this-name-will-push-the-char-limit" // 37 chars + 36 char suffix = 73 chars total
+		a.Spec.Notifications.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	err := monitoringv1.AddToScheme(sch)
+	assert.NoError(t, err)
+	err = v1alpha1.AddToScheme(sch)
+	assert.NoError(t, err)
+
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	prometheusAPIFound = true
+	err = r.reconcileNotificationsController(a)
+	assert.NoError(t, err)
+
+	// List all ServiceMonitors and find the one for notifications
+	testServiceMonitorList := &monitoringv1.ServiceMonitorList{}
+	err = r.List(context.TODO(), testServiceMonitorList, &client.ListOptions{Namespace: a.Namespace})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(testServiceMonitorList.Items))
+
+	testServiceMonitor := testServiceMonitorList.Items[0]
+	// Verify the name is truncated to 63 characters
+	assert.LessOrEqual(t, len(testServiceMonitor.GetName()), 63, "ServiceMonitor name exceeds 63 character limit")
+	// Verify the ServiceMonitor was created successfully
+	assert.NotEmpty(t, testServiceMonitor.GetName())
+}
+
 func TestReconcileNotifications_CreateSecret(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {

--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -597,6 +597,35 @@ func TestReconcileNotifications_ServiceMonitorWithLongName(t *testing.T) {
 	assert.LessOrEqual(t, len(testServiceMonitor.GetName()), 63, "ServiceMonitor name exceeds 63 character limit")
 	// Verify the ServiceMonitor was created successfully
 	assert.NotEmpty(t, testServiceMonitor.GetName())
+
+	// Verify the notifications metrics Service exists and is labeled correctly
+	serviceName := argoutil.NameWithSuffix(a.ObjectMeta, "notifications-controller-metrics")
+	testService := &v1.Service{}
+	err = r.Get(context.TODO(), types.NamespacedName{
+		Name:      serviceName,
+		Namespace: a.Namespace,
+	}, testService)
+	assert.NoError(t, err, "Notifications metrics Service should exist")
+
+	// Verify Service name is also within 63 char limit
+	assert.LessOrEqual(t, len(testService.Name), 63, "Service name exceeds 63 character limit")
+
+	// Verify ServiceMonitor selector matches Service labels
+	// This ensures Prometheus can actually scrape metrics from the Service
+	serviceLabelValue := testService.Labels[common.ArgoCDKeyName]
+	smSelectorValue := testServiceMonitor.Spec.Selector.MatchLabels[common.ArgoCDKeyName]
+	assert.Equal(t, serviceLabelValue, smSelectorValue,
+		"ServiceMonitor selector must match Service labels for metrics scraping to work")
+
+	// Verify both use the same truncated name
+	assert.Equal(t, serviceName, serviceLabelValue,
+		"Service label should use the truncated service name")
+	assert.Equal(t, serviceName, smSelectorValue,
+		"ServiceMonitor selector should use the truncated service name")
+
+	// Verify the alignment is preserved after truncation
+	assert.NotEmpty(t, serviceLabelValue, "Service label should not be empty")
+	assert.NotEmpty(t, smSelectorValue, "ServiceMonitor selector should not be empty")
 }
 
 func TestReconcileNotifications_CreateSecret(t *testing.T) {

--- a/controllers/argocd/prometheus.go
+++ b/controllers/argocd/prometheus.go
@@ -291,7 +291,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 					},
 					Expr: intstr.IntOrString{
 						Type:   intstr.String,
-						StrVal: fmt.Sprintf("kube_statefulset_status_replicas{statefulset=\"%s\", namespace=\"%s\"} != kube_statefulset_status_replicas_ready{statefulset=\"%s\", namespace=\"%s\"} ", cr.Name+"-application-controller", cr.Namespace, cr.Name+"-application-controller", cr.Namespace),
+						StrVal: fmt.Sprintf("kube_statefulset_status_replicas{statefulset=\"%s\", namespace=\"%s\"} != kube_statefulset_status_replicas_ready{statefulset=\"%s\", namespace=\"%s\"} ", applicationControllerResourceName(cr), cr.Namespace, applicationControllerResourceName(cr), cr.Namespace),
 					},
 					For: ptr.To((monitoringv1.Duration)("1m")),
 					Labels: map[string]string{

--- a/controllers/argocd/prometheus.go
+++ b/controllers/argocd/prometheus.go
@@ -92,9 +92,7 @@ func newServiceMonitorWithName(name string, cr *argoproj.ArgoCD) *monitoringv1.S
 
 // newServiceMonitorWithSuffix returns a new ServiceMonitor instance for the given ArgoCD using the given suffix.
 func newServiceMonitorWithSuffix(suffix string, cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
-	name := fmt.Sprintf("%s-%s", cr.Name, suffix)
-	// Resource names must not exceed 63 characters
-	name = argoutil.TruncateWithHash(name, 63)
+	name := nameWithSuffix(suffix, cr)
 	return newServiceMonitorWithName(name, cr)
 }
 
@@ -308,7 +306,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 					},
 					Expr: intstr.IntOrString{
 						Type:   intstr.String,
-						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", cr.Name+"-server", cr.Namespace, cr.Name+"-server", cr.Namespace),
+						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", nameWithSuffix("server", cr), cr.Namespace, nameWithSuffix("server", cr), cr.Namespace),
 					},
 					For: ptr.To((monitoringv1.Duration)("1m")),
 					Labels: map[string]string{
@@ -322,7 +320,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 					},
 					Expr: intstr.IntOrString{
 						Type:   intstr.String,
-						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", cr.Name+"-repo-server", cr.Namespace, cr.Name+"-repo-server", cr.Namespace),
+						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", nameWithSuffix("repo-server", cr), cr.Namespace, nameWithSuffix("repo-server", cr), cr.Namespace),
 					},
 					For: ptr.To((monitoringv1.Duration)("1m")),
 					Labels: map[string]string{
@@ -336,7 +334,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 					},
 					Expr: intstr.IntOrString{
 						Type:   intstr.String,
-						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", cr.Name+"-applicationset-controller", cr.Namespace, cr.Name+"-applicationset-controller", cr.Namespace),
+						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", nameWithSuffix("applicationset-controller", cr), cr.Namespace, nameWithSuffix("applicationset-controller", cr), cr.Namespace),
 					},
 					For: ptr.To((monitoringv1.Duration)("5m")),
 					Labels: map[string]string{
@@ -350,7 +348,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 					},
 					Expr: intstr.IntOrString{
 						Type:   intstr.String,
-						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", cr.Name+"-dex-server", cr.Namespace, cr.Name+"-dex-server", cr.Namespace),
+						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", nameWithSuffix("dex-server", cr), cr.Namespace, nameWithSuffix("dex-server", cr), cr.Namespace),
 					},
 					For: ptr.To((monitoringv1.Duration)("5m")),
 					Labels: map[string]string{
@@ -364,7 +362,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 					},
 					Expr: intstr.IntOrString{
 						Type:   intstr.String,
-						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", cr.Name+"-notifications-controller", cr.Namespace, cr.Name+"-notifications-controller", cr.Namespace),
+						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", nameWithSuffix("notifications-controller", cr), cr.Namespace, nameWithSuffix("notifications-controller", cr), cr.Namespace),
 					},
 					For: ptr.To((monitoringv1.Duration)("5m")),
 					Labels: map[string]string{
@@ -378,7 +376,7 @@ func (r *ReconcileArgoCD) reconcilePrometheusRule(cr *argoproj.ArgoCD) error {
 					},
 					Expr: intstr.IntOrString{
 						Type:   intstr.String,
-						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", cr.Name+"-redis", cr.Namespace, cr.Name+"-redis", cr.Namespace),
+						StrVal: fmt.Sprintf("kube_deployment_status_replicas{deployment=\"%s\", namespace=\"%s\"} != kube_deployment_status_replicas_ready{deployment=\"%s\", namespace=\"%s\"} ", nameWithSuffix("redis", cr), cr.Namespace, nameWithSuffix("redis", cr), cr.Namespace),
 					},
 					For: ptr.To((monitoringv1.Duration)("5m")),
 					Labels: map[string]string{

--- a/controllers/argocd/prometheus.go
+++ b/controllers/argocd/prometheus.go
@@ -92,7 +92,10 @@ func newServiceMonitorWithName(name string, cr *argoproj.ArgoCD) *monitoringv1.S
 
 // newServiceMonitorWithSuffix returns a new ServiceMonitor instance for the given ArgoCD using the given suffix.
 func newServiceMonitorWithSuffix(suffix string, cr *argoproj.ArgoCD) *monitoringv1.ServiceMonitor {
-	return newServiceMonitorWithName(fmt.Sprintf("%s-%s", cr.Name, suffix), cr)
+	name := fmt.Sprintf("%s-%s", cr.Name, suffix)
+	// Resource names must not exceed 63 characters
+	name = argoutil.TruncateWithHash(name, 63)
+	return newServiceMonitorWithName(name, cr)
 }
 
 // getMetricsEndpoint returns the desired ServiceMonitor endpoint built from the component's metrics spec.

--- a/controllers/argocd/prometheus_test.go
+++ b/controllers/argocd/prometheus_test.go
@@ -74,7 +74,7 @@ func TestReconcileWorkloadStatusAlertRule(t *testing.T) {
 							},
 							Expr: intstr.IntOrString{
 								Type:   intstr.String,
-								StrVal: fmt.Sprintf("kube_statefulset_status_replicas{statefulset=\"%s\", namespace=\"%s\"} != kube_statefulset_status_replicas_ready{statefulset=\"%s\", namespace=\"%s\"} ", test.argocd.Name+"-application-controller", test.argocd.Namespace, test.argocd.Name+"-application-controller", test.argocd.Namespace),
+								StrVal: fmt.Sprintf("kube_statefulset_status_replicas{statefulset=\"%s\", namespace=\"%s\"} != kube_statefulset_status_replicas_ready{statefulset=\"%s\", namespace=\"%s\"} ", applicationControllerResourceName(test.argocd), test.argocd.Namespace, applicationControllerResourceName(test.argocd), test.argocd.Namespace),
 							},
 							For: ptr.To((monitoringv1.Duration)("1m")),
 							Labels: map[string]string{

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -44,12 +44,15 @@ func newRoleForApplicationSourceNamespaces(namespace string, rules []v1.PolicyRu
 }
 
 func generateResourceName(argoComponentName string, cr *argoproj.ArgoCD) string {
-	return cr.Name + "-" + argoComponentName
+	return argoutil.NameWithSuffix(cr.ObjectMeta, argoComponentName)
 }
 
 // GenerateUniqueResourceName generates unique names for cluster scoped resources
 func GenerateUniqueResourceName(argoComponentName string, cr *argoproj.ArgoCD) string {
-	return cr.Name + "-" + cr.Namespace + "-" + argoComponentName
+	// For cluster-scoped resources, we need to include namespace to ensure uniqueness
+	// First create name-namespace prefix, then add component suffix
+	namespacedName := fmt.Sprintf("%s-%s", argoutil.TruncateCRName(cr.Name), cr.Namespace)
+	return argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", namespacedName, argoComponentName), 63)
 }
 
 func newClusterRole(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) *v1.ClusterRole {

--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -49,10 +49,7 @@ func generateResourceName(argoComponentName string, cr *argoproj.ArgoCD) string 
 
 // GenerateUniqueResourceName generates unique names for cluster scoped resources
 func GenerateUniqueResourceName(argoComponentName string, cr *argoproj.ArgoCD) string {
-	// For cluster-scoped resources, we need to include namespace to ensure uniqueness
-	// First create name-namespace prefix, then add component suffix
-	namespacedName := fmt.Sprintf("%s-%s", argoutil.TruncateCRName(cr.Name), cr.Namespace)
-	return argoutil.TruncateWithHash(fmt.Sprintf("%s-%s", namespacedName, argoComponentName), 63)
+	return cr.Name + "-" + cr.Namespace + "-" + argoComponentName
 }
 
 func newClusterRole(name string, rules []v1.PolicyRule, cr *argoproj.ArgoCD) *v1.ClusterRole {

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -75,9 +75,7 @@ func getRoleBindingNameForSourceNamespaces(argocdName, targetNamespace string) s
 func newRoleBindingWithname(name string, cr *argoproj.ArgoCD) *v1.RoleBinding {
 	roleBinding := newRoleBinding(cr)
 
-	// Truncate the name to stay within 63 character limit
-	fullName := fmt.Sprintf("%s-%s", cr.Name, name)
-	roleBinding.Name = argoutil.TruncateWithHash(fullName, argoutil.GetMaxLabelLength())
+	roleBinding.Name = nameWithSuffix(name, cr)
 
 	labels := roleBinding.Labels
 	labels[common.ArgoCDKeyName] = name

--- a/controllers/argocd/route.go
+++ b/controllers/argocd/route.go
@@ -64,7 +64,7 @@ func newRouteWithName(name string, cr *argoproj.ArgoCD) *routev1.Route {
 
 // newRouteWithSuffix returns a new Route with the given name suffix for the ArgoCD.
 func newRouteWithSuffix(suffix string, cr *argoproj.ArgoCD) *routev1.Route {
-	return newRouteWithName(fmt.Sprintf("%s-%s", cr.Name, suffix), cr)
+	return newRouteWithName(nameWithSuffix(suffix, cr), cr)
 }
 
 // reconcileRoutes will ensure that all ArgoCD Routes are present.
@@ -322,7 +322,10 @@ func (r *ReconcileArgoCD) reconcileApplicationSetControllerWebhookRoute(cr *argo
 		host = cr.Spec.ApplicationSet.WebhookServer.Host
 	} else {
 		// Generate the default host
-		baseHost := fmt.Sprintf("%s-%s-%s", cr.Name, common.ApplicationSetControllerWebhookSuffix, cr.Namespace)
+		// For hostnames, we need to ensure the base doesn't exceed DNS label limits
+		// Format: <cr-name>-<suffix>-<namespace>
+		truncatedName := argoutil.TruncateCRName(cr.Name)
+		baseHost := fmt.Sprintf("%s-%s-%s", truncatedName, common.ApplicationSetControllerWebhookSuffix, cr.Namespace)
 		ingressConfig := &configv1.Ingress{}
 		err := r.Get(context.TODO(), client.ObjectKey{Name: "cluster"}, ingressConfig)
 		if err != nil {

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -153,7 +153,7 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: applicationControllerResourceName(argocd), Namespace: "argocd-operator"}, ctrlSts)
 		assert.NoError(t, err)
 		ctrlRollout, ok := ctrlSts.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok {
@@ -188,7 +188,7 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 		if !ok || repoRollout != repoRolloutNew {
 			t.Errorf("Did not expect rollout of argocd-repo-server, but it did happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: applicationControllerResourceName(argocd), Namespace: "argocd-operator"}, ctrlSts)
 		assert.NoError(t, err)
 		ctrlRolloutNew, ok := ctrlSts.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok || ctrlRollout != ctrlRolloutNew {
@@ -234,7 +234,7 @@ func Test_ReconcileArgoCD_ReconcileRepoTLSSecret(t *testing.T) {
 		if !ok || repoRollout == repoRolloutNew {
 			t.Errorf("Expected rollout of argocd-repo-server, but it didn't happen: %v", repoDepl.Spec.Template.Labels)
 		}
-		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: applicationControllerResourceName(argocd), Namespace: "argocd-operator"}, ctrlSts)
 		assert.NoError(t, err)
 		ctrlRolloutNew, ok = ctrlSts.Spec.Template.Labels["repo.tls.cert.changed"]
 		if !ok || ctrlRollout == ctrlRolloutNew {
@@ -580,7 +580,7 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected rollout of argocd-redis, but it didn't happen: %v", redisDepl.Spec.Template.Labels)
 		}
-		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: applicationControllerResourceName(argocd), Namespace: "argocd-operator"}, ctrlSts)
 		assert.NoError(t, err)
 		ctrlRollout, ok := ctrlSts.Spec.Template.Labels[certChangedLabel]
 		if !ok {
@@ -620,7 +620,7 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 		if !ok || redisRollout != redisRolloutNew {
 			t.Errorf("Did not expect rollout of argocd-redis, but it did happen: %v", redisDepl.Spec.Template.Labels)
 		}
-		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: applicationControllerResourceName(argocd), Namespace: "argocd-operator"}, ctrlSts)
 		assert.NoError(t, err)
 		ctrlRolloutNew, ok := ctrlSts.Spec.Template.Labels[certChangedLabel]
 		if !ok || ctrlRollout != ctrlRolloutNew {
@@ -671,7 +671,7 @@ func Test_ReconcileArgoCD_ReconcileRedisTLSSecret(t *testing.T) {
 		if !ok || redisRollout == redisRolloutNew {
 			t.Errorf("Expected rollout of argocd-redis, but it didn't happen: %v", redisDepl.Spec.Template.Labels)
 		}
-		err = r.Get(context.TODO(), types.NamespacedName{Name: "argocd-application-controller", Namespace: "argocd-operator"}, ctrlSts)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: applicationControllerResourceName(argocd), Namespace: "argocd-operator"}, ctrlSts)
 		assert.NoError(t, err)
 		ctrlRolloutNew, ok = ctrlSts.Spec.Template.Labels[certChangedLabel]
 		if !ok || ctrlRollout == ctrlRolloutNew {

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -111,7 +111,7 @@ func (r *ReconcileArgoCD) reconcileMetricsService(cr *argoproj.ArgoCD) error {
 	}
 
 	svc.Spec.Selector = map[string]string{
-		common.ArgoCDKeyName: nameWithSuffix("application-controller", cr),
+		common.ArgoCDKeyName: applicationControllerResourceName(cr),
 	}
 
 	svc.Spec.Ports = []corev1.ServicePort{

--- a/controllers/argocd/service.go
+++ b/controllers/argocd/service.go
@@ -162,9 +162,14 @@ func (r *ReconcileArgoCD) reconcileRedisHAAnnounceServices(cr *argoproj.ArgoCD) 
 
 		svc.Spec.PublishNotReadyAddresses = true
 
+		// Use the actual StatefulSet name to derive the pod name ensuring consistency
+		// when StatefulSet names get truncated for long CR names.
+		redisHAStatefulSet := redisHAStatefulSetName(cr)
+		redisPodName := fmt.Sprintf("%s-%d", redisHAStatefulSet, i)
+
 		svc.Spec.Selector = map[string]string{
 			common.ArgoCDKeyName:               nameWithSuffix("redis-ha", cr),
-			common.ArgoCDKeyStatefulSetPodName: nameWithSuffix(fmt.Sprintf("redis-ha-server-%d", i), cr),
+			common.ArgoCDKeyStatefulSetPodName: redisPodName,
 		}
 
 		svc.Spec.Ports = []corev1.ServicePort{

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -16,7 +16,6 @@ package argocd
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
@@ -53,7 +52,7 @@ func newServiceAccountWithName(name string, cr *argoproj.ArgoCD) *corev1.Service
 }
 
 func getServiceAccountName(crName, name string) string {
-	return fmt.Sprintf("%s-%s", crName, name)
+	return argoutil.NameWithSuffix(metav1.ObjectMeta{Name: crName}, name)
 }
 
 // reconcileServiceAccounts will ensure that all ArgoCD Service Accounts are configured.

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -85,6 +85,7 @@ func newStatefulSetWithName(name string, component string, cr *argoproj.ArgoCD) 
 }
 
 // newStatefulSetWithSuffix returns a new StatefulSet instance for the given ArgoCD using the given suffix.
+// Uses the 52-char StatefulSet naming to prevent controller-revision label overflow for all StatefulSets.
 func newStatefulSetWithSuffix(suffix string, component string, cr *argoproj.ArgoCD) *appsv1.StatefulSet {
 	return newStatefulSetWithName(argoutil.NameWithSuffixForStatefulSet(cr.ObjectMeta, suffix), component, cr)
 }
@@ -819,10 +820,44 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 		}
 	}
 
-	existing := newStatefulSetWithSuffix("application-controller", "application-controller", cr)
+	existing := newStatefulSetWithName(applicationControllerResourceName(cr), "application-controller", cr)
 	ssExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, existing.Name, existing)
 	if err != nil {
 		return err
+	}
+
+	// Check for and clean up old StatefulSet if the naming strategy has changed.
+	// This ensures backward compatibility when upgrading from previous operator versions
+	// that may have used different naming conventions.
+	oldStatefulSetName := nameWithSuffix("application-controller", cr)
+	if oldStatefulSetName != existing.Name {
+		oldSS := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      oldStatefulSetName,
+				Namespace: cr.Namespace,
+			},
+		}
+		oldExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, oldStatefulSetName, oldSS)
+		if err != nil {
+			return err
+		}
+		if oldExists {
+			// Verify the old StatefulSet is owned by this ArgoCD CR before deleting
+			if !metav1.IsControlledBy(oldSS, cr) {
+				log.Info("Found StatefulSet with legacy name but it is not owned by this ArgoCD CR, skipping cleanup", "oldName", oldStatefulSetName, "cr", cr.Name)
+			} else {
+				log.Info("Cleaning up old application controller StatefulSet with legacy name", "oldName", oldStatefulSetName, "newName", existing.Name)
+				argoutil.LogResourceDeletion(log, oldSS, "removing StatefulSet with legacy name")
+				if err := r.Delete(context.TODO(), oldSS); err != nil {
+					return err
+				}
+				// If the new StatefulSet doesn't exist yet, it will be created in the next reconciliation.
+				// If it already exists, we just cleaned up the orphaned old one.
+				if !ssExists {
+					return nil
+				}
+			}
+		}
 	}
 	if ssExists {
 		if !cr.Spec.Controller.IsEnabled() {

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -406,6 +406,39 @@ func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoproj.ArgoCD) error {
 	if err != nil {
 		return err
 	}
+
+	// Check for and clean up old StatefulSet if the naming strategy has changed.
+	// Previous operator versions used nameWithSuffix (63-char cap); new names use NameWithSuffixForStatefulSet (52-char cap).
+	oldStatefulSetName := nameWithSuffix("redis-ha-server", cr)
+	if oldStatefulSetName != existing.Name {
+		oldSS := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      oldStatefulSetName,
+				Namespace: cr.Namespace,
+			},
+		}
+		oldExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, oldStatefulSetName, oldSS)
+		if err != nil {
+			return err
+		}
+		if oldExists {
+			// Verify the old StatefulSet is owned by this ArgoCD CR before deleting
+			if !metav1.IsControlledBy(oldSS, cr) {
+				log.Info("Found StatefulSet with legacy name but it is not owned by this ArgoCD CR, skipping cleanup", "oldName", oldStatefulSetName, "cr", cr.Name)
+			} else {
+				log.Info("Cleaning up old Redis HA StatefulSet with legacy name", "oldName", oldStatefulSetName, "newName", existing.Name)
+				argoutil.LogResourceDeletion(log, oldSS, "removing StatefulSet with legacy name")
+				if err := r.Delete(context.TODO(), oldSS); err != nil {
+					return err
+				}
+				// If the new StatefulSet doesn't exist yet, it will be created in the next reconciliation.
+				// If it already exists, we just cleaned up the orphaned old one.
+				if !ssExists {
+					return nil
+				}
+			}
+		}
+	}
 	if ssExists {
 		if !cr.Spec.HA.Enabled || !cr.Spec.Redis.IsEnabled() {
 			// StatefulSet exists but either HA or component enabled flag has been set to false, delete the StatefulSet
@@ -827,8 +860,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 	}
 
 	// Check for and clean up old StatefulSet if the naming strategy has changed.
-	// This ensures backward compatibility when upgrading from previous operator versions
-	// that may have used different naming conventions.
+	// Previous operator versions used nameWithSuffix (63-char cap); new names use NameWithSuffixForStatefulSet (52-char cap).
 	oldStatefulSetName := nameWithSuffix("application-controller", cr)
 	if oldStatefulSetName != existing.Name {
 		oldSS := &appsv1.StatefulSet{

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -86,7 +86,7 @@ func newStatefulSetWithName(name string, component string, cr *argoproj.ArgoCD) 
 
 // newStatefulSetWithSuffix returns a new StatefulSet instance for the given ArgoCD using the given suffix.
 func newStatefulSetWithSuffix(suffix string, component string, cr *argoproj.ArgoCD) *appsv1.StatefulSet {
-	return newStatefulSetWithName(nameWithSuffix(suffix, cr), component, cr)
+	return newStatefulSetWithName(argoutil.NameWithSuffixForStatefulSet(cr.ObjectMeta, suffix), component, cr)
 }
 
 func (r *ReconcileArgoCD) reconcileRedisStatefulSet(cr *argoproj.ArgoCD) error {
@@ -604,7 +604,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 
 	replicas := r.getApplicationControllerReplicaCount(cr)
 
-	ss := newStatefulSetWithSuffix("application-controller", "application-controller", cr)
+	ss := newStatefulSetWithName(applicationControllerResourceName(cr), "application-controller", cr)
 	ss.Spec.Replicas = &replicas
 	controllerEnv := cr.Spec.Controller.Env
 	// Sharding setting explicitly overrides a value set in the env
@@ -679,7 +679,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 	}
 
 	AddSeccompProfileForOpenShift(r.Client, podSpec)
-	podSpec.ServiceAccountName = nameWithSuffix("argocd-application-controller", cr)
+	podSpec.ServiceAccountName = nameWithSuffix(common.ArgoCDApplicationControllerComponent, cr)
 
 	controllerVolumes := []corev1.Volume{
 		{
@@ -748,7 +748,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 				PodAffinityTerm: corev1.PodAffinityTerm{
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							common.ArgoCDKeyName: nameWithSuffix("argocd-application-controller", cr),
+							common.ArgoCDKeyName: applicationControllerResourceName(cr),
 						},
 					},
 					TopologyKey: common.ArgoCDKeyHostname,
@@ -989,7 +989,7 @@ func updateNodePlacementStateful(existing *appsv1.StatefulSet, ss *appsv1.Statef
 func containsInvalidImage(cr argoproj.ArgoCD, r *ReconcileArgoCD) (bool, error) {
 
 	podList := &corev1.PodList{}
-	applicationControllerListOption := client.MatchingLabels{common.ArgoCDKeyName: fmt.Sprintf("%s-%s", cr.Name, "application-controller")}
+	applicationControllerListOption := client.MatchingLabels{common.ArgoCDKeyName: applicationControllerResourceName(&cr)}
 
 	if err := r.List(context.TODO(), podList, applicationControllerListOption, client.InNamespace(cr.Namespace)); err != nil {
 		log.Error(err, "Failed to list Pods")

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -198,6 +199,59 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_HA_enabled(t *testing.T) {
 	a.Spec.HA.Enabled = false
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
 	assert.Errorf(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s), "not found")
+}
+
+func TestReconcileArgoCD_reconcileRedisStatefulSet_MigratesFromLegacyName(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	// Create ArgoCD with a long name that will trigger abbreviation for Redis HA
+	// redis-ha-server suffix is 16 chars, so we need CR name > 36 chars to exceed 52 char limit
+	a := makeTestArgoCD(func(cr *argoproj.ArgoCD) {
+		cr.Name = "this-is-a-very-long-argocd-cr-name-for-testing"
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	a.Spec.HA.Enabled = true
+
+	// Create old-style StatefulSet with full unabbreviated name
+	oldStatefulSetName := nameWithSuffix("redis-ha-server", a)
+	oldSS := newStatefulSetWithSuffix("redis-ha-server", "redis", a)
+	oldSS.Name = oldStatefulSetName // Force old naming
+	err := controllerutil.SetControllerReference(a, oldSS, r.Scheme)
+	assert.NoError(t, err)
+	err = r.Create(context.TODO(), oldSS)
+	assert.NoError(t, err)
+
+	// First reconcile deletes old StatefulSet
+	assert.NoError(t, r.reconcileRedisStatefulSet(a))
+
+	// Verify old StatefulSet is deleted
+	oldSSCheck := &appsv1.StatefulSet{}
+	err = r.Get(context.TODO(), types.NamespacedName{
+		Name:      oldStatefulSetName,
+		Namespace: a.Namespace,
+	}, oldSSCheck)
+	assert.True(t, apierrors.IsNotFound(err), "Old StatefulSet should be deleted after first reconcile")
+
+	// Second reconcile creates new StatefulSet with abbreviated name
+	assert.NoError(t, r.reconcileRedisStatefulSet(a))
+
+	// Verify new StatefulSet exists with abbreviated name
+	newStatefulSetName := argoutil.NameWithSuffixForStatefulSet(a.ObjectMeta, "redis-ha-server")
+	newSS := &appsv1.StatefulSet{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      newStatefulSetName,
+		Namespace: a.Namespace,
+	}, newSS))
+
+	// Verify names are different (migration occurred)
+	assert.NotEqual(t, oldStatefulSetName, newStatefulSetName, "Old and new names should differ")
 }
 
 func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1125,4 +1126,91 @@ func TestApplicationControllerStatefulSetWithLongCRName(t *testing.T) {
 
 	saName := nameWithSuffix(common.ArgoCDApplicationControllerComponent, a)
 	assert.LessOrEqual(t, len(saName), argoutil.GetMaxLabelLength())
+}
+
+func TestReconcileArgoCD_reconcileApplicationControllerStatefulSet_LegacyCleanup(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	// Create ArgoCD with a long name that triggers abbreviation
+	longName := "this-name-will-push-the-char-limit"
+	a := makeTestArgoCD()
+	a.Name = longName
+
+	// Create a legacy StatefulSet with old naming (owned by this CR)
+	oldStatefulSetName := argoutil.NameWithSuffix(a.ObjectMeta, "application-controller")
+	trueVal := true
+	legacyOwnedSS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oldStatefulSetName,
+			Namespace: a.Namespace,
+			Labels: map[string]string{
+				common.ArgoCDKeyComponent: "application-controller",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "argoproj.io/v1beta1",
+					Kind:               "ArgoCD",
+					Name:               a.Name,
+					UID:                a.UID,
+					Controller:         &trueVal,
+					BlockOwnerDeletion: &trueVal,
+				},
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: func() *int32 { r := int32(1); return &r }(),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					common.ArgoCDKeyName: oldStatefulSetName,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						common.ArgoCDKeyName: oldStatefulSetName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "argocd-application-controller",
+							Image: "quay.io/argoproj/argocd:latest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resObjs := []client.Object{a, legacyOwnedSS}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	// First reconcile - should delete the old StatefulSet and return early
+	err := r.reconcileApplicationControllerStatefulSet(a, false)
+	assert.NoError(t, err)
+
+	// Verify legacy owned StatefulSet was deleted
+	err = r.Get(context.TODO(), types.NamespacedName{
+		Name:      legacyOwnedSS.Name,
+		Namespace: legacyOwnedSS.Namespace,
+	}, legacyOwnedSS)
+	assert.True(t, apierrors.IsNotFound(err), "Legacy owned StatefulSet should be deleted")
+
+	// Second reconcile - should create the new StatefulSet with abbreviated name
+	err = r.reconcileApplicationControllerStatefulSet(a, false)
+	assert.NoError(t, err)
+
+	// Verify new StatefulSet with abbreviated name exists
+	newStatefulSetName := argoutil.NameWithSuffixForStatefulSet(a.ObjectMeta, "application-controller")
+	newSS := &appsv1.StatefulSet{}
+	err = r.Get(context.TODO(), types.NamespacedName{
+		Name:      newStatefulSetName,
+		Namespace: a.Namespace,
+	}, newSS)
+	assert.NoError(t, err, "New StatefulSet with abbreviated name should exist")
+	assert.Contains(t, newSS.Name, "app-controller", "Should use abbreviated suffix")
 }

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -216,7 +216,7 @@ func TestReconcileArgoCD_reconcileApplicationController(t *testing.T) {
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -262,7 +262,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withRedisTLS(t *testing.
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -304,7 +304,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withUpdate(t *testing.T)
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -373,7 +373,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withResources(t *testing
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -540,7 +540,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 		assert.NoError(t, r.Get(
 			context.TODO(),
 			types.NamespacedName{
-				Name:      "argocd-application-controller",
+				Name:      applicationControllerResourceName(a),
 				Namespace: a.Namespace,
 			},
 			ss))
@@ -592,7 +592,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withAppSync(t *testing.T
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -647,7 +647,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withEnv(t *testing.T) {
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -724,7 +724,7 @@ func Test_ContainsInvalidImage(t *testing.T) {
 			Name:      "argo-cd-application-controller",
 			Namespace: a.Namespace,
 			Labels: map[string]string{
-				common.ArgoCDKeyName: fmt.Sprintf("%s-%s", a.Name, "application-controller"),
+				common.ArgoCDKeyName: applicationControllerResourceName(a),
 			},
 		},
 	}
@@ -857,7 +857,7 @@ func TestReconcileAppController_Initcontainer(t *testing.T) {
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -874,7 +874,7 @@ func TestReconcileAppController_Initcontainer(t *testing.T) {
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -905,7 +905,7 @@ func TestReconcileArgoCD_sidecarcontainer(t *testing.T) {
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -922,7 +922,7 @@ func TestReconcileArgoCD_sidecarcontainer(t *testing.T) {
 	assert.NoError(t, r.Get(
 		context.TODO(),
 		types.NamespacedName{
-			Name:      "argocd-application-controller",
+			Name:      applicationControllerResourceName(a),
 			Namespace: a.Namespace,
 		},
 		ss))
@@ -1090,12 +1090,10 @@ func TestStatefulSetWithLongName(t *testing.T) {
 	}
 	assert.NotNil(t, redisStatefulset, "Redis HA statefulset should exist")
 
-	// Verify that the StatefulSet name is truncated and within limits
-	assert.LessOrEqual(t, len(redisStatefulset.Name), 63)
+	// Verify that the StatefulSet name is truncated and within limits for controller revisions
+	assert.LessOrEqual(t, len(redisStatefulset.Name), argoutil.GetMaxStatefulSetNameLength())
+	assert.LessOrEqual(t, len(redisStatefulset.Name)+11, argoutil.GetMaxLabelLength())
 	assert.Contains(t, redisStatefulset.Name, "redis")
-
-	// Verify that the StatefulSet name contains the "server" suffix (unique identifier)
-	assert.Contains(t, redisStatefulset.Name, "redis-ha-server", "StatefulSet name should contain the full suffix for uniqueness")
 
 	// Verify that the component label is set correctly
 	assert.Equal(t, "redis", redisStatefulset.Labels[common.ArgoCDKeyComponent])
@@ -1109,4 +1107,22 @@ func TestStatefulSetWithLongName(t *testing.T) {
 
 	// Verify that the service name uses the component name (our fix)
 	assert.Equal(t, expectedComponentName, redisStatefulset.Spec.ServiceName)
+}
+
+func TestApplicationControllerStatefulSetWithLongCRName(t *testing.T) {
+	longName := "long-cr-name-for-statefulset-test"
+	a := makeTestArgoCD()
+	a.Name = longName
+
+	resourceName := applicationControllerResourceName(a)
+	ss := newStatefulSetWithName(resourceName, "application-controller", a)
+
+	assert.LessOrEqual(t, len(ss.Name), argoutil.GetMaxStatefulSetNameLength())
+	assert.LessOrEqual(t, len(ss.Name)+11, argoutil.GetMaxLabelLength())
+	assert.Equal(t, resourceName, ss.Labels[common.ArgoCDKeyName])
+	assert.Equal(t, resourceName, ss.Spec.Template.Labels[common.ArgoCDKeyName])
+	assert.Equal(t, resourceName, ss.Spec.Selector.MatchLabels[common.ArgoCDKeyName])
+
+	saName := nameWithSuffix(common.ArgoCDApplicationControllerComponent, a)
+	assert.LessOrEqual(t, len(saName), argoutil.GetMaxLabelLength())
 }

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -420,6 +420,12 @@ func nameWithSuffix(suffix string, cr *argoproj.ArgoCD) string {
 	return argoutil.NameWithSuffix(cr.ObjectMeta, suffix)
 }
 
+// applicationControllerResourceName returns the application controller StatefulSet name and
+// the app.kubernetes.io/name label value for its pods.
+func applicationControllerResourceName(cr *argoproj.ArgoCD) string {
+	return argoutil.NameWithSuffixForStatefulSet(cr.ObjectMeta, "application-controller")
+}
+
 // InspectCluster will verify the availability of extra features available to the cluster, such as Prometheus and
 // OpenShift Routes.
 func InspectCluster() error {

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -426,6 +426,11 @@ func applicationControllerResourceName(cr *argoproj.ArgoCD) string {
 	return argoutil.NameWithSuffixForStatefulSet(cr.ObjectMeta, "application-controller")
 }
 
+// redisHAStatefulSetName returns the Redis HA StatefulSet name.
+func redisHAStatefulSetName(cr *argoproj.ArgoCD) string {
+	return argoutil.NameWithSuffixForStatefulSet(cr.ObjectMeta, "redis-ha-server")
+}
+
 // InspectCluster will verify the availability of extra features available to the cluster, such as Prometheus and
 // OpenShift Routes.
 func InspectCluster() error {

--- a/controllers/argocdexport/job.go
+++ b/controllers/argocdexport/job.go
@@ -184,7 +184,8 @@ func newExportPodSpec(cr *argoproj.ArgoCDExport, argocdName string, client clien
 	}}
 
 	pod.RestartPolicy = corev1.RestartPolicyOnFailure
-	pod.ServiceAccountName = fmt.Sprintf("%s-%s", argocdName, "argocd-application-controller")
+	// Use the proper naming function to construct service account name
+	pod.ServiceAccountName = argoutil.NameWithSuffix(metav1.ObjectMeta{Name: argocdName}, common.ArgoCDApplicationControllerComponent)
 	pod.Volumes = []corev1.Volume{
 		getArgoStorageVolume("backup-storage", cr),
 		getArgoSecretVolume("secret-storage", cr),

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -44,6 +44,12 @@ const (
 	maxSuffixLength = 25
 	// maxCRNameLength is the maximum length for ArgoCD CR names to accommodate longest suffix
 	maxCRNameLength = maxLabelLength - maxSuffixLength - 1 // -1 for hyphen separator
+	// statefulSetControllerRevisionOverhead is appended by Kubernetes to StatefulSet
+	// controller revision labels ("-" + 10 character hash).
+	statefulSetControllerRevisionOverhead = 11
+	// maxStatefulSetNameLength is the maximum length for StatefulSet names so that
+	// controller revision labels stay within the 63 character limit.
+	maxStatefulSetNameLength = maxLabelLength - statefulSetControllerRevisionOverhead
 )
 
 // AppendStringMap will append the map `add` to the given map `src` and return the result.
@@ -130,7 +136,22 @@ func IsObjectFound(client client.Client, namespace string, name string, obj clie
 // The object name is truncated first, then the full suffix is appended to preserve suffix readability.
 // Example: Given a long resource name, this ensures suffixes like "redis-initial-password" remain intact.
 func NameWithSuffix(meta metav1.ObjectMeta, suffix string) string {
-	return fmt.Sprintf("%s-%s", TruncateCRName(meta.Name), suffix)
+	fullName := fmt.Sprintf("%s-%s", TruncateCRName(meta.Name), suffix)
+	return TruncateWithHash(fullName, maxLabelLength)
+}
+
+// NameWithSuffixForStatefulSet returns a StatefulSet name that stays within the Kubernetes
+// label length limit after controller revision hash suffixes are applied.
+// Abbreviates "application-controller" to "app-controller" for better readability.
+func NameWithSuffixForStatefulSet(meta metav1.ObjectMeta, suffix string) string {
+	// Abbreviate application-controller to preserve readability in truncated names
+	abbreviatedSuffix := suffix
+	if suffix == "application-controller" {
+		abbreviatedSuffix = "app-controller"
+	}
+
+	fullName := fmt.Sprintf("%s-%s", TruncateCRName(meta.Name), abbreviatedSuffix)
+	return TruncateWithHash(fullName, maxStatefulSetNameLength)
 }
 
 // FqdnServiceRef will return the FQDN referencing a specific service name, as set up by the operator, with the
@@ -238,6 +259,12 @@ func GetMaxLabelLength() int {
 // This is exposed for external packages that need to check CR name length
 func GetMaxCRNameLength() int {
 	return maxCRNameLength
+}
+
+// GetMaxStatefulSetNameLength returns the maximum length for StatefulSet names.
+// This is exposed for testing purposes.
+func GetMaxStatefulSetNameLength() int {
+	return maxStatefulSetNameLength
 }
 
 // TruncateWithHash truncates a string to a maximum length and adds a hash suffix to ensure uniqueness

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -142,15 +142,27 @@ func NameWithSuffix(meta metav1.ObjectMeta, suffix string) string {
 
 // NameWithSuffixForStatefulSet returns a StatefulSet name that stays within the Kubernetes
 // label length limit after controller revision hash suffixes are applied.
-// Abbreviates "application-controller" to "app-controller" for better readability.
+// Preserves the original suffix when possible to maintain backward compatibility.
+// Only abbreviates or truncates when the full name would exceed maxStatefulSetNameLength.
 func NameWithSuffixForStatefulSet(meta metav1.ObjectMeta, suffix string) string {
-	// Abbreviate application-controller to preserve readability in truncated names
-	abbreviatedSuffix := suffix
-	if suffix == "application-controller" {
-		abbreviatedSuffix = "app-controller"
+	truncatedCRName := TruncateCRName(meta.Name)
+	fullName := fmt.Sprintf("%s-%s", truncatedCRName, suffix)
+
+	// If the full name fits within the limit, use it as-is to maintain backward compatibility
+	if len(fullName) <= maxStatefulSetNameLength {
+		return fullName
 	}
 
-	fullName := fmt.Sprintf("%s-%s", TruncateCRName(meta.Name), abbreviatedSuffix)
+	// Name is too long. For application-controller, try abbreviating first
+	if suffix == "application-controller" {
+		abbreviated := fmt.Sprintf("%s-%s", truncatedCRName, "app-controller")
+		if len(abbreviated) <= maxStatefulSetNameLength {
+			return abbreviated
+		}
+		// If abbreviation still doesn't fit, fall through to hash truncation below
+	}
+
+	// As a last resort, truncate with hash to fit within the limit
 	return TruncateWithHash(fullName, maxStatefulSetNameLength)
 }
 

--- a/controllers/argoutil/resource_test.go
+++ b/controllers/argoutil/resource_test.go
@@ -183,10 +183,16 @@ func TestNameWithSuffixForStatefulSet(t *testing.T) {
 			expectContains: "app-controller",
 		},
 		{
-			name:           "truncates with hash for very long CR names",
+			name:           "abbreviates suffix for very long CR names",
 			crName:         "very-long-argocd-instance-name-that-needs-truncation-and-more",
 			suffix:         "application-controller",
-			expectContains: "", // Will be truncated with hash
+			expectContains: "app-controller", // CR name truncated, suffix abbreviated to fit
+		},
+		{
+			name:           "truncates with hash for very long CR names with non-abbreviated suffix",
+			crName:         "very-long-argocd-instance-name-that-needs-truncation-and-more",
+			suffix:         "redis-ha-server",
+			expectContains: "", // No abbreviation for redis-ha-server, falls through to hash truncation
 		},
 	}
 

--- a/controllers/argoutil/resource_test.go
+++ b/controllers/argoutil/resource_test.go
@@ -154,6 +154,107 @@ func TestTruncateWithHashUniqueness(t *testing.T) {
 	}
 }
 
+func TestNameWithSuffixForStatefulSet(t *testing.T) {
+	tests := []struct {
+		name           string
+		crName         string
+		suffix         string
+		expectContains string
+	}{
+		{
+			name:           "abbreviates suffix to preserve readability for short names",
+			crName:         "argocd",
+			suffix:         "application-controller",
+			expectContains: "app-controller",
+		},
+		{
+			name:           "stays within controller revision limit with medium CR name",
+			crName:         "argocd-sharding-algorithm-test",
+			suffix:         "application-controller",
+			expectContains: "app-controller",
+		},
+		{
+			name:           "truncates and abbreviates for long CR names to fit within 52 char limit",
+			crName:         "long-cr-name-for-statefulset-test",
+			suffix:         "application-controller",
+			expectContains: "app-controller",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NameWithSuffixForStatefulSet(metav1.ObjectMeta{Name: tt.crName}, tt.suffix)
+
+			// Verify StatefulSet name stays within limit
+			assert.LessOrEqual(t, len(result), GetMaxStatefulSetNameLength(),
+				"StatefulSet name must be <= %d chars", GetMaxStatefulSetNameLength())
+
+			// Verify that after Kubernetes adds controller revision (11 chars), total stays within 63
+			assert.LessOrEqual(t, len(result)+11, GetMaxLabelLength(),
+				"StatefulSet name + controller revision must be <= %d chars", GetMaxLabelLength())
+
+			// Verify suffix is abbreviated for readability
+			assert.Contains(t, result, tt.expectContains,
+				"Should contain readable abbreviated suffix")
+
+			// Verify function is deterministic
+			result2 := NameWithSuffixForStatefulSet(metav1.ObjectMeta{Name: tt.crName}, tt.suffix)
+			assert.Equal(t, result, result2, "Function should be deterministic")
+		})
+	}
+}
+
+func TestNameWithSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		crName string
+		suffix string
+	}{
+		{
+			name:   "returns concatenated name when both parts fit within limit",
+			crName: "argocd",
+			suffix: "redis",
+		},
+		{
+			name:   "truncates CR name when combined length exceeds limit",
+			crName: "argocd",
+			suffix: "argocd-application-controller",
+		},
+		{
+			name:   "handles long CR name with short suffix",
+			crName: "long-argocd-cr-name-exceeding-limit",
+			suffix: "server",
+		},
+		{
+			name:   "applies double truncation for service account names exceeding limit",
+			crName: "long-argocd-cr-name-exceeding-limit",
+			suffix: "argocd-application-controller",
+		},
+		{
+			name:   "truncates both CR name and suffix when extremely long",
+			crName: "extremely-long-argocd-instance-name-that-exceeds-maximum-limits",
+			suffix: "very-long-suffix-for-service-account-resource",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NameWithSuffix(metav1.ObjectMeta{Name: tt.crName}, tt.suffix)
+
+			// Verify result stays within Kubernetes label limit
+			assert.LessOrEqual(t, len(result), GetMaxLabelLength(),
+				"Result must be <= %d chars", GetMaxLabelLength())
+
+			// Verify function is deterministic
+			result2 := NameWithSuffix(metav1.ObjectMeta{Name: tt.crName}, tt.suffix)
+			assert.Equal(t, result, result2, "Function should be deterministic")
+
+			// Verify result is not empty
+			assert.NotEmpty(t, result, "Result should not be empty")
+		})
+	}
+}
+
 func TestTruncateCRName(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/controllers/argoutil/resource_test.go
+++ b/controllers/argoutil/resource_test.go
@@ -160,24 +160,33 @@ func TestNameWithSuffixForStatefulSet(t *testing.T) {
 		crName         string
 		suffix         string
 		expectContains string
+		expectExact    string // For backward compatibility tests where we expect exact name
 	}{
 		{
-			name:           "abbreviates suffix to preserve readability for short names",
+			name:           "preserves full suffix for short CR names (backward compatibility)",
 			crName:         "argocd",
 			suffix:         "application-controller",
-			expectContains: "app-controller",
+			expectExact:    "argocd-application-controller",
+			expectContains: "application-controller",
 		},
 		{
-			name:           "stays within controller revision limit with medium CR name",
-			crName:         "argocd-sharding-algorithm-test",
+			name:           "preserves full suffix for medium CR names (backward compatibility)",
+			crName:         "example-argocd",
+			suffix:         "application-controller",
+			expectExact:    "example-argocd-application-controller",
+			expectContains: "application-controller",
+		},
+		{
+			name:           "abbreviates suffix for long CR names to stay within 52 char limit",
+			crName:         "this-name-will-push-the-char-limit",
 			suffix:         "application-controller",
 			expectContains: "app-controller",
 		},
 		{
-			name:           "truncates and abbreviates for long CR names to fit within 52 char limit",
-			crName:         "long-cr-name-for-statefulset-test",
+			name:           "truncates with hash for very long CR names",
+			crName:         "very-long-argocd-instance-name-that-needs-truncation-and-more",
 			suffix:         "application-controller",
-			expectContains: "app-controller",
+			expectContains: "", // Will be truncated with hash
 		},
 	}
 
@@ -193,9 +202,17 @@ func TestNameWithSuffixForStatefulSet(t *testing.T) {
 			assert.LessOrEqual(t, len(result)+11, GetMaxLabelLength(),
 				"StatefulSet name + controller revision must be <= %d chars", GetMaxLabelLength())
 
-			// Verify suffix is abbreviated for readability
-			assert.Contains(t, result, tt.expectContains,
-				"Should contain readable abbreviated suffix")
+			// Verify exact name for backward compatibility cases
+			if tt.expectExact != "" {
+				assert.Equal(t, tt.expectExact, result,
+					"Should preserve original naming for backward compatibility")
+			}
+
+			// Verify suffix is present when expected
+			if tt.expectContains != "" {
+				assert.Contains(t, result, tt.expectContains,
+					"Should contain expected suffix")
+			}
 
 			// Verify function is deterministic
 			result2 := NameWithSuffixForStatefulSet(metav1.ObjectMeta{Name: tt.crName}, tt.suffix)

--- a/tests/ginkgo/parallel/1-140_validate_statefulset_naming_migration_test.go
+++ b/tests/ginkgo/parallel/1-140_validate_statefulset_naming_migration_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+
+	Context("1-140_validate_statefulset_naming_migration", func() {
+
+		var (
+			k8sClient client.Client
+			ctx       context.Context
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+			k8sClient, _ = utils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		It("should preserve original naming for short CR names (backward compatibility)", func() {
+
+			By("creating namespace for test")
+			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-short-name")
+			defer cleanupFunc()
+
+			// Use a short CR name that does not need abbreviation
+			crName := "example-argocd"
+
+			By("creating ArgoCD CR with short name")
+			argoCDInstance := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      crName,
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{},
+			}
+			Expect(k8sClient.Create(ctx, argoCDInstance)).To(Succeed())
+
+			By("waiting for operator to reconcile")
+			Eventually(argoCDInstance, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			// For short CR names full "application-controller" suffix should be preserved
+			expectedStatefulSetName := argoutil.NameWithSuffixForStatefulSet(argoCDInstance.ObjectMeta, "application-controller")
+			statefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      expectedStatefulSetName,
+					Namespace: ns.Name,
+				},
+			}
+
+			By(fmt.Sprintf("verifying StatefulSet preserves original suffix: %s", expectedStatefulSetName))
+			Eventually(statefulSet, "2m", "5s").Should(k8sFixture.ExistByName())
+
+			// Verify it uses the full suffix, not abbreviated
+			Expect(expectedStatefulSetName).To(Equal(crName + "-application-controller"))
+
+			By("verifying no migration occurred (exactly one application controller StatefulSet)")
+			statefulSetList := &appsv1.StatefulSetList{}
+			Eventually(func() int {
+				listOpts := []client.ListOption{
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"app.kubernetes.io/component": "application-controller"},
+				}
+				err := k8sClient.List(ctx, statefulSetList, listOpts...)
+				if err != nil {
+					return -1
+				}
+				return len(statefulSetList.Items)
+			}, "1m", "5s").Should(Equal(1), "Should have exactly one application controller StatefulSet (no migration)")
+
+			By("verifying StatefulSet has correct pod template labels")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: expectedStatefulSetName, Namespace: ns.Name}, statefulSet)
+				if err != nil {
+					return false
+				}
+				podName := statefulSet.Spec.Template.Labels["app.kubernetes.io/name"]
+				GinkgoWriter.Printf("Pod label 'app.kubernetes.io/name': %s (length: %d)\n", podName, len(podName))
+				return len(podName) <= 63 && len(podName) > 0
+			}, "1m", "2s").Should(BeTrue())
+
+			By("verifying application controller pod is running")
+			Eventually(func() bool {
+				podList := &corev1.PodList{}
+				listOpts := []client.ListOption{
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"app.kubernetes.io/name": expectedStatefulSetName},
+				}
+				err := k8sClient.List(ctx, podList, listOpts...)
+				if err != nil {
+					return false
+				}
+				if len(podList.Items) == 0 {
+					return false
+				}
+				for _, pod := range podList.Items {
+					if pod.Status.Phase == corev1.PodRunning {
+						GinkgoWriter.Printf("Application controller pod is running: %s\n", pod.Name)
+						return true
+					}
+				}
+				return false
+			}, "5m", "5s").Should(BeTrue())
+		})
+
+		It("should abbreviate naming only for long CR names", func() {
+
+			By("creating namespace for test")
+			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-long-name")
+			defer cleanupFunc()
+
+			// Use a long CR name that will trigger abbreviation
+			crName := "this-name-will-push-the-char-limit"
+
+			By("creating ArgoCD CR with long name")
+			argoCDInstance := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      crName,
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{},
+			}
+			Expect(k8sClient.Create(ctx, argoCDInstance)).To(Succeed())
+
+			By("waiting for operator to reconcile and create StatefulSet with abbreviated name")
+			Eventually(argoCDInstance, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			// New StatefulSet name should use abbreviation for long CR names
+			newStatefulSetName := argoutil.NameWithSuffixForStatefulSet(argoCDInstance.ObjectMeta, "application-controller")
+			newStatefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      newStatefulSetName,
+					Namespace: ns.Name,
+				},
+			}
+
+			By(fmt.Sprintf("verifying StatefulSet uses abbreviated suffix: %s", newStatefulSetName))
+			Eventually(newStatefulSet, "2m", "5s").Should(k8sFixture.ExistByName())
+
+			// Verify it uses abbreviated suffix
+			Expect(newStatefulSetName).To(ContainSubstring("app-controller"))
+			Expect(newStatefulSetName).NotTo(ContainSubstring("application-controller"))
+
+			By("verifying StatefulSet has correct pod template labels (within 63 char limit)")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: newStatefulSetName, Namespace: ns.Name}, newStatefulSet)
+				if err != nil {
+					return false
+				}
+				// Verify pod labels are within Kubernetes 63 character limit
+				podName := newStatefulSet.Spec.Template.Labels["app.kubernetes.io/name"]
+				GinkgoWriter.Printf("Pod label 'app.kubernetes.io/name': %s (length: %d)\n", podName, len(podName))
+				return len(podName) <= 63 && len(podName) > 0
+			}, "1m", "2s").Should(BeTrue())
+
+			By("verifying application controller pod is running")
+			Eventually(func() bool {
+				podList := &corev1.PodList{}
+				listOpts := []client.ListOption{
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"app.kubernetes.io/name": newStatefulSetName},
+				}
+				err := k8sClient.List(ctx, podList, listOpts...)
+				if err != nil {
+					return false
+				}
+				if len(podList.Items) == 0 {
+					return false
+				}
+				for _, pod := range podList.Items {
+					if pod.Status.Phase == corev1.PodRunning {
+						GinkgoWriter.Printf("Application controller pod is running: %s\n", pod.Name)
+						return true
+					}
+				}
+				return false
+			}, "5m", "5s").Should(BeTrue())
+		})
+	})
+})

--- a/tests/ginkgo/parallel/1-140_validate_statefulset_naming_migration_test.go
+++ b/tests/ginkgo/parallel/1-140_validate_statefulset_naming_migration_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
@@ -209,6 +210,352 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				}
 				return false
 			}, "5m", "5s").Should(BeTrue())
+		})
+
+		It("should preserve Redis HA naming for short CR names (backward compatibility)", func() {
+			By("creating namespace for test")
+			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-redis-short-name")
+			defer cleanupFunc()
+
+			crName := "example-argocd"
+
+			By("creating ArgoCD CR with short name and HA enabled")
+			argoCDInstance := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      crName,
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					HA: argov1beta1api.ArgoCDHASpec{
+						Enabled: true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCDInstance)).To(Succeed())
+
+			// For short CR names full "redis-ha-server" suffix should be preserved
+			expectedStatefulSetName := argoutil.NameWithSuffixForStatefulSet(argoCDInstance.ObjectMeta, "redis-ha-server")
+			statefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      expectedStatefulSetName,
+					Namespace: ns.Name,
+				},
+			}
+
+			By("waiting for operator to create Redis HA StatefulSet with preserved name")
+			Eventually(statefulSet, "5m", "5s").Should(k8sFixture.ExistByName())
+
+			// Verify it uses the full suffix, not abbreviated
+			Expect(expectedStatefulSetName).To(Equal(crName + "-redis-ha-server"))
+
+			By("verifying no migration occurred (exactly one Redis HA StatefulSet)")
+			statefulSetList := &appsv1.StatefulSetList{}
+			Eventually(func() int {
+				listOpts := []client.ListOption{
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"app.kubernetes.io/component": "redis"},
+				}
+				err := k8sClient.List(ctx, statefulSetList, listOpts...)
+				if err != nil {
+					return -1
+				}
+				return len(statefulSetList.Items)
+			}, "2m", "5s").Should(Equal(1))
+
+			By("verifying StatefulSet name is within 52 character limit")
+			Expect(len(expectedStatefulSetName)).To(BeNumerically("<=", 52))
+		})
+
+		It("should abbreviate Redis HA naming for long CR names", func() {
+			By("creating namespace for test")
+			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-redis-long-name")
+			defer cleanupFunc()
+
+			// Use a CR name long enough that {cr}-redis-ha-server exceeds the 52-char StatefulSet limit
+			crName := "this-is-a-very-long-argocd-cr-name-for-testing"
+
+			By("creating ArgoCD CR with long name and HA enabled")
+			argoCDInstance := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      crName,
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					HA: argov1beta1api.ArgoCDHASpec{
+						Enabled: true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCDInstance)).To(Succeed())
+
+			// New StatefulSet name should be truncated to fit within the 52-char limit
+			newStatefulSetName := argoutil.NameWithSuffixForStatefulSet(argoCDInstance.ObjectMeta, "redis-ha-server")
+			newStatefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      newStatefulSetName,
+					Namespace: ns.Name,
+				},
+			}
+
+			By(fmt.Sprintf("waiting for operator to create truncated Redis HA StatefulSet: %s", newStatefulSetName))
+			Eventually(newStatefulSet, "5m", "5s").Should(k8sFixture.ExistByName())
+
+			// Verify STS name is hash-truncated to fit within the 52-char limit
+			fullName := fmt.Sprintf("%s-redis-ha-server", crName)
+			Expect(newStatefulSetName).NotTo(Equal(fullName), "Name should be truncated")
+			Expect(len(newStatefulSetName)).To(BeNumerically("<=", 52), "Redis HA StatefulSet name should not exceed 52 characters")
+
+			By("verifying pod template label uses truncated redis-ha component name")
+			expectedRedisLabel := argoutil.NameWithSuffix(argoCDInstance.ObjectMeta, "redis-ha")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: newStatefulSetName, Namespace: ns.Name}, newStatefulSet)
+				if err != nil {
+					return false
+				}
+				podName := newStatefulSet.Spec.Template.Labels["app.kubernetes.io/name"]
+				GinkgoWriter.Printf("Pod label 'app.kubernetes.io/name': %s (length: %d)\n", podName, len(podName))
+				return podName == expectedRedisLabel && len(podName) <= 63
+			}, "2m", "5s").Should(BeTrue())
+
+			By("verifying no old-style StatefulSet exists (exactly one Redis HA StatefulSet)")
+			statefulSetList := &appsv1.StatefulSetList{}
+			Eventually(func() int {
+				listOpts := []client.ListOption{
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"app.kubernetes.io/component": "redis"},
+				}
+				err := k8sClient.List(ctx, statefulSetList, listOpts...)
+				if err != nil {
+					return -1
+				}
+				return len(statefulSetList.Items)
+			}, "2m", "5s").Should(Equal(1))
+		})
+
+		It("should migrate existing application controller StatefulSet from old long name to abbreviated name", func() {
+			By("creating namespace for test")
+			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-app-migration")
+			defer cleanupFunc()
+
+			crName := "this-name-will-push-the-char-limit"
+
+			By("creating ArgoCD CR with long name")
+			argoCDInstance := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      crName,
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{},
+			}
+			Expect(k8sClient.Create(ctx, argoCDInstance)).To(Succeed())
+
+			// Wait briefly for ArgoCD CR to be picked up by the operator
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      argoCDInstance.Name,
+					Namespace: argoCDInstance.Namespace,
+				}, argoCDInstance)
+			}, "30s", "2s").Should(Succeed())
+
+			By("creating legacy StatefulSet with previous operator naming (nameWithSuffix)")
+			oldStatefulSetName := argoutil.NameWithSuffix(argoCDInstance.ObjectMeta, "application-controller")
+			oldSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      oldStatefulSetName,
+					Namespace: ns.Name,
+					Labels: map[string]string{
+						"app.kubernetes.io/name":      oldStatefulSetName,
+						"app.kubernetes.io/part-of":   "argocd",
+						"app.kubernetes.io/component": "application-controller",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         "argoproj.io/v1beta1",
+						Kind:               "ArgoCD",
+						Name:               argoCDInstance.Name,
+						UID:                argoCDInstance.UID,
+						Controller:         ptr.To(true),
+						BlockOwnerDeletion: ptr.To(true),
+					}},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(1)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name": oldStatefulSetName,
+						},
+					},
+					ServiceName: oldStatefulSetName,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name": oldStatefulSetName,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "application-controller",
+								Image: "quay.io/argoproj/argocd:latest",
+							}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oldSS)).To(Succeed())
+
+			By("verifying old StatefulSet exists")
+			Eventually(oldSS).Should(k8sFixture.ExistByName())
+
+			By("waiting for operator to detect and migrate the StatefulSet")
+			newStatefulSetName := argoutil.NameWithSuffixForStatefulSet(argoCDInstance.ObjectMeta, "application-controller")
+
+			By(fmt.Sprintf("verifying old StatefulSet is eventually deleted: %s", oldStatefulSetName))
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      oldStatefulSetName,
+					Namespace: ns.Name,
+				}, oldSS)
+				return err != nil
+			}, "3m", "5s").Should(BeTrue(), "Old StatefulSet should be deleted during migration")
+
+			By(fmt.Sprintf("verifying new StatefulSet is created with abbreviated name: %s", newStatefulSetName))
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      newStatefulSetName,
+					Namespace: ns.Name,
+				},
+			}
+			Eventually(newSS, "3m", "5s").Should(k8sFixture.ExistByName())
+
+			By("verifying only one application controller StatefulSet exists")
+			statefulSetList := &appsv1.StatefulSetList{}
+			Eventually(func() int {
+				listOpts := []client.ListOption{
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"app.kubernetes.io/component": "application-controller"},
+				}
+				err := k8sClient.List(ctx, statefulSetList, listOpts...)
+				if err != nil {
+					return -1
+				}
+				return len(statefulSetList.Items)
+			}, "2m", "5s").Should(Equal(1), "Should have exactly one application controller StatefulSet")
+
+			By("verifying the ArgoCD instance becomes available after migration")
+			Eventually(argoCDInstance, "5m", "5s").Should(argocdFixture.BeAvailable())
+		})
+
+		It("should migrate existing Redis HA StatefulSet from old long name to abbreviated name", func() {
+			By("creating namespace for test")
+			ns, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-redis-migration")
+			defer cleanupFunc()
+
+			crName := "this-is-a-very-long-argocd-cr-name-for-testing"
+
+			By("creating ArgoCD CR with long name and HA enabled")
+			argoCDInstance := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      crName,
+					Namespace: ns.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					HA: argov1beta1api.ArgoCDHASpec{
+						Enabled: true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCDInstance)).To(Succeed())
+
+			// Wait briefly for ArgoCD CR to be picked up
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      argoCDInstance.Name,
+					Namespace: argoCDInstance.Namespace,
+				}, argoCDInstance)
+			}, "30s", "2s").Should(Succeed())
+
+			By("creating legacy Redis HA StatefulSet with previous operator naming (nameWithSuffix)")
+			oldStatefulSetName := argoutil.NameWithSuffix(argoCDInstance.ObjectMeta, "redis-ha-server")
+			oldRedisLabel := argoutil.NameWithSuffix(argoCDInstance.ObjectMeta, "redis-ha")
+			oldSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      oldStatefulSetName,
+					Namespace: ns.Name,
+					Labels: map[string]string{
+						"app.kubernetes.io/name":      oldRedisLabel,
+						"app.kubernetes.io/part-of":   "argocd",
+						"app.kubernetes.io/component": "redis",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         "argoproj.io/v1beta1",
+						Kind:               "ArgoCD",
+						Name:               argoCDInstance.Name,
+						UID:                argoCDInstance.UID,
+						Controller:         ptr.To(true),
+						BlockOwnerDeletion: ptr.To(true),
+					}},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(3)),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name": oldRedisLabel,
+						},
+					},
+					ServiceName: oldRedisLabel,
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name": oldRedisLabel,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "redis",
+								Image: "redis:7.0.11-alpine",
+							}},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oldSS)).To(Succeed())
+
+			By("verifying old Redis HA StatefulSet exists")
+			Eventually(oldSS).Should(k8sFixture.ExistByName())
+
+			By("waiting for operator to detect and migrate the Redis HA StatefulSet")
+			newStatefulSetName := argoutil.NameWithSuffixForStatefulSet(argoCDInstance.ObjectMeta, "redis-ha-server")
+
+			By(fmt.Sprintf("verifying old Redis HA StatefulSet is eventually deleted: %s", oldStatefulSetName))
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      oldStatefulSetName,
+					Namespace: ns.Name,
+				}, oldSS)
+				return err != nil
+			}, "3m", "5s").Should(BeTrue(), "Old Redis HA StatefulSet should be deleted during migration")
+
+			By(fmt.Sprintf("verifying new Redis HA StatefulSet is created with abbreviated name: %s", newStatefulSetName))
+			newSS := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      newStatefulSetName,
+					Namespace: ns.Name,
+				},
+			}
+			Eventually(newSS, "3m", "5s").Should(k8sFixture.ExistByName())
+
+			By("verifying only one Redis HA StatefulSet exists")
+			statefulSetList := &appsv1.StatefulSetList{}
+			Eventually(func() int {
+				listOpts := []client.ListOption{
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"app.kubernetes.io/component": "redis"},
+				}
+				err := k8sClient.List(ctx, statefulSetList, listOpts...)
+				if err != nil {
+					return -1
+				}
+				return len(statefulSetList.Items)
+			}, "2m", "5s").Should(Equal(1), "Should have exactly one Redis HA StatefulSet")
 		})
 	})
 })

--- a/tests/ginkgo/sequential/1-002_validate_cluster_config_test.go
+++ b/tests/ginkgo/sequential/1-002_validate_cluster_config_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argocd"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/configmap"
@@ -73,25 +75,25 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 
 			By("verifying ClusterRole/Bindings exist")
 			appcontrollerCRB := &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "example-argocd-argocd-e2e-cluster-config-argocd-application-controller"},
+				ObjectMeta: metav1.ObjectMeta{Name: argocd.GenerateUniqueResourceName(common.ArgoCDApplicationControllerComponent, argoCDInstance)},
 			}
 			Eventually(appcontrollerCRB).Should(k8sFixture.ExistByName())
 
 			serverCRB := &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "example-argocd-argocd-e2e-cluster-config-argocd-server"},
+				ObjectMeta: metav1.ObjectMeta{Name: argocd.GenerateUniqueResourceName(common.ArgoCDServerComponent, argoCDInstance)},
 			}
 			Eventually(serverCRB).Should(k8sFixture.ExistByName())
 
 			appControllerCR := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-argocd-argocd-e2e-cluster-config-argocd-application-controller",
+					Name: argocd.GenerateUniqueResourceName(common.ArgoCDApplicationControllerComponent, argoCDInstance),
 				},
 			}
 			Eventually(appControllerCR).Should(k8sFixture.ExistByName())
 
 			serverCR := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-argocd-argocd-e2e-cluster-config-argocd-server",
+					Name: argocd.GenerateUniqueResourceName(common.ArgoCDServerComponent, argoCDInstance),
 				},
 			}
 			Eventually(serverCR).Should(k8sFixture.ExistByName())
@@ -121,13 +123,13 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			Eventually(argoCDInstance, "5m", "5s").Should(argocdFixture.HaveApplicationSetControllerStatus("Running"))
 
 			appSetClusterRole := &rbacv1.ClusterRole{
-				ObjectMeta: metav1.ObjectMeta{Name: "example-argocd-argocd-e2e-cluster-config-argocd-applicationset-controller"},
+				ObjectMeta: metav1.ObjectMeta{Name: argocd.GenerateUniqueResourceName(common.ArgoCDApplicationSetControllerComponent, argoCDInstance)},
 			}
 			Eventually(appSetClusterRole).Should(k8sFixture.ExistByName())
 
 			appSetCRB := &rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-argocd-argocd-e2e-cluster-config-argocd-applicationset-controller",
+					Name: argocd.GenerateUniqueResourceName(common.ArgoCDApplicationSetControllerComponent, argoCDInstance),
 				},
 			}
 			Eventually(appSetCRB).Should(k8sFixture.ExistByName())

--- a/tests/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
+++ b/tests/ginkgo/sequential/1-037_validate_applicationset_in_any_namespace_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argocd"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	applicationFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/application"
 	appprojectFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/appproject"
@@ -774,7 +775,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("first verify that the ClusterRole was not automatically created for the Argo CD instance")
 			clusterRole := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        argoCD.Name + "-" + argoCD.Namespace + "-" + common.ArgoCDApplicationSetControllerComponent,
+					Name:        argocd.GenerateUniqueResourceName(common.ArgoCDApplicationSetControllerComponent, argoCD),
 					Annotations: common.DefaultAnnotations(argoCD.Name, argoCD.Namespace),
 				},
 			}
@@ -787,7 +788,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("first verify that ClusterRoleBinding was not automatically created for the Argo CD instance")
 			clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        argoCD.Name + "-" + argoCD.Namespace + "-" + common.ArgoCDApplicationSetControllerComponent,
+					Name:        argocd.GenerateUniqueResourceName(common.ArgoCDApplicationSetControllerComponent, argoCD),
 					Annotations: common.DefaultAnnotations(argoCD.Name, argoCD.Namespace),
 				},
 				Subjects: []rbacv1.Subject{
@@ -1174,7 +1175,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("verifying ApplicationSet controller ClusterRole has expected rules")
 			appsetClusterRole := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: argoCD.Name + "-" + argoCD.Namespace + "-" + common.ArgoCDApplicationSetControllerComponent,
+					Name: argocd.GenerateUniqueResourceName(common.ArgoCDApplicationSetControllerComponent, argoCD),
 				},
 			}
 			Eventually(appsetClusterRole, "5m", "10s").Should(k8sFixture.ExistByName())

--- a/tests/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
+++ b/tests/ginkgo/sequential/1-058_validate_notifications_source_namespaces_test.go
@@ -29,6 +29,7 @@ import (
 	argov1alpha1api "github.com/argoproj-labs/argocd-operator/api/v1alpha1"
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
+	argocdcontroller "github.com/argoproj-labs/argocd-operator/controllers/argocd"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
@@ -161,7 +162,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("verifying ClusterRole is created for notifications controller")
 			notifClusterRole := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-argocd-" + argocdNS.Name + "-argocd-notifications-controller",
+					Name: argocdcontroller.GenerateUniqueResourceName(common.ArgoCDNotificationsControllerComponent, argocd),
 				},
 			}
 			Eventually(notifClusterRole).Should(k8sFixture.ExistByName())
@@ -169,7 +170,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("verifying ClusterRoleBinding is created for notifications controller")
 			notifClusterRoleBinding := &rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-argocd-" + argocdNS.Name + "-argocd-notifications-controller",
+					Name: argocdcontroller.GenerateUniqueResourceName(common.ArgoCDNotificationsControllerComponent, argocd),
 				},
 			}
 			Eventually(notifClusterRoleBinding).Should(k8sFixture.ExistByName())
@@ -615,7 +616,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("verifying ClusterRole is created for notifications controller")
 			notifClusterRole := &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-argocd-" + argocdNS.Name + "-argocd-notifications-controller",
+					Name: argocdcontroller.GenerateUniqueResourceName(common.ArgoCDNotificationsControllerComponent, argocd),
 				},
 			}
 			Eventually(notifClusterRole, "3m", "5s").Should(k8sFixture.ExistByName())
@@ -623,7 +624,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			By("verifying ClusterRoleBinding is created for notifications controller")
 			notifClusterRoleBinding := &rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "example-argocd-" + argocdNS.Name + "-argocd-notifications-controller",
+					Name: argocdcontroller.GenerateUniqueResourceName(common.ArgoCDNotificationsControllerComponent, argocd),
 				},
 			}
 			Eventually(notifClusterRoleBinding, "3m", "5s").Should(k8sFixture.ExistByName())


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
JIRA - https://redhat.atlassian.net/browse/GITOPS-9785

**What does this PR do / why we need it**:
Fixes #2181 
where ArgoCD custom resources with names exceeding 29 characters caused the application controller StatefulSet to fail creation with the error "must be no more than 63 bytes". The root cause was that Kubernetes automatically appends an 11-character controller revision suffix (a hyphen plus 10-character hash) to StatefulSet names for version tracking, and the operator was not accounting for this overhead when generating StatefulSet names. When combined with long CR names and the full "application-controller" suffix (22 characters) the total length exceeded Kubernetes' 63-byte label limit.

Now I implemented a fix by adding a new NameWithSuffixForStatefulSet() function that ensures StatefulSet names stay within the Kubernetes 63-character limit while reserving space for controller revision suffixes. To make truncated names more readable, I abbreviate application-controller to app-controller before truncation avoiding awkward cutoffs. I also updated the existing NameWithSuffix() function to better handle truncation and ensure all generated resource names remain within the allowed limit.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #2181 

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized application-controller naming and introduced StatefulSet-safe name generation with legacy-name cleanup to ensure consistent selection and smooth migration.

* **Bug Fixes**
  * Updated network policies, services, and monitoring selectors to use the standardized controller names and ensured long resource names are truncated/hashed to fit Kubernetes limits.

* **Tests**
  * Added and expanded unit and E2E tests validating deterministic naming, length/abbreviation behavior, truncation, and migration/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->