### PR TITLE
Fix panic due to GOLANG_FIPS=1 (#2226)

### DIFF
--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -2999,6 +2999,10 @@ func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabled(t *testing.T) {
 			foundEnv = true
 			assert.Equal(t, env.Value, "fips140=on", "GODEBUG environment must be set to fips140=on when fips is enabled")
 		}
+		if env.Name == "GOLANG_FIPS" {
+			foundEnv = true
+			assert.Equal(t, env.Value, "0", "GOLANG_FIPS environment must be set to 0 when fips is enabled")
+		}
 	}
 	assert.True(t, foundEnv, "environment GODEBUG must be set when FIPS is enabled")
 }

--- a/controllers/argocd/repo_server.go
+++ b/controllers/argocd/repo_server.go
@@ -132,7 +132,16 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argocdoperatorv1beta1.Argo
 			repoEnv = append(repoEnv, corev1.EnvVar{
 				Name:  "GODEBUG",
 				Value: "fips140=on",
-			})
+			},
+				// GOLANG_FIPS and GODEBUG=fips140=on are both mutaully exclusive.
+				// GOLANG_FIPS=1 is set by default but it causes issues
+				// since we are explicitly setting GODEBUG=fips140=on to skip unsupported fips ssh algorithms in Argo CD.
+				// See https://github.com/argoproj/argo-cd/issues/24155,
+				// so we need to set GOLANG_FIPS=0 to avoid the conflict.
+				corev1.EnvVar{
+					Name:  "GOLANG_FIPS",
+					Value: "0",
+				})
 		}
 	}
 


### PR DESCRIPTION
panic: opensslcrypto: GOLANG_FIPS and GODEBUG=fips140 are mutually exclusive; use GOLANG_FIPS=1 for OpenSSL FIPS or GODEBUG=fips140=auto with -tags=no_openssl for native FIPS

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
