### PR TITLE
fix(reposerver): added support for allowing customers to set custom GODEBUG settings in repo server deployments

### DIFF
--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -3068,18 +3068,20 @@ func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGoDebugEnv(t
 
 	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
-	foundEnv := false
+	foundGoDebug := false
+	foundGoLangFips := false
 	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
 		if env.Name == "GODEBUG" {
-			foundEnv = true
-			assert.Equal(t, env.Value, "fips140=on,tlsmlkem=0", "GODEBUG environment must be set to user provided value when fips is enabled")
+			foundGoDebug = true
+			assert.Equal(t, "fips140=on,tlsmlkem=0", env.Value, "GODEBUG environment must be set to user provided value when fips is enabled")
 		}
 		if env.Name == "GOLANG_FIPS" {
-			foundEnv = true
-			assert.Equal(t, env.Value, "0", "GOLANG_FIPS environment must be set to 0 when fips is enabled")
+			foundGoLangFips = true
+			assert.Equal(t, "0", env.Value, "GOLANG_FIPS environment must be set to 0 when fips is enabled")
 		}
 	}
-	assert.True(t, foundEnv, "environment GODEBUG must be set to user provided value when FIPS is enabled, and GOLANG_FIPS env var should be set to 0 when fips is enabled in GODEBUG")
+	assert.True(t, foundGoDebug, "environment GODEBUG must be set to user provided value when FIPS is enabled")
+	assert.True(t, foundGoLangFips, "GOLANG_FIPS env var should be set to 0 when fips140=on is present in GODEBUG")
 }
 
 func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGoDebugEnvFipsOff(t *testing.T) {
@@ -3112,18 +3114,19 @@ func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGoDebugEnvFi
 
 	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
-	foundEnv := false
+	foundGoDebug := false
+	foundGoLangFips := false
 	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
 		if env.Name == "GODEBUG" {
-			foundEnv = true
-			assert.Equal(t, env.Value, "fips140=off,tlsmlkem=0", "GODEBUG environment must be set to user provided value when fips is enabled")
+			foundGoDebug = true
+			assert.Equal(t, "fips140=off,tlsmlkem=0", env.Value, "GODEBUG environment must be set to user provided value when fips is enabled")
 		}
 		if env.Name == "GOLANG_FIPS" {
-			foundGoLangFipsEnv := false
-			assert.False(t, foundGoLangFipsEnv, "1", "environment GODEBUG must be set to user provided value when FIPS is enabled, and no GOLANG_FIPS env var should be set when fips is switched off in GODEBUG")
+			foundGoLangFips = true
 		}
 	}
-	assert.True(t, foundEnv, "environment GODEBUG must be set to user provided value when FIPS is enabled, and no GOLANG_FIPS env var should be set when fips is switched off in GODEBUG")
+	assert.True(t, foundGoDebug, "environment GODEBUG must be set to user provided value when FIPS is enabled")
+	assert.False(t, foundGoLangFips, "GOLANG_FIPS env var should not be set when fips140=off is present in GODEBUG")
 }
 
 func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGoDebugEnvFipsMissing(t *testing.T) {
@@ -3156,18 +3159,92 @@ func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGoDebugEnvFi
 
 	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
-	foundEnv := false
+	foundGoDebug := false
+	foundGoLangFips := false
 	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
 		if env.Name == "GODEBUG" {
-			foundEnv = true
-			assert.Equal(t, env.Value, "tlsmlkem=0", "GODEBUG environment must be set to user provided value when fips is enabled")
+			foundGoDebug = true
+			assert.Equal(t, "tlsmlkem=0", env.Value, "GODEBUG environment must be set to user provided value when fips is enabled")
 		}
 		if env.Name == "GOLANG_FIPS" {
-			foundGoLangFipsEnv := false
-			assert.False(t, foundGoLangFipsEnv, "environment GODEBUG must be set to user provided value when FIPS is enabled, and no GOLANG_FIPS env var should be set when fips is setting is missing in GODEBUG")
+			foundGoLangFips = true
 		}
 	}
-	assert.True(t, foundEnv, "environment GODEBUG must be set to user provided value when FIPS is enabled, and no GOLANG_FIPS env var should be set when fips is switched off in GODEBUG")
+	assert.True(t, foundGoDebug, "environment GODEBUG must be set to user provided value when FIPS is enabled")
+	assert.False(t, foundGoLangFips, "GOLANG_FIPS env var should not be set when fips140 setting is missing from GODEBUG")
+}
+
+func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGolangFipsEnv(t *testing.T) {
+	cr := makeTestArgoCD()
+	cr.Spec.Repo.Env = []corev1.EnvVar{
+		{
+			Name:  "GOLANG_FIPS",
+			Value: "1",
+		},
+	}
+	resObjs := []client.Object{cr}
+	subresObjs := []client.Object{cr}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	r.FipsConfigChecker = &MockTrueFipsChecker{}
+
+	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
+
+	d := &appsv1.Deployment{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
+
+	foundGoDebug := false
+	foundGoLangFips := false
+	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "GODEBUG" {
+			foundGoDebug = true
+			assert.Equal(t, "fips140=on", env.Value, "GODEBUG must be set to fips140=on when fips is enabled")
+		}
+		if env.Name == "GOLANG_FIPS" {
+			foundGoLangFips = true
+			assert.Equal(t, "1", env.Value, "user provided GOLANG_FIPS value must be preserved")
+		}
+	}
+	assert.True(t, foundGoDebug, "environment GODEBUG must be set when FIPS is enabled")
+	assert.True(t, foundGoLangFips, "GOLANG_FIPS env var must be present")
+}
+
+func TestReconcileArgoCD_reconcileRepoServerWithFipsDisabledAndCustomGoDebugEnv(t *testing.T) {
+	cr := makeTestArgoCD()
+	cr.Spec.Repo.Env = []corev1.EnvVar{
+		{
+			Name:  "GODEBUG",
+			Value: "http2debug=1",
+		},
+	}
+	resObjs := []client.Object{cr}
+	subresObjs := []client.Object{cr}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	r.FipsConfigChecker = &MockFalseFipsChecker{}
+
+	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
+
+	d := &appsv1.Deployment{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
+
+	foundGoDebug := false
+	foundGoLangFips := false
+	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "GODEBUG" {
+			foundGoDebug = true
+			assert.Equal(t, "http2debug=1", env.Value, "user provided GODEBUG must be preserved when FIPS is disabled")
+		}
+		if env.Name == "GOLANG_FIPS" {
+			foundGoLangFips = true
+		}
+	}
+	assert.True(t, foundGoDebug, "user provided GODEBUG must be preserved when FIPS is disabled")
+	assert.False(t, foundGoLangFips, "GOLANG_FIPS env var should not be set when FIPS is disabled")
 }
 
 func TestDeploymentWithLongName(t *testing.T) {

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -38,13 +38,12 @@ const (
 	testNoProxy    = ".example.com"
 )
 
-var (
-	deploymentNames = []string{
-		"argocd-repo-server",
-		"argocd-dex-server",
-		"argocd-redis",
-		"argocd-server"}
-)
+var deploymentNames = []string{
+	"argocd-repo-server",
+	"argocd-dex-server",
+	"argocd-redis",
+	"argocd-server",
+}
 
 type MockTrueFipsChecker struct{}
 
@@ -77,7 +76,6 @@ func TestReconcileArgoCD_reconcileRepoDeployment_replicas(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Repo.Replicas = &test.replicas
 			})
@@ -333,7 +331,6 @@ func TestReconcileArgoCD_reconcile_ServerDeployment_env(t *testing.T) {
 		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "FOO", Value: "BAR"})
 		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "BAR", Value: "FOO"})
 	})
-
 }
 
 func TestReconcileArgoCD_reconcileRepoDeployment_env(t *testing.T) {
@@ -547,7 +544,6 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 		containsDefaultMount := false
 
 		for _, volumeMount := range container.VolumeMounts {
-
 			if volumeMount.Name == testMount.Name {
 				containsTestMount = true
 			} else if volumeMount.MountPath == "/tmp" {
@@ -571,7 +567,6 @@ func TestReconcileArgoCD_reconcileRepoDeployment_mounts(t *testing.T) {
 
 		assert.True(t, containsTestMountVolume, "should contain test-mount molume")
 		assert.False(t, containsDefaultVolume, "should not contain default tmp volume")
-
 	})
 }
 
@@ -645,6 +640,7 @@ func TestReconcileArgoCD_reconcileRepoDeployment_missingInitContainers(t *testin
 	assert.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
 	assert.Equal(t, deployment.Spec.Template.Spec.InitContainers[0].Name, "copyutil")
 }
+
 func TestReconcileArgoCD_reconcileRepoDeployment_unexpectedInitContainer(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD()
@@ -724,7 +720,6 @@ func TestReconcileArgoCD_reconcileRepoDeployment_command(t *testing.T) {
 // reconcileRepoDeployments creates a Deployment with the proxy settings from the
 // environment propagated.
 func TestReconcileArgoCD_reconcileDeployments_proxy(t *testing.T) {
-
 	t.Setenv("HTTP_PROXY", testHTTPProxy)
 	t.Setenv("HTTPS_PROXY", testHTTPSProxy)
 	t.Setenv("no_proxy", testNoProxy)
@@ -900,8 +895,8 @@ func TestReconcileArgoCD_reconcileDeployments_HA_proxy_with_resources(t *testing
 	assert.Equal(t, deployment.Spec.Template.Spec.Containers[0].Resources, newResources)
 	assert.Equal(t, deployment.Spec.Template.Spec.InitContainers[0].Resources, newResources)
 	assert.Equal(t, deployment.Spec.Strategy.RollingUpdate.MaxSurge, &intstr.IntOrString{IntVal: 0})
-
 }
+
 func TestReconcileArgoCD_reconcileRedisHAProxyDeployment_ModifyContainerSpec(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
@@ -1217,7 +1212,7 @@ func TestReconcileArgoCD_reconcileDeployment_nodePlacement(t *testing.T) {
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-	err := r.reconcileRepoDeployment(a, false) //can use other deployments as well
+	err := r.reconcileRepoDeployment(a, false) // can use other deployments as well
 	assert.NoError(t, err)
 	deployment := &appsv1.Deployment{}
 	err = r.Get(context.TODO(), types.NamespacedName{
@@ -1244,6 +1239,7 @@ func deploymentDefaultNodeSelector() map[string]string {
 	}
 	return nodeSelector
 }
+
 func deploymentDefaultTolerations() []corev1.Toleration {
 	toleration := []corev1.Toleration{
 		{
@@ -2205,7 +2201,6 @@ func operationProcessors(n int32) argoCDOpt {
 }
 
 func Test_UpdateNodePlacement(t *testing.T) {
-
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-sample-server",
@@ -2518,13 +2513,16 @@ func serverDefaultVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      "ssh-known-hosts",
 			MountPath: "/app/config/ssh",
-		}, {
+		},
+		{
 			Name:      "tls-certs",
 			MountPath: "/app/config/tls",
-		}, {
+		},
+		{
 			Name:      "argocd-repo-server-tls",
 			MountPath: "/app/config/server/tls",
-		}, {
+		},
+		{
 			Name:      common.ArgoCDRedisServerTLSSecretName,
 			MountPath: "/app/config/server/tls/redis",
 		},
@@ -2570,7 +2568,6 @@ func TestReconcileArgoCD_reconcile_RepoServerChanges(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Repo.MountSAToken = test.mountSAToken
 				a.Spec.Repo.ServiceAccount = test.serviceAccount
@@ -2756,7 +2753,6 @@ func TestReconcileArgoCD_reconcileRepoDeployment_serviceAccount(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
-
 			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
 				a.Spec.Repo.ServiceAccount = test.serviceAccountName
 			})
@@ -2935,7 +2931,6 @@ func Test_getRolloutInitContainer(t *testing.T) {
 
 			assert.Equalf(t, tt.wantImage, containers[0].Image, "Image check")
 			assert.Equalf(t, tt.wantEnv, containers[0].Env, "Env check")
-
 		})
 	}
 }
@@ -2968,7 +2963,6 @@ func TestSetReplicasAndEnvVar_WhenServerReplicasIsDefined(t *testing.T) {
 		assert.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
 		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "ARGOCD_API_SERVER_REPLICAS", Value: "2"})
 	})
-
 }
 
 func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabled(t *testing.T) {
@@ -3042,6 +3036,138 @@ func TestReconcileArgoCD_reconcileRepoServerWithFipsDisabled(t *testing.T) {
 		}
 	}
 	assert.False(t, foundEnv, "environment GODEBUG must NOT be set when FIPS is disabled")
+}
+
+func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGoDebugEnv(t *testing.T) {
+	cr := makeTestArgoCD()
+	cr.Spec.Repo.Env = []corev1.EnvVar{
+		{
+			Name:  "GODEBUG",
+			Value: "fips140=on,tlsmlkem=0",
+		},
+	}
+	resObjs := []client.Object{cr}
+	subresObjs := []client.Object{cr}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	r.FipsConfigChecker = &MockTrueFipsChecker{}
+	repoServerRemote := "https://remote.repo-server.instance"
+
+	cr.Spec.Repo.Remote = &repoServerRemote
+	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
+
+	d := &appsv1.Deployment{}
+
+	assert.ErrorContains(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d),
+		"deployments.apps \""+cr.Name+"-repo-server\" not found")
+
+	// once remote is set to nil, reconciliation should trigger deployment resource creation
+	cr.Spec.Repo.Remote = nil
+
+	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
+	foundEnv := false
+	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "GODEBUG" {
+			foundEnv = true
+			assert.Equal(t, env.Value, "fips140=on,tlsmlkem=0", "GODEBUG environment must be set to user provided value when fips is enabled")
+		}
+		if env.Name == "GOLANG_FIPS" {
+			foundEnv = true
+			assert.Equal(t, env.Value, "0", "GOLANG_FIPS environment must be set to 0 when fips is enabled")
+		}
+	}
+	assert.True(t, foundEnv, "environment GODEBUG must be set to user provided value when FIPS is enabled, and GOLANG_FIPS env var should be set to 0 when fips is enabled in GODEBUG")
+}
+
+func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGoDebugEnvFipsOff(t *testing.T) {
+	cr := makeTestArgoCD()
+	cr.Spec.Repo.Env = []corev1.EnvVar{
+		{
+			Name:  "GODEBUG",
+			Value: "fips140=off,tlsmlkem=0",
+		},
+	}
+	resObjs := []client.Object{cr}
+	subresObjs := []client.Object{cr}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	r.FipsConfigChecker = &MockTrueFipsChecker{}
+	repoServerRemote := "https://remote.repo-server.instance"
+
+	cr.Spec.Repo.Remote = &repoServerRemote
+	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
+
+	d := &appsv1.Deployment{}
+
+	assert.ErrorContains(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d),
+		"deployments.apps \""+cr.Name+"-repo-server\" not found")
+
+	// once remote is set to nil, reconciliation should trigger deployment resource creation
+	cr.Spec.Repo.Remote = nil
+
+	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
+	foundEnv := false
+	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "GODEBUG" {
+			foundEnv = true
+			assert.Equal(t, env.Value, "fips140=off,tlsmlkem=0", "GODEBUG environment must be set to user provided value when fips is enabled")
+		}
+		if env.Name == "GOLANG_FIPS" {
+			foundGoLangFipsEnv := false
+			assert.False(t, foundGoLangFipsEnv, "1", "environment GODEBUG must be set to user provided value when FIPS is enabled, and no GOLANG_FIPS env var should be set when fips is switched off in GODEBUG")
+		}
+	}
+	assert.True(t, foundEnv, "environment GODEBUG must be set to user provided value when FIPS is enabled, and no GOLANG_FIPS env var should be set when fips is switched off in GODEBUG")
+}
+
+func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabledAndCustomGoDebugEnvFipsMissing(t *testing.T) {
+	cr := makeTestArgoCD()
+	cr.Spec.Repo.Env = []corev1.EnvVar{
+		{
+			Name:  "GODEBUG",
+			Value: "tlsmlkem=0",
+		},
+	}
+	resObjs := []client.Object{cr}
+	subresObjs := []client.Object{cr}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	r.FipsConfigChecker = &MockTrueFipsChecker{}
+	repoServerRemote := "https://remote.repo-server.instance"
+
+	cr.Spec.Repo.Remote = &repoServerRemote
+	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
+
+	d := &appsv1.Deployment{}
+
+	assert.ErrorContains(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d),
+		"deployments.apps \""+cr.Name+"-repo-server\" not found")
+
+	// once remote is set to nil, reconciliation should trigger deployment resource creation
+	cr.Spec.Repo.Remote = nil
+
+	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
+	foundEnv := false
+	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "GODEBUG" {
+			foundEnv = true
+			assert.Equal(t, env.Value, "tlsmlkem=0", "GODEBUG environment must be set to user provided value when fips is enabled")
+		}
+		if env.Name == "GOLANG_FIPS" {
+			foundGoLangFipsEnv := false
+			assert.False(t, foundGoLangFipsEnv, "environment GODEBUG must be set to user provided value when FIPS is enabled, and no GOLANG_FIPS env var should be set when fips is setting is missing in GODEBUG")
+		}
+	}
+	assert.True(t, foundEnv, "environment GODEBUG must be set to user provided value when FIPS is enabled, and no GOLANG_FIPS env var should be set when fips is switched off in GODEBUG")
 }
 
 func TestDeploymentWithLongName(t *testing.T) {

--- a/controllers/argocd/repo_server.go
+++ b/controllers/argocd/repo_server.go
@@ -129,19 +129,15 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argocdoperatorv1beta1.Argo
 			return err
 		}
 		if fipsEnabled {
-			repoEnv = append(repoEnv, corev1.EnvVar{
-				Name:  "GODEBUG",
-				Value: "fips140=on",
-			},
-				// GOLANG_FIPS and GODEBUG=fips140=on are both mutaully exclusive.
-				// GOLANG_FIPS=1 is set by default but it causes issues
-				// since we are explicitly setting GODEBUG=fips140=on to skip unsupported fips ssh algorithms in Argo CD.
-				// See https://github.com/argoproj/argo-cd/issues/24155,
-				// so we need to set GOLANG_FIPS=0 to avoid the conflict.
-				corev1.EnvVar{
-					Name:  "GOLANG_FIPS",
-					Value: "0",
-				})
+			repoEnv = argoutil.EnvMerge(repoEnv, argoutil.GetFIPSGoDebugEnv(), false)
+			for _, env := range repoEnv {
+				if env.Name == "GODEBUG" {
+					if strings.Contains(env.Value, "fips140=on") {
+						repoEnv = argoutil.EnvMerge(repoEnv, argoutil.GetFIPSGoLangFipsEnv(), false)
+					}
+					break
+				}
+			}
 		}
 	}
 
@@ -211,12 +207,10 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argocdoperatorv1beta1.Argo
 	}
 
 	if !volumeMountOverridesTmpVolume {
-
 		repoServerVolumeMounts = append(repoServerVolumeMounts, corev1.VolumeMount{
 			Name:      "tmp",
 			MountPath: "/tmp",
 		})
-
 	}
 
 	if cr.Spec.Repo.VolumeMounts != nil {

--- a/controllers/argocd/repo_server.go
+++ b/controllers/argocd/repo_server.go
@@ -129,15 +129,7 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argocdoperatorv1beta1.Argo
 			return err
 		}
 		if fipsEnabled {
-			repoEnv = argoutil.EnvMerge(repoEnv, argoutil.GetFIPSGoDebugEnv(), false)
-			for _, env := range repoEnv {
-				if env.Name == "GODEBUG" {
-					if strings.Contains(env.Value, "fips140=on") {
-						repoEnv = argoutil.EnvMerge(repoEnv, argoutil.GetFIPSGoLangFipsEnv(), false)
-					}
-					break
-				}
-			}
+			repoEnv = argoutil.DecorateWithFIPSEnv(repoEnv)
 		}
 	}
 

--- a/controllers/argoutil/fips.go
+++ b/controllers/argoutil/fips.go
@@ -2,6 +2,8 @@ package argoutil
 
 import (
 	"os"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // FipsConfigChecker defines the behavior for reading the FIPS config.
@@ -47,4 +49,29 @@ func fileExists(path string) (bool, error) {
 		return false, err
 	}
 	return !info.IsDir(), nil
+}
+
+// GetFIPSGoDebugEnv returns the environment variable GODEBUG set to fips140=on.
+func GetFIPSGoDebugEnv() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "GODEBUG",
+			Value: "fips140=on",
+		},
+	}
+}
+
+// GetFIPSGoLangEnv returns the environment variable GOLANG_FIPS set to 0. This must be added only if the GODEBUG environment variable contains fips140=on.
+func GetFIPSGoLangFipsEnv() []corev1.EnvVar {
+	// GOLANG_FIPS and GODEBUG=fips140=on are both mutaully exclusive.
+	// GOLANG_FIPS=1 is set by default but it causes issues
+	// since we are explicitly setting GODEBUG=fips140=on to skip unsupported fips ssh algorithms in Argo CD.
+	// See https://github.com/argoproj/argo-cd/issues/24155,
+	// so we need to set GOLANG_FIPS=0 to avoid the conflict.
+	return []corev1.EnvVar{
+		{
+			Name:  "GOLANG_FIPS",
+			Value: "0",
+		},
+	}
 }

--- a/controllers/argoutil/fips.go
+++ b/controllers/argoutil/fips.go
@@ -2,6 +2,7 @@ package argoutil
 
 import (
 	"os"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -51,27 +52,42 @@ func fileExists(path string) (bool, error) {
 	return !info.IsDir(), nil
 }
 
-// GetFIPSGoDebugEnv returns the environment variable GODEBUG set to fips140=on.
-func GetFIPSGoDebugEnv() []corev1.EnvVar {
-	return []corev1.EnvVar{
-		{
-			Name:  "GODEBUG",
-			Value: "fips140=on",
-		},
+// DecorateWithFIPSEnv adds environment variables required to enable FIPS in go runtime.
+// If user has set this value already, this method does not override it. If the environment variable
+// GODEBUG contains fips140=on, it will also set GOLANG_FIPS=0 as these two environments are
+// mutually exclusive.
+func DecorateWithFIPSEnv(in []corev1.EnvVar) []corev1.EnvVar {
+	mergedEnv := EnvMerge(in, []corev1.EnvVar{{
+		Name:  "GODEBUG",
+		Value: "fips140=on",
+	}}, false)
+	for _, env := range mergedEnv {
+		if env.Name == "GODEBUG" {
+			if hasGodebugEntry(env.Value, "fips140=on") {
+				// GOLANG_FIPS and GODEBUG=fips140=on are both mutually exclusive.
+				// GOLANG_FIPS=1 is set by default, but it causes issues
+				// since we are explicitly setting GODEBUG=fips140=on to skip
+				// unsupported fips ssh algorithms in Argo CD.
+				// See https://github.com/argoproj/argo-cd/issues/24155,
+				// so we need to set GOLANG_FIPS=0 to avoid the conflict.
+				mergedEnv = EnvMerge(mergedEnv, []corev1.EnvVar{{
+					Name:  "GOLANG_FIPS",
+					Value: "0",
+				}}, false)
+			}
+			break
+		}
 	}
+	return mergedEnv
 }
 
-// GetFIPSGoLangEnv returns the environment variable GOLANG_FIPS set to 0. This must be added only if the GODEBUG environment variable contains fips140=on.
-func GetFIPSGoLangFipsEnv() []corev1.EnvVar {
-	// GOLANG_FIPS and GODEBUG=fips140=on are both mutaully exclusive.
-	// GOLANG_FIPS=1 is set by default but it causes issues
-	// since we are explicitly setting GODEBUG=fips140=on to skip unsupported fips ssh algorithms in Argo CD.
-	// See https://github.com/argoproj/argo-cd/issues/24155,
-	// so we need to set GOLANG_FIPS=0 to avoid the conflict.
-	return []corev1.EnvVar{
-		{
-			Name:  "GOLANG_FIPS",
-			Value: "0",
-		},
+// hasGodebugEntry checks whether a comma-separated GODEBUG value contains an
+// exact entry (e.g. "fips140=on").
+func hasGodebugEntry(godebugValue, entry string) bool {
+	for _, e := range strings.Split(godebugValue, ",") {
+		if e == entry {
+			return true
+		}
 	}
+	return false
 }

--- a/controllers/argoutil/fips_test.go
+++ b/controllers/argoutil/fips_test.go
@@ -1,12 +1,12 @@
 package argoutil
 
-// Assisted by : Gemini 2.5 Pro
-// The unit tests in this file were generated with the assistance of Google's Gemini 2.5 Pro.
-
 import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // TestIsHostRunningInFipsMode validates the FIPS check function that checks if the host is running in FIPS mode.
@@ -96,6 +96,97 @@ func TestIsHostRunningInFipsMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecorateWithFIPSEnv(t *testing.T) {
+	t.Run("Empty input adds GODEBUG and GOLANG_FIPS", func(t *testing.T) {
+		result := DecorateWithFIPSEnv(nil)
+		assert.Len(t, result, 2)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "fips140=on"})
+		assert.Contains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "0"})
+	})
+
+	t.Run("No GODEBUG in input adds both vars and preserves existing", func(t *testing.T) {
+		input := []corev1.EnvVar{
+			{Name: "HOME", Value: "/home/argocd"},
+		}
+		result := DecorateWithFIPSEnv(input)
+		assert.Len(t, result, 3)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "fips140=on"})
+		assert.Contains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "0"})
+		assert.Contains(t, result, corev1.EnvVar{Name: "HOME", Value: "/home/argocd"})
+	})
+
+	t.Run("Custom GODEBUG without fips140=on is preserved and GOLANG_FIPS not added", func(t *testing.T) {
+		input := []corev1.EnvVar{
+			{Name: "GODEBUG", Value: "http2debug=1"},
+		}
+		result := DecorateWithFIPSEnv(input)
+		assert.Len(t, result, 1)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "http2debug=1"})
+		assert.NotContains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "0"})
+	})
+
+	t.Run("Custom GODEBUG with fips140=off is preserved and GOLANG_FIPS not added", func(t *testing.T) {
+		input := []corev1.EnvVar{
+			{Name: "GODEBUG", Value: "fips140=off"},
+		}
+		result := DecorateWithFIPSEnv(input)
+		assert.Len(t, result, 1)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "fips140=off"})
+		assert.NotContains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "0"})
+	})
+
+	t.Run("Custom GODEBUG with fips140=on adds GOLANG_FIPS", func(t *testing.T) {
+		input := []corev1.EnvVar{
+			{Name: "GODEBUG", Value: "fips140=on"},
+		}
+		result := DecorateWithFIPSEnv(input)
+		assert.Len(t, result, 2)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "fips140=on"})
+		assert.Contains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "0"})
+	})
+
+	t.Run("Custom GODEBUG with fips140=on among other settings adds GOLANG_FIPS", func(t *testing.T) {
+		input := []corev1.EnvVar{
+			{Name: "GODEBUG", Value: "http2debug=1,fips140=on,tls13=1"},
+		}
+		result := DecorateWithFIPSEnv(input)
+		assert.Len(t, result, 2)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "http2debug=1,fips140=on,tls13=1"})
+		assert.Contains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "0"})
+	})
+
+	t.Run("Existing GOLANG_FIPS is not overridden", func(t *testing.T) {
+		input := []corev1.EnvVar{
+			{Name: "GOLANG_FIPS", Value: "1"},
+		}
+		result := DecorateWithFIPSEnv(input)
+		assert.Len(t, result, 2)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "fips140=on"})
+		assert.Contains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "1"})
+	})
+
+	t.Run("Custom GODEBUG without fips140 and existing GOLANG_FIPS both preserved", func(t *testing.T) {
+		input := []corev1.EnvVar{
+			{Name: "GODEBUG", Value: "http2debug=1"},
+			{Name: "GOLANG_FIPS", Value: "1"},
+		}
+		result := DecorateWithFIPSEnv(input)
+		assert.Len(t, result, 2)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "http2debug=1"})
+		assert.Contains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "1"})
+	})
+
+	t.Run("Substring fips140=onward does not trigger GOLANG_FIPS", func(t *testing.T) {
+		input := []corev1.EnvVar{
+			{Name: "GODEBUG", Value: "fips140=onward"},
+		}
+		result := DecorateWithFIPSEnv(input)
+		assert.Len(t, result, 1)
+		assert.Contains(t, result, corev1.EnvVar{Name: "GODEBUG", Value: "fips140=onward"})
+		assert.NotContains(t, result, corev1.EnvVar{Name: "GOLANG_FIPS", Value: "0"})
+	})
 }
 
 // TestFileExists runs a series of table-driven tests to validate the fileExists function.


### PR DESCRIPTION


**What type of PR is this?**
/kind bug

Fix for bug [GITOPS-10507](https://redhat.atlassian.net/browse/GITOPS-10507)


**What does this PR do / why we need it**:
When running in a FIPS cluster, `GODEBUG` is set to fips140=on by the operator. When the customer tries to override this environment variable via `spec.repo.env`, it is not taken into account and the operator ignores the user provided value and continues to use the `GODEBUG` environment value `fips140=on`.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes [GITOPS-10507](https://redhat.atlassian.net/browse/GITOPS-10507)

**How to test changes / Special notes to the reviewer**:
In a FIPS cluster, try setting a custom environment variable for the repo server component via `spec.repo.env` array of environment variables. Check the repo server pod to see if the environment variable set in the Argo CD Custom resource is used or the hardcoded default value `fips140=on` is used.

Detailed Steps:
1. Create a FIPS based Cluster
2. Create an `ArgoCD` with name `test` and namespace `test` custom resource with the env variable  name `GODEBUG` with value `tlsmkelem=0`
```
kubectl create ns test
kubectl create argocd test -n test
```
4. Exec into the repo server pod and see if the `GODEBUG` value set (tlsmkelem=0) in step 2 is being used.
```
kubectl exec pod test-repo-server -n test sh env GODEBUG
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FIPS environment handling for repo-server when custom `GODEBUG` is provided.
  * Preserves existing `GODEBUG` and conditionally applies `GOLANG_FIPS=0` only when `GODEBUG` contains the exact `fips140=on` entry.
  * Avoids adding `GOLANG_FIPS` when `GODEBUG` indicates FIPS is off or does not specify `fips140=on`.

* **Tests**
  * Expanded repo-server reconciliation and unit test coverage for custom, disabled, and missing FIPS-related settings in `GODEBUG`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->