### PR TITLE
chore(docs): Clean unused document links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,8 +51,9 @@ nav:
   - Ingress: usage/ingress.md
   - Insights: usage/insights.md
   - Dex: usage/dex.md
-  - Notifications: usage/notifications.md
-  - Notifications in Any Namespace: usage/notifications-in-any-namespace.md
+  - Notifications:
+    - Basics: usage/notifications.md
+    - Notifications in Any Namespace: usage/notifications-in-any-namespace.md
   - Resource Management: usage/resource_management.md
   - Routes: usage/routes.md
   - Webhook secrets: usage/webhook-secrets.md
@@ -77,4 +78,3 @@ nav:
     - OpenAPI: developer-guide/openapi.md
 - Releases ⧉: https://github.com/argoproj-labs/argocd-operator/releases
 - Upgrading: upgrading.md
-- Roadmap ⧉: https://github.com/argoproj-labs/argocd-operator/milestones


### PR DESCRIPTION
- We do not seem to use milestones/roadmap for years anymore

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
/kind chore
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

Clean the clutter in the docs.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

make serve-docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Argo CD Notifications documentation with detailed configuration guidance and usage examples.
  * Clarified that notifications are disabled by default and documented the Kubernetes resources created when enabled.
  * Reorganized documentation site navigation for improved usability.
  * Removed auto-generated API reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->