### PR TITLE
fix: adjust agent's clusterole to have read permissions for common kubernetes resources

### DIFF
--- a/controllers/argocdagent/agent/role.go
+++ b/controllers/argocdagent/agent/role.go
@@ -276,6 +276,47 @@ func buildPolicyRuleForClusterRole(cr *argoproj.ArgoCD) []v1.PolicyRule {
 				"patch",
 			},
 		},
+		// Give get permissions for common core Kubernetes resources
+		{
+			APIGroups: []string{""},
+			Resources: []string{
+				"pods",
+				"services",
+				"endpoints",
+				"persistentvolumeclaims",
+				"configmaps",
+				"serviceaccounts",
+			},
+			Verbs: []string{"get"},
+		},
+		{
+			APIGroups: []string{"apps"},
+			Resources: []string{
+				"deployments",
+				"replicasets",
+				"statefulsets",
+				"daemonsets",
+			},
+			Verbs: []string{"get"},
+		},
+		{
+			APIGroups: []string{"networking.k8s.io"},
+			Resources: []string{
+				"ingresses",
+				"networkpolicies",
+			},
+			Verbs: []string{"get"},
+		},
+		{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{
+				"roles",
+				"rolebindings",
+				"clusterroles",
+				"clusterrolebindings",
+			},
+			Verbs: []string{"get"},
+		},
 	}
 
 	// Conditionally allow namespace create/get only if requested

--- a/controllers/argocdagent/agent/role_test.go
+++ b/controllers/argocdagent/agent/role_test.go
@@ -535,7 +535,7 @@ func TestBuildPolicyRuleForClusterRole_Table(t *testing.T) {
 				},
 			}
 
-			assert.Len(t, rules, 2)
+			assert.Len(t, rules, 6)
 			assert.Equal(t, appRules, rules[1])
 
 			if tt.createNamespace {


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind enhancement

**What does this PR do / why we need it**:

This PR adjusts the default cluster role that is deployed for the Agent component of Argo CD Agent. With the current permissions, a user will get errors when trying to access resources on the UI. The updated role gives `get` permissions to common core Kubernetes resources (minus secrets). 

Any custom resources would need to be added to the role. 

The role is from the following page in the Argo CD Agent docs:
https://argocd-agent.readthedocs.io/latest/user-guide/live-resources/#rbac-requirements

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Destination-based mapping now supports read access to additional Kubernetes resources, including workloads, services, secrets, and role bindings.
  * Expanded permissions cover common core, apps, networking, and RBAC resources.

* **Bug Fixes**
  * Improved access coverage for destination-based mapping without changing existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->