### PR TITLE
fix(redis): remove unused SENTINELAUTH placeholder and dead code from redis init script

### DIFF
--- a/build/redis/init.sh.tpl
+++ b/build/redis/init.sh.tpl
@@ -266,10 +266,4 @@ echo "Setting redis auth values.."
 ESCAPED_AUTH=$(echo "${AUTH}" | sed -e 's/[\/&]/\\&/g');
 sed -i "s/__REPLACE_DEFAULT_AUTH__/${ESCAPED_AUTH}/" "${REDIS_CONF}" "${SENTINEL_CONF}"
 
-if [ "${SENTINELAUTH:-}" ]; then
-    echo "Setting sentinel auth values"
-    ESCAPED_AUTH_SENTINEL=$(echo "$SENTINELAUTH" | sed -e 's/[\/&]/\\&/g');
-    sed -i "s/__REPLACE_DEFAULT_SENTINEL_AUTH__/${ESCAPED_AUTH_SENTINEL}/" "$SENTINEL_CONF"
-fi
-
 echo "$(date) Ready..."


### PR DESCRIPTION
The `__REPLACE_DEFAULT_SENTINEL_AUTH__` placeholder in `build/redis/init.sh.tpl` has no corresponding template configuration and the SENTINELAUTH feature was never fully implemented. This removes the dead code block that references it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Redis authentication configuration during initialization. Support for separate sentinel authentication configuration has been removed in favor of streamlined password-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->