### PR TITLE
feat: gate openshfitOAuth with openshfit check and add logs

### DIFF
--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -55,7 +55,7 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoproj.ArgoCD, argocdStatus *argopr
 			// https://github.com/argoproj-labs/argocd-operator/pull/615 ==> conflict
 			errMsg = "must supply valid dex configuration when requested SSO provider is dex"
 			isError = true
-		} else if cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth && !IsOpenShiftCluster() {
+		} else if cr.Spec.SSO.Dex.OpenShiftOAuth && !IsOpenShiftCluster() {
 			errMsg = "OpenShift OAuth is not supported on non-OpenShift clusters"
 			isError = true
 		} else if cr.Spec.SSO.Keycloak != nil {

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -55,12 +55,13 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoproj.ArgoCD, argocdStatus *argopr
 			// https://github.com/argoproj-labs/argocd-operator/pull/615 ==> conflict
 			errMsg = "must supply valid dex configuration when requested SSO provider is dex"
 			isError = true
-		} else if cr.Spec.SSO.Dex.OpenShiftOAuth && !IsOpenShiftCluster() {
-			errMsg = "OpenShift OAuth is not supported on non-OpenShift clusters"
-			isError = true
 		} else if cr.Spec.SSO.Keycloak != nil {
 			errMsg = "keycloak configuration is specified even though Dex is enabled. Keycloak support has been deprecated and is no longer available."
 			isError = true
+		}
+
+		if cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth && !IsOpenShiftCluster() {
+			log.Info(fmt.Sprintf("warning: OpenShift OAuth is not supported on non-OpenShift clusters for Argo CD %s in namespace %s", cr.Name, cr.Namespace))
 		}
 
 		if isError {

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -55,13 +55,12 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoproj.ArgoCD, argocdStatus *argopr
 			// https://github.com/argoproj-labs/argocd-operator/pull/615 ==> conflict
 			errMsg = "must supply valid dex configuration when requested SSO provider is dex"
 			isError = true
+		} else if cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth && !IsOpenShiftCluster() {
+			errMsg = "OpenShift OAuth is not supported on non-OpenShift clusters"
+			isError = true
 		} else if cr.Spec.SSO.Keycloak != nil {
 			errMsg = "keycloak configuration is specified even though Dex is enabled. Keycloak support has been deprecated and is no longer available."
 			isError = true
-		}
-
-		if cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth && !IsOpenShiftCluster() {
-			log.Info(fmt.Sprintf("warning: OpenShift OAuth is not supported on non-OpenShift clusters for Argo CD %s in namespace %s", cr.Name, cr.Namespace))
 		}
 
 		if isError {

--- a/controllers/argocd/sso.go
+++ b/controllers/argocd/sso.go
@@ -55,6 +55,9 @@ func (r *ReconcileArgoCD) reconcileSSO(cr *argoproj.ArgoCD, argocdStatus *argopr
 			// https://github.com/argoproj-labs/argocd-operator/pull/615 ==> conflict
 			errMsg = "must supply valid dex configuration when requested SSO provider is dex"
 			isError = true
+		} else if cr.Spec.SSO.Dex != nil && cr.Spec.SSO.Dex.OpenShiftOAuth && !IsOpenShiftCluster() {
+			errMsg = "OpenShift OAuth is not supported on non-OpenShift clusters"
+			isError = true
 		} else if cr.Spec.SSO.Keycloak != nil {
 			errMsg = "keycloak configuration is specified even though Dex is enabled. Keycloak support has been deprecated and is no longer available."
 			isError = true

--- a/controllers/argocd/sso_test.go
+++ b/controllers/argocd/sso_test.go
@@ -130,7 +130,7 @@ func TestReconcile_illegalSSOConfiguration(t *testing.T) {
 			wantSSOConfigLegalStatus: "Failed",
 		},
 		{
-			name: "openshiftOAuth enabled on non-OpenShift cluster",
+			name: "openshiftOAuth enabled on non-OpenShift cluster - warning only",
 			argoCD: makeTestArgoCD(func(ac *argoproj.ArgoCD) {
 				ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
 					Provider: argoproj.SSOProviderTypeDex,
@@ -139,9 +139,8 @@ func TestReconcile_illegalSSOConfiguration(t *testing.T) {
 					},
 				}
 			}),
-			wantErr:                  true,
-			Err:                      errors.New("illegal SSO configuration: OpenShift OAuth is not supported on non-OpenShift clusters"),
-			wantSSOConfigLegalStatus: "Failed",
+			wantErr:                  false,
+			wantSSOConfigLegalStatus: "",
 		},
 		{
 			name: "openshiftOAuth enabled on OpenShift cluster - no validation error",

--- a/controllers/argocd/sso_test.go
+++ b/controllers/argocd/sso_test.go
@@ -36,6 +36,8 @@ func TestReconcile_illegalSSOConfiguration(t *testing.T) {
 	tests := []struct {
 		name                     string
 		argoCD                   *argoproj.ArgoCD
+		setup                    func()
+		teardown                 func()
 		wantErr                  bool
 		Err                      error
 		wantSSOConfigLegalStatus string
@@ -127,10 +129,49 @@ func TestReconcile_illegalSSOConfiguration(t *testing.T) {
 			Err:                      errors.New("illegal SSO configuration: Unsupported SSO provider type. Supported provider is dex"),
 			wantSSOConfigLegalStatus: "Failed",
 		},
+		{
+			name: "openshiftOAuth enabled on non-OpenShift cluster",
+			argoCD: makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+				ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
+						OpenShiftOAuth: true,
+					},
+				}
+			}),
+			wantErr:                  true,
+			Err:                      errors.New("illegal SSO configuration: OpenShift OAuth is not supported on non-OpenShift clusters"),
+			wantSSOConfigLegalStatus: "Failed",
+		},
+		{
+			name: "openshiftOAuth enabled on OpenShift cluster - no validation error",
+			argoCD: makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+				ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+					Provider: argoproj.SSOProviderTypeDex,
+					Dex: &argoproj.ArgoCDDexSpec{
+						OpenShiftOAuth: true,
+					},
+				}
+			}),
+			setup: func() {
+				versionAPIFound = true
+			},
+			teardown: func() {
+				versionAPIFound = false
+			},
+			wantErr:                  false,
+			wantSSOConfigLegalStatus: "",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.setup != nil {
+				test.setup()
+			}
+			if test.teardown != nil {
+				defer test.teardown()
+			}
 
 			resObjs := []client.Object{test.argoCD}
 			subresObjs := []client.Object{test.argoCD}

--- a/tests/ginkgo/parallel/1-141_openshiftOAuth-on-xks-openshift_test.go
+++ b/tests/ginkgo/parallel/1-141_openshiftOAuth-on-xks-openshift_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+
+	Context("1-141_openshiftOAuth-on-xks-openshift", func() {
+
+		var (
+			k8sClient client.Client
+			ctx       context.Context
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		It("should report an error condition when OpenShiftOAuth is enabled on a non-OpenShift cluster", func() {
+			if fixture.RunningOnOpenShift() {
+				Skip("This test validates behavior on non-OpenShift clusters only")
+			}
+
+			By("creating namespace for test")
+			ns, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+			defer cleanupFunc()
+
+			By("creating an ArgoCD instance with OpenShiftOAuth enabled")
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: ns.Name},
+				Spec: argov1beta1api.ArgoCDSpec{
+					SSO: &argov1beta1api.ArgoCDSSOSpec{
+						Provider: argov1beta1api.SSOProviderTypeDex,
+						Dex: &argov1beta1api.ArgoCDDexSpec{
+							OpenShiftOAuth: true,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("verifying the ArgoCD instance reports Failed phase and SSO status")
+			Eventually(argoCD, "2m", "5s").Should(
+				And(argocdFixture.HavePhase("Failed"),
+					argocdFixture.HaveSSOStatus("Failed"),
+				))
+
+			By("verifying the status condition reports unsupported OpenShiftOAuth on non-OpenShift cluster")
+			Eventually(argoCD, "2m", "5s").Should(argocdFixture.HaveCondition(metav1.Condition{
+				Message: "illegal SSO configuration: OpenShift OAuth is not supported on non-OpenShift clusters",
+				Reason:  "ErrorOccurred",
+				Status:  "False",
+				Type:    "Reconciled",
+			}))
+		})
+	})
+})

--- a/tests/ginkgo/parallel/1-141_openshiftOAuth-on-xks-openshift_test.go
+++ b/tests/ginkgo/parallel/1-141_openshiftOAuth-on-xks-openshift_test.go
@@ -45,7 +45,7 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			ctx = context.Background()
 		})
 
-		It("should report an error condition when OpenShiftOAuth is enabled on a non-OpenShift cluster", func() {
+		It("should not fail reconciliation when OpenShiftOAuth is enabled on a non-OpenShift cluster", func() {
 			if fixture.RunningOnOpenShift() {
 				Skip("This test validates behavior on non-OpenShift clusters only")
 			}
@@ -68,14 +68,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			}
 			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
 
-			By("verifying the ArgoCD instance reports Failed phase and SSO status")
-			Eventually(argoCD, "2m", "5s").Should(
-				And(argocdFixture.HavePhase("Failed"),
-					argocdFixture.HaveSSOStatus("Failed"),
-				))
-
-			By("verifying the status condition reports unsupported OpenShiftOAuth on non-OpenShift cluster")
-			Eventually(argoCD, "2m", "5s").Should(argocdFixture.HaveCondition(metav1.Condition{
+			By("verifying the ArgoCD instance does not fail due to illegal SSO configuration for OpenShiftOAuth")
+			Consistently(argoCD, "30s", "5s").ShouldNot(argocdFixture.HaveCondition(metav1.Condition{
 				Message: "illegal SSO configuration: OpenShift OAuth is not supported on non-OpenShift clusters",
 				Reason:  "ErrorOccurred",
 				Status:  "False",

--- a/tests/ginkgo/sequential/1-133_validate_namespacemanagement_does_not_block_dex_token_renewal_test.go
+++ b/tests/ginkgo/sequential/1-133_validate_namespacemanagement_does_not_block_dex_token_renewal_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
@@ -121,8 +120,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					SSO: &argov1beta1api.ArgoCDSSOSpec{
 						Provider: argov1beta1api.SSOProviderTypeDex,
 						Dex: &argov1beta1api.ArgoCDDexSpec{
-							OpenShiftOAuth:       true,
-							EnableSATokenRenewal: ptr.To(true),
+							OpenShiftOAuth: true,
 						},
 					},
 					Server: argov1beta1api.ArgoCDServerSpec{


### PR DESCRIPTION
assisted-by: claude-code

**What type of PR is this?**
/kind enhancement 

**What does this PR do / why we need it**:
Currently we have no check in sso to warn user openshiftOAuth is only supported on Openshift. This PR adds checks that logs if users uses this field on non-openshfit platforms. Users will be notified via logs if it is unsupported.
 
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to mark SSO as failed when OpenShift OAuth is enabled on a non-OpenShift cluster.
  * Invalid SSO configurations now surface clear errors and a failed SSO status.
  * OpenShift OAuth remains supported on OpenShift clusters.

* **Tests**
  * Expanded SSO coverage across OpenShift and non-OpenShift environments.
  * Added end-to-end validation for unsupported configurations and status reporting.
  * Verified default token renewal behavior remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->