### PR TITLE
fix: Use == 0 instead of <= 0 for len(SCMProviders) check

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -104,7 +104,7 @@ func (r *ReconcileArgoCD) getArgoApplicationSetCommand(cr *argoproj.ArgoCD) ([]s
 		// appset in any ns is enabled and no scmProviders allow list is specified,
 		// disables scm & PR generators to prevent potential security issues
 		// https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Appset-Any-Namespace/#scm-providers-secrets-consideration
-		if len(appsetsSourceNamespaces) > 0 && (len(cr.Spec.ApplicationSet.SCMProviders) <= 0) {
+		if len(appsetsSourceNamespaces) > 0 && len(cr.Spec.ApplicationSet.SCMProviders) == 0 {
 			cmd = append(cmd, "--enable-scm-providers=false")
 		}
 	}


### PR DESCRIPTION
len() never returns negative, so <= 0 is equivalent to == 0 but misleading. Replacing with idiomatic == 0 check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified the ApplicationSet SCM provider validation check without changing behavior for empty or missing provider lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->