### PR TITLE
chore(deps): bump image-updater from 1.1.2 to 1.1.3; bump argocd from 3.3.10 to 3.3.12

### DIFF
--- a/build/util/Dockerfile
+++ b/build/util/Dockerfile
@@ -1,5 +1,5 @@
-# Argo CD v3.3.10
-FROM quay.io/argoproj/argocd@sha256:05d68bf224df7cd39713012c19226a33c374f2f3bd65df7b9088349e4ac3e6a2 as argocd
+# Argo CD v3.3.12
+FROM quay.io/argoproj/argocd@sha256:4bce55cc507df87fe1d672a6d03a2ef1d17d36d11b61589f39ac5b14839ca99a as argocd
 
 # Final Image
 FROM docker.io/library/ubuntu:24.04

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -70,7 +70,7 @@ const (
 	ArgoCDDefaultArgoImage = "quay.io/argoproj/argocd"
 
 	// ArgoCDDefaultArgoVersion is the Argo CD container image digest to use when version not specified.
-	ArgoCDDefaultArgoVersion = "sha256:05d68bf224df7cd39713012c19226a33c374f2f3bd65df7b9088349e4ac3e6a2" // v3.3.10
+	ArgoCDDefaultArgoVersion = "sha256:4bce55cc507df87fe1d672a6d03a2ef1d17d36d11b61589f39ac5b14839ca99a" // v3.3.12
 
 	// ArgoCDDefaultBackupKeyLength is the length of the generated default backup key.
 	ArgoCDDefaultBackupKeyLength = 32

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	DefaultImageUpdaterImage      = "quay.io/argoprojlabs/argocd-image-updater"
-	DefaultImageUpdaterTag        = "v1.1.2"
+	DefaultImageUpdaterTag        = "v1.1.3"
 	ArgocdImageUpdaterConfigCM    = "argocd-image-updater-config"
 	ArgocdImageUpdaterSSHConfigCM = "argocd-image-updater-ssh-config"
 	ArgocdImageUpdaterSecret      = "argocd-image-updater-secret" // #nosec G101

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/argoproj-labs/argocd-operator
 go 1.25.9
 
 require (
-	github.com/argoproj/argo-cd/v3 v3.3.10
+	github.com/argoproj/argo-cd/v3 v3.3.12
 	github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d
 	github.com/cert-manager/cert-manager v1.15.4
 	github.com/go-logr/logr v1.4.3
@@ -53,7 +53,7 @@ require (
 )
 
 require (
-	github.com/argoproj-labs/argocd-image-updater v1.1.2
+	github.com/argoproj-labs/argocd-image-updater v1.1.3
 	github.com/google/go-github/v75 v75.0.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,10 +35,10 @@ github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj-labs/argocd-image-updater v1.1.2 h1:z7zXF30lGap5DqHdVRPWd6qtOKXh1czl5WL0iEXi3lE=
-github.com/argoproj-labs/argocd-image-updater v1.1.2/go.mod h1:EpwMlbWGInyqkRhCWAD18bvgNdk/s7SUSEXtM+K9ApE=
-github.com/argoproj/argo-cd/v3 v3.3.10 h1:3QE36lhN/0ntjwl2TH13xL23w2J2AaXgC0Dxn0469h4=
-github.com/argoproj/argo-cd/v3 v3.3.10/go.mod h1:LdPjAnIFbx0khaB6vLsOKrGoSWeJ8kzOt//jF1ltCPg=
+github.com/argoproj-labs/argocd-image-updater v1.1.3 h1:/kPvpuig9Y5zq5rJE4tAC+I8yAtvvKsVS8ZB693Lp+Q=
+github.com/argoproj-labs/argocd-image-updater v1.1.3/go.mod h1:jR1GYyDoLM/kBPmG0BbXwPnQO51LP6Tg19Y/cXT6CfA=
+github.com/argoproj/argo-cd/v3 v3.3.12 h1:1MaIMR+KkSzaRyu5kigXZVaM66c01W+orqfhKw/pHl4=
+github.com/argoproj/argo-cd/v3 v3.3.12/go.mod h1:LdPjAnIFbx0khaB6vLsOKrGoSWeJ8kzOt//jF1ltCPg=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d h1:iUJYrbSvpV9n8vyl1sBt1GceM60HhHfnHxuzcm5apDg=
 github.com/argoproj/gitops-engine v0.7.1-0.20251217140045-5baed5604d2d/go.mod h1:PauXVUVcfiTgC+34lDdWzPS101g4NpsUtDAjFBnWf94=
 github.com/argoproj/pkg v0.13.7-0.20250305113207-cbc37dc61de5 h1:YBoLSjpoaJXaXAldVvBRKJuOPvIXz9UOv6S96gMJM/Q=


### PR DESCRIPTION

**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
 /kind chore
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
Needed for gitops 1.20.z

bump image-updater to latest patch release, which also brings in latest patch release for argocd

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
