### PR TITLE
fix: Remove GODEBUG env required for fips

### DIFF
--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -2968,41 +2968,6 @@ func TestSetReplicasAndEnvVar_WhenServerReplicasIsDefined(t *testing.T) {
 
 }
 
-func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabled(t *testing.T) {
-	cr := makeTestArgoCD()
-
-	resObjs := []client.Object{cr}
-	subresObjs := []client.Object{cr}
-	runtimeObjs := []runtime.Object{}
-	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
-	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
-	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
-	r.FipsConfigChecker = &MockTrueFipsChecker{}
-	repoServerRemote := "https://remote.repo-server.instance"
-
-	cr.Spec.Repo.Remote = &repoServerRemote
-	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
-
-	d := &appsv1.Deployment{}
-
-	assert.ErrorContains(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d),
-		"deployments.apps \""+cr.Name+"-repo-server\" not found")
-
-	// once remote is set to nil, reconciliation should trigger deployment resource creation
-	cr.Spec.Repo.Remote = nil
-
-	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
-	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
-	foundEnv := false
-	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
-		if env.Name == "GODEBUG" {
-			foundEnv = true
-			assert.Equal(t, env.Value, "fips140=on", "GODEBUG environment must be set to fips140=on when fips is enabled")
-		}
-	}
-	assert.True(t, foundEnv, "environment GODEBUG must be set when FIPS is enabled")
-}
-
 func TestReconcileArgoCD_reconcileRepoServerWithFipsDisabled(t *testing.T) {
 	cr := makeTestArgoCD()
 

--- a/controllers/argocd/repo_server.go
+++ b/controllers/argocd/repo_server.go
@@ -121,21 +121,6 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argocdoperatorv1beta1.Argo
 		repoEnv = argoutil.EnvMerge(repoEnv, []corev1.EnvVar{{Name: "ARGOCD_EXEC_TIMEOUT", Value: fmt.Sprintf("%ds", *cr.Spec.Repo.ExecTimeout)}}, true)
 	}
 
-	// if running in a FIPS enabled host, set the GODEBUG env wit appropriate value
-	fipsConfigChecker := r.FipsConfigChecker
-	if fipsConfigChecker != nil {
-		fipsEnabled, err := fipsConfigChecker.IsFipsEnabled()
-		if err != nil {
-			return err
-		}
-		if fipsEnabled {
-			repoEnv = append(repoEnv, corev1.EnvVar{
-				Name:  "GODEBUG",
-				Value: "fips140=on",
-			})
-		}
-	}
-
 	AddSeccompProfileForOpenShift(r.Client, &deploy.Spec.Template.Spec)
 
 	deploy.Spec.Template.Spec.InitContainers = []corev1.Container{{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
The `GODEBUG=fips140=on` environment variable was added in #1822 as a workaround to skip SSH algorithms that caused a panic in the Go crypto library when running in FIPS mode.

The crypto library panic has now been fixed in `crypto v0.43.0`, and this workaround is no longer required because the latest Argo CD uses `crypto v0.49.0`.

This environment variable now causes the repo-server to fail during startup because it conflicts with another FIPS-related variable that is set by default:

```text
panic: opensslcrypto: GOLANG_FIPS and GODEBUG=fips140 are mutually exclusive; use GOLANG_FIPS=1 for OpenSSL FIPS or GODEBUG=fips140=auto with -tags=no_openssl for native FIPS
```

I have not cleaned up all the FIPS-related code in this PR because we are in the middle of a release. We can remove the remaining unused code in a follow-up PR.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
