### PR TITLE
fix: cherry-pick skip terminating source namespaces (#2280) to `release-0.18`

### DIFF
--- a/controllers/argocd/role.go
+++ b/controllers/argocd/role.go
@@ -232,6 +232,14 @@ func (r *ReconcileArgoCD) reconcileRoleForApplicationSourceNamespaces(name strin
 		if err := r.Get(context.TODO(), types.NamespacedName{Name: sourceNamespace}, namespace); err != nil {
 			return err
 		}
+
+		// Creating content in a terminating namespace is forbidden and should not
+		// prevent reconciliation of the remaining source namespaces.
+		if namespace.DeletionTimestamp != nil {
+			log.Info(fmt.Sprintf("Skipping terminating namespace %s", namespace.Name))
+			continue
+		}
+
 		// do not reconcile roles for namespaces already containing managed-by label
 		// as it already contains roles with permissions to manipulate application resources
 		// reconciled during reconcilation of ManagedNamespaces

--- a/controllers/argocd/role_test.go
+++ b/controllers/argocd/role_test.go
@@ -261,6 +261,52 @@ func TestReconcileArgoCD_reconcileRoleForApplicationSourceNamespaces(t *testing.
 	assert.Equal(t, expectedRules, reconciledRole.Rules)
 }
 
+func TestReconcileRoleForApplicationSourceNamespaces_TerminatingNamespace(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	terminatingNamespace := "terminating-source-ns"
+	activeNamespace := "active-source-ns"
+	a := makeTestArgoCD()
+	allowClusterConfigNamespaces(t, a.Namespace)
+	a.Spec = argoproj.ArgoCDSpec{
+		SourceNamespaces: []string{
+			terminatingNamespace,
+			activeNamespace,
+		},
+	}
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+	assert.NoError(t, createNamespaceManagedByClusterArgoCDLabel(r, terminatingNamespace, a.Namespace))
+	assert.NoError(t, createNamespaceManagedByClusterArgoCDLabel(r, activeNamespace, a.Namespace))
+
+	terminatingNS := &corev1.Namespace{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: terminatingNamespace}, terminatingNS))
+	terminatingNS.Finalizers = []string{"test.argoproj.io/finalizer"}
+	assert.NoError(t, r.Update(context.TODO(), terminatingNS))
+	assert.NoError(t, r.Delete(context.TODO(), terminatingNS))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: terminatingNamespace}, terminatingNS))
+	assert.NotNil(t, terminatingNS.DeletionTimestamp)
+
+	workloadIdentifier := common.ArgoCDServerComponent + "-custom"
+	expectedRules := policyRuleForServerApplicationSourceNamespaces()
+	assert.NoError(t, r.reconcileRoleForApplicationSourceNamespaces(workloadIdentifier, expectedRules, a))
+
+	reconciledRole := &v1.Role{}
+	terminatingRoleName := getRoleNameForApplicationSourceNamespaces(terminatingNamespace, a)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: terminatingRoleName, Namespace: terminatingNamespace}, reconciledRole)
+	assert.True(t, errors.IsNotFound(err), "expected no role to be reconciled in terminating namespace")
+
+	activeRoleName := getRoleNameForApplicationSourceNamespaces(activeNamespace, a)
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: activeRoleName, Namespace: activeNamespace}, reconciledRole))
+	assert.Equal(t, expectedRules, reconciledRole.Rules)
+}
+
 func TestReconcileArgoCD_RoleHooks(t *testing.T) {
 	defer resetHooks()()
 	a := makeTestArgoCD()

--- a/controllers/argocd/rolebinding.go
+++ b/controllers/argocd/rolebinding.go
@@ -241,6 +241,13 @@ func (r *ReconcileArgoCD) reconcileRoleBinding(name string, rules []v1.PolicyRul
 				return err
 			}
 
+			// Creating content in a terminating namespace is forbidden and should not
+			// prevent reconciliation of the remaining source namespaces.
+			if namespace.DeletionTimestamp != nil {
+				log.Info(fmt.Sprintf("Skipping terminating namespace %s", namespace.Name))
+				continue
+			}
+
 			// do not reconcile rolebindings for namespaces already containing managed-by label
 			// as it already contains rolebindings with permissions to manipulate application resources
 			// reconciled during reconcilation of ManagedNamespaces

--- a/controllers/argocd/rolebinding_test.go
+++ b/controllers/argocd/rolebinding_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -334,6 +335,66 @@ func TestReconcileArgoCD_reconcileRoleBinding_forSourceNamespaces(t *testing.T) 
 
 	// Verify the RoleBinding name is exactly maxLabelLength characters
 	assert.Equal(t, argoutil.GetMaxLabelLength(), len(roleBinding.Name), "RoleBinding name should be exactly maxLabelLength characters")
+}
+
+func TestReconcileArgoCD_reconcileRoleBinding_skipsTerminatingSourceNamespaces(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	terminatingSourceNamespace := "terminating-source-ns"
+	activeSourceNamespace := "active-source-ns"
+	a := makeTestArgoCD()
+	allowClusterConfigNamespaces(t, a.Namespace)
+	a.Spec = argoproj.ArgoCDSpec{
+		SourceNamespaces: []string{
+			terminatingSourceNamespace,
+			activeSourceNamespace,
+		},
+	}
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+	assert.NoError(t, createNamespaceManagedByClusterArgoCDLabel(r, terminatingSourceNamespace, a.Namespace))
+	assert.NoError(t, createNamespaceManagedByClusterArgoCDLabel(r, activeSourceNamespace, a.Namespace))
+
+	terminatingNamespace := &corev1.Namespace{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: terminatingSourceNamespace}, terminatingNamespace))
+	terminatingNamespace.Finalizers = []string{"test.argoproj.io/finalizer"}
+	assert.NoError(t, r.Update(context.TODO(), terminatingNamespace))
+	assert.NoError(t, r.Delete(context.TODO(), terminatingNamespace))
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: terminatingSourceNamespace}, terminatingNamespace))
+	assert.NotNil(t, terminatingNamespace.DeletionTimestamp)
+
+	assert.NoError(t, r.reconcileRoleBinding(common.ArgoCDServerComponent, policyRuleForApplicationController(), a))
+
+	roleBinding := &rbacv1.RoleBinding{}
+	terminatingRoleBindingName := getRoleBindingNameForSourceNamespaces(a.Name, terminatingSourceNamespace)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: terminatingRoleBindingName, Namespace: terminatingSourceNamespace}, roleBinding)
+	assert.True(t, errors.IsNotFound(err), "expected no rolebinding to be reconciled in terminating namespace")
+
+	activeRoleBindingName := getRoleBindingNameForSourceNamespaces(a.Name, activeSourceNamespace)
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: activeRoleBindingName, Namespace: activeSourceNamespace}, roleBinding))
+	assert.Equal(t, rbacv1.RoleRef{
+		APIGroup: rbacv1.GroupName,
+		Kind:     "Role",
+		Name:     getRoleNameForApplicationSourceNamespaces(activeSourceNamespace, a),
+	}, roleBinding.RoleRef)
+	assert.Equal(t, []rbacv1.Subject{
+		{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      getServiceAccountName(a.Name, common.ArgoCDServerComponent),
+			Namespace: a.Namespace,
+		},
+		{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      getServiceAccountName(a.Name, common.ArgoCDApplicationControllerComponent),
+			Namespace: a.Namespace,
+		},
+	}, roleBinding.Subjects)
 }
 
 func TestTruncateWithHash(t *testing.T) {

--- a/tests/ginkgo/sequential/1-132_validate_handle_terminating_source_namespaces_test.go
+++ b/tests/ginkgo/sequential/1-132_validate_handle_terminating_source_namespaces_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
@@ -186,8 +185,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					Project: "default",
 					SyncPolicy: &argocdv1alpha1.SyncPolicy{
 						Automated: &argocdv1alpha1.SyncPolicyAutomated{
-							Prune:    ptr.To(true),
-							SelfHeal: ptr.To(true),
+							Prune:    true,
+							SelfHeal: true,
 						},
 					},
 				},

--- a/tests/ginkgo/sequential/1-132_validate_handle_terminating_source_namespaces_test.go
+++ b/tests/ginkgo/sequential/1-132_validate_handle_terminating_source_namespaces_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sequential
+
+import (
+	"context"
+	"fmt"
+
+	argocdv1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	appFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/application"
+	appprojectFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/appproject"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	configmapFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/configmap"
+	deploymentFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	namespaceFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/namespace"
+	statefulsetFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/statefulset"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
+
+	Context("1-132_validate_handle_terminating_source_namespaces", func() {
+
+		var (
+			k8sClient                client.Client
+			ctx                      context.Context
+			argoNS                   *corev1.Namespace
+			terminatingNS            *corev1.Namespace
+			activeNS                 *corev1.Namespace
+			configMapTerminatingNS   *corev1.ConfigMap
+			argoNSCleanupFunc        func()
+			terminatingNSCleanupFunc func()
+			activeNSCleanupFunc      func()
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureSequentialCleanSlate()
+
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			fixture.OutputDebugOnFail(argoNS, terminatingNS, activeNS)
+
+			if configMapTerminatingNS != nil {
+				configmapFixture.Update(configMapTerminatingNS, func(cm *corev1.ConfigMap) {
+					cm.Finalizers = nil
+				})
+			}
+			if activeNSCleanupFunc != nil {
+				activeNSCleanupFunc()
+			}
+			if terminatingNSCleanupFunc != nil {
+				terminatingNSCleanupFunc()
+			}
+			if argoNSCleanupFunc != nil {
+				argoNSCleanupFunc()
+			}
+		})
+
+		It("ensures that if one source namespace is stuck in terminating, it does not prevent other source namespaces from being managed or deployed to", func() {
+			By("creating cluster-scoped Argo CD instance with sourceNamespaces wildcard")
+			argoNS, argoNSCleanupFunc = fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-cluster-config")
+			terminatingNS, terminatingNSCleanupFunc = fixture.CreateNamespaceWithCleanupFunc("src-1-132-terminating")
+
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "example-argocd", Namespace: argoNS.Name},
+				Spec: argov1beta1api.ArgoCDSpec{
+					SourceNamespaces: []string{"src-1-132-*"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD CR to be reconciled and the instance to be ready")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			By("verifying terminating source namespace is initially managed")
+			Eventually(terminatingNS).Should(namespaceFixture.HaveLabel("argocd.argoproj.io/managed-by-cluster-argocd", argoNS.Name))
+
+			terminatingRoleName := fmt.Sprintf("%s_%s", argoCD.Name, terminatingNS.Name)
+			Eventually(&rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: terminatingRoleName, Namespace: terminatingNS.Name},
+			}).Should(k8sFixture.ExistByName())
+			Eventually(&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: terminatingRoleName, Namespace: terminatingNS.Name},
+			}).Should(k8sFixture.ExistByName())
+
+			By("creating a ConfigMap with an unowned finalizer in the terminating source namespace")
+			configMapTerminatingNS = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "blocking-finalizer-cm",
+					Namespace:  terminatingNS.Name,
+					Finalizers: []string{"some.random/finalizer"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, configMapTerminatingNS)).To(Succeed())
+
+			By("deleting the terminating source namespace, which puts it into a simulated stuck Terminating state")
+			go func() {
+				defer GinkgoRecover()
+				Expect(k8sClient.Delete(ctx, terminatingNS)).To(Succeed())
+			}()
+
+			By("verifying source namespace moves into terminating state")
+			Eventually(terminatingNS).Should(namespaceFixture.HavePhase(corev1.NamespaceTerminating))
+
+			By("creating an active source namespace that matches the same sourceNamespaces pattern")
+			activeNS, activeNSCleanupFunc = fixture.CreateNamespaceWithCleanupFunc("src-1-132-active")
+
+			By("verifying Role/RoleBinding are created in the active source namespace")
+			activeRoleName := fmt.Sprintf("%s_%s", argoCD.Name, activeNS.Name)
+			Eventually(&rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: activeRoleName, Namespace: activeNS.Name},
+			}, "2m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: activeRoleName, Namespace: activeNS.Name},
+			}, "2m", "5s").Should(k8sFixture.ExistByName())
+			Eventually(activeNS).Should(namespaceFixture.HaveLabel("argocd.argoproj.io/managed-by-cluster-argocd", argoNS.Name))
+
+			By("verifying ArgoCD CR remains Available")
+			Eventually(argoCD, "2m", "5s").Should(argocdFixture.BeAvailable())
+			Consistently(argoCD, "20s", "5s").Should(argocdFixture.BeAvailable())
+
+			By("verifying --application-namespaces is set on server and application-controller")
+			serverDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: argoCD.Name + "-server", Namespace: argoNS.Name},
+			}
+			Eventually(serverDeployment).Should(k8sFixture.ExistByName())
+			Eventually(serverDeployment).Should(deploymentFixture.HaveContainerCommandSubstring("--application-namespaces", 0))
+
+			appControllerStatefulSet := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: argoCD.Name + "-application-controller", Namespace: argoNS.Name},
+			}
+			Eventually(appControllerStatefulSet).Should(k8sFixture.ExistByName())
+			Eventually(appControllerStatefulSet).Should(statefulsetFixture.HaveContainerCommandSubstring("--application-namespaces", 0))
+
+			By("allowing Applications from the active source namespace in the default AppProject")
+			appProject := &argocdv1alpha1.AppProject{
+				ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: argoNS.Name},
+			}
+			Eventually(appProject).Should(k8sFixture.ExistByName())
+			appprojectFixture.Update(appProject, func(project *argocdv1alpha1.AppProject) {
+				project.Spec.SourceNamespaces = append(project.Spec.SourceNamespaces, activeNS.Name)
+			})
+
+			By("creating a test Argo CD Application in the active source namespace")
+			app := &argocdv1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: activeNS.Name},
+				Spec: argocdv1alpha1.ApplicationSpec{
+					Source: &argocdv1alpha1.ApplicationSource{
+						Path:           "test/examples/kustomize-guestbook",
+						RepoURL:        "https://github.com/redhat-developer/gitops-operator",
+						TargetRevision: "HEAD",
+					},
+					Destination: argocdv1alpha1.ApplicationDestination{
+						Namespace: activeNS.Name,
+						Server:    "https://kubernetes.default.svc",
+					},
+					Project: "default",
+					SyncPolicy: &argocdv1alpha1.SyncPolicy{
+						Automated: &argocdv1alpha1.SyncPolicyAutomated{
+							Prune:    ptr.To(true),
+							SelfHeal: ptr.To(true),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).To(Succeed())
+
+			By("verifying Argo CD is successfully able to deploy to the active source namespace")
+			Eventually(app, "4m", "5s").Should(appFixture.HaveSyncStatusCode(argocdv1alpha1.SyncStatusCodeSynced))
+		})
+	})
+})


### PR DESCRIPTION
**What type of PR is this?**


/kind bug 
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**: 

Cherry-pick #2280 to release-0-18

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
