### PR TITLE
fix: prevent infinite reconciliation loop for NamespaceManagement misconfiguration

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -327,7 +327,7 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 			log.Error(err, "Failed to disable NamespaceManagement feature")
 			return reconcile.Result{}, argocd, argoCDStatus, err
 		}
-	} else if len(argocd.Spec.NamespaceManagement) == 0 {
+	} else if len(argocd.Spec.NamespaceManagement) == 0 && isNamespaceManagementEnabled() {
 		// Handle cleanup of NamespaceManagement RBAC when the feature is removed from the ArgoCD CR.
 		nsMgmtList := &argoproj.NamespaceManagementList{}
 		if err := r.List(context.TODO(), nsMgmtList); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug 

**What does this PR do / why we need it**:
While reproducing the bug in this JIRA https://redhat.atlassian.net/browse/GITOPS-10363
When the feature flag is disabled AND spec.namespaceManagement is nil/empty, PATH 3 in if condition runs repeatedly trying to remove RBACs for existing NamespaceManagement CRs. But since the CRs still exist, this triggers continuous reconciliation with logs like 
2026-07-22T09:25:36-04:00	INFO	controller_argocd	Removing the RBACs created for the namespace: managed-ns-1
which is unnecessary

So I have added a guard in if condition to prevent deleting of RBACs unnecessarily

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes 
Partially fixes https://redhat.atlassian.net/browse/GITOPS-10363
The real bug mentioned in ticket is reproducible yet 

**How to test changes / Special notes to the reviewer**:
1. Install operator without the feature flag:
     make install
     unset ALLOW_NAMESPACE_MANAGEMENT_IN_NAMESPACE_SCOPED_INSTANCES
     make run

2. Create ArgoCD instance:
kubectl create namespace test-argocd
kubectl create namespace managed-ns-1

kubectl apply -f - <<EOF
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
  name: test-argocd
  namespace: test-argocd
 spec:
  server:
   route:
    enabled: false
EOF

3. Create NamespaceManagement CR:
  kubectl create namespace managed-ns-1
  cat <<EOF | kubectl apply -f -
  apiVersion: argoproj.io/v1beta1
  kind: NamespaceManagement
  metadata:
    name: managed-ns-1
    namespace: managed-ns-1
  spec:
    managedBy: test-argocd
EOF

4. check logs in make run terminal
No removing RBAC logs and see expected logs