### PR TITLE
fix: Use logr key-value pairs in log.Error instead of printf format

### DIFF
--- a/controllers/argocd/networkpolicies.go
+++ b/controllers/argocd/networkpolicies.go
@@ -233,7 +233,7 @@ func (r *ReconcileArgoCD) ReconcileDexServerNetworkPolicy(cr *argoproj.ArgoCD) e
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -247,7 +247,7 @@ func (r *ReconcileArgoCD) ReconcileDexServerNetworkPolicy(cr *argoproj.ArgoCD) e
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -338,7 +338,7 @@ func (r *ReconcileArgoCD) ReconcileApplicationSetControllerNetworkPolicy(cr *arg
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -352,7 +352,7 @@ func (r *ReconcileArgoCD) ReconcileApplicationSetControllerNetworkPolicy(cr *arg
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -706,7 +706,7 @@ func (r *ReconcileArgoCD) ReconcileNotificationsControllerNetworkPolicy(cr *argo
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -720,7 +720,7 @@ func (r *ReconcileArgoCD) ReconcileNotificationsControllerNetworkPolicy(cr *argo
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -786,7 +786,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDServerNetworkPolicy(cr *argoproj.ArgoCD
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -800,7 +800,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDServerNetworkPolicy(cr *argoproj.ArgoCD
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -881,7 +881,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDApplicationControllerNetworkPolicy(cr *
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -895,7 +895,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDApplicationControllerNetworkPolicy(cr *
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -1023,7 +1023,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDRepoServerNetworkPolicy(cr *argoproj.Ar
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -1037,7 +1037,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDRepoServerNetworkPolicy(cr *argoproj.Ar
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -1109,7 +1109,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterNetworkPolicy(name string, cr *ar
 		if len(changes) > 0 {
 			argoutil.LogResourceUpdate(log, existing, "updating", strings.Join(changes, ", "))
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, fmt.Sprintf("Failed to update %s network policy in namespace: %s", existing.Name, cr.Namespace))
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -1121,7 +1121,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterNetworkPolicy(name string, cr *ar
 	}
 	argoutil.LogResourceCreation(log, policy)
 	if err := r.Create(context.TODO(), policy); err != nil {
-		log.Error(err, fmt.Sprintf("Failed to create %s network policy in namespace: %s", policy.Name, cr.Namespace))
+		log.Error(err, "Failed to create network policy", "name", policy.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", policy.Name, cr.Namespace, err)
 	}
 	return nil


### PR DESCRIPTION
logr.Logger.Error does not support printf-style formatting. Passing %s placeholders with extra positional args produces incorrect, unstructured log output. Converting all call sites in controllers/argocd/networkpolicies.go to use logr's key-value pair convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for network policy creation and updates by presenting policy names and namespaces as structured details.
  * Network policy behavior and returned errors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->