### PR TITLE
docs: enforce tokenref strict mode for AppSet-in-anyNS

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,6 +1,81 @@
 # Upgrading
 
 This page contains upgrade instructions and migration guides for the Argo CD Operator.
+## Upgrading from Operator ≤0.18 (Argo CD ≤3.3.+) to Operator 0.19+ (Argo CD 3.4.+)
+
+### ApplicationSet tokenRef strict mode
+If you're upgrading to an operator version that defaults ApplicationSet tokenRef strict mode when ApplicationSets in any namespace are configured, note the following changes:
+
+1. When `.spec.applicationSet.sourceNamespaces` expands to at least one cluster namespace, the operator sets `applicationsetcontroller.enable.tokenref.strict.mode` to `"true"` in `argocd-cmd-params-cm`
+2. The ApplicationSet controller requires Secrets referenced by SCM Provider and Pull Request generators via `tokenRef` to be labeled `argocd.argoproj.io/secret-type: scm-creds`
+3. Manual edits to this key in `argocd-cmd-params-cm` are corrected on reconcile; use the ArgoCD CR (`.spec.applicationSet.sourceNamespaces` and/or `.spec.cmdParams`) to change behavior
+4. You may opt out via `.spec.cmdParams`, but this is not recommended, see [ApplicationSets in Any Namespace](./usage/appsets-in-any-namespace.md#opting-out-of-tokenref-strict-mode)
+
+### Detection
+
+The following users are **unaffected** by this change:
+- Users who do not configure `.spec.applicationSet.sourceNamespaces` on their ArgoCD CR
+- Users whose `.spec.applicationSet.sourceNamespaces` patterns match no cluster namespace
+- Users who do not have ApplicationSets that use an SCM Provider or Pull Request generator with a `tokenRef` pointing at a Secret for API authentication
+- Users whose SCM `tokenRef` Secrets already have `argocd.argoproj.io/secret-type: scm-creds`
+
+The following users are **affected** and should perform remediation:
+- Users with a non-empty expanded `.spec.applicationSet.sourceNamespaces` list whose ApplicationSets use an **SCM Provider** or **Pull Request** generator with a **`tokenRef`** pointing at a Secret for API authentication
+- Users whose referenced Secrets are missing the `argocd.argoproj.io/secret-type: scm-creds` label
+
+### Remediation Steps
+
+1. **Find ApplicationSets using `tokenRef`:**
+
+```bash
+kubectl get applicationsets -A -o yaml | grep -B5 -A3 'tokenRef:'
+```
+
+Review SCM Provider and Pull Request generator blocks in each ApplicationSet.
+
+2. **Identify referenced Secrets:**
+
+For each `tokenRef`, note `secretName` and namespace (often the Argo CD namespace or the ApplicationSet namespace).
+
+```bash
+kubectl get secret -n <namespace> <secretName> -o yaml
+```
+
+3. **Label SCM credential Secrets:**
+
+```bash
+kubectl label secret -n <namespace> <secretName> \
+  argocd.argoproj.io/secret-type=scm-creds
+```
+
+Or in Git or your secret management workflow:
+
+```yaml
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: scm-creds
+```
+
+4. **Verify after upgrade or reconcile:**
+
+```bash
+kubectl get cm -n <argocd-namespace> argocd-cmd-params-cm -o yaml
+kubectl logs -n <argocd-namespace> deploy/<instance>-applicationset-controller --tail=50
+```
+
+Confirm `applicationsetcontroller.enable.tokenref.strict.mode` is `"true"` when source namespaces are configured, and that ApplicationSets reconcile without tokenRef or secret errors.
+
+5. **Temporary opt-out (migration only):**
+
+If you need time to label Secrets, set `.spec.cmdParams` on the ArgoCD CR:
+
+```yaml
+spec:
+  cmdParams:
+    applicationsetcontroller.enable.tokenref.strict.mode: "false"
+```
+
+This removes the `scm-creds` label requirement and is **not recommended** for production. Prefer labeling Secrets and keeping strict mode enabled. See [ApplicationSets in Any Namespace](./usage/appsets-in-any-namespace.md#tokenref-strict-mode) for details.
 
 ## Upgrading from Operator ≤0.14 (Argo CD ≤2.14) to Operator 0.15+ (Argo CD 3.0+)
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,15 +1,15 @@
 # Upgrading
 
 This page contains upgrade instructions and migration guides for the Argo CD Operator.
-## Upgrading from Operator ≤0.18 (Argo CD ≤3.3.+) to Operator 0.19+ (Argo CD 3.4.+)
+## Upgrading from Operator ≤0.18 to Operator 0.19+
 
 ### ApplicationSet tokenRef strict mode
 If you're upgrading to an operator version that defaults ApplicationSet tokenRef strict mode when ApplicationSets in any namespace are configured, note the following changes:
 
 1. When `.spec.applicationSet.sourceNamespaces` expands to at least one cluster namespace, the operator sets `applicationsetcontroller.enable.tokenref.strict.mode` to `"true"` in `argocd-cmd-params-cm`
 2. The ApplicationSet controller requires Secrets referenced by SCM Provider and Pull Request generators via `tokenRef` to be labeled `argocd.argoproj.io/secret-type: scm-creds`
-3. Manual edits to this key in `argocd-cmd-params-cm` are corrected on reconcile; use the ArgoCD CR (`.spec.applicationSet.sourceNamespaces` and/or `.spec.cmdParams`) to change behavior
-4. You may opt out via `.spec.cmdParams`, but this is not recommended, see [ApplicationSets in Any Namespace](./usage/appsets-in-any-namespace.md#opting-out-of-tokenref-strict-mode)
+3. Manual edits to this key in `argocd-cmd-params-cm` are corrected on reconcile; use the ArgoCD CR (`.spec.cmdParams`) to change behavior
+4. You may opt out via `.spec.cmdParams`, but this is not recommended; see [ApplicationSets in Any Namespace](./usage/appsets-in-any-namespace.md#tokenref-strict-mode)
 
 ### Detection
 

--- a/docs/usage/appsets-in-any-namespace.md
+++ b/docs/usage/appsets-in-any-namespace.md
@@ -124,34 +124,15 @@ Only one of either `managed-by` or `applicationset-managed-by-cluster-argocd` la
 
 ## TokenRef strict mode
 
-When you configure ApplicationSets in any namespace via `.spec.applicationSet.sourceNamespaces`, the Operator automatically manages ApplicationSet `tokenRef` restrictions in operator-owned `argocd-cmd-params-cm`.
+`tokenRef` allows an ApplicationSet generator to reference a Secret that contains authentication details, such as a Git access token.
 
-| Setting | Value |
-|:-|:-|
-| ConfigMap key | `applicationsetcontroller.enable.tokenref.strict.mode` |
-| ApplicationSet controller environment variable | `ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE` |
-| Required Secret label (when strict mode is `true`) | `argocd.argoproj.io/secret-type: scm-creds` |
+When `.spec.applicationSet.sourceNamespaces` is configured on the ArgoCD CR, the Operator enables tokenRef strict mode by default. In this mode, Secrets referenced by SCM Provider or Pull Request generators through `tokenRef` must be labeled `argocd.argoproj.io/secret-type: scm-creds`. This helps prevent ApplicationSets from referencing Secrets outside the allowed namespace scope.
 
-For more details, see the upstream [tokenRef restrictions](https://argo-cd.readthedocs.io/en/latest/operator-manual/applicationset/Appset-Any-Namespace/#tokenref-restrictions) documentation.
+We recommend keeping strict mode enabled. Disabling it can allow ApplicationSets to reference Secrets more broadly, which may increase the risk of accidental or unauthorized Secret access.
 
-### When the Operator sets the default
+For more details, see the upstream [tokenRef restrictions](https://argo-cd.readthedocs.io/en/latest/operator-manual/applicationset/Appset-Any-Namespace/#tokenref-restrictions) documentation. If you are upgrading from a previous operator version, see [ApplicationSet tokenRef strict mode](../upgrading.md#applicationset-tokenref-strict-mode) in the upgrade guide.
 
-The Operator always writes `applicationsetcontroller.enable.tokenref.strict.mode` in `argocd-cmd-params-cm`:
-
-| Condition | Value |
-|:-|:-|
-| `.spec.applicationSet.sourceNamespaces` is empty, unset, or matches no cluster namespace | `"false"` |
-| `.spec.applicationSet.sourceNamespaces` expands (glob or regex) to at least one cluster namespace | `"true"` |
-| `.spec.cmdParams` explicitly sets the key | User value wins (see [Opting out](#opting-out-of-tokenref-strict-mode)) |
-
-The default uses expanded `.spec.applicationSet.sourceNamespaces` only. It does not depend on the cluster-config namespace or on intersection with `.spec.sourceNamespaces`. ApplicationSet RBAC, labels, and `--applicationset-namespaces` still follow their existing rules.
-
-When strict mode is enabled, Secrets referenced by ApplicationSet SCM Provider and Pull Request generators via `tokenRef` must carry the label `argocd.argoproj.io/secret-type` with value `scm-creds`. This limits which Secrets can be used as SCM credentials and reduces the risk of secret exfiltration when ApplicationSets run outside the Argo CD control-plane namespace.
-
-The ArgoCD CR is the source of truth for this setting. The Operator reconciles the desired value into `argocd-cmd-params-cm` and corrects manual edits to this key on reconcile. To change behavior, update `.spec.applicationSet.sourceNamespaces` and/or `.spec.cmdParams`; do not edit `argocd-cmd-params-cm` directly.
-### Opting out of tokenRef strict mode
-
-If you must disable strict mode while `.spec.applicationSet.sourceNamespaces` is configured, set the key in `.spec.cmdParams` on the ArgoCD CR:
+If required, you can disable strict mode by setting `.spec.cmdParams` on the ArgoCD CR:
 
 ```yaml
 apiVersion: argoproj.io/v1beta1
@@ -167,5 +148,5 @@ spec:
 ```
 
 !!! important
-    Disabling tokenRef strict mode while ApplicationSets are allowed in non-control-plane namespaces removes the requirement that SCM `tokenRef` Secrets are labeled `argocd.argoproj.io/secret-type: scm-creds`. This weakens protection against referencing arbitrary Secrets (including in the Argo CD namespace) from ApplicationSets users can create in other namespaces. Only opt out temporarily during migration, or if you have compensating controls. Prefer labeling Secrets and keeping strict mode enabled.
+    Only disable strict mode temporarily during migration, or if you have compensating controls. Prefer labeling Secrets with `argocd.argoproj.io/secret-type: scm-creds` and keeping strict mode enabled.
 

--- a/docs/usage/appsets-in-any-namespace.md
+++ b/docs/usage/appsets-in-any-namespace.md
@@ -122,5 +122,51 @@ This will configure ApplicationSet controller to allow the defined URLs for SCM 
 
 Only one of either `managed-by` or `applicationset-managed-by-cluster-argocd` labels can be applied to a given namespace. We will be prioritizing `managed-by` label in case of a conflict as this feature is currently in beta, so the new roles/rolebindings will not be created if namespace is already labelled with `managed-by` label, and they will be deleted if a namespace is first added to the `.spec.applicationSet.sourceNamespaces` list and is later also labelled with `managed-by` label.
 
+## TokenRef strict mode
 
+When you configure ApplicationSets in any namespace via `.spec.applicationSet.sourceNamespaces`, the Operator automatically manages ApplicationSet `tokenRef` restrictions in operator-owned `argocd-cmd-params-cm`.
+
+| Setting | Value |
+|:-|:-|
+| ConfigMap key | `applicationsetcontroller.enable.tokenref.strict.mode` |
+| ApplicationSet controller environment variable | `ARGOCD_APPLICATIONSET_CONTROLLER_TOKENREF_STRICT_MODE` |
+| Required Secret label (when strict mode is `true`) | `argocd.argoproj.io/secret-type: scm-creds` |
+
+For more details, see the upstream [tokenRef restrictions](https://argo-cd.readthedocs.io/en/latest/operator-manual/applicationset/Appset-Any-Namespace/#tokenref-restrictions) documentation.
+
+### When the Operator sets the default
+
+The Operator always writes `applicationsetcontroller.enable.tokenref.strict.mode` in `argocd-cmd-params-cm`:
+
+| Condition | Value |
+|:-|:-|
+| `.spec.applicationSet.sourceNamespaces` is empty, unset, or matches no cluster namespace | `"false"` |
+| `.spec.applicationSet.sourceNamespaces` expands (glob or regex) to at least one cluster namespace | `"true"` |
+| `.spec.cmdParams` explicitly sets the key | User value wins (see [Opting out](#opting-out-of-tokenref-strict-mode)) |
+
+The default uses expanded `.spec.applicationSet.sourceNamespaces` only. It does not depend on the cluster-config namespace or on intersection with `.spec.sourceNamespaces`. ApplicationSet RBAC, labels, and `--applicationset-namespaces` still follow their existing rules.
+
+When strict mode is enabled, Secrets referenced by ApplicationSet SCM Provider and Pull Request generators via `tokenRef` must carry the label `argocd.argoproj.io/secret-type` with value `scm-creds`. This limits which Secrets can be used as SCM credentials and reduces the risk of secret exfiltration when ApplicationSets run outside the Argo CD control-plane namespace.
+
+The ArgoCD CR is the source of truth for this setting. The Operator reconciles the desired value into `argocd-cmd-params-cm` and corrects manual edits to this key on reconcile. To change behavior, update `.spec.applicationSet.sourceNamespaces` and/or `.spec.cmdParams` do not edit `argocd-cmd-params-cm` directly.
+
+### Opting out of tokenRef strict mode
+
+If you must disable strict mode while `.spec.applicationSet.sourceNamespaces` is configured, set the key in `.spec.cmdParams` on the ArgoCD CR:
+
+```yaml
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example
+spec:
+  applicationSet:
+    sourceNamespaces:
+      - foo
+  cmdParams:
+    applicationsetcontroller.enable.tokenref.strict.mode: "false"
+```
+
+!!! important
+    Disabling tokenRef strict mode while ApplicationSets are allowed in non-control-plane namespaces removes the requirement that SCM `tokenRef` Secrets are labeled `argocd.argoproj.io/secret-type: scm-creds`. This weakens protection against referencing arbitrary Secrets (including in the Argo CD namespace) from ApplicationSets users can create in other namespaces. Only opt out temporarily during migration, or if you have compensating controls. Prefer labeling Secrets and keeping strict mode enabled.
 

--- a/docs/usage/appsets-in-any-namespace.md
+++ b/docs/usage/appsets-in-any-namespace.md
@@ -148,8 +148,7 @@ The default uses expanded `.spec.applicationSet.sourceNamespaces` only. It does 
 
 When strict mode is enabled, Secrets referenced by ApplicationSet SCM Provider and Pull Request generators via `tokenRef` must carry the label `argocd.argoproj.io/secret-type` with value `scm-creds`. This limits which Secrets can be used as SCM credentials and reduces the risk of secret exfiltration when ApplicationSets run outside the Argo CD control-plane namespace.
 
-The ArgoCD CR is the source of truth for this setting. The Operator reconciles the desired value into `argocd-cmd-params-cm` and corrects manual edits to this key on reconcile. To change behavior, update `.spec.applicationSet.sourceNamespaces` and/or `.spec.cmdParams` do not edit `argocd-cmd-params-cm` directly.
-
+The ArgoCD CR is the source of truth for this setting. The Operator reconciles the desired value into `argocd-cmd-params-cm` and corrects manual edits to this key on reconcile. To change behavior, update `.spec.applicationSet.sourceNamespaces` and/or `.spec.cmdParams`; do not edit `argocd-cmd-params-cm` directly.
 ### Opting out of tokenRef strict mode
 
 If you must disable strict mode while `.spec.applicationSet.sourceNamespaces` is configured, set the key in `.spec.cmdParams` on the ArgoCD CR:


### PR DESCRIPTION
Assisted-by: Cursor

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
/kind documentation 
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
Adds operator documentation for ApplicationSet tokenRef strict mode defaulting: user guide in appsets-in-any-namespace.md and migration guide in upgrading.md for 0.19+  

Complements implementation in #2194.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ X] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an upgrade guide for Operator 0.19+ covering ApplicationSet tokenRef strict mode, who is affected, required Secret labelling, verification steps, and step-by-step remediation to locate and fix tokenRef usages.
  * Added usage guidance on tokenRef strict mode when ApplicationSets run outside the control plane, how to temporarily opt out, and an important security warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->