### PR TITLE
fix: do not copy all ArgoCD CR annotations to operator's generated resources(#2214) to 0.18 #2228

### DIFF
--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -146,12 +146,9 @@ func LabelsForCluster(cr *argoproj.ArgoCD) map[string]string {
 	return labels
 }
 
-// annotationsForCluster returns the annotations for all cluster resources.
+// AnnotationsForCluster returns the annotations for all cluster resources.
 func AnnotationsForCluster(cr *argoproj.ArgoCD) map[string]string {
 	annotations := common.DefaultAnnotations(cr.Name, cr.Namespace)
-	for key, val := range cr.Annotations {
-		annotations[key] = val
-	}
 	return annotations
 }
 

--- a/controllers/argoutil/resource_test.go
+++ b/controllers/argoutil/resource_test.go
@@ -20,6 +20,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 func TestTruncateWithHash(t *testing.T) {
@@ -250,4 +254,42 @@ func TestGetImagePullPolicy(t *testing.T) {
 			assert.Equal(t, tt.expectedPullPolicy, result, tt.description)
 		})
 	}
+}
+
+// Argo CD tracking annotations applied by a parent (central) Argo CD instance to the ArgoCD CR.
+const (
+	reproduceArgoCDTrackingIDAnnotation     = "argocd.argoproj.io/tracking-id"
+	reproduceArgoCDInstallationIDAnnotation = "argocd.argoproj.io/installation-id"
+)
+
+// TestAnnotationsForCluster_DoesNotPropagateCRAnnotations verifies AnnotationsForCluster returns
+// only the operator's default annotations.
+func TestAnnotationsForCluster_DoesNotPropagateCRAnnotations(t *testing.T) {
+	cr := &argoproj.ArgoCD{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "appteam",
+			Namespace: "appteam-argocd",
+			Annotations: map[string]string{
+				reproduceArgoCDTrackingIDAnnotation:     "central-gitops:argoproj.io/ArgoCD:gitops/appteam",
+				reproduceArgoCDInstallationIDAnnotation: "central-argocd",
+				"example.com/team":                      "platform",
+			},
+		},
+	}
+
+	annotations := AnnotationsForCluster(cr)
+
+	// Only operator defaults are present.
+	assert.Equal(t, "appteam", annotations[common.AnnotationName])
+	assert.Equal(t, "appteam-argocd", annotations[common.AnnotationNamespace])
+
+	// No annotations are inherited from the CR.
+	assert.NotContains(t, annotations, reproduceArgoCDTrackingIDAnnotation,
+		"central Argo CD tracking-id must not be copied to operator-managed resources")
+	assert.NotContains(t, annotations, reproduceArgoCDInstallationIDAnnotation,
+		"central Argo CD installation-id must not be copied to operator-managed resources")
+	assert.NotContains(t, annotations, "example.com/team",
+		"CR annotations must not be propagated to operator-managed resources")
+
+	assert.Len(t, annotations, 2, "only the two default annotations should be present")
 }

--- a/tests/ginkgo/fixture/k8s/fixture.go
+++ b/tests/ginkgo/fixture/k8s/fixture.go
@@ -41,6 +41,34 @@ func HaveAnnotationWithValue(key string, value string) matcher.GomegaMatcher {
 	}, BeTrue())
 }
 
+// NotHaveAnnotation verifies that the given annotation key is absent from the object.
+func NotHaveAnnotation(key string) matcher.GomegaMatcher {
+
+	return WithTransform(func(k8sObject client.Object) bool {
+		k8sClient, _, err := utils.GetE2ETestKubeClientWithError()
+		if err != nil {
+			GinkgoWriter.Println(err)
+			return false
+		}
+
+		err = k8sClient.Get(context.Background(), client.ObjectKeyFromObject(k8sObject), k8sObject)
+		if err != nil {
+			GinkgoWriter.Println("NotHaveAnnotation:", err)
+			return false
+		}
+
+		annotations := k8sObject.GetAnnotations()
+		if annotations == nil {
+			return true
+		}
+
+		_, exists := annotations[key]
+		GinkgoWriter.Println("NotHaveAnnotation - key:", key, "exists:", exists)
+		return !exists
+
+	}, BeTrue())
+}
+
 func HaveLabelWithValue(key string, value string) matcher.GomegaMatcher {
 
 	return WithTransform(func(k8sObject client.Object) bool {

--- a/tests/ginkgo/sequential/1-131_validate_rolebinding_no_tracking_annotation_propagation_test.go
+++ b/tests/ginkgo/sequential/1-131_validate_rolebinding_no_tracking_annotation_propagation_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sequential
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+// When an ArgoCD CR is itself managed by another Argo CD instance, it
+// carries Argo CD resource-tracking annotations (e.g. argocd.argoproj.io/tracking-id). The
+// operator should not propagate those annotations onto the RoleBindings it creates in managed
+// namespaces, otherwise the central Argo CD treats those RoleBindings as owned resources and
+// prunes them.
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
+
+	Context("1-131_validate_rolebinding_no_tracking_annotation_propagation", func() {
+
+		const (
+			trackingIDAnnotation     = "argocd.argoproj.io/tracking-id"
+			installationIDAnnotation = "argocd.argoproj.io/installation-id"
+		)
+
+		var (
+			k8sClient client.Client
+			ctx       context.Context
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureSequentialCleanSlate()
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		It("does not propagate Argo CD tracking annotations from the ArgoCD CR to RoleBindings created in managed namespaces", func() {
+
+			By("creating a namespace to contain the Argo CD instance")
+			argoCDNS, cleanupFunc := fixture.CreateNamespaceWithCleanupFunc("appteam-argocd-1-131")
+			defer cleanupFunc()
+
+			By("creating a managed namespace where the operator will create RoleBindings")
+			managedNS, cleanupFunc := fixture.CreateManagedNamespaceWithCleanupFunc("appteam-apps-1-131", argoCDNS.Name)
+			defer cleanupFunc()
+
+			By("creating an ArgoCD instance carrying tracking annotations, as if deployed by a central Argo CD")
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "appteam",
+					Namespace: argoCDNS.Name,
+					Annotations: map[string]string{
+						trackingIDAnnotation:     "central-gitops:argoproj.io/ArgoCD:central/appteam",
+						installationIDAnnotation: "central-argocd",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			rbNames := []string{"appteam-argocd-application-controller", "appteam-argocd-server"}
+
+			By("verifying the operator created the expected RoleBindings in the managed namespace")
+			for _, rbName := range rbNames {
+				roleBinding := &rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: managedNS.Name},
+				}
+				Eventually(roleBinding, "60s", "5s").Should(k8sFixture.ExistByName())
+			}
+
+			By("verifying the RoleBindings did NOT inherit the Argo CD tracking annotations from the CR")
+			for _, rbName := range rbNames {
+				roleBinding := &rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: managedNS.Name},
+				}
+				// The operator's own default annotation should be present
+				Eventually(roleBinding).Should(k8sFixture.HaveAnnotationWithValue(common.AnnotationName, argoCD.Name))
+				// Central Argo CD's tracking annotations are not present.
+				Consistently(roleBinding, "15s", "3s").Should(k8sFixture.NotHaveAnnotation(trackingIDAnnotation))
+				Consistently(roleBinding, "5s", "1s").Should(k8sFixture.NotHaveAnnotation(installationIDAnnotation))
+			}
+
+			By("verifying the RoleBindings in the Argo CD's own namespace also did NOT inherit the tracking annotations")
+			for _, rbName := range rbNames {
+				roleBinding := &rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: argoCDNS.Name},
+				}
+				Eventually(roleBinding, "60s", "5s").Should(k8sFixture.ExistByName())
+				Eventually(roleBinding).Should(k8sFixture.HaveAnnotationWithValue(common.AnnotationName, argoCD.Name))
+				Consistently(roleBinding, "5s", "1s").Should(k8sFixture.NotHaveAnnotation(trackingIDAnnotation))
+				Consistently(roleBinding, "5s", "1s").Should(k8sFixture.NotHaveAnnotation(installationIDAnnotation))
+			}
+		})
+
+	})
+})


### PR DESCRIPTION
This PR is a cherry pick from: (#2214)

(cherry picked commit 5eedcfe310f6baa83157e8ea8b6c1064a845ed59)

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug 
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
