### PR TITLE
chore: Refactor repeated `[]corev1.EnvVar` manipulation

### DIFF
--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -2996,10 +2996,10 @@ func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabled(t *testing.T) {
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
 	env := d.Spec.Template.Spec.Containers[0].Env
 	godebug := argoutil.EnvGet(env, "GODEBUG")
-	assert.NotNil(t, godebug, "environment GODEBUG must be set when FIPS is enabled")
+	require.NotNil(t, godebug, "environment GODEBUG must be set when FIPS is enabled")
 	assert.Equal(t, "fips140=on", godebug.Value, "GODEBUG environment must be set to fips140=on when fips is enabled")
 	golangFips := argoutil.EnvGet(env, "GOLANG_FIPS")
-	assert.NotNil(t, golangFips, "environment GOLANG_FIPS must be set when FIPS is enabled")
+	require.NotNil(t, golangFips, "environment GOLANG_FIPS must be set when FIPS is enabled")
 	assert.Equal(t, "0", golangFips.Value, "GOLANG_FIPS environment must be set to 0 when fips is enabled")
 }
 

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -2295,17 +2294,16 @@ func refuteDeploymentHasProxyVars(t *testing.T, c client.Client, name string) {
 	}, deployment)
 	assert.NoError(t, err)
 
-	names := []string{"http_proxy", "https_proxy", "no_proxy"}
-	for _, name := range names {
+	proxyNames := []string{
+		"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+		"http_proxy", "https_proxy", "no_proxy",
+	}
+	for _, proxyName := range proxyNames {
 		for _, c := range deployment.Spec.Template.Spec.Containers {
-			for _, envVar := range c.Env {
-				assert.NotEqual(t, strings.ToLower(envVar.Name), name)
-			}
+			assert.Nil(t, argoutil.EnvGet(c.Env, proxyName), "container %q should not have %s", c.Name, proxyName)
 		}
 		for _, c := range deployment.Spec.Template.Spec.InitContainers {
-			for _, envVar := range c.Env {
-				assert.NotEqual(t, strings.ToLower(envVar.Name), name)
-			}
+			assert.Nil(t, argoutil.EnvGet(c.Env, proxyName), "init container %q should not have %s", c.Name, proxyName)
 		}
 	}
 }
@@ -2996,18 +2994,13 @@ func TestReconcileArgoCD_reconcileRepoServerWithFipsEnabled(t *testing.T) {
 
 	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
-	foundEnv := false
-	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
-		if env.Name == "GODEBUG" {
-			foundEnv = true
-			assert.Equal(t, env.Value, "fips140=on", "GODEBUG environment must be set to fips140=on when fips is enabled")
-		}
-		if env.Name == "GOLANG_FIPS" {
-			foundEnv = true
-			assert.Equal(t, env.Value, "0", "GOLANG_FIPS environment must be set to 0 when fips is enabled")
-		}
-	}
-	assert.True(t, foundEnv, "environment GODEBUG must be set when FIPS is enabled")
+	env := d.Spec.Template.Spec.Containers[0].Env
+	godebug := argoutil.EnvGet(env, "GODEBUG")
+	assert.NotNil(t, godebug, "environment GODEBUG must be set when FIPS is enabled")
+	assert.Equal(t, "fips140=on", godebug.Value, "GODEBUG environment must be set to fips140=on when fips is enabled")
+	golangFips := argoutil.EnvGet(env, "GOLANG_FIPS")
+	assert.NotNil(t, golangFips, "environment GOLANG_FIPS must be set when FIPS is enabled")
+	assert.Equal(t, "0", golangFips.Value, "GOLANG_FIPS environment must be set to 0 when fips is enabled")
 }
 
 func TestReconcileArgoCD_reconcileRepoServerWithFipsDisabled(t *testing.T) {
@@ -3035,13 +3028,7 @@ func TestReconcileArgoCD_reconcileRepoServerWithFipsDisabled(t *testing.T) {
 
 	assert.NoError(t, r.reconcileRepoDeployment(cr, false))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: cr.Name + "-repo-server", Namespace: cr.Namespace}, d))
-	foundEnv := false
-	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
-		if env.Name == "GODEBUG" {
-			foundEnv = true
-		}
-	}
-	assert.False(t, foundEnv, "environment GODEBUG must NOT be set when FIPS is disabled")
+	assert.Nil(t, argoutil.EnvGet(d.Spec.Template.Spec.Containers[0].Env, "GODEBUG"), "environment GODEBUG must NOT be set when FIPS is disabled")
 }
 
 func TestDeploymentWithLongName(t *testing.T) {

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -60,11 +60,8 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 	//   - "ns1,ns2,...": watches specific namespaces.
 	//     Base role in cr.Namespace + manager Role in each listed namespace.
 	watchNamespaces := ""
-	for _, env := range cr.Spec.ImageUpdater.Env {
-		if env.Name == "IMAGE_UPDATER_WATCH_NAMESPACES" {
-			watchNamespaces = strings.TrimSpace(env.Value)
-			break
-		}
+	if env := argoutil.EnvGet(cr.Spec.ImageUpdater.Env, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
+		watchNamespaces = strings.TrimSpace(env.Value)
 	}
 
 	// When the mode is not cluster-scoped, remove any ClusterRole/ClusterRoleBinding that may

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -1019,14 +1019,7 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_RevertDrift(t *testing.T) {
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 
-	envVarFound := false
-	for _, env := range s.Spec.Template.Spec.Containers[0].Env {
-		if env.Name == "NEW_ENV_VAR" {
-			envVarFound = true
-			break
-		}
-	}
-	assert.False(t, envVarFound, "NEW_ENV_VAR should not be present")
+	assert.Nil(t, argoutil.EnvGet(s.Spec.Template.Spec.Containers[0].Env, "NEW_ENV_VAR"), "NEW_ENV_VAR should not be present")
 
 	// Modify the SecurityContext
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
@@ -1053,14 +1046,7 @@ func TestReconcileArgoCD_reconcileRedisStatefulSet_RevertDrift(t *testing.T) {
 	assert.NoError(t, r.reconcileRedisStatefulSet(a))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: s.Name, Namespace: a.Namespace}, s))
 
-	envVarFound = false
-	for _, env := range s.Spec.Template.Spec.InitContainers[0].Env {
-		if env.Name == "NEW_ENV_VAR" {
-			envVarFound = true
-			break
-		}
-	}
-	assert.False(t, envVarFound, "NEW_ENV_VAR should not be present")
+	assert.Nil(t, argoutil.EnvGet(s.Spec.Template.Spec.InitContainers[0].Env, "NEW_ENV_VAR"), "NEW_ENV_VAR should not be present")
 
 	// Modify the container volume and volume mount
 	s.Spec.Template.Spec.Containers[0].VolumeMounts = append(s.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{

--- a/controllers/argoutil/env.go
+++ b/controllers/argoutil/env.go
@@ -6,6 +6,48 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// EnvGet returns a pointer to the EnvVar with the given name, or nil if not found.
+// The pointer refers into envs, so callers may update the entry in place.
+func EnvGet(envs []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range envs {
+		if envs[i].Name == name {
+			return &envs[i]
+		}
+	}
+	return nil
+}
+
+// EnvRemove returns a copy of envs with any EnvVar named name removed.
+// Order of remaining entries is preserved.
+func EnvRemove(envs []corev1.EnvVar, name string) []corev1.EnvVar {
+	result := make([]corev1.EnvVar, 0, len(envs))
+	for _, e := range envs {
+		if e.Name != name {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// EnvSet returns a copy of envs with env upserted by Name: existing entry is
+// replaced in place, otherwise env is appended. Order of other entries is preserved.
+func EnvSet(envs []corev1.EnvVar, env corev1.EnvVar) []corev1.EnvVar {
+	result := make([]corev1.EnvVar, 0, len(envs)+1)
+	found := false
+	for _, e := range envs {
+		if e.Name == env.Name {
+			result = append(result, env)
+			found = true
+		} else {
+			result = append(result, e)
+		}
+	}
+	if !found {
+		result = append(result, env)
+	}
+	return result
+}
+
 // EnvMerge merges two slices of EnvVar entries into a single one. If existing
 // has an EnvVar with same Name attribute as one in merge, the EnvVar is not
 // merged unless override is set to true.

--- a/controllers/argoutil/env_test.go
+++ b/controllers/argoutil/env_test.go
@@ -8,6 +8,58 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func Test_EnvGet(t *testing.T) {
+	envs := []corev1.EnvVar{{Name: "FOO", Value: "BAR"}, {Name: "BAZ", ValueFrom: &corev1.EnvVarSource{}}}
+
+	e := EnvGet(envs, "FOO")
+	assert.NotNil(t, e)
+	assert.Equal(t, "BAR", e.Value)
+
+	e = EnvGet(envs, "BAZ")
+	assert.NotNil(t, e)
+	assert.NotNil(t, e.ValueFrom)
+
+	assert.Nil(t, EnvGet(envs, "MISSING"))
+	assert.Nil(t, EnvGet(nil, "FOO"))
+
+	// In-place update via the returned pointer
+	EnvGet(envs, "FOO").Value = "UPDATED"
+	assert.Equal(t, "UPDATED", envs[0].Value)
+}
+
+func Test_EnvRemove(t *testing.T) {
+	envs := []corev1.EnvVar{
+		{Name: "FOO", Value: "BAR"},
+		{Name: "BAR", Value: "FOO"},
+		{Name: "BAZ", Value: "BAZ"},
+	}
+
+	r := EnvRemove(envs, "BAR")
+	assert.Equal(t, []corev1.EnvVar{{Name: "FOO", Value: "BAR"}, {Name: "BAZ", Value: "BAZ"}}, r)
+
+	r = EnvRemove(envs, "MISSING")
+	assert.Equal(t, envs, r)
+
+	r = EnvRemove(nil, "FOO")
+	assert.Empty(t, r)
+}
+
+func Test_EnvSet(t *testing.T) {
+	envs := []corev1.EnvVar{
+		{Name: "FOO", Value: "BAR"},
+		{Name: "BAR", Value: "FOO"},
+	}
+
+	r := EnvSet(envs, corev1.EnvVar{Name: "FOO", Value: "NEW"})
+	assert.Equal(t, []corev1.EnvVar{{Name: "FOO", Value: "NEW"}, {Name: "BAR", Value: "FOO"}}, r)
+
+	r = EnvSet(envs, corev1.EnvVar{Name: "BAZ", Value: "BAZ"})
+	assert.Equal(t, []corev1.EnvVar{{Name: "FOO", Value: "BAR"}, {Name: "BAR", Value: "FOO"}, {Name: "BAZ", Value: "BAZ"}}, r)
+
+	r = EnvSet(nil, corev1.EnvVar{Name: "FOO", Value: "BAR"})
+	assert.Equal(t, []corev1.EnvVar{{Name: "FOO", Value: "BAR"}}, r)
+}
+
 func Test_EnvMerge(t *testing.T) {
 	t.Run("Merge non-existing env", func(t *testing.T) {
 		e := []corev1.EnvVar{

--- a/tests/ginkgo/fixture/deployment/fixture.go
+++ b/tests/ginkgo/fixture/deployment/fixture.go
@@ -11,6 +11,7 @@ import (
 	matcher "github.com/onsi/gomega/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,19 +30,12 @@ func GetEnv(d *appsv1.Deployment, container string, key string) (*string, error)
 		return nil, err
 	}
 
-	containers := d.Spec.Template.Spec.Containers
-
-	for idc := range containers {
-
-		if containers[idc].Name == container {
-			for idx := range containers[idc].Env {
-
-				currEnv := containers[idc].Env[idx]
-
-				if currEnv.Name == key {
-					return &currEnv.Value, nil
-				}
-			}
+	for idc := range d.Spec.Template.Spec.Containers {
+		if d.Spec.Template.Spec.Containers[idc].Name != container {
+			continue
+		}
+		if env := argoutil.EnvGet(d.Spec.Template.Spec.Containers[idc].Env, key); env != nil {
+			return &env.Value, nil
 		}
 	}
 	return nil, nil
@@ -51,32 +45,12 @@ func GetEnv(d *appsv1.Deployment, container string, key string) (*string, error)
 func SetEnv(depl *appsv1.Deployment, container string, key string, value string) {
 
 	Update(depl, func(d *appsv1.Deployment) {
-		containers := d.Spec.Template.Spec.Containers
-
-		newEnvVars := []corev1.EnvVar{}
-
-		match := false
-		for idc := range containers {
-
-			if containers[idc].Name == container {
-				for idx := range containers[idc].Env {
-
-					currEnv := containers[idc].Env[idx]
-
-					if currEnv.Name == key {
-						// replace with the value from the param
-						newEnvVars = append(newEnvVars, corev1.EnvVar{Name: key, Value: value})
-						match = true
-					} else {
-						newEnvVars = append(newEnvVars, currEnv)
-					}
-				}
-
-				if !match {
-					newEnvVars = append(newEnvVars, corev1.EnvVar{Name: key, Value: value})
-				}
-
-				containers[idc].Env = newEnvVars
+		for idc := range d.Spec.Template.Spec.Containers {
+			if d.Spec.Template.Spec.Containers[idc].Name == container {
+				d.Spec.Template.Spec.Containers[idc].Env = argoutil.EnvSet(
+					d.Spec.Template.Spec.Containers[idc].Env,
+					corev1.EnvVar{Name: key, Value: value},
+				)
 			}
 		}
 	})
@@ -86,23 +60,10 @@ func SetEnv(depl *appsv1.Deployment, container string, key string, value string)
 func RemoveEnv(depl *appsv1.Deployment, container string, key string) {
 
 	Update(depl, func(d *appsv1.Deployment) {
-		containers := d.Spec.Template.Spec.Containers
-
-		for idc := range containers {
-			if containers[idc].Name == container {
-				newEnvVars := []corev1.EnvVar{}
-				for idx := range containers[idc].Env {
-
-					currEnv := containers[idc].Env[idx]
-
-					if currEnv.Name == key {
-						// don't add, thus causing it to be removed
-					} else {
-						newEnvVars = append(newEnvVars, currEnv)
-					}
-				}
-
-				containers[idc].Env = newEnvVars
+		for idc := range d.Spec.Template.Spec.Containers {
+			if d.Spec.Template.Spec.Containers[idc].Name == container {
+				d.Spec.Template.Spec.Containers[idc].Env = argoutil.EnvRemove(
+					d.Spec.Template.Spec.Containers[idc].Env, key)
 			}
 		}
 	})
@@ -343,13 +304,9 @@ func HaveContainerWithEnvVar(envKey string, envValue string, containerIndex int)
 
 		container := containers[containerIndex]
 
-		for _, env := range container.Env {
-			if env.Name == envKey {
-				GinkgoWriter.Println("HaveContainerWithEnvVar - Key ", envKey, " Expected:", envValue, "Actual:", env.Value)
-				if env.Value == envValue {
-					return true
-				}
-			}
+		if env := argoutil.EnvGet(container.Env, envKey); env != nil {
+			GinkgoWriter.Println("HaveContainerWithEnvVar - Key ", envKey, " Expected:", envValue, "Actual:", env.Value)
+			return env.Value == envValue
 		}
 
 		return false

--- a/tests/ginkgo/fixture/fixture.go
+++ b/tests/ginkgo/fixture/fixture.go
@@ -29,6 +29,7 @@ import (
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	osFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/os"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 )
@@ -347,14 +348,9 @@ func waitForAllEnvVarsToBeRemovedFromDeployments(ns string, envVarKeys []string,
 
 				// For each env var we are looking for
 				for _, envVarKey := range envVarKeys {
-
-					for _, containerEnvKey := range container.Env {
-
-						if containerEnvKey.Name == envVarKey {
-							GinkgoWriter.Println("Waiting:", containerEnvKey, "is still present in Deployment ", depl.Name)
-							return false
-						}
-
+					if env := argoutil.EnvGet(container.Env, envVarKey); env != nil {
+						GinkgoWriter.Println("Waiting:", env, "is still present in Deployment ", depl.Name)
+						return false
 					}
 				}
 			}

--- a/tests/ginkgo/fixture/statefulset/fixture.go
+++ b/tests/ginkgo/fixture/statefulset/fixture.go
@@ -12,6 +12,7 @@ import (
 	matcher "github.com/onsi/gomega/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -255,13 +256,9 @@ func HaveContainerWithEnvVar(envKey string, envValue string, containerIndex int)
 
 		container := containers[containerIndex]
 
-		for _, env := range container.Env {
-			if env.Name == envKey {
-				GinkgoWriter.Println("HaveContainerWithEnvVar - Key ", envKey, " Expected:", envValue, "Actual:", env.Value)
-				if env.Value == envValue {
-					return true
-				}
-			}
+		if env := argoutil.EnvGet(container.Env, envKey); env != nil {
+			GinkgoWriter.Println("HaveContainerWithEnvVar - Key ", envKey, " Expected:", envValue, "Actual:", env.Value)
+			return env.Value == envValue
 		}
 
 		return false
@@ -281,15 +278,13 @@ func HaveContainerWithEnvVarFromConfigMap(envKey string, configMapName string, c
 
 		container := containers[containerIndex]
 
-		for _, env := range container.Env {
-			if env.Name == envKey {
-				if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil {
-					ref := env.ValueFrom.ConfigMapKeyRef
-					GinkgoWriter.Println("HaveContainerWithEnvVarFromConfigMap - Key:", envKey,
-						"Expected ConfigMap:", configMapName, "Key:", configMapKey,
-						"Actual ConfigMap:", ref.Name, "Key:", ref.Key)
-					return ref.Name == configMapName && ref.Key == configMapKey
-				}
+		if env := argoutil.EnvGet(container.Env, envKey); env != nil {
+			if env.ValueFrom != nil && env.ValueFrom.ConfigMapKeyRef != nil {
+				ref := env.ValueFrom.ConfigMapKeyRef
+				GinkgoWriter.Println("HaveContainerWithEnvVarFromConfigMap - Key:", envKey,
+					"Expected ConfigMap:", configMapName, "Key:", configMapKey,
+					"Actual ConfigMap:", ref.Name, "Key:", ref.Key)
+				return ref.Name == configMapName && ref.Key == configMapKey
 			}
 		}
 

--- a/tests/ginkgo/parallel/1-048_validate_controller_sharding_test.go
+++ b/tests/ginkgo/parallel/1-048_validate_controller_sharding_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
@@ -84,14 +85,9 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			statefulSet := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "argocd-application-controller", Namespace: ns.Name}}
 			Eventually(statefulSet).Should(k8sFixture.ExistByName())
-			var match bool
-			for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
-				if env.Name == "ARGOCD_CONTROLLER_REPLICAS" && env.Value == "3" {
-					match = true
-					break
-				}
-			}
-			Expect(match).To(BeTrue(), "StatefulSet should have expected ARGOCD_CONTROLLER_REPLICAS")
+			env := argoutil.EnvGet(statefulSet.Spec.Template.Spec.Containers[0].Env, "ARGOCD_CONTROLLER_REPLICAS")
+			Expect(env).NotTo(BeNil(), "StatefulSet should have ARGOCD_CONTROLLER_REPLICAS")
+			Expect(env.Value).To(Equal("3"), "StatefulSet should have expected ARGOCD_CONTROLLER_REPLICAS")
 
 			By("ensuring algorithm can be set")
 			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
@@ -116,20 +112,15 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("checking if ARGOCD_CONTROLLER_SHARDING_ALGORITHM env var is not set in app controller StatefulSet")
 			Eventually(statefulSet).Should(k8sFixture.ExistByName())
-			Eventually(func() bool {
+			Eventually(func() *corev1.EnvVar {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), statefulSet); err != nil {
-					return false
+					return &corev1.EnvVar{} // keep polling until Get succeeds
 				}
 				if len(statefulSet.Spec.Template.Spec.Containers) == 0 {
-					return false
+					return &corev1.EnvVar{}
 				}
-				for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
-					if env.Name == "ARGOCD_CONTROLLER_SHARDING_ALGORITHM" {
-						return false
-					}
-				}
-				return true
-			}, "60s", "5s").Should(BeTrue(), "StatefulSet should have no env variable named ARGOCD_CONTROLLER_SHARDING_ALGORITHM")
+				return argoutil.EnvGet(statefulSet.Spec.Template.Spec.Containers[0].Env, "ARGOCD_CONTROLLER_SHARDING_ALGORITHM")
+			}, "60s", "5s").Should(BeNil(), "StatefulSet should have no env variable named ARGOCD_CONTROLLER_SHARDING_ALGORITHM")
 
 			By("disabling sharding")
 			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
@@ -147,15 +138,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 
 			By("verifying ARGOCD_CONTROLLER_REPLICAS is no longer present in StatefulSet")
 			Eventually(statefulSet).Should(k8sFixture.ExistByName())
-			var replicasVarFound bool
-			for _, env := range statefulSet.Spec.Template.Spec.Containers[0].Env {
-				GinkgoWriter.Println(env)
-				if env.Name == "ARGOCD_CONTROLLER_REPLICAS" {
-					replicasVarFound = true
-					break
-				}
-			}
-			Expect(replicasVarFound).To(BeFalse(), "If sharding is disabled then the ARGOCD_CONTROLLER_REPLICAS var is not set")
+			Expect(argoutil.EnvGet(statefulSet.Spec.Template.Spec.Containers[0].Env, "ARGOCD_CONTROLLER_REPLICAS")).
+				To(BeNil(), "If sharding is disabled then the ARGOCD_CONTROLLER_REPLICAS var is not set")
 		})
 	})
 })

--- a/tests/ginkgo/sequential/1-130_validate_deployment_image_and_version_test.go
+++ b/tests/ginkgo/sequential/1-130_validate_deployment_image_and_version_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 )
@@ -45,26 +46,21 @@ const (
 // --- Local Helpers (kept inline for reuse in this test) ---
 
 func ensureEnv(ctx context.Context, c client.Client, d *appsv1.Deployment) (string, bool) {
-	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
-		if env.Name == "ARGOCD_IMAGE" {
-			return env.Value, false
-		}
+	if env := argoutil.EnvGet(d.Spec.Template.Spec.Containers[0].Env, "ARGOCD_IMAGE"); env != nil {
+		return env.Value, false
 	}
-	d.Spec.Template.Spec.Containers[0].Env =
-		append(d.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "ARGOCD_IMAGE", Value: defaultImage})
+	d.Spec.Template.Spec.Containers[0].Env = argoutil.EnvSet(
+		d.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{Name: "ARGOCD_IMAGE", Value: defaultImage},
+	)
 	Expect(c.Update(ctx, d)).To(Succeed())
 	waitForDeploymentReady(ctx, c, d)
 	return defaultImage, true
 }
 
 func removeEnv(ctx context.Context, c client.Client, d *appsv1.Deployment) {
-	var newEnvs []corev1.EnvVar
-	for _, env := range d.Spec.Template.Spec.Containers[0].Env {
-		if env.Name != "ARGOCD_IMAGE" {
-			newEnvs = append(newEnvs, env)
-		}
-	}
-	d.Spec.Template.Spec.Containers[0].Env = newEnvs
+	d.Spec.Template.Spec.Containers[0].Env = argoutil.EnvRemove(
+		d.Spec.Template.Spec.Containers[0].Env, "ARGOCD_IMAGE")
 	Expect(c.Update(ctx, d)).To(Succeed())
 	waitForDeploymentReady(ctx, c, d)
 }


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
/kind chore
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

Introduce 3 helper methods over tireless manipulation in loops.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable helpers to get, set, and remove container environment variables while preserving order.
* **Bug Fixes**
  * Improved environment-variable detection and assertions for proxy and FIPS behavior.
  * Refined how image updater watch namespaces are read and how drift reversion is verified.
* **Tests**
  * Added unit tests for the new environment helpers.
  * Updated Ginkgo fixtures and controller tests to use the helpers for consistent env validation and setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->