### PR TITLE
fix(hack): improve update-dependencies scripts to always inspect images on linux/amd64 platform; optimize git clone

### DIFF
--- a/hack/update-dependencies-script/main.go
+++ b/hack/update-dependencies-script/main.go
@@ -534,19 +534,16 @@ func cloneArgoCDRepoIntoTempDir(latestReleaseVersionTag string) (string, error) 
 		return "", err
 	}
 
-	if _, _, err := runCommandWithWorkDir(tmpDir, "git", "clone", "https://github.com/argoproj/argo-cd"); err != nil {
+	if _, _, err := runCommandWithWorkDir(tmpDir, "git", "clone",
+		"--depth", "1",
+		"--branch", latestReleaseVersionTag,
+		"--single-branch",
+		"--no-tags",
+		"https://github.com/argoproj/argo-cd"); err != nil {
 		return "", err
 	}
 
 	newWorkDir := filepath.Join(tmpDir, "argo-cd")
-
-	commands := [][]string{
-		{"git", "checkout", latestReleaseVersionTag},
-	}
-
-	if err := runCommandListWithWorkDir(newWorkDir, commands); err != nil {
-		return "", err
-	}
 
 	return newWorkDir, nil
 }
@@ -554,7 +551,7 @@ func cloneArgoCDRepoIntoTempDir(latestReleaseVersionTag string) (string, error) 
 // retrieveSHA256DigestUsingSkopeo determines the SHA256 digest value for a given container image
 func retrieveSHA256DigestUsingSkopeo(url string) *processedContainerImage {
 
-	stdout, _, err := runCommandWithWorkDir("", "skopeo", "inspect", "--no-tags", "docker://"+url)
+	stdout, _, err := runCommandWithWorkDir("", "skopeo", "inspect", "--no-tags", "--override-os", "linux", "--override-arch", "amd64", "docker://"+url)
 	if err != nil {
 		exitWithError(fmt.Errorf("unexpected skopeo error: %v", err))
 		return nil


### PR DESCRIPTION


**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
/kind enhancement
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
To support running it on any platform;
to optimize git clone operation by limiting it to the required tag.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the dependency update workflow to fetch only the needed release branch or tag, making updates faster and lighter.
  * Standardized image digest lookup for Linux/amd64 to make dependency resolution more consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->