### PR TITLE
chore(e2e): sync sharding test with downstream

### DIFF
--- a/tests/ginkgo/parallel/1-048_validate_controller_sharding_test.go
+++ b/tests/ginkgo/parallel/1-048_validate_controller_sharding_test.go
@@ -116,7 +116,20 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("checking if ARGOCD_CONTROLLER_SHARDING_ALGORITHM env var is not set in app controller StatefulSet")
 			Eventually(statefulSet).Should(k8sFixture.ExistByName())
-			Eventually(statefulSet, "60s", "5s").ShouldNot(statefulset.HaveContainerWithEnvVar("ARGOCD_CONTROLLER_SHARDING_ALGORITHM", "round-robin", 0), "Statefulset should not have ARGOCD_CONTROLLER_SHARDING_ALGORITHM")
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet); err != nil {
+					return false
+				}
+				if len(statefulSet.Spec.Template.Spec.Containers) == 0 {
+					return false
+				}
+				for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+					if env.Name == "ARGOCD_CONTROLLER_SHARDING_ALGORITHM" {
+						return false
+					}
+				}
+				return true
+			}, "60s", "5s").Should(BeTrue(), "StatefulSet should have no env variable named ARGOCD_CONTROLLER_SHARDING_ALGORITHM")
 
 			By("disabling sharding")
 			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind chore

**What does this PR do / why we need it**:

This PR syncs the file `tests/ginkgo/parallel/1-048_validate_controller_sharding_test.go` with the changes made in downstream test from [this PR](https://github.com/redhat-developer/gitops-operator/pull/1179). 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved the validation for controller sharding settings by repeatedly checking the live controller state over time, reducing flakiness.
  * Strengthened the “sharding algorithm unset” assertion to confirm the environment variable is truly absent from the controller’s container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->