### PR TITLE
feat: deprecate dynamicScalingEnabled in ArgoCD CR

### DIFF
--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -122,7 +122,8 @@ type ArgoCDApplicationControllerShardSpec struct {
 	// Replicas defines the number of replicas to run in the Application controller shard.
 	Replicas int32 `json:"replicas,omitempty"`
 
-	// DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component
+	// Deprecated: dynamicScalingEnabled is deprecated and will be removed in a future release.
+	// DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component.
 	DynamicScalingEnabled *bool `json:"dynamicScalingEnabled,omitempty"`
 
 	// MinShards defines the minimum number of shards at any given point

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -155,7 +155,8 @@ type ArgoCDApplicationControllerShardSpec struct {
 	// Replicas defines the number of replicas to run in the Application controller shard.
 	Replicas int32 `json:"replicas,omitempty"`
 
-	// DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component
+	// Deprecated: dynamicScalingEnabled is deprecated and will be removed in a future release.
+	// DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component.
 	DynamicScalingEnabled *bool `json:"dynamicScalingEnabled,omitempty"`
 
 	// MinShards defines the minimum number of shards at any given point

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-06-02T12:28:46Z"
+    createdAt: "2026-06-30T07:22:31Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -1386,8 +1386,9 @@ spec:
                         minimum: 1
                         type: integer
                       dynamicScalingEnabled:
-                        description: DynamicScalingEnabled defines whether dynamic
-                          scaling should be enabled for Application Controller component
+                        description: |-
+                          Deprecated: dynamicScalingEnabled is deprecated and will be removed in a future release.
+                          DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component.
                         type: boolean
                       enabled:
                         description: Enabled defines whether sharding should be enabled
@@ -14243,8 +14244,9 @@ spec:
                         minimum: 1
                         type: integer
                       dynamicScalingEnabled:
-                        description: DynamicScalingEnabled defines whether dynamic
-                          scaling should be enabled for Application Controller component
+                        description: |-
+                          Deprecated: dynamicScalingEnabled is deprecated and will be removed in a future release.
+                          DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component.
                         type: boolean
                       enabled:
                         description: Enabled defines whether sharding should be enabled

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -1375,8 +1375,9 @@ spec:
                         minimum: 1
                         type: integer
                       dynamicScalingEnabled:
-                        description: DynamicScalingEnabled defines whether dynamic
-                          scaling should be enabled for Application Controller component
+                        description: |-
+                          Deprecated: dynamicScalingEnabled is deprecated and will be removed in a future release.
+                          DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component.
                         type: boolean
                       enabled:
                         description: Enabled defines whether sharding should be enabled
@@ -14232,8 +14233,9 @@ spec:
                         minimum: 1
                         type: integer
                       dynamicScalingEnabled:
-                        description: DynamicScalingEnabled defines whether dynamic
-                          scaling should be enabled for Application Controller component
+                        description: |-
+                          Deprecated: dynamicScalingEnabled is deprecated and will be removed in a future release.
+                          DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component.
                         type: boolean
                       enabled:
                         description: Enabled defines whether sharding should be enabled

--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -563,7 +563,8 @@ func getArgoControllerContainerEnv(cr *argoproj.ArgoCD, replicas int32) []corev1
 		Value: "/home/argocd",
 	})
 
-	if cr.Spec.Controller.Sharding.Enabled || (cr.Spec.Controller.Sharding.DynamicScalingEnabled != nil && *cr.Spec.Controller.Sharding.DynamicScalingEnabled) {
+	//lint:ignore SA1019 known to be deprecated
+	if cr.Spec.Controller.Sharding.Enabled || (cr.Spec.Controller.Sharding.DynamicScalingEnabled != nil && *cr.Spec.Controller.Sharding.DynamicScalingEnabled) { //nolint:staticcheck // SA1019: honor deprecated field for backward compatibility
 		env = append(env, corev1.EnvVar{
 			Name:  "ARGOCD_CONTROLLER_REPLICAS",
 			Value: fmt.Sprint(replicas),
@@ -619,7 +620,8 @@ func (r *ReconcileArgoCD) getApplicationControllerReplicaCount(cr *argoproj.Argo
 	var minShards = cr.Spec.Controller.Sharding.MinShards
 	var maxShards = cr.Spec.Controller.Sharding.MaxShards
 
-	if cr.Spec.Controller.Sharding.DynamicScalingEnabled != nil && *cr.Spec.Controller.Sharding.DynamicScalingEnabled {
+	//lint:ignore SA1019 known to be deprecated
+	if cr.Spec.Controller.Sharding.DynamicScalingEnabled != nil && *cr.Spec.Controller.Sharding.DynamicScalingEnabled { //nolint:staticcheck // SA1019: honor deprecated field for backward compatibility
 
 		// TODO: add the same validations to Validation Webhook once webhook has been introduced
 		if minShards < 1 {

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -550,6 +550,7 @@ func TestReconcileArgoCD_reconcileApplicationController_withSharding(t *testing.
 		},
 		{
 			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
+				//nolint:staticcheck // SA1019: honor deprecated field for backward compatibility
 				DynamicScalingEnabled: boolPtr(true),
 				MinShards:             2,
 				MaxShards:             4,
@@ -822,8 +823,9 @@ func TestReconcileArgoCD_reconcileApplicationController_withDynamicSharding(t *t
 	}{
 		{
 			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
-				Enabled:               false,
-				Replicas:              1,
+				Enabled:  false,
+				Replicas: 1,
+				//nolint:staticcheck // SA1019: honor deprecated field for backward compatibility
 				DynamicScalingEnabled: boolPtr(true),
 				MinShards:             2,
 				MaxShards:             4,
@@ -834,8 +836,9 @@ func TestReconcileArgoCD_reconcileApplicationController_withDynamicSharding(t *t
 		{
 			// Replicas less than minimum shards
 			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
-				Enabled:               false,
-				Replicas:              1,
+				Enabled:  false,
+				Replicas: 1,
+				//nolint:staticcheck // SA1019: honor deprecated field for backward compatibility
 				DynamicScalingEnabled: boolPtr(true),
 				MinShards:             1,
 				MaxShards:             4,
@@ -846,8 +849,9 @@ func TestReconcileArgoCD_reconcileApplicationController_withDynamicSharding(t *t
 		{
 			// Replicas more than maximum shards
 			sharding: argoproj.ArgoCDApplicationControllerShardSpec{
-				Enabled:               false,
-				Replicas:              1,
+				Enabled:  false,
+				Replicas: 1,
+				//nolint:staticcheck // SA1019: honor deprecated field for backward compatibility
 				DynamicScalingEnabled: boolPtr(true),
 				MinShards:             1,
 				MaxShards:             2,

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argocd-operator.v0.19.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argocd-operator.v0.19.0.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-06-02T12:28:46Z"
+    createdAt: "2026-06-30T07:22:31Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
@@ -1386,8 +1386,9 @@ spec:
                         minimum: 1
                         type: integer
                       dynamicScalingEnabled:
-                        description: DynamicScalingEnabled defines whether dynamic
-                          scaling should be enabled for Application Controller component
+                        description: |-
+                          Deprecated: dynamicScalingEnabled is deprecated and will be removed in a future release.
+                          DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component.
                         type: boolean
                       enabled:
                         description: Enabled defines whether sharding should be enabled
@@ -14243,8 +14244,9 @@ spec:
                         minimum: 1
                         type: integer
                       dynamicScalingEnabled:
-                        description: DynamicScalingEnabled defines whether dynamic
-                          scaling should be enabled for Application Controller component
+                        description: |-
+                          Deprecated: dynamicScalingEnabled is deprecated and will be removed in a future release.
+                          DynamicScalingEnabled defines whether dynamic scaling should be enabled for Application Controller component.
                         type: boolean
                       enabled:
                         description: Enabled defines whether sharding should be enabled

--- a/docs/reference/argocd.md
+++ b/docs/reference/argocd.md
@@ -175,7 +175,7 @@ AppSync | 3m | AppSync is used to control the sync frequency of ArgoCD Applicati
 Sharding.enabled | false | Whether to enable sharding on the ArgoCD Application Controller component. Useful when managing a large number of clusters to relieve memory pressure on the controller component. | |
 Sharding.replicas | 1 | The number of replicas that will be used to support sharding of the ArgoCD Application Controller. | Must be greater than 0 |
 Env | [Empty] | Environment to set for the application controller workloads | |
-Sharding.dynamicScalingEnabled | true | Whether to enable dynamic scaling of the ArgoCD Application Controller component. This will ignore the configuration of `Sharding.enabled` and `Sharding.replicas` | |
+Sharding.dynamicScalingEnabled | true | **Deprecated**Whether to enable dynamic scaling of the ArgoCD Application Controller component. This will ignore the configuration of `Sharding.enabled` and `Sharding.replicas` | |
 Sharding.minShards | 1 | The minimum number of replicas of the ArgoCD Application Controller component. | Must be greater than 0 |
 Sharding.maxShards | 1 | The maximum number of replicas of the ArgoCD Application Controller component. | Must be greater than `Sharding.minShards` |
 Sharding.clustersPerShard | 1 | The number of clusters that need to be handles by each shard. In case the replica count has reached the maxShards, the shards will manage more than one cluster. | Must be greater than 0 |


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
/kind enhancement 
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:
Marks spec.controller.sharding.dynamicScalingEnabled as deprecated in the ArgoCD CR

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [X] Documentation has been updated.


Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked the `dynamicScalingEnabled` controller option as **Deprecated** across the API comments, CRD schema descriptions, and the reference documentation.
  * Added an explicit note that `dynamicScalingEnabled` will be removed in a future release.
  * Kept the existing behavior description intact so users understand what the setting currently controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->