### PR TITLE
feat: add label selector support for Argo CD Agent principal and agent components

### DIFF
--- a/api/v1alpha1/argocd_conversion.go
+++ b/api/v1alpha1/argocd_conversion.go
@@ -816,6 +816,7 @@ func ConvertAlphaToBetaPrincipal(src *PrincipalSpec) *v1beta1.PrincipalSpec {
 			LogLevel:      src.LogLevel,
 			LogFormat:     src.LogFormat,
 			Image:         src.Image,
+			LabelSelector: src.LabelSelector,
 			Env:           src.Env,
 			Server:        ConvertAlphaToBetaPrincipalServer(src.Server),
 			Redis:         ConvertAlphaToBetaPrincipalRedis(src.Redis),
@@ -849,6 +850,7 @@ func ConvertBetaToAlphaPrincipal(src *v1beta1.PrincipalSpec) *PrincipalSpec {
 			LogLevel:      src.LogLevel,
 			LogFormat:     src.LogFormat,
 			Image:         src.Image,
+			LabelSelector: src.LabelSelector,
 			Env:           src.Env,
 			Server:        ConvertBetaToAlphaPrincipalServer(src.Server),
 			Redis:         ConvertBetaToAlphaPrincipalRedis(src.Redis),
@@ -1008,16 +1010,17 @@ func ConvertAlphaToBetaAgent(src *AgentSpec) *v1beta1.AgentSpec {
 	var dst *v1beta1.AgentSpec
 	if src != nil {
 		dst = &v1beta1.AgentSpec{
-			Enabled:   src.Enabled,
-			Creds:     src.Creds,
-			LogLevel:  src.LogLevel,
-			LogFormat: src.LogFormat,
-			Image:     src.Image,
-			Env:       src.Env,
-			Client:    ConvertAlphaToBetaAgentClient(src.Client),
-			Redis:     ConvertAlphaToBetaAgentRedis(src.Redis),
-			TLS:       ConvertAlphaToBetaAgentTLS(src.TLS),
-			Metrics:   ConvertAlphaToBetaMetrics(src.Metrics),
+			Enabled:       src.Enabled,
+			Creds:         src.Creds,
+			LogLevel:      src.LogLevel,
+			LogFormat:     src.LogFormat,
+			Image:         src.Image,
+			LabelSelector: src.LabelSelector,
+			Env:           src.Env,
+			Client:        ConvertAlphaToBetaAgentClient(src.Client),
+			Redis:         ConvertAlphaToBetaAgentRedis(src.Redis),
+			TLS:           ConvertAlphaToBetaAgentTLS(src.TLS),
+			Metrics:       ConvertAlphaToBetaMetrics(src.Metrics),
 		}
 	}
 	return dst
@@ -1027,16 +1030,17 @@ func ConvertBetaToAlphaAgent(src *v1beta1.AgentSpec) *AgentSpec {
 	var dst *AgentSpec
 	if src != nil {
 		dst = &AgentSpec{
-			Enabled:   src.Enabled,
-			Creds:     src.Creds,
-			LogLevel:  src.LogLevel,
-			LogFormat: src.LogFormat,
-			Image:     src.Image,
-			Env:       src.Env,
-			Client:    ConvertBetaToAlphaAgentClient(src.Client),
-			Redis:     ConvertBetaToAlphaAgentRedis(src.Redis),
-			TLS:       ConvertBetaToAlphaAgentTLS(src.TLS),
-			Metrics:   ConvertBetaToAlphaMetrics(src.Metrics),
+			Enabled:       src.Enabled,
+			Creds:         src.Creds,
+			LogLevel:      src.LogLevel,
+			LogFormat:     src.LogFormat,
+			Image:         src.Image,
+			LabelSelector: src.LabelSelector,
+			Env:           src.Env,
+			Client:        ConvertBetaToAlphaAgentClient(src.Client),
+			Redis:         ConvertBetaToAlphaAgentRedis(src.Redis),
+			TLS:           ConvertBetaToAlphaAgentTLS(src.TLS),
+			Metrics:       ConvertBetaToAlphaMetrics(src.Metrics),
 		}
 	}
 	return dst

--- a/api/v1alpha1/argocd_conversion_test.go
+++ b/api/v1alpha1/argocd_conversion_test.go
@@ -568,11 +568,12 @@ func TestAlphaToBetaConversion(t *testing.T) {
 				allowGenerate := true
 				cr.Spec.ArgoCDAgent = &ArgoCDAgentSpec{
 					Principal: &PrincipalSpec{
-						Enabled:   &enabled,
-						Auth:      "mtls:CN=([^,]+)",
-						LogLevel:  "info",
-						LogFormat: "text",
-						Image:     "quay.io/user/argocd-agent:v1",
+						Enabled:       &enabled,
+						Auth:          "mtls:CN=([^,]+)",
+						LogLevel:      "info",
+						LogFormat:     "text",
+						Image:         "quay.io/user/argocd-agent:v1",
+						LabelSelector: "argocd-agent=true",
 						Server: &PrincipalServerSpec{
 							EnableWebSocket:      &enableWebSocket,
 							KeepAliveMinInterval: "30s",
@@ -617,11 +618,12 @@ func TestAlphaToBetaConversion(t *testing.T) {
 				insecureGenerate := true
 				cr.Spec.ArgoCDAgent = &v1beta1.ArgoCDAgentSpec{
 					Principal: &v1beta1.PrincipalSpec{
-						Enabled:   &enabled,
-						Auth:      "mtls:CN=([^,]+)",
-						LogLevel:  "info",
-						LogFormat: "text",
-						Image:     "quay.io/user/argocd-agent:v1",
+						Enabled:       &enabled,
+						Auth:          "mtls:CN=([^,]+)",
+						LogLevel:      "info",
+						LogFormat:     "text",
+						Image:         "quay.io/user/argocd-agent:v1",
+						LabelSelector: "argocd-agent=true",
 						Server: &v1beta1.PrincipalServerSpec{
 							EnableWebSocket:      &enableWebSocket,
 							KeepAliveMinInterval: "30s",
@@ -718,11 +720,12 @@ func TestAlphaToBetaConversion(t *testing.T) {
 				insecure := true
 				cr.Spec.ArgoCDAgent = &ArgoCDAgentSpec{
 					Agent: &AgentSpec{
-						Enabled:   &enabled,
-						Creds:     "mtls:any",
-						LogLevel:  "info",
-						LogFormat: "text",
-						Image:     "quay.io/user/argocd-agent:v1",
+						Enabled:       &enabled,
+						Creds:         "mtls:any",
+						LogLevel:      "info",
+						LogFormat:     "text",
+						Image:         "quay.io/user/argocd-agent:v1",
+						LabelSelector: "argocd-agent=true",
 						Client: &AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
@@ -749,11 +752,12 @@ func TestAlphaToBetaConversion(t *testing.T) {
 				insecure := true
 				cr.Spec.ArgoCDAgent = &v1beta1.ArgoCDAgentSpec{
 					Agent: &v1beta1.AgentSpec{
-						Enabled:   &enabled,
-						Creds:     "mtls:any",
-						LogLevel:  "info",
-						LogFormat: "text",
-						Image:     "quay.io/user/argocd-agent:v1",
+						Enabled:       &enabled,
+						Creds:         "mtls:any",
+						LogLevel:      "info",
+						LogFormat:     "text",
+						Image:         "quay.io/user/argocd-agent:v1",
+						LabelSelector: "argocd-agent=true",
 						Client: &v1beta1.AgentClientSpec{
 							PrincipalServerAddress: "argocd-agent-principal.example.com",
 							PrincipalServerPort:    "443",
@@ -973,11 +977,12 @@ func TestBetaToAlphaConversion(t *testing.T) {
 				insecureGenerate := true
 				cr.Spec.ArgoCDAgent = &v1beta1.ArgoCDAgentSpec{
 					Principal: &v1beta1.PrincipalSpec{
-						Enabled:   &enabled,
-						Auth:      "mtls:CN=([^,]+)",
-						LogLevel:  "info",
-						LogFormat: "text",
-						Image:     "quay.io/user/argocd-agent:v1",
+						Enabled:       &enabled,
+						Auth:          "mtls:CN=([^,]+)",
+						LogLevel:      "info",
+						LogFormat:     "text",
+						Image:         "quay.io/user/argocd-agent:v1",
+						LabelSelector: "argocd-agent=true",
 						Env: []corev1.EnvVar{
 							{Name: "TEST_ENV", Value: "test-value"},
 						},
@@ -1025,11 +1030,12 @@ func TestBetaToAlphaConversion(t *testing.T) {
 				insecureGenerate := true
 				cr.Spec.ArgoCDAgent = &ArgoCDAgentSpec{
 					Principal: &PrincipalSpec{
-						Enabled:   &enabled,
-						Auth:      "mtls:CN=([^,]+)",
-						LogLevel:  "info",
-						LogFormat: "text",
-						Image:     "quay.io/user/argocd-agent:v1",
+						Enabled:       &enabled,
+						Auth:          "mtls:CN=([^,]+)",
+						LogLevel:      "info",
+						LogFormat:     "text",
+						Image:         "quay.io/user/argocd-agent:v1",
+						LabelSelector: "argocd-agent=true",
 						Env: []corev1.EnvVar{
 							{Name: "TEST_ENV", Value: "test-value"},
 						},
@@ -1129,11 +1135,12 @@ func TestBetaToAlphaConversion(t *testing.T) {
 				insecure := true
 				cr.Spec.ArgoCDAgent = &v1beta1.ArgoCDAgentSpec{
 					Agent: &v1beta1.AgentSpec{
-						Enabled:   &enabled,
-						Creds:     "mtls:any",
-						LogLevel:  "info",
-						LogFormat: "text",
-						Image:     "quay.io/user/argocd-agent:v1",
+						Enabled:       &enabled,
+						Creds:         "mtls:any",
+						LogLevel:      "info",
+						LogFormat:     "text",
+						Image:         "quay.io/user/argocd-agent:v1",
+						LabelSelector: "argocd-agent=true",
 						Env: []corev1.EnvVar{
 							{Name: "TEST_ENV", Value: "test-value"},
 						},
@@ -1163,11 +1170,12 @@ func TestBetaToAlphaConversion(t *testing.T) {
 				insecure := true
 				cr.Spec.ArgoCDAgent = &ArgoCDAgentSpec{
 					Agent: &AgentSpec{
-						Enabled:   &enabled,
-						Creds:     "mtls:any",
-						LogLevel:  "info",
-						LogFormat: "text",
-						Image:     "quay.io/user/argocd-agent:v1",
+						Enabled:       &enabled,
+						Creds:         "mtls:any",
+						LogLevel:      "info",
+						LogFormat:     "text",
+						Image:         "quay.io/user/argocd-agent:v1",
+						LabelSelector: "argocd-agent=true",
 						Env: []corev1.EnvVar{
 							{Name: "TEST_ENV", Value: "test-value"},
 						},

--- a/api/v1alpha1/argocd_types.go
+++ b/api/v1alpha1/argocd_types.go
@@ -1208,6 +1208,10 @@ type PrincipalSpec struct {
 	// Image is the name of Argo CD Agent image
 	Image string `json:"image,omitempty"`
 
+	// LabelSelector is a Kubernetes label selector that restricts which resources the principal watches.
+	// Only resources matching this selector will be listed, watched, and processed by the principal.
+	LabelSelector string `json:"labelSelector,omitempty"`
+
 	// Env lets you specify environment for principal pods
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
@@ -1337,6 +1341,10 @@ type AgentSpec struct {
 
 	// Image is the name of Argo CD Agent image
 	Image string `json:"image,omitempty"`
+
+	// LabelSelector is a Kubernetes label selector that restricts which resources the agent watches.
+	// Only resources matching this selector will be listed, watched, and processed by the agent.
+	LabelSelector string `json:"labelSelector,omitempty"`
 
 	// Env lets you specify environment for agent pods
 	Env []corev1.EnvVar `json:"env,omitempty"`

--- a/api/v1beta1/argocd_types.go
+++ b/api/v1beta1/argocd_types.go
@@ -1427,6 +1427,10 @@ type PrincipalSpec struct {
 	// DestinationBasedMapping is the flag to enable destination based mapping for the Principal component.
 	DestinationBasedMapping *bool `json:"destinationBasedMapping,omitempty"`
 
+	// LabelSelector is a Kubernetes label selector that restricts which resources the principal watches.
+	// Only resources matching this selector will be listed, watched, and processed by the principal.
+	LabelSelector string `json:"labelSelector,omitempty"`
+
 	// Metrics defines the metrics configuration for the Principal ServiceMonitor.
 	Metrics *ArgoCDMetricsSpec `json:"metrics,omitempty"`
 }
@@ -1558,6 +1562,10 @@ type AgentSpec struct {
 
 	// DestinationBasedMapping defines the options for destination based mapping for the Agent component.
 	DestinationBasedMapping *DestinationBasedMappingSpec `json:"destinationBasedMapping,omitempty"`
+
+	// LabelSelector is a Kubernetes label selector that restricts which resources the agent watches.
+	// Only resources matching this selector will be listed, watched, and processed by the agent.
+	LabelSelector string `json:"labelSelector,omitempty"`
 
 	// Metrics defines the metrics configuration for the Agent ServiceMonitor.
 	Metrics *ArgoCDMetricsSpec `json:"metrics,omitempty"`

--- a/bundle/manifests/argoproj.io_argocds.yaml
+++ b/bundle/manifests/argoproj.io_argocds.yaml
@@ -699,6 +699,11 @@ spec:
                       image:
                         description: Image is the name of Argo CD Agent image
                         type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the agent watches.
+                          Only resources matching this selector will be listed, watched, and processed by the agent.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Agent component.
@@ -937,6 +942,11 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the principal watches.
+                          Only resources matching this selector will be listed, watched, and processed by the principal.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Principal component.
@@ -11892,6 +11902,11 @@ spec:
                       image:
                         description: Image is the name of Argo CD Agent image
                         type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the agent watches.
+                          Only resources matching this selector will be listed, watched, and processed by the agent.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Agent component.
@@ -12194,6 +12209,11 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the principal watches.
+                          Only resources matching this selector will be listed, watched, and processed by the principal.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Principal component.

--- a/config/crd/bases/argoproj.io_argocds.yaml
+++ b/config/crd/bases/argoproj.io_argocds.yaml
@@ -688,6 +688,11 @@ spec:
                       image:
                         description: Image is the name of Argo CD Agent image
                         type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the agent watches.
+                          Only resources matching this selector will be listed, watched, and processed by the agent.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Agent component.
@@ -926,6 +931,11 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the principal watches.
+                          Only resources matching this selector will be listed, watched, and processed by the principal.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Principal component.
@@ -11881,6 +11891,11 @@ spec:
                       image:
                         description: Image is the name of Argo CD Agent image
                         type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the agent watches.
+                          Only resources matching this selector will be listed, watched, and processed by the agent.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Agent component.
@@ -12183,6 +12198,11 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the principal watches.
+                          Only resources matching this selector will be listed, watched, and processed by the principal.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Principal component.

--- a/controllers/argocdagent/agent/deployment.go
+++ b/controllers/argocdagent/agent/deployment.go
@@ -366,6 +366,10 @@ func buildAgentContainerEnv(cr *argoproj.ArgoCD) []corev1.EnvVar {
 			Name:  EnvArgoCDAgentAllowedNamespaces,
 			Value: getAgentAllowedNamespaces(cr),
 		},
+		{
+			Name:  EnvArgoCDAgentLabelSelector,
+			Value: getAgentLabelSelector(cr),
+		},
 	}
 
 	env = append(env, argoutil.GetRedisAuthEnv()...)
@@ -400,6 +404,7 @@ const (
 	EnvArgoCDAgentDestinationBasedMap = "ARGOCD_AGENT_DESTINATION_BASED_MAPPING"
 	EnvArgoCDAgentCreateNamespace     = "ARGOCD_AGENT_CREATE_NAMESPACE"
 	EnvArgoCDAgentAllowedNamespaces   = "ARGOCD_AGENT_ALLOWED_NAMESPACES"
+	EnvArgoCDAgentLabelSelector       = "ARGOCD_AGENT_LABEL_SELECTOR"
 )
 
 // Logging Configuration
@@ -433,6 +438,13 @@ func getAgentCreateNamespace(cr *argoproj.ArgoCD) string {
 func getAgentAllowedNamespaces(cr *argoproj.ArgoCD) string {
 	if hasAgent(cr) && len(cr.Spec.ArgoCDAgent.Agent.AllowedNamespaces) > 0 {
 		return strings.Join(cr.Spec.ArgoCDAgent.Agent.AllowedNamespaces, ",")
+	}
+	return ""
+}
+
+func getAgentLabelSelector(cr *argoproj.ArgoCD) string {
+	if hasAgent(cr) && cr.Spec.ArgoCDAgent.Agent.LabelSelector != "" {
+		return cr.Spec.ArgoCDAgent.Agent.LabelSelector
 	}
 	return ""
 }

--- a/controllers/argocdagent/agent/deployment_test.go
+++ b/controllers/argocdagent/agent/deployment_test.go
@@ -802,3 +802,81 @@ func TestReconcileAgentDeployment_ResourceRequirements(t *testing.T) {
 
 	assert.Equal(t, updatedResources, deployment.Spec.Template.Spec.Containers[0].Resources)
 }
+
+func withAgentLabelSelector(selector string) argoCDOpt {
+	return func(a *argoproj.ArgoCD) {
+		if a.Spec.ArgoCDAgent == nil {
+			a.Spec.ArgoCDAgent = &argoproj.ArgoCDAgentSpec{}
+		}
+		if a.Spec.ArgoCDAgent.Agent == nil {
+			a.Spec.ArgoCDAgent.Agent = &argoproj.AgentSpec{}
+		}
+		a.Spec.ArgoCDAgent.Agent.LabelSelector = selector
+	}
+}
+
+func TestGetAgentLabelSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		cr       *argoproj.ArgoCD
+		expected string
+	}{
+		{
+			name:     "agent not configured",
+			cr:       makeTestArgoCD(),
+			expected: "",
+		},
+		{
+			name:     "agent enabled without label selector",
+			cr:       makeTestArgoCD(withAgentEnabled(true)),
+			expected: "",
+		},
+		{
+			name:     "label selector set",
+			cr:       makeTestArgoCD(withAgentEnabled(true), withAgentLabelSelector("argocd-agent=true")),
+			expected: "argocd-agent=true",
+		},
+		{
+			name:     "empty label selector",
+			cr:       makeTestArgoCD(withAgentEnabled(true), withAgentLabelSelector("")),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getAgentLabelSelector(tt.cr))
+		})
+	}
+}
+
+func TestBuildAgentContainerEnv_LabelSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		cr       *argoproj.ArgoCD
+		expected string
+	}{
+		{
+			name:     "default empty label selector",
+			cr:       makeTestArgoCD(withAgentEnabled(true)),
+			expected: "",
+		},
+		{
+			name:     "custom label selector",
+			cr:       makeTestArgoCD(withAgentEnabled(true), withAgentLabelSelector("argocd-agent=true")),
+			expected: "argocd-agent=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envVars := buildAgentContainerEnv(tt.cr)
+			envMap := make(map[string]string)
+			for _, e := range envVars {
+				envMap[e.Name] = e.Value
+			}
+			assert.Equal(t, tt.expected, envMap[EnvArgoCDAgentLabelSelector],
+				"ARGOCD_AGENT_LABEL_SELECTOR mismatch")
+		})
+	}
+}

--- a/controllers/argocdagent/deployment.go
+++ b/controllers/argocdagent/deployment.go
@@ -407,6 +407,9 @@ func buildPrincipalContainerEnv(cr *argoproj.ArgoCD, centralTLSProfile tlsProfil
 		}, {
 			Name:  EnvArgoCDPrincipalDestinationBasedMapping,
 			Value: getPrincipalDestinationBasedMapping(cr),
+		}, {
+			Name:  EnvArgoCDPrincipalLabelSelector,
+			Value: getPrincipalLabelSelector(cr),
 		},
 	}
 
@@ -445,6 +448,7 @@ const (
 	EnvArgoCDPrincipalJwtSecretName             = "ARGOCD_PRINCIPAL_JWT_SECRET_NAME"
 	EnvArgoCDPrincipalImage                     = "ARGOCD_PRINCIPAL_IMAGE"
 	EnvArgoCDPrincipalDestinationBasedMapping   = "ARGOCD_PRINCIPAL_DESTINATION_BASED_MAPPING"
+	EnvArgoCDPrincipalLabelSelector             = "ARGOCD_PRINCIPAL_LABEL_SELECTOR"
 	EnvArgoCDPrincipalTlsMinVersion             = "ARGOCD_PRINCIPAL_TLS_MIN_VERSION"
 	EnvArgoCDPrincipalCipherSuites              = "ARGOCD_PRINCIPAL_TLS_CIPHERSUITES"
 )
@@ -501,6 +505,13 @@ func getPrincipalDestinationBasedMapping(cr *argoproj.ArgoCD) string {
 		return strconv.FormatBool(*cr.Spec.ArgoCDAgent.Principal.DestinationBasedMapping)
 	}
 	return "false"
+}
+
+func getPrincipalLabelSelector(cr *argoproj.ArgoCD) string {
+	if hasPrincipal(cr) && cr.Spec.ArgoCDAgent.Principal.LabelSelector != "" {
+		return cr.Spec.ArgoCDAgent.Principal.LabelSelector
+	}
+	return ""
 }
 
 func getPrincipalAllowedNamespaces(cr *argoproj.ArgoCD) string {

--- a/controllers/argocdagent/deployment_test.go
+++ b/controllers/argocdagent/deployment_test.go
@@ -785,3 +785,81 @@ func TestGetPrincipalTlsConfig(t *testing.T) {
 		})
 	}
 }
+
+func withPrincipalLabelSelector(selector string) argoCDOpt {
+	return func(a *argoproj.ArgoCD) {
+		if a.Spec.ArgoCDAgent == nil {
+			a.Spec.ArgoCDAgent = &argoproj.ArgoCDAgentSpec{}
+		}
+		if a.Spec.ArgoCDAgent.Principal == nil {
+			a.Spec.ArgoCDAgent.Principal = &argoproj.PrincipalSpec{}
+		}
+		a.Spec.ArgoCDAgent.Principal.LabelSelector = selector
+	}
+}
+
+func TestGetPrincipalLabelSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		cr       *argoproj.ArgoCD
+		expected string
+	}{
+		{
+			name:     "principal not configured",
+			cr:       makeTestArgoCD(),
+			expected: "",
+		},
+		{
+			name:     "principal enabled without label selector",
+			cr:       makeTestArgoCD(withPrincipalEnabled(true)),
+			expected: "",
+		},
+		{
+			name:     "label selector set",
+			cr:       makeTestArgoCD(withPrincipalEnabled(true), withPrincipalLabelSelector("argocd-agent=true")),
+			expected: "argocd-agent=true",
+		},
+		{
+			name:     "empty label selector",
+			cr:       makeTestArgoCD(withPrincipalEnabled(true), withPrincipalLabelSelector("")),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getPrincipalLabelSelector(tt.cr))
+		})
+	}
+}
+
+func TestBuildPrincipalContainerEnv_LabelSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		cr       *argoproj.ArgoCD
+		expected string
+	}{
+		{
+			name:     "default empty label selector",
+			cr:       makeTestArgoCD(withPrincipalEnabled(true)),
+			expected: "",
+		},
+		{
+			name:     "custom label selector",
+			cr:       makeTestArgoCD(withPrincipalEnabled(true), withPrincipalLabelSelector("argocd-agent=true")),
+			expected: "argocd-agent=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envVars := buildPrincipalContainerEnv(tt.cr, tlsprofile.TLSConfigProfile{})
+			envMap := make(map[string]string)
+			for _, e := range envVars {
+				envMap[e.Name] = e.Value
+			}
+			assert.Equal(t, tt.expected, envMap[EnvArgoCDPrincipalLabelSelector],
+				"ARGOCD_PRINCIPAL_LABEL_SELECTOR mismatch")
+		})
+	}
+}

--- a/controllers/argocdagent/example/argocd-agent.yaml
+++ b/controllers/argocdagent/example/argocd-agent.yaml
@@ -19,6 +19,8 @@ spec:
       logLevel: "info"
       # Log format (text or json)
       logFormat: "text"
+      # Label selector to restrict which resources the agent watches
+      labelSelector: "argocd-agent=true"
       # Container image for the ArgoCD Agent
       image: "quay.io/argoprojlabs/argocd-agent:v0.7.0"
       # Environment variables for the Agent component

--- a/controllers/argocdagent/example/argocd-principal.yaml
+++ b/controllers/argocdagent/example/argocd-principal.yaml
@@ -19,6 +19,8 @@ spec:
       logLevel: "info"
       # Log format (text or json)
       logFormat: "text"
+      # Label selector to restrict which resources the principal watches
+      labelSelector: "argocd-agent=true"
       # Container image for the ArgoCD Agent
       image: "quay.io/argoprojlabs/argocd-agent:v0.7.0"
       # Environment variables for the Principal component

--- a/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
+++ b/deploy/olm-catalog/argocd-operator/0.19.0/argoproj.io_argocds.yaml
@@ -699,6 +699,11 @@ spec:
                       image:
                         description: Image is the name of Argo CD Agent image
                         type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the agent watches.
+                          Only resources matching this selector will be listed, watched, and processed by the agent.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Agent component.
@@ -937,6 +942,11 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the principal watches.
+                          Only resources matching this selector will be listed, watched, and processed by the principal.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Principal component.
@@ -11892,6 +11902,11 @@ spec:
                       image:
                         description: Image is the name of Argo CD Agent image
                         type: string
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the agent watches.
+                          Only resources matching this selector will be listed, watched, and processed by the agent.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Agent component.
@@ -12194,6 +12209,11 @@ spec:
                               the JWT signing key.
                             type: string
                         type: object
+                      labelSelector:
+                        description: |-
+                          LabelSelector is a Kubernetes label selector that restricts which resources the principal watches.
+                          Only resources matching this selector will be listed, watched, and processed by the principal.
+                        type: string
                       logFormat:
                         description: LogFormat refers to the log format used by the
                           Principal component.

--- a/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
+++ b/tests/ginkgo/sequential/1-051_validate_argocd_agent_principal_test.go
@@ -105,6 +105,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 									"*",
 								},
 							},
+							LabelSelector: "argocd-agent=true",
 							TLS: &argov1beta1api.PrincipalTLSSpec{
 								InsecureGenerate: ptr.To(true),
 							},
@@ -222,6 +223,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				argocdagent.EnvArgoCDPrincipalResourceProxySecretName:   agentResourceProxyTLSSecretName,
 				argocdagent.EnvArgoCDPrincipalResourceProxyCaSecretName: agentRootCASecretName,
 				argocdagent.EnvArgoCDPrincipalJwtSecretName:             agentJWTSecretName,
+				argocdagent.EnvArgoCDPrincipalLabelSelector:             "argocd-agent=true",
 			}
 
 			principalResources = agentFixture.PrincipalResources{
@@ -437,6 +439,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				ac.Spec.ArgoCDAgent.Principal.Server.KeepAliveMinInterval = "60s"
 				ac.Spec.ArgoCDAgent.Principal.Server.EnableWebSocket = ptr.To(true)
 				ac.Spec.ArgoCDAgent.Principal.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+				ac.Spec.ArgoCDAgent.Principal.LabelSelector = "env=staging"
 
 				ac.Spec.ArgoCDAgent.Principal.Namespace.AllowedNamespaces = []string{"agent-managed", "agent-autonomous"}
 				ac.Spec.ArgoCDAgent.Principal.Namespace.EnableNamespaceCreate = ptr.To(true)
@@ -507,6 +510,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectedEnvVariables[argocdagent.EnvArgoCDPrincipalTLSSecretName] = "argocd-agent-principal-tls-v2"
 			expectedEnvVariables[argocdagent.EnvArgoCDPrincipalTLSServerRootCASecretName] = "argocd-agent-ca-v2"
 			expectedEnvVariables[argocdagent.EnvArgoCDPrincipalJwtSecretName] = "argocd-agent-jwt-v2"
+			expectedEnvVariables[argocdagent.EnvArgoCDPrincipalLabelSelector] = "env=staging"
 
 			for key, value := range expectedEnvVariables {
 				Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: key, Value: value}), "Environment variable %s should be set to %s", key, value)

--- a/tests/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
+++ b/tests/ginkgo/sequential/1-052_validate_argocd_agent_agent_test.go
@@ -88,10 +88,11 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					},
 					ArgoCDAgent: &argov1beta1api.ArgoCDAgentSpec{
 						Agent: &argov1beta1api.AgentSpec{
-							Enabled:   ptr.To(true),
-							Creds:     "mtls:any",
-							LogLevel:  "info",
-							LogFormat: "text",
+							Enabled:       ptr.To(true),
+							Creds:         "mtls:any",
+							LogLevel:      "info",
+							LogFormat:     "text",
+							LabelSelector: "argocd-agent=true",
 							Client: &argov1beta1api.AgentClientSpec{
 								PrincipalServerAddress: "argocd-agent-principal.example.com",
 								PrincipalServerPort:    "443",
@@ -185,6 +186,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				agent.EnvArgoCDAgentKeepAliveInterval:   "30s",
 				agent.EnvArgoCDAgentRedisAddress:        fmt.Sprintf("%s-%s:%d", argoCDName, "redis", common.ArgoCDDefaultRedisPort),
 				agent.EnvArgoCDAgentEnableResourceProxy: "true",
+				agent.EnvArgoCDAgentLabelSelector:       "argocd-agent=true",
 			}
 		})
 
@@ -399,6 +401,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				ac.Spec.ArgoCDAgent.Agent.LogLevel = "trace"
 				ac.Spec.ArgoCDAgent.Agent.LogFormat = "json"
 				ac.Spec.ArgoCDAgent.Agent.Image = "quay.io/argoprojlabs/argocd-agent:v0.5.1"
+				ac.Spec.ArgoCDAgent.Agent.LabelSelector = "env=staging"
 
 				ac.Spec.ArgoCDAgent.Agent.Client.KeepAliveInterval = "60s"
 				ac.Spec.ArgoCDAgent.Agent.Client.EnableWebSocket = ptr.To(true)
@@ -444,6 +447,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			expectedEnvVariables[agent.EnvArgoCDAgentTLSInsecure] = "true"
 			expectedEnvVariables[agent.EnvArgoCDAgentTLSSecretName] = "argocd-agent-client-tls-v2"
 			expectedEnvVariables[agent.EnvArgoCDAgentTLSRootCASecretName] = "argocd-agent-ca-v2"
+			expectedEnvVariables[agent.EnvArgoCDAgentLabelSelector] = "env=staging"
 
 			for key, value := range expectedEnvVariables {
 				Expect(container.Env).To(ContainElement(corev1.EnvVar{Name: key, Value: value}), "Environment variable %s should be set to %s", key, value)


### PR DESCRIPTION
The hybrid architecture of Argo CD Agent requires label selectors for proper isolation of agent-managed and local workloads. This PR adds a first-class `labelSelector` field to both PrincipalSpec and AgentSpec, which gets translated to the ARGOCD_PRINCIPAL_LABEL_SELECTOR and ARGOCD_AGENT_LABEL_SELECTOR environment variables respectively.

/kind enhancement

Assisted by: Cursor






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added label selector settings for both the agent and principal so you can limit which resources they watch and process.
  * Updated deployment behavior to pass the configured selector into runtime settings for each component.

* **Bug Fixes**
  * Ensured label selector values are preserved when converting and validating configurations across supported versions.

* **Documentation**
  * Updated configuration schemas and examples to show the new selector option and its expected usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->