### PR TITLE
fix: legacy Dex SA token cleanup to find Kubernetes auto-generated secrets without operator label

### DIFF
--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -164,15 +164,13 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoproj.ArgoCD) (*string,
 func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) error {
 	dexSAName := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, cr).Name
 	secretList := &corev1.SecretList{}
-	if err := r.List(context.TODO(), secretList,
-		client.InNamespace(cr.Namespace),
-		client.MatchingLabels(map[string]string{
-			common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
-		}),
-	); err != nil {
+	if err := r.List(context.TODO(), secretList, client.InNamespace(cr.Namespace)); err != nil {
 		return err
 	}
-	var deleteErrs []error
+	var (
+		deleteErrs         []error
+		deletedSecretNames = map[string]struct{}{}
+	)
 	for i := range secretList.Items {
 		s := &secretList.Items[i]
 		if s.Type != corev1.SecretTypeServiceAccountToken {
@@ -181,14 +179,14 @@ func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) 
 		if s.Annotations[corev1.ServiceAccountNameKey] != dexSAName {
 			continue
 		}
-
-		if !strings.HasPrefix(s.Name, dexSAName+"-token-") {
+		argoutil.LogResourceDeletion(log, s, "removing legacy Dex service account token secret")
+		if err := r.Delete(context.TODO(), s); err != nil {
+			if !apierrors.IsNotFound(err) {
+				deleteErrs = append(deleteErrs, fmt.Errorf("delete legacy dex token secret %s/%s: %w", s.Namespace, s.Name, err))
+			}
 			continue
 		}
-		argoutil.LogResourceDeletion(log, s, "removing legacy Dex service account token secret")
-		if err := r.Delete(context.TODO(), s); err != nil && !apierrors.IsNotFound(err) {
-			deleteErrs = append(deleteErrs, fmt.Errorf("delete legacy dex token secret %s/%s: %w", s.Namespace, s.Name, err))
-		}
+		deletedSecretNames[s.Name] = struct{}{}
 	}
 	sa := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, cr)
 	if err := argoutil.FetchObject(r.Client, cr.Namespace, sa.Name, sa); err != nil {
@@ -197,10 +195,9 @@ func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) 
 		}
 		return errors.Join(append([]error{err}, deleteErrs...)...)
 	}
-	var filtered []corev1.ObjectReference
+	filtered := make([]corev1.ObjectReference, 0, len(sa.Secrets))
 	for _, ref := range sa.Secrets {
-		// Legacy auto token refs only (matches delete loop).
-		if strings.HasPrefix(ref.Name, dexSAName+"-token-") {
+		if _, deleted := deletedSecretNames[ref.Name]; deleted {
 			continue
 		}
 		filtered = append(filtered, ref)

--- a/controllers/argocd/dex.go
+++ b/controllers/argocd/dex.go
@@ -164,15 +164,13 @@ func (r *ReconcileArgoCD) getDexOAuthClientSecret(cr *argoproj.ArgoCD) (*string,
 func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) error {
 	dexSAName := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, cr).Name
 	secretList := &corev1.SecretList{}
-	if err := r.List(context.TODO(), secretList,
-		client.InNamespace(cr.Namespace),
-		client.MatchingLabels(map[string]string{
-			common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
-		}),
-	); err != nil {
+	if err := r.List(context.TODO(), secretList, client.InNamespace(cr.Namespace)); err != nil {
 		return err
 	}
-	var deleteErrs []error
+	var (
+		deleteErrs         []error
+		deletedSecretNames = map[string]struct{}{}
+	)
 	for i := range secretList.Items {
 		s := &secretList.Items[i]
 		if s.Type != corev1.SecretTypeServiceAccountToken {
@@ -181,14 +179,14 @@ func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) 
 		if s.Annotations[corev1.ServiceAccountNameKey] != dexSAName {
 			continue
 		}
-
-		if !strings.HasPrefix(s.Name, dexSAName+"-token-") {
-			continue
-		}
 		argoutil.LogResourceDeletion(log, s, "removing legacy Dex service account token secret")
-		if err := r.Delete(context.TODO(), s); err != nil && !apierrors.IsNotFound(err) {
-			deleteErrs = append(deleteErrs, fmt.Errorf("delete legacy dex token secret %s/%s: %w", s.Namespace, s.Name, err))
+		if err := r.Delete(context.TODO(), s); err != nil {
+			if !apierrors.IsNotFound(err) {
+				deleteErrs = append(deleteErrs, fmt.Errorf("delete legacy dex token secret %s/%s: %w", s.Namespace, s.Name, err))
+				continue
+			}
 		}
+		deletedSecretNames[s.Name] = struct{}{}
 	}
 	sa := newServiceAccountWithName(common.ArgoCDDefaultDexServiceAccountName, cr)
 	if err := argoutil.FetchObject(r.Client, cr.Namespace, sa.Name, sa); err != nil {
@@ -197,10 +195,9 @@ func (r *ReconcileArgoCD) reconcileDexLegacySATokenSecrets(cr *argoproj.ArgoCD) 
 		}
 		return errors.Join(append([]error{err}, deleteErrs...)...)
 	}
-	var filtered []corev1.ObjectReference
+	filtered := make([]corev1.ObjectReference, 0, len(sa.Secrets))
 	for _, ref := range sa.Secrets {
-		// Legacy auto token refs only (matches delete loop).
-		if strings.HasPrefix(ref.Name, dexSAName+"-token-") {
+		if _, deleted := deletedSecretNames[ref.Name]; deleted {
 			continue
 		}
 		filtered = append(filtered, ref)

--- a/controllers/argocd/dex_test.go
+++ b/controllers/argocd/dex_test.go
@@ -2,7 +2,6 @@ package argocd
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -1414,16 +1413,70 @@ func TestReconcileArgoCD_reconcileDexLegacySATokenSecrets(t *testing.T) {
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 	assert.NoError(t, createNamespace(r, a.Namespace, ""))
 
-	// Create the Dex SA so the function can fetch it.
 	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
 	assert.NoError(t, err)
 
 	dexSAName := a.Name + "-" + common.ArgoCDDefaultDexServiceAccountName
 
-	// Create a legacy kubernetes.io/service-account-token Secret.
+	// Kubernetes auto-generated SA token secret: no operator label, uses SA name in the name.
 	legacySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dexSAName + "-token-abc12",
+			Name:      "argocd-dex-server-token-abc12",
+			Namespace: a.Namespace,
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: dexSAName,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+	assert.NoError(t, r.Create(context.TODO(), legacySecret))
+
+	sa := &corev1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(),
+		types.NamespacedName{Name: dexSAName, Namespace: a.Namespace}, sa))
+	sa.Secrets = append(sa.Secrets, corev1.ObjectReference{Name: legacySecret.Name})
+	assert.NoError(t, r.Update(context.TODO(), sa))
+
+	assert.NoError(t, r.reconcileDexLegacySATokenSecrets(a))
+
+	deleted := &corev1.Secret{}
+	err = r.Get(context.TODO(),
+		types.NamespacedName{Name: legacySecret.Name, Namespace: a.Namespace}, deleted)
+	assert.True(t, apierrors.IsNotFound(err), "legacy SA token Secret must be deleted")
+
+	updatedSA := &corev1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(),
+		types.NamespacedName{Name: dexSAName, Namespace: a.Namespace}, updatedSA))
+	for _, ref := range updatedSA.Secrets {
+		assert.NotEqual(t, legacySecret.Name, ref.Name,
+			"SA.secrets must not contain legacy token reference")
+	}
+}
+
+func TestReconcileArgoCD_reconcileDexLegacySATokenSecrets_OperatorCreatedSecret(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	a := makeTestArgoCD(func(ac *argoproj.ArgoCD) {
+		ac.Spec.SSO = &argoproj.ArgoCDSSOSpec{
+			Provider: argoproj.SSOProviderTypeDex,
+			Dex:      &argoproj.ArgoCDDexSpec{OpenShiftOAuth: true},
+		}
+	})
+
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, []client.Object{a}, []client.Object{a}, nil)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+
+	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
+	assert.NoError(t, err)
+
+	dexSAName := a.Name + "-" + common.ArgoCDDefaultDexServiceAccountName
+
+	// Operator-created SA token secret has operator label.
+	legacySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dexSAName + "-token-op123",
 			Namespace: a.Namespace,
 			Labels: map[string]string{
 				common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
@@ -1436,29 +1489,25 @@ func TestReconcileArgoCD_reconcileDexLegacySATokenSecrets(t *testing.T) {
 	}
 	assert.NoError(t, r.Create(context.TODO(), legacySecret))
 
-	// Also add a reference to that Secret in the SA.secrets list.
 	sa := &corev1.ServiceAccount{}
 	assert.NoError(t, r.Get(context.TODO(),
 		types.NamespacedName{Name: dexSAName, Namespace: a.Namespace}, sa))
 	sa.Secrets = append(sa.Secrets, corev1.ObjectReference{Name: legacySecret.Name})
 	assert.NoError(t, r.Update(context.TODO(), sa))
 
-	// Run the cleanup.
 	assert.NoError(t, r.reconcileDexLegacySATokenSecrets(a))
 
-	// Legacy Secret must be deleted.
 	deleted := &corev1.Secret{}
 	err = r.Get(context.TODO(),
 		types.NamespacedName{Name: legacySecret.Name, Namespace: a.Namespace}, deleted)
-	assert.True(t, apierrors.IsNotFound(err), "legacy SA token Secret must be deleted")
+	assert.True(t, apierrors.IsNotFound(err), "operator-created legacy SA token Secret must be deleted")
 
-	// SA.secrets must no longer reference the legacy token.
 	updatedSA := &corev1.ServiceAccount{}
 	assert.NoError(t, r.Get(context.TODO(),
 		types.NamespacedName{Name: dexSAName, Namespace: a.Namespace}, updatedSA))
 	for _, ref := range updatedSA.Secrets {
-		assert.False(t, strings.HasPrefix(ref.Name, dexSAName+"-token-"),
-			"SA.secrets must not contain legacy token reference %q", ref.Name)
+		assert.NotEqual(t, legacySecret.Name, ref.Name,
+			"SA.secrets must not contain operator-created legacy token reference")
 	}
 }
 
@@ -1479,26 +1528,39 @@ func TestReconcileArgoCD_reconcileDexLegacySATokenSecrets_IgnoresUnrelatedSecret
 	_, err := r.reconcileServiceAccount(common.ArgoCDDefaultDexServiceAccountName, a)
 	assert.NoError(t, err)
 
-	// Opaque Secret with a similar name must not be deleted.
+	// Opaque Secret with a similar name must not be deleted (wrong type).
 	opaqueSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "argocd-dex-server-token-opaque",
 			Namespace: a.Namespace,
-			Labels: map[string]string{
-				common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
-			},
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
 	assert.NoError(t, r.Create(context.TODO(), opaqueSecret))
 
+	// SA token secret for a different SA must not be deleted (wrong annotation).
+	otherSATokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-sa-token-xyz",
+			Namespace: a.Namespace,
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: "some-other-sa",
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+	assert.NoError(t, r.Create(context.TODO(), otherSATokenSecret))
+
 	assert.NoError(t, r.reconcileDexLegacySATokenSecrets(a))
 
-	// Opaque Secret must still exist.
 	kept := &corev1.Secret{}
 	assert.NoError(t, r.Get(context.TODO(),
 		types.NamespacedName{Name: opaqueSecret.Name, Namespace: a.Namespace}, kept),
 		"Opaque Secret must not be deleted by legacy cleanup")
+
+	assert.NoError(t, r.Get(context.TODO(),
+		types.NamespacedName{Name: otherSATokenSecret.Name, Namespace: a.Namespace}, kept),
+		"SA token secret for a different SA must not be deleted by legacy cleanup")
 }
 
 func TestReconcileArgoCD_reconcileDexDeployment_customLabelsAndAnnotations(t *testing.T) {

--- a/tests/ginkgo/parallel/1-095_validate_dex_clientsecret_test.go
+++ b/tests/ginkgo/parallel/1-095_validate_dex_clientsecret_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
-	"github.com/argoproj-labs/argocd-operator/common"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
 	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
@@ -97,7 +96,6 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				}
 				for _, s := range secretList.Items {
 					if s.Type == corev1.SecretTypeServiceAccountToken &&
-						strings.HasPrefix(s.Name, dexSAName+"-token-") &&
 						s.Annotations[corev1.ServiceAccountNameKey] == dexSAName {
 						return false
 					}
@@ -186,15 +184,12 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 			dexSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: dexSAName, Namespace: ns.Name}}
 			Eventually(dexSA).Should(k8sFixture.ExistByName())
 
-			legacyName := dexSAName + "-token-e2elegacy"
-			By("creating a legacy non-expiring kubernetes.io/service-account-token Secret for the Dex SA (operator-tracked label required for cleanup list)")
+			legacyName := "argocd-dex-server-token-e2elegacy"
+			By("creating a legacy non-expiring kubernetes.io/service-account-token Secret for the Dex SA (simulates Kubernetes auto-generated secret without operator label)")
 			legacySecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      legacyName,
 					Namespace: ns.Name,
-					Labels: map[string]string{
-						common.ArgoCDTrackedByOperatorLabel: common.ArgoCDAppName,
-					},
 					Annotations: map[string]string{
 						corev1.ServiceAccountNameKey: dexSAName,
 					},

--- a/tests/ginkgo/sequential/1-133_validate_namespacemanagement_does_not_block_dex_token_renewal_test.go
+++ b/tests/ginkgo/sequential/1-133_validate_namespacemanagement_does_not_block_dex_token_renewal_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
@@ -121,8 +120,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					SSO: &argov1beta1api.ArgoCDSSOSpec{
 						Provider: argov1beta1api.SSOProviderTypeDex,
 						Dex: &argov1beta1api.ArgoCDDexSpec{
-							OpenShiftOAuth:       true,
-							EnableSATokenRenewal: ptr.To(true),
+							OpenShiftOAuth: true,
 						},
 					},
 					Server: argov1beta1api.ArgoCDServerSpec{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug 

**What does this PR do / why we need it**:
The legacy Dex SA token cleanup function reconcileDexLegacySATokenSecrets silently failed to find and delete Kubernetes auto-generated kubernetes.io/service-account-token secrets during upgrades. This happened because -

1. The List query filtered by operator.argoproj.io/tracked-by: argocd label, which Kubernetes auto-generated secrets don't have.
2. The name prefix check expected <cr-name>-argocd-dex-server-token- but real auto-generated secrets use <sa-name>-token-<rand> (e.g. argocd-dex-server-token-tjbmp).

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
JIRA - https://redhat.atlassian.net/browse/GITOPS-10585

Fixes #?

**How to test changes / Special notes to the reviewer**:
1. Create an ArgoCD instance with Dex and OpenShift OAuth enabled
2. Create a fake legacy secret simulating a Kubernetes auto-generated SA token (no operator label, annotation pointing to the Dex SA):
kubectl create -f - <<EOF
  apiVersion: v1
  kind: Secret
  metadata:
    name: argocd-dex-server-token-fake1
    annotations:
      kubernetes.io/service-account.name: <dex-sa-name>
  type: kubernetes.io/service-account-token
EOF
3. Add it to the SA's .secrets list
4. Trigger a reconcile (annotate the ArgoCD CR)
5. Verify the legacy secret is deleted and the SA reference is removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of legacy Dex service-account token Secrets, including Kubernetes-generated Secrets without operator labels.
  * Preserved unrelated Secrets and service-account references, including similarly named or other service-account Secrets.
  * Improved handling of already-removed Secrets and deletion failures during cleanup.
* **Tests**
  * Expanded coverage for labeled, unlabeled, similarly named, unrelated, and operator-created Secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->