### PR TITLE
ci: add Codecov coverage upload with unit-tests flag

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+flags:
+  unit-tests:
+    carryforward: true
+coverage:
+  status:
+    patch:
+      default:
+        threshold: 2
+    project:
+      default:
+        threshold: 2
+ignore:
+  - "**/*_test.go"
+  - "**/mocks/*"
+  - "test/**/*"
+  - "vendor/**/*"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,3 +31,12 @@ jobs:
 
     - name: Test
       run: make test
+
+    - name: Upload code coverage to codecov.io
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: cover.out
+        flags: unit-tests
+        fail_ci_if_error: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds Codecov upload step to the Go CI workflow with the `unit-tests` flag
- Adds `.codecov.yml` with flag definition, `carryforward: true`, and a 2% threshold
- The workflow already generates `cover.out` via `make test` — this just uploads it

## Test plan
- [ ] Verify CI workflow passes with the Codecov upload step
- [ ] Confirm coverage appears on Codecov after merge and first push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated code coverage tracking with a 2% minimum threshold for project and patch checks; excluded test, mock and vendored files from coverage.
  * Added a CI step to upload Go unit-test coverage (uses repository secret for authentication and tags the upload) and configured it not to fail the workflow if the upload errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->