### PR TITLE
fix: Do not set DEX UID on OCP not to violate security policy constraint

### DIFF
--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -422,7 +422,8 @@ func (r *ReconcileArgoCD) reconcileDexDeployment(cr *argoproj.ArgoCD) error {
 	// otherwise it refuses to create the container (CreateContainerConfigError).
 	dexSecCtx := argoutil.DefaultSecurityContext()
 	dexImage := getDexContainerImage(cr)
-	if strings.HasPrefix(dexImage, common.ArgoCDDefaultDexImage) {
+	// Skip for OCP - let the cluster make sure it is within the range.
+	if strings.HasPrefix(dexImage, common.ArgoCDDefaultDexImage) && !IsOpenShiftCluster() {
 		dexUID := common.ArgoCDDefaultDexRunAsUser
 		dexSecCtx.RunAsUser = &dexUID
 	}


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

Do not hardcode UID, it prevents DEX from starting in OCP: "provider restricted-v2: .containers[0].runAsUser: Invalid value: 1001: must be in the ranges: [1000700000 1000709999]"

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Dex deployment security context on OpenShift clusters so platform-specific requirements are respected and unnecessary user-level restrictions are avoided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->