### PR TITLE
chore(OWNERS): Move ex-approvers to emeritus, add new ones

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,23 @@
-owners:
-- jomkz
+# https://www.kubernetes.dev/docs/guide/owners/
 
 approvers:
-- iam-veeramalla
-- wtam2018
+- anandf
+- anandrkskd
+- chetan-rns
 - jannfis
-- jopit
+- jgwest
+- olivergondza
+- svghadi
+- wtam2018
 
 reviewers:
-- iam-veeramalla
-- wtam2018
-- jannfis
-- jopit
-- jaideepr97
-- ishitasequeira 
-- reginapizza
-- ciiay
-- svghadi
-- saumeya
+- jparsai
+- Rizwana777
 
+emeritus_approvers:
+- ciiay
+- iam-veeramalla
+- ishitasequeira
+- jomkz
+- reginapizza
+- saumeya


### PR DESCRIPTION
This synchronizing the declared owners with the ACL. The `owners` key is actually not something the format support.

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
/kind chore
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team governance structure with changes to approvers and reviewers.
  * Introduced an emeritus approvers section for former team members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->