### PR TITLE
feat(configmap): mask the token value annotation in the ArgoCD UI/CLI on OpenShift

### DIFF
--- a/common/keys.go
+++ b/common/keys.go
@@ -195,6 +195,9 @@ const (
 	// ArgoCDKeyUsersAnonymousEnabled is the configuration key for anonymous user access.
 	ArgoCDKeyUsersAnonymousEnabled = "users.anonymous.enabled"
 
+	// ArgoCDKeyResourceSensitiveMaskAnnotations is the key to mask metadata.annotations values in UI/CLI on Secrets.
+	ArgoCDKeyResourceSensitiveMaskAnnotations = "resource.sensitive.mask.annotations"
+
 	// ArgoCDDexImageEnvName is the environment variable used to get the image
 	// to used for the Dex container.
 	ArgoCDDexImageEnvName = "ARGOCD_DEX_IMAGE"

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -515,6 +515,27 @@ func (r *ReconcileArgoCD) reconcileArgoConfigMap(cr *argoproj.ArgoCD) error {
 		cm.Data[common.ArgoCDServerRBACDisableFineGrainedInheritance] = "false"
 	}
 
+	// On OpenShift, mask the token value annotation in the ArgoCD UI/CLI to
+	// prevent accidental exposure of service account token secrets.
+	// Appends to any value already set via ExtraConfig; skips if already present.
+	if IsOpenShiftCluster() {
+		const tokenAnnotation = "openshift.io/token-secret.value"
+		if existing, ok := cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations]; ok && existing != "" {
+			alreadyPresent := false
+			for _, entry := range strings.Split(existing, ",") {
+				if strings.TrimSpace(entry) == tokenAnnotation {
+					alreadyPresent = true
+					break
+				}
+			}
+			if !alreadyPresent {
+				cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations] = existing + "," + tokenAnnotation
+			}
+		} else {
+			cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations] = tokenAnnotation
+		}
+	}
+
 	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
 		return err
 	}

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -2002,14 +2002,14 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_sensitiveAnnotations(t *testing.
 		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 		err := r.reconcileArgoConfigMap(a)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		cm := &corev1.ConfigMap{}
 		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		_, exists := cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations]
 		assert.False(t, exists, "resource.sensitive.mask.annotations should not be set on non-OpenShift clusters")
 	})
@@ -2028,14 +2028,14 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_sensitiveAnnotations(t *testing.
 		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 		err := r.reconcileArgoConfigMap(a)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		cm := &corev1.ConfigMap{}
 		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "openshift.io/token-secret.value", cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations])
 	})
 
@@ -2065,17 +2065,17 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_sensitiveAnnotations(t *testing.
 		}
 		argoutil.AddTrackedByOperatorLabel(&existingCM.ObjectMeta)
 		err := r.Create(context.TODO(), existingCM)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = r.reconcileArgoConfigMap(a)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		cm := &corev1.ConfigMap{}
 		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "openshift.io/token-secret.value", cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations])
 	})
 
@@ -2096,14 +2096,14 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_sensitiveAnnotations(t *testing.
 		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 		err := r.reconcileArgoConfigMap(a)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		cm := &corev1.ConfigMap{}
 		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "some.other/annotation,openshift.io/token-secret.value",
 			cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations])
 	})
@@ -2125,14 +2125,14 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_sensitiveAnnotations(t *testing.
 		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 		err := r.reconcileArgoConfigMap(a)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		cm := &corev1.ConfigMap{}
 		err = r.Get(context.TODO(), types.NamespacedName{
 			Name:      common.ArgoCDConfigMapName,
 			Namespace: testNamespace,
 		}, cm)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "some.other/annotation,openshift.io/token-secret.value",
 			cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations],
 			"token annotation should not be duplicated")

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -1984,3 +1984,157 @@ func TestReconcileArgoCD_reconcileArgoCmdParamsConfigMap_tokenRefStrictDefault(t
 		})
 	}
 }
+
+func TestReconcileArgoCD_reconcileArgoConfigMap_sensitiveAnnotations(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	t.Run("non-openshift: key absent", func(t *testing.T) {
+		original := versionAPIFound
+		versionAPIFound = false
+		defer func() { versionAPIFound = original }()
+
+		a := makeTestArgoCD()
+		resObjs := []client.Object{a}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err := r.reconcileArgoConfigMap(a)
+		assert.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: testNamespace,
+		}, cm)
+		assert.NoError(t, err)
+		_, exists := cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations]
+		assert.False(t, exists, "resource.sensitive.mask.annotations should not be set on non-OpenShift clusters")
+	})
+
+	t.Run("openshift: key present on create", func(t *testing.T) {
+		original := versionAPIFound
+		versionAPIFound = true
+		defer func() { versionAPIFound = original }()
+
+		a := makeTestArgoCD()
+		resObjs := []client.Object{a}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err := r.reconcileArgoConfigMap(a)
+		assert.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: testNamespace,
+		}, cm)
+		assert.NoError(t, err)
+		assert.Equal(t, "openshift.io/token-secret.value", cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations])
+	})
+
+	t.Run("openshift: key added via update when cm already exists without it", func(t *testing.T) {
+		original := versionAPIFound
+		versionAPIFound = true
+		defer func() { versionAPIFound = original }()
+
+		a := makeTestArgoCD()
+		resObjs := []client.Object{a}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		// Pre-create the ConfigMap without the sensitive key, simulating an
+		// existing deployment being upgraded to an operator version that adds this key.
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.ArgoCDConfigMapName,
+				Namespace: a.Namespace,
+			},
+			Data: map[string]string{
+				"admin.enabled": "true",
+			},
+		}
+		argoutil.AddTrackedByOperatorLabel(&existingCM.ObjectMeta)
+		err := r.Create(context.TODO(), existingCM)
+		assert.NoError(t, err)
+
+		err = r.reconcileArgoConfigMap(a)
+		assert.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: testNamespace,
+		}, cm)
+		assert.NoError(t, err)
+		assert.Equal(t, "openshift.io/token-secret.value", cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations])
+	})
+
+	t.Run("openshift: ExtraConfig has different annotation, token annotation is appended", func(t *testing.T) {
+		original := versionAPIFound
+		versionAPIFound = true
+		defer func() { versionAPIFound = original }()
+
+		a := makeTestArgoCD()
+		a.Spec.ExtraConfig = map[string]string{
+			common.ArgoCDKeyResourceSensitiveMaskAnnotations: "some.other/annotation",
+		}
+		resObjs := []client.Object{a}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err := r.reconcileArgoConfigMap(a)
+		assert.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: testNamespace,
+		}, cm)
+		assert.NoError(t, err)
+		assert.Equal(t, "some.other/annotation,openshift.io/token-secret.value",
+			cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations])
+	})
+
+	t.Run("openshift: ExtraConfig already contains token annotation, no duplicate added", func(t *testing.T) {
+		original := versionAPIFound
+		versionAPIFound = true
+		defer func() { versionAPIFound = original }()
+
+		a := makeTestArgoCD()
+		a.Spec.ExtraConfig = map[string]string{
+			common.ArgoCDKeyResourceSensitiveMaskAnnotations: "some.other/annotation,openshift.io/token-secret.value",
+		}
+		resObjs := []client.Object{a}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err := r.reconcileArgoConfigMap(a)
+		assert.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      common.ArgoCDConfigMapName,
+			Namespace: testNamespace,
+		}, cm)
+		assert.NoError(t, err)
+		assert.Equal(t, "some.other/annotation,openshift.io/token-secret.value",
+			cm.Data[common.ArgoCDKeyResourceSensitiveMaskAnnotations],
+			"token annotation should not be duplicated")
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
On GitOPS operator on Openshift any secret of type "kubernetes.io/dockercfg" has the annotation "openshift.io/token-secret.value" with the token in clear that can be seen by the administrator of the gitops project and the token could be used to have access to unwanted resources, these secrets should be automatically hidden instead of requiring manual addition.

**Have you updated the necessary documentation?**
no

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/RFE-7499

Fixes #?

**How to test changes / Special notes to the reviewer**:
The e2e will follow in gitops operator repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for automatically masking sensitive `metadata.annotations` values in the Argo CD UI and CLI by honoring a new sensitive-mask annotation key on OpenShift.

* **Bug Fixes**
  * Ensures the masking entry is added or backfilled during Argo CD ConfigMap reconciliation on OpenShift.
  * Avoids duplicate entries and appends the token-secret masking value only when missing, without overwriting existing configuration.

* **Tests**
  * Added reconciliation tests covering OpenShift vs non-OpenShift behavior, backfill for existing ConfigMaps, override/append handling, and de-duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->