### PR TITLE
fix(agent): Reconcile principal redis volume correctly

### DIFF
--- a/controllers/argocdagent/deployment.go
+++ b/controllers/argocdagent/deployment.go
@@ -289,6 +289,21 @@ func updateDeploymentIfChanged(compName, saName string, cr *argoproj.ArgoCD, dep
 		deployment.Spec.Template.Spec.Containers[0].Args = buildArgs(compName)
 	}
 
+	redisAuthVolume, redisAuthMount := argoutil.MountRedisAuthToArgo(cr)
+	desiredVolumeMounts := append(buildVolumeMounts(), redisAuthMount)
+	desiredVolumes := append(buildVolumes(), redisAuthVolume)
+	if !reflect.DeepEqual(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, desiredVolumeMounts) {
+		log.Info("deployment container volume mounts are being updated")
+		changed = true
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = desiredVolumeMounts
+	}
+
+	if !reflect.DeepEqual(deployment.Spec.Template.Spec.Volumes, desiredVolumes) {
+		log.Info("deployment container volumes are being updated")
+		changed = true
+		deployment.Spec.Template.Spec.Volumes = desiredVolumes
+	}
+
 	if !reflect.DeepEqual(deployment.Spec.Template.Spec.Containers[0].SecurityContext, buildSecurityContext()) {
 		log.Info("deployment container security context is being updated")
 		changed = true

--- a/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -19,6 +19,7 @@ package sequential
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,6 +36,7 @@ import (
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/controllers/argocdagent"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	agentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/agent"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
@@ -509,6 +511,41 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			for key, value := range expectedEnvVariables {
 				Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: key, Value: value}), "Environment variable %s should be set to %s", key, value)
 			}
+		})
+
+		It("Should restore Redis Auth volume and mount if removed from principal deployment", func() {
+			By("Creating ArgoCD instance normally")
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+			Eventually(principalDeployment).Should(k8sFixture.ExistByName())
+
+			fmt.Printf("principalDeployment.Spec.Template.Spec.Volumes: %v\n", principalDeployment.Spec.Template.Spec.Volumes)
+
+			By("Removing Redis Auth volume and mount from the deployment")
+			err := k8sClient.Get(ctx, client.ObjectKey{Name: argoCDAgentPrincipalName, Namespace: ns.Name}, principalDeployment)
+			Expect(err).ToNot(HaveOccurred())
+
+			principalDeployment.Spec.Template.Spec.Volumes = slices.DeleteFunc(principalDeployment.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
+				return v.Name == argoutil.RedisAuthVolumeName
+			})
+			principalDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = slices.DeleteFunc(principalDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, func(vm corev1.VolumeMount) bool {
+				return vm.Name == argoutil.RedisAuthVolumeName
+			})
+			Expect(k8sClient.Update(ctx, principalDeployment)).To(Succeed())
+
+			By("Redis Auth volume and mount are re-added by the operator")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: argoCDAgentPrincipalName, Namespace: ns.Name}, principalDeployment)
+				if err != nil {
+					return false
+				}
+				volFound := slices.ContainsFunc(principalDeployment.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
+					return v.Name == argoutil.RedisAuthVolumeName
+				})
+				mountFound := slices.ContainsFunc(principalDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, func(vm corev1.VolumeMount) bool {
+					return vm.Name == argoutil.RedisAuthVolumeName
+				})
+				return volFound && mountFound
+			}, "10s", "1s").Should(BeTrue(), "Redis Auth volume and mount should be restored to the principal deployment")
 		})
 
 		It("should handle route disabled configuration correctly", func() {

--- a/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -516,21 +516,26 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 		It("Should restore Redis Auth volume and mount if removed from principal deployment", func() {
 			By("Creating ArgoCD instance normally")
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
 			Eventually(principalDeployment).Should(k8sFixture.ExistByName())
-
-			fmt.Printf("principalDeployment.Spec.Template.Spec.Volumes: %v\n", principalDeployment.Spec.Template.Spec.Volumes)
 
 			By("Removing Redis Auth volume and mount from the deployment")
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: argoCDAgentPrincipalName, Namespace: ns.Name}, principalDeployment)
 			Expect(err).ToNot(HaveOccurred())
 
-			principalDeployment.Spec.Template.Spec.Volumes = slices.DeleteFunc(principalDeployment.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
-				return v.Name == argoutil.RedisAuthVolumeName
+			deploymentFixture.Update(principalDeployment, func(p *appsv1.Deployment) {
+				volLen := len(p.Spec.Template.Spec.Volumes)
+				mountLen := len(p.Spec.Template.Spec.Containers[0].VolumeMounts)
+				p.Spec.Template.Spec.Volumes = slices.DeleteFunc(p.Spec.Template.Spec.Volumes, func(v corev1.Volume) bool {
+					return v.Name == argoutil.RedisAuthVolumeName
+				})
+				p.Spec.Template.Spec.Containers[0].VolumeMounts = slices.DeleteFunc(p.Spec.Template.Spec.Containers[0].VolumeMounts, func(vm corev1.VolumeMount) bool {
+					return vm.Name == argoutil.RedisAuthVolumeName
+				})
+				// Double check we have actually removed the volume and mount
+				Expect(p.Spec.Template.Spec.Volumes).To(HaveLen(volLen - 1))
+				Expect(p.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(mountLen - 1))
 			})
-			principalDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = slices.DeleteFunc(principalDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, func(vm corev1.VolumeMount) bool {
-				return vm.Name == argoutil.RedisAuthVolumeName
-			})
-			Expect(k8sClient.Update(ctx, principalDeployment)).To(Succeed())
 
 			By("Redis Auth volume and mount are re-added by the operator")
 			Eventually(func() bool {


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the operator’s reconciliation for the principal deployment to also monitor pod volumes and container volume mounts, ensuring Redis authentication volumes and mounts are automatically restored if removed.

* **Tests**
  * Added a sequential end-to-end test that deletes the Redis authentication volume and corresponding volume mount from the principal deployment, then verifies the operator reinstalls both within a short retry window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->