### PR TITLE
Feat: Add support for passing ImagePullSecret for operator SA

### DIFF
--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -2058,6 +2058,8 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: ENABLE_CONVERSION_WEBHOOK
                   value: "true"
+                - name: IMAGE_PULL_SECRETS
+                  value: ""
                 image: quay.io/argoprojlabs/argocd-operator:v0.19.0
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/argocd-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/argocd-operator.clusterserviceversion.yaml
@@ -257,7 +257,7 @@ metadata:
     capabilities: Deep Insights
     categories: Integration & Delivery
     certified: "false"
-    createdAt: "2026-08-05T21:22:50Z"
+    createdAt: "2026-08-13T08:49:48Z"
     description: Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.
     operators.operatorframework.io/builder: operator-sdk-v1.35.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -2058,8 +2058,6 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: ENABLE_CONVERSION_WEBHOOK
                   value: "true"
-                - name: IMAGE_PULL_SECRETS
-                  value: ""
                 image: quay.io/argoprojlabs/argocd-operator:v0.19.0
                 livenessProbe:
                   httpGet:

--- a/common/defaults.go
+++ b/common/defaults.go
@@ -51,6 +51,9 @@ const (
 	// ArgoCDRedisHAComponent is the name of the Redis HA control plane component
 	ArgoCDRedisHAComponent = "argocd-redis-ha"
 
+	// ArgoCDRepoServerComponent is the name of the Repo server control plane component
+	ArgoCDRepoServerComponent = "argocd-repo-server"
+
 	// ArgoCDDexServerComponent is the name of the Dex server control plane component
 	ArgoCDDexServerComponent = "argocd-dex-server"
 

--- a/common/keys.go
+++ b/common/keys.go
@@ -292,6 +292,10 @@ const (
 	// ArgoCDImagePullPolicyEnvName is the environment variable used to get the global image pull policy
 	// for all ArgoCD components managed by the operator.
 	ArgoCDImagePullPolicyEnvName = "IMAGE_PULL_POLICY"
+
+	// ArgoCDImagePullSecretsEnvName is the environment variable used to get the global image pull secrets
+	// for all ArgoCD ServiceAccounts managed by the operator. Comma-separated list of secret names.
+	ArgoCDImagePullSecretsEnvName = "IMAGE_PULL_SECRETS"
 	// ArgoCDWebTerminalEnabledKey is the configuration key for enabling the web terminal.
 	ArgoCDWebTerminalEnabledKey = "exec.enabled"
 	// ArgoCDWebTerminalEnabledDefaultValue is the default value for enabling the web terminal.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,5 +59,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
+        # - name: IMAGE_PULL_SECRETS
+        #   value: ""
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,7 +59,5 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
-        # - name: IMAGE_PULL_SECRETS
-        #   value: ""
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -523,6 +523,12 @@ func (r *ReconcileArgoCD) reconcileApplicationSetServiceAccount(cr *argoproj.Arg
 		if err != nil {
 			return sa, err
 		}
+	} else {
+		desired := argoutil.GetImagePullSecrets()
+		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+			sa.ImagePullSecrets = desired
+			return sa, r.Update(context.TODO(), sa)
+		}
 	}
 
 	return sa, nil

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -755,6 +755,37 @@ func TestReconcileApplicationSetServiceAccount_WithImagePullSecrets(t *testing.T
 	assert.Equal(t, []v1.LocalObjectReference{{Name: "appset-pull-secret"}}, testSa.ImagePullSecrets)
 }
 
+func TestReconcileApplicationSetServiceAccount_UpdateExistingImagePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{
+		Enabled: new(true),
+	}
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	// Create SA without imagePullSecrets
+	_, err := r.reconcileApplicationSetServiceAccount(a)
+	assert.NoError(t, err)
+
+	// Set env var and reconcile again — should update existing SA
+	t.Setenv("IMAGE_PULL_SECRETS", "new-pull-secret")
+	_, err = r.reconcileApplicationSetServiceAccount(a)
+	assert.NoError(t, err)
+
+	testSa := &v1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-applicationset-controller",
+		Namespace: a.Namespace,
+	}, testSa))
+	assert.Equal(t, []v1.LocalObjectReference{{Name: "new-pull-secret"}}, testSa.ImagePullSecrets)
+}
+
 // Test creation/cleanup of applicationset-controller clusterrole & clusterrolebinding
 func TestReconcileApplicationSet_ClusterRBACCreationAndCleanup(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))

--- a/controllers/argocd/applicationset_test.go
+++ b/controllers/argocd/applicationset_test.go
@@ -727,6 +727,34 @@ func TestReconcileApplicationSet_ServiceAccount(t *testing.T) {
 	appsetAssertExpectedLabels(t, &sa.ObjectMeta)
 }
 
+func TestReconcileApplicationSetServiceAccount_WithImagePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+	a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{
+		Enabled: new(true),
+	}
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	t.Setenv("IMAGE_PULL_SECRETS", "appset-pull-secret")
+
+	sa, err := r.reconcileApplicationSetServiceAccount(a)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	testSa := &v1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-applicationset-controller",
+		Namespace: a.Namespace,
+	}, testSa))
+	assert.Equal(t, []v1.LocalObjectReference{{Name: "appset-pull-secret"}}, testSa.ImagePullSecrets)
+}
+
 // Test creation/cleanup of applicationset-controller clusterrole & clusterrolebinding
 func TestReconcileApplicationSet_ClusterRBACCreationAndCleanup(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))

--- a/controllers/argocd/deployment_test.go
+++ b/controllers/argocd/deployment_test.go
@@ -2737,17 +2737,17 @@ func TestReconcileArgoCD_reconcileRepoDeployment_serviceAccount(t *testing.T) {
 		}, {
 			testName:                      "Empty serviceAccountName field in the spec should have updated value",
 			serviceAccountName:            "",
-			expectedServiceAccountName:    "",
+			expectedServiceAccountName:    "argocd-argocd-repo-server",
 			isServiceAccountNameChanged:   true,
 			newServiceAccountName:         "builder",
 			newExpectedServiceAccountName: "builder",
 		}, {
-			testName:                      "serviceAccountName field in the spec should be changed to empty",
+			testName:                      "serviceAccountName field in the spec should be changed to empty and use default",
 			serviceAccountName:            "builder",
 			expectedServiceAccountName:    "builder",
 			isServiceAccountNameChanged:   true,
 			newServiceAccountName:         "",
-			newExpectedServiceAccountName: "",
+			newExpectedServiceAccountName: "argocd-argocd-repo-server",
 		},
 	}
 
@@ -3535,4 +3535,52 @@ func TestArgoCDServerAndRepoServerDeploymentArgs(t *testing.T) {
 	assert.NoError(t, r.reconcileRepoDeployment(a, false))
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: "argocd-repo-server", Namespace: a.Namespace}, deployment))
 	assert.Equal(t, args, deployment.Spec.Template.Spec.Containers[0].Args)
+}
+
+func TestReconcileRepoServerDeployment_DefaultServiceAccount(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	err := r.reconcileRepoDeployment(a, false)
+	assert.NoError(t, err)
+
+	deployment := &appsv1.Deployment{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-repo-server",
+		Namespace: a.Namespace,
+	}, deployment))
+
+	assert.Equal(t, "argocd-argocd-repo-server", deployment.Spec.Template.Spec.ServiceAccountName)
+}
+
+func TestReconcileRepoServerDeployment_CustomServiceAccount(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.Repo.ServiceAccount = "custom-sa"
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	err := r.reconcileRepoDeployment(a, false)
+	assert.NoError(t, err)
+
+	deployment := &appsv1.Deployment{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      "argocd-repo-server",
+		Namespace: a.Namespace,
+	}, deployment))
+
+	assert.Equal(t, "custom-sa", deployment.Spec.Template.Spec.ServiceAccountName)
 }

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -342,6 +342,12 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterServiceAccount(cr *argoproj.ArgoC
 		return nil, r.Delete(context.TODO(), sa)
 	}
 
+	desired := argoutil.GetImagePullSecrets()
+	if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+		sa.ImagePullSecrets = desired
+		return sa, r.Update(context.TODO(), sa)
+	}
+
 	return sa, nil
 }
 

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -137,6 +137,33 @@ func TestReconcileImageUpdater_CreateServiceAccount(t *testing.T) {
 
 }
 
+func TestReconcileImageUpdaterServiceAccount_WithImagePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	t.Setenv("IMAGE_PULL_SECRETS", "imgupd-pull-secret")
+
+	sa, err := r.reconcileImageUpdaterServiceAccount(a)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	testSa := &v1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDImageUpdaterControllerComponent, a),
+		Namespace: a.Namespace,
+	}, testSa))
+	assert.Equal(t, []v1.LocalObjectReference{{Name: "imgupd-pull-secret"}}, testSa.ImagePullSecrets)
+}
+
 func TestReconcileImageUpdater_CreateRoleBinding(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -164,6 +164,36 @@ func TestReconcileImageUpdaterServiceAccount_WithImagePullSecrets(t *testing.T) 
 	assert.Equal(t, []v1.LocalObjectReference{{Name: "imgupd-pull-secret"}}, testSa.ImagePullSecrets)
 }
 
+func TestReconcileImageUpdaterServiceAccount_UpdateExistingImagePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	// Create SA without imagePullSecrets
+	_, err := r.reconcileImageUpdaterServiceAccount(a)
+	assert.NoError(t, err)
+
+	// Set env var and reconcile again — should update existing SA
+	t.Setenv("IMAGE_PULL_SECRETS", "new-imgupd-secret")
+	_, err = r.reconcileImageUpdaterServiceAccount(a)
+	assert.NoError(t, err)
+
+	testSa := &v1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDImageUpdaterControllerComponent, a),
+		Namespace: a.Namespace,
+	}, testSa))
+	assert.Equal(t, []v1.LocalObjectReference{{Name: "new-imgupd-secret"}}, testSa.ImagePullSecrets)
+}
+
 func TestReconcileImageUpdater_CreateRoleBinding(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -242,6 +242,12 @@ func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoproj.Argo
 		return nil, r.Delete(context.TODO(), sa)
 	}
 
+	desired := argoutil.GetImagePullSecrets()
+	if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+		sa.ImagePullSecrets = desired
+		return sa, r.Update(context.TODO(), sa)
+	}
+
 	return sa, nil
 }
 

--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -101,6 +101,33 @@ func TestReconcileNotifications_CreateServiceAccount(t *testing.T) {
 
 }
 
+func TestReconcileNotificationsServiceAccount_WithImagePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.Notifications.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	t.Setenv("IMAGE_PULL_SECRETS", "notif-pull-secret")
+
+	sa, err := r.reconcileNotificationsServiceAccount(a)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	testSa := &v1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+		Namespace: a.Namespace,
+	}, testSa))
+	assert.Equal(t, []v1.LocalObjectReference{{Name: "notif-pull-secret"}}, testSa.ImagePullSecrets)
+}
+
 func TestReconcileNotifications_CreateRoleBinding(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {

--- a/controllers/argocd/notifications_test.go
+++ b/controllers/argocd/notifications_test.go
@@ -128,6 +128,36 @@ func TestReconcileNotificationsServiceAccount_WithImagePullSecrets(t *testing.T)
 	assert.Equal(t, []v1.LocalObjectReference{{Name: "notif-pull-secret"}}, testSa.ImagePullSecrets)
 }
 
+func TestReconcileNotificationsServiceAccount_UpdateExistingImagePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.Notifications.Enabled = true
+	})
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	// Create SA without imagePullSecrets
+	_, err := r.reconcileNotificationsServiceAccount(a)
+	assert.NoError(t, err)
+
+	// Set env var and reconcile again — should update existing SA
+	t.Setenv("IMAGE_PULL_SECRETS", "new-notif-secret")
+	_, err = r.reconcileNotificationsServiceAccount(a)
+	assert.NoError(t, err)
+
+	testSa := &v1.ServiceAccount{}
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+		Name:      generateResourceName(common.ArgoCDNotificationsControllerComponent, a),
+		Namespace: a.Namespace,
+	}, testSa))
+	assert.Equal(t, []v1.LocalObjectReference{{Name: "new-notif-secret"}}, testSa.ImagePullSecrets)
+}
+
 func TestReconcileNotifications_CreateRoleBinding(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 	a := makeTestArgoCD(func(a *argoproj.ArgoCD) {

--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -440,8 +440,15 @@ func getPolicyRuleList(client client.Client, cr *argoproj.ArgoCD) []struct {
 		}, {
 			name:       common.ArgoCDRedisComponent,
 			policyRule: policyRuleForRedis(client),
+		}, {
+			name:       common.ArgoCDRepoServerComponent,
+			policyRule: policyRuleForRepoServer(),
 		},
 	}
+}
+
+func policyRuleForRepoServer() []v1.PolicyRule {
+	return nil
 }
 
 func getPolicyRuleClusterRoleList() []struct {

--- a/controllers/argocd/policyrule.go
+++ b/controllers/argocd/policyrule.go
@@ -448,7 +448,7 @@ func getPolicyRuleList(client client.Client, cr *argoproj.ArgoCD) []struct {
 }
 
 func policyRuleForRepoServer() []v1.PolicyRule {
-	return nil
+	return []v1.PolicyRule{}
 }
 
 func getPolicyRuleClusterRoleList() []struct {

--- a/controllers/argocd/repo_server.go
+++ b/controllers/argocd/repo_server.go
@@ -109,6 +109,8 @@ func (r *ReconcileArgoCD) reconcileRepoDeployment(cr *argocdoperatorv1beta1.Argo
 
 	if cr.Spec.Repo.ServiceAccount != "" {
 		deploy.Spec.Template.Spec.ServiceAccountName = cr.Spec.Repo.ServiceAccount
+	} else {
+		deploy.Spec.Template.Spec.ServiceAccountName = getServiceAccountName(cr.Name, common.ArgoCDRepoServerComponent)
 	}
 
 	// Global proxy env vars go first

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -36,6 +37,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -932,6 +934,86 @@ func (r *ReconcileArgoCD) reconcileSecrets(cr *argoproj.ArgoCD) error {
 	}
 
 	return nil
+}
+
+func (r *ReconcileArgoCD) reconcileImagePullSecrets(cr *argoproj.ArgoCD) error {
+	secretRefs := argoutil.GetImagePullSecrets()
+	if len(secretRefs) == 0 {
+		return nil
+	}
+
+	operatorNS, err := argoutil.GetOperatorNamespace()
+	if err != nil {
+		log.Info("cannot determine operator namespace, skipping image pull secret copy", "error", err)
+		return nil
+	}
+
+	if operatorNS == cr.Namespace {
+		return nil
+	}
+
+	for _, ref := range secretRefs {
+		src := &corev1.Secret{}
+		if err := argoutil.FetchObject(r.Client, operatorNS, ref.Name, src); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("image pull secret not found in operator namespace, skipping",
+					"secret", ref.Name, "operatorNamespace", operatorNS)
+				continue
+			}
+			return err
+		}
+
+		dst := &corev1.Secret{}
+		dstExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, ref.Name, dst)
+		if err != nil {
+			return err
+		}
+
+		if dstExists {
+			needsUpdate := !reflect.DeepEqual(dst.Data, src.Data) || dst.Type != src.Type
+			if !needsUpdate && hasOwnerReference(dst, cr) {
+				continue
+			}
+			dst.Data = src.Data
+			dst.Type = src.Type
+			if err := controllerutil.SetControllerReference(cr, dst, r.Scheme); err != nil {
+				return err
+			}
+			argoutil.LogResourceUpdate(log, dst, "image pull secret data changed")
+			if err := r.Update(context.TODO(), dst); err != nil {
+				return err
+			}
+			continue
+		}
+
+		dst = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ref.Name,
+				Namespace: cr.Namespace,
+				Labels:    argoutil.LabelsForCluster(cr),
+			},
+			Type: src.Type,
+			Data: src.Data,
+		}
+
+		if err := controllerutil.SetControllerReference(cr, dst, r.Scheme); err != nil {
+			return err
+		}
+		argoutil.LogResourceCreation(log, dst)
+		if err := r.Create(context.TODO(), dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hasOwnerReference(obj metav1.Object, owner metav1.Object) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == owner.GetUID() {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *ReconcileArgoCD) getClusterSecrets(cr *argoproj.ArgoCD) (*corev1.SecretList, error) {

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -1379,4 +1380,218 @@ type getAlwaysErrClient struct {
 
 func (c *getAlwaysErrClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
 	return c.getErr
+}
+
+func setupOperatorNamespaceFile(t *testing.T, ns string) {
+	t.Helper()
+	dir := t.TempDir()
+	nsFile := filepath.Join(dir, "namespace")
+	require.NoError(t, os.WriteFile(nsFile, []byte(ns), 0644))
+	old := argoutil.OperatorNamespaceFile
+	argoutil.OperatorNamespaceFile = nsFile
+	t.Cleanup(func() { argoutil.OperatorNamespaceFile = old })
+}
+
+func TestReconcileImagePullSecrets_NoEnvVar(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	// No IMAGE_PULL_SECRETS set — should be a no-op
+	err := r.reconcileImagePullSecrets(a)
+	assert.NoError(t, err)
+}
+
+func TestReconcileImagePullSecrets_SameNamespace(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	// Operator runs in same namespace as CR
+	setupOperatorNamespaceFile(t, a.Namespace)
+	t.Setenv("IMAGE_PULL_SECRETS", "my-secret")
+
+	err := r.reconcileImagePullSecrets(a)
+	assert.NoError(t, err)
+
+	// Secret should not be created (same namespace, nothing to copy)
+	secret := &corev1.Secret{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "my-secret", Namespace: a.Namespace}, secret)
+	assert.True(t, errors.Is(err, err) && err != nil) // not found is fine, secret wasn't created
+}
+
+func TestReconcileImagePullSecrets_CreatesInTargetNamespace(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	srcSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: "operator-ns",
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(`{"auths":{}}`),
+		},
+	}
+
+	resObjs := []client.Object{a, srcSecret}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	setupOperatorNamespaceFile(t, "operator-ns")
+	t.Setenv("IMAGE_PULL_SECRETS", "my-pull-secret")
+
+	err := r.reconcileImagePullSecrets(a)
+	assert.NoError(t, err)
+
+	// Verify secret was copied to CR namespace
+	dst := &corev1.Secret{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "my-pull-secret", Namespace: a.Namespace}, dst)
+	assert.NoError(t, err)
+	assert.Equal(t, corev1.SecretTypeDockerConfigJson, dst.Type)
+	assert.Equal(t, srcSecret.Data, dst.Data)
+
+	// Verify owner reference set
+	assert.Len(t, dst.OwnerReferences, 1)
+	assert.Equal(t, a.Name, dst.OwnerReferences[0].Name)
+}
+
+func TestReconcileImagePullSecrets_SkipsWhenDataAndOwnerUnchanged(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	secretData := map[string][]byte{
+		".dockerconfigjson": []byte(`{"auths":{}}`),
+	}
+
+	srcSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: "operator-ns",
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: secretData,
+	}
+
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+
+	dstSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: a.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: argoproj.GroupVersion.String(),
+					Kind:       "ArgoCD",
+					Name:       a.Name,
+					UID:        a.UID,
+				},
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: secretData,
+	}
+
+	resObjs := []client.Object{a, srcSecret, dstSecret}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	setupOperatorNamespaceFile(t, "operator-ns")
+	t.Setenv("IMAGE_PULL_SECRETS", "my-pull-secret")
+
+	err := r.reconcileImagePullSecrets(a)
+	assert.NoError(t, err)
+
+	// Data and owner ref unchanged — verify no update happened
+	dst := &corev1.Secret{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "my-pull-secret", Namespace: a.Namespace}, dst)
+	assert.NoError(t, err)
+	assert.Equal(t, dstSecret.ResourceVersion, dst.ResourceVersion)
+}
+
+func TestReconcileImagePullSecrets_UpdatesWhenDataChanged(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	srcSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: "operator-ns",
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(`{"auths":{"new":"creds"}}`),
+		},
+	}
+
+	dstSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: a.Namespace,
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			".dockerconfigjson": []byte(`{"auths":{"old":"creds"}}`),
+		},
+	}
+
+	resObjs := []client.Object{a, srcSecret, dstSecret}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	setupOperatorNamespaceFile(t, "operator-ns")
+	t.Setenv("IMAGE_PULL_SECRETS", "my-pull-secret")
+
+	err := r.reconcileImagePullSecrets(a)
+	assert.NoError(t, err)
+
+	dst := &corev1.Secret{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "my-pull-secret", Namespace: a.Namespace}, dst)
+	assert.NoError(t, err)
+	assert.Equal(t, srcSecret.Data, dst.Data)
+}
+
+func TestReconcileImagePullSecrets_SourceMissing(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	setupOperatorNamespaceFile(t, "operator-ns")
+	t.Setenv("IMAGE_PULL_SECRETS", "nonexistent-secret")
+
+	// Should not error — just log warning and continue
+	err := r.reconcileImagePullSecrets(a)
+	assert.NoError(t, err)
+
+	// Verify no secret created in CR namespace
+	dst := &corev1.Secret{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "nonexistent-secret", Namespace: a.Namespace}, dst)
+	assert.Error(t, err)
 }

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -16,6 +16,7 @@ package argocd
 
 import (
 	"context"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
@@ -36,6 +37,7 @@ func newServiceAccount(cr *argoproj.ArgoCD) *corev1.ServiceAccount {
 			Namespace: cr.Namespace,
 			Labels:    argoutil.LabelsForCluster(cr),
 		},
+		ImagePullSecrets: argoutil.GetImagePullSecrets(),
 	}
 }
 
@@ -129,6 +131,12 @@ func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoproj.Argo
 			// Delete any existing Service Account as no longer needed
 			argoutil.LogResourceDeletion(log, sa, "component is being uninstalled")
 			return sa, r.Delete(context.TODO(), sa)
+		}
+
+		desired := argoutil.GetImagePullSecrets()
+		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+			sa.ImagePullSecrets = desired
+			return sa, r.Update(context.TODO(), sa)
 		}
 		return sa, nil
 	}

--- a/controllers/argocd/service_account_test.go
+++ b/controllers/argocd/service_account_test.go
@@ -30,6 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/common"
 )
 
 func TestReconcileArgoCD_reconcileServiceAccountPermissions(t *testing.T) {
@@ -150,6 +151,111 @@ func TestReconcileArgoCD_reconcileServiceAccountClusterPermissions(t *testing.T)
 	//TODO: https://github.com/stretchr/testify/pull/1022 introduced ErrorContains, but is not yet available in a tagged release. Revert to ErrorContains once this becomes available
 	assert.Error(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRoleName}, reconcileClusterRole))
 	assert.Contains(t, r.Client.Get(context.TODO(), types.NamespacedName{Name: expectedClusterRoleName}, reconcileClusterRole).Error(), "not found")
+}
+
+func TestReconcileServiceAccount_WithImagePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+
+	t.Setenv("IMAGE_PULL_SECRETS", "my-pull-secret")
+
+	sa, err := r.reconcileServiceAccount(common.ArgoCDServerComponent, a)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	reconciledSA := &corev1.ServiceAccount{}
+	expectedName := fmt.Sprintf("%s-%s", a.Name, common.ArgoCDServerComponent)
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledSA))
+	assert.Equal(t, []corev1.LocalObjectReference{{Name: "my-pull-secret"}}, reconciledSA.ImagePullSecrets)
+}
+
+func TestReconcileServiceAccount_WithoutImagePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+
+	sa, err := r.reconcileServiceAccount(common.ArgoCDServerComponent, a)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	reconciledSA := &corev1.ServiceAccount{}
+	expectedName := fmt.Sprintf("%s-%s", a.Name, common.ArgoCDServerComponent)
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledSA))
+	assert.Nil(t, reconciledSA.ImagePullSecrets)
+}
+
+func TestReconcileServiceAccount_UpdateExistingWithPullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+
+	// Create SA without pull secrets
+	_, err := r.reconcileServiceAccount(common.ArgoCDServerComponent, a)
+	assert.NoError(t, err)
+
+	// Now set env var and re-reconcile
+	t.Setenv("IMAGE_PULL_SECRETS", "new-secret")
+	_, err = r.reconcileServiceAccount(common.ArgoCDServerComponent, a)
+	assert.NoError(t, err)
+
+	reconciledSA := &corev1.ServiceAccount{}
+	expectedName := fmt.Sprintf("%s-%s", a.Name, common.ArgoCDServerComponent)
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledSA))
+	assert.Equal(t, []corev1.LocalObjectReference{{Name: "new-secret"}}, reconciledSA.ImagePullSecrets)
+}
+
+func TestReconcileServiceAccount_UpdateExistingRemovePullSecrets(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+	a := makeTestArgoCD()
+
+	resObjs := []client.Object{a}
+	subresObjs := []client.Object{a}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	assert.NoError(t, createNamespace(r, a.Namespace, ""))
+
+	// Create SA with pull secrets
+	t.Setenv("IMAGE_PULL_SECRETS", "old-secret")
+	_, err := r.reconcileServiceAccount(common.ArgoCDServerComponent, a)
+	assert.NoError(t, err)
+
+	// Remove env var and re-reconcile
+	os.Unsetenv("IMAGE_PULL_SECRETS")
+	_, err = r.reconcileServiceAccount(common.ArgoCDServerComponent, a)
+	assert.NoError(t, err)
+
+	reconciledSA := &corev1.ServiceAccount{}
+	expectedName := fmt.Sprintf("%s-%s", a.Name, common.ArgoCDServerComponent)
+	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{Name: expectedName, Namespace: a.Namespace}, reconciledSA))
+	assert.Nil(t, reconciledSA.ImagePullSecrets)
 }
 
 func testRules() []v1.PolicyRule {

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -552,6 +552,12 @@ func (r *ReconcileArgoCD) reconcileResources(cr *argoproj.ArgoCD, argocdStatus *
 		return err
 	}
 
+	log.Info("reconciling image pull secrets")
+	if err := r.reconcileImagePullSecrets(cr); err != nil {
+		log.Info(err.Error())
+		return err
+	}
+
 	log.Info("reconciling service accounts")
 	if err := r.reconcileServiceAccounts(cr); err != nil {
 		log.Info(err.Error())

--- a/controllers/argocdagent/agent/service_account.go
+++ b/controllers/argocdagent/agent/service_account.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -57,7 +58,14 @@ func ReconcileAgentServiceAccount(client client.Client, compName string, cr *arg
 			}
 			return sa, nil
 		}
-		// Service account exists and agent is enabled, nothing to do
+		// Service account exists and agent is enabled, check imagePullSecrets
+		desired := argoutil.GetImagePullSecrets()
+		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+			sa.ImagePullSecrets = desired
+			if err := client.Update(context.TODO(), sa); err != nil {
+				return nil, fmt.Errorf("failed to update agent service account %s imagePullSecrets: %v", sa.Name, err)
+			}
+		}
 		return sa, nil
 	}
 
@@ -85,6 +93,7 @@ func buildServiceAccount(compName string, cr *argoproj.ArgoCD) *corev1.ServiceAc
 			Namespace: cr.Namespace,
 			Labels:    buildLabelsForAgent(cr.Name, compName),
 		},
+		ImagePullSecrets: argoutil.GetImagePullSecrets(),
 	}
 }
 

--- a/controllers/argocdagent/agent/service_account_test.go
+++ b/controllers/argocdagent/agent/service_account_test.go
@@ -205,6 +205,57 @@ func TestReconcileAgentServiceAccount_ServiceAccountExists_AgentEnabled(t *testi
 	assert.Equal(t, buildLabelsForAgent(cr.Name, testAgentCompName), retrievedSA.Labels)
 }
 
+func TestReconcileAgentServiceAccount_WithImagePullSecrets(t *testing.T) {
+	cr := makeTestArgoCD(withAgentEnabled(true))
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerScheme()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	t.Setenv("IMAGE_PULL_SECRETS", "agent-pull-secret")
+
+	sa, err := ReconcileAgentServiceAccount(cl, testAgentCompName, cr, sch)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	retrievedSA := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName),
+		Namespace: cr.Namespace,
+	}, retrievedSA)
+	assert.NoError(t, err)
+	assert.Equal(t, []corev1.LocalObjectReference{{Name: "agent-pull-secret"}}, retrievedSA.ImagePullSecrets)
+}
+
+func TestReconcileAgentServiceAccount_UpdatePullSecrets(t *testing.T) {
+	cr := makeTestArgoCD(withAgentEnabled(true))
+
+	existingSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testAgentCompName),
+			Namespace: cr.Namespace,
+			Labels:    buildLabelsForAgent(cr.Name, testAgentCompName),
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSA}
+	sch := makeTestReconcilerScheme()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	t.Setenv("IMAGE_PULL_SECRETS", "updated-agent-secret")
+
+	_, err := ReconcileAgentServiceAccount(cl, testAgentCompName, cr, sch)
+	assert.NoError(t, err)
+
+	retrievedSA := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testAgentCompName),
+		Namespace: cr.Namespace,
+	}, retrievedSA)
+	assert.NoError(t, err)
+	assert.Equal(t, []corev1.LocalObjectReference{{Name: "updated-agent-secret"}}, retrievedSA.ImagePullSecrets)
+}
+
 func TestReconcileAgentServiceAccount_ServiceAccountExists_AgentNotSet(t *testing.T) {
 	// Test case: ServiceAccount exists but agent is not set (nil)
 	// Expected behavior: Should delete the ServiceAccount

--- a/controllers/argocdagent/service_account.go
+++ b/controllers/argocdagent/service_account.go
@@ -17,6 +17,7 @@ package argocdagent
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -57,7 +58,14 @@ func ReconcilePrincipalServiceAccount(client client.Client, compName string, cr 
 			}
 			return sa, nil
 		}
-		// Service account exists and principal is enabled, nothing to do
+		// Service account exists and principal is enabled, check imagePullSecrets
+		desired := argoutil.GetImagePullSecrets()
+		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+			sa.ImagePullSecrets = desired
+			if err := client.Update(context.TODO(), sa); err != nil {
+				return nil, fmt.Errorf("failed to update principal service account %s imagePullSecrets: %v", sa.Name, err)
+			}
+		}
 		return sa, nil
 	}
 
@@ -85,6 +93,7 @@ func buildServiceAccount(compName string, cr *argoproj.ArgoCD) *corev1.ServiceAc
 			Namespace: cr.Namespace,
 			Labels:    buildLabelsForAgentPrincipal(cr.Name, compName),
 		},
+		ImagePullSecrets: argoutil.GetImagePullSecrets(),
 	}
 }
 

--- a/controllers/argocdagent/service_account_test.go
+++ b/controllers/argocdagent/service_account_test.go
@@ -283,6 +283,57 @@ func TestReconcilePrincipalServiceAccount_ServiceAccountDoesNotExist_AgentNotSet
 	assert.True(t, errors.IsNotFound(err))
 }
 
+func TestReconcilePrincipalServiceAccount_WithImagePullSecrets(t *testing.T) {
+	cr := makeTestArgoCD(withPrincipalEnabled(true))
+
+	resObjs := []client.Object{cr}
+	sch := makeTestReconcilerScheme()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	t.Setenv("IMAGE_PULL_SECRETS", "principal-pull-secret")
+
+	sa, err := ReconcilePrincipalServiceAccount(cl, testCompName, cr, sch)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	retrievedSA := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName),
+		Namespace: cr.Namespace,
+	}, retrievedSA)
+	assert.NoError(t, err)
+	assert.Equal(t, []corev1.LocalObjectReference{{Name: "principal-pull-secret"}}, retrievedSA.ImagePullSecrets)
+}
+
+func TestReconcilePrincipalServiceAccount_UpdatePullSecrets(t *testing.T) {
+	cr := makeTestArgoCD(withPrincipalEnabled(true))
+
+	existingSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateAgentResourceName(cr.Name, testCompName),
+			Namespace: cr.Namespace,
+			Labels:    buildLabelsForAgentPrincipal(cr.Name, testCompName),
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSA}
+	sch := makeTestReconcilerScheme()
+	cl := makeTestReconcilerClient(sch, resObjs)
+
+	t.Setenv("IMAGE_PULL_SECRETS", "new-pull-secret")
+
+	_, err := ReconcilePrincipalServiceAccount(cl, testCompName, cr, sch)
+	assert.NoError(t, err)
+
+	retrievedSA := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{
+		Name:      generateAgentResourceName(cr.Name, testCompName),
+		Namespace: cr.Namespace,
+	}, retrievedSA)
+	assert.NoError(t, err)
+	assert.Equal(t, []corev1.LocalObjectReference{{Name: "new-pull-secret"}}, retrievedSA.ImagePullSecrets)
+}
+
 func TestReconcilePrincipalServiceAccount_ServiceAccountExists_AgentNotSet(t *testing.T) {
 	// Test case: ServiceAccount exists but agent is not set (nil)
 	// Expected behavior: Should delete the ServiceAccount

--- a/controllers/argoutil/namespace.go
+++ b/controllers/argoutil/namespace.go
@@ -15,6 +15,7 @@
 package argoutil
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -37,6 +38,21 @@ func allowedNamespace(current string, namespaces string) bool {
 		}
 	}
 	return false
+}
+
+// OperatorNamespaceFile is the path to the in-cluster service account namespace file.
+var OperatorNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+func GetOperatorNamespace() (string, error) {
+	data, err := os.ReadFile(OperatorNamespaceFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read operator namespace: %w", err)
+	}
+	ns := strings.TrimSpace(string(data))
+	if ns == "" {
+		return "", fmt.Errorf("operator namespace file is empty")
+	}
+	return ns, nil
 }
 
 func splitList(s string) []string {

--- a/controllers/argoutil/namespace_test.go
+++ b/controllers/argoutil/namespace_test.go
@@ -1,0 +1,50 @@
+package argoutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetOperatorNamespace(t *testing.T) {
+	t.Run("reads namespace from file", func(t *testing.T) {
+		dir := t.TempDir()
+		nsFile := filepath.Join(dir, "namespace")
+		require.NoError(t, os.WriteFile(nsFile, []byte("operator-ns\n"), 0644))
+
+		old := OperatorNamespaceFile
+		OperatorNamespaceFile = nsFile
+		defer func() { OperatorNamespaceFile = old }()
+
+		ns, err := GetOperatorNamespace()
+		assert.NoError(t, err)
+		assert.Equal(t, "operator-ns", ns)
+	})
+
+	t.Run("returns error when file empty", func(t *testing.T) {
+		dir := t.TempDir()
+		nsFile := filepath.Join(dir, "namespace")
+		require.NoError(t, os.WriteFile(nsFile, []byte("  \n"), 0644))
+
+		old := OperatorNamespaceFile
+		OperatorNamespaceFile = nsFile
+		defer func() { OperatorNamespaceFile = old }()
+
+		ns, err := GetOperatorNamespace()
+		assert.Error(t, err)
+		assert.Empty(t, ns)
+	})
+
+	t.Run("returns error when file missing", func(t *testing.T) {
+		old := OperatorNamespaceFile
+		OperatorNamespaceFile = "/nonexistent/path/namespace"
+		defer func() { OperatorNamespaceFile = old }()
+
+		ns, err := GetOperatorNamespace()
+		assert.Error(t, err)
+		assert.Empty(t, ns)
+	})
+}

--- a/controllers/argoutil/resource.go
+++ b/controllers/argoutil/resource.go
@@ -351,3 +351,24 @@ func GetImagePullPolicy(policy corev1.PullPolicy) corev1.PullPolicy {
 
 	}
 }
+
+// GetImagePullSecrets returns the image pull secrets configured via the IMAGE_PULL_SECRETS
+// environment variable. Returns nil if no secrets are configured.
+func GetImagePullSecrets() []corev1.LocalObjectReference {
+	envValue := os.Getenv(common.ArgoCDImagePullSecretsEnvName)
+	if envValue == "" {
+		return nil
+	}
+
+	var refs []corev1.LocalObjectReference
+	for _, name := range strings.Split(envValue, ",") {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			refs = append(refs, corev1.LocalObjectReference{Name: name})
+		}
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+	return refs
+}

--- a/controllers/argoutil/resource_test.go
+++ b/controllers/argoutil/resource_test.go
@@ -448,3 +448,68 @@ func TestAnnotationsForCluster_DoesNotPropagateCRAnnotations(t *testing.T) {
 
 	assert.Len(t, annotations, 2, "only the two default annotations should be present")
 }
+
+func TestGetImagePullSecrets(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		expected []corev1.LocalObjectReference
+	}{
+		{
+			name:     "unset env var returns nil",
+			setEnv:   false,
+			expected: nil,
+		},
+		{
+			name:     "empty env var returns nil",
+			envValue: "",
+			setEnv:   true,
+			expected: nil,
+		},
+		{
+			name:     "single secret",
+			envValue: "my-secret",
+			setEnv:   true,
+			expected: []corev1.LocalObjectReference{{Name: "my-secret"}},
+		},
+		{
+			name:     "multiple secrets",
+			envValue: "secret1,secret2,secret3",
+			setEnv:   true,
+			expected: []corev1.LocalObjectReference{
+				{Name: "secret1"},
+				{Name: "secret2"},
+				{Name: "secret3"},
+			},
+		},
+		{
+			name:     "whitespace handling",
+			envValue: " secret1 , secret2 ",
+			setEnv:   true,
+			expected: []corev1.LocalObjectReference{
+				{Name: "secret1"},
+				{Name: "secret2"},
+			},
+		},
+		{
+			name:     "trailing comma",
+			envValue: "secret1,",
+			setEnv:   true,
+			expected: []corev1.LocalObjectReference{{Name: "secret1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(common.ArgoCDImagePullSecretsEnvName, tt.envValue)
+			} else {
+				os.Unsetenv(common.ArgoCDImagePullSecretsEnvName)
+			}
+
+			result := GetImagePullSecrets()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/tests/ginkgo/fixture/secret/fixture.go
+++ b/tests/ginkgo/fixture/secret/fixture.go
@@ -106,6 +106,13 @@ func NotHaveDataKey(key string) matcher.GomegaMatcher {
 
 }
 
+// Exist returns true if the Secret exists in the cluster
+func Exist() matcher.GomegaMatcher {
+	return fetchSecret(func(sec *corev1.Secret) bool {
+		return true
+	})
+}
+
 // This is intentionally NOT exported, for now. Create another function in this file/package that calls this function, and export that.
 func fetchSecret(f func(*corev1.Secret) bool) matcher.GomegaMatcher {
 

--- a/tests/ginkgo/fixture/serviceaccount/fixture.go
+++ b/tests/ginkgo/fixture/serviceaccount/fixture.go
@@ -1,0 +1,46 @@
+package serviceaccount
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	matcher "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+func HaveImagePullSecret(secretName string) matcher.GomegaMatcher {
+	return WithTransform(func(sa *corev1.ServiceAccount) bool {
+		k8sClient, _ := utils.GetE2ETestKubeClient()
+
+		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(sa), sa)
+		if err != nil {
+			GinkgoWriter.Println("HaveImagePullSecret:", err)
+			return false
+		}
+
+		for _, ref := range sa.ImagePullSecrets {
+			if ref.Name == secretName {
+				return true
+			}
+		}
+		GinkgoWriter.Println("HaveImagePullSecret: secret", secretName, "not found in", sa.ImagePullSecrets)
+		return false
+	}, BeTrue())
+}
+
+func Exist() matcher.GomegaMatcher {
+	return WithTransform(func(sa *corev1.ServiceAccount) bool {
+		k8sClient, _ := utils.GetE2ETestKubeClient()
+
+		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(sa), sa)
+		if err != nil {
+			GinkgoWriter.Println("Exist:", err)
+			return false
+		}
+		return true
+	}, BeTrue())
+}

--- a/tests/ginkgo/parallel/1-142_validate_image_pull_secrets_test.go
+++ b/tests/ginkgo/parallel/1-142_validate_image_pull_secrets_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parallel
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	saFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/serviceaccount"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
+
+	Context("1-142_validate_image_pull_secrets", func() {
+
+		var (
+			ctx       context.Context
+			k8sClient client.Client
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureParallelCleanSlate()
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+		})
+
+		It("validates that all ArgoCD SAs have imagePullSecrets when env var is set", func() {
+			Skip("requires IMAGE_PULL_SECRETS env var set on operator deployment")
+
+			secretName := os.Getenv("IMAGE_PULL_SECRETS")
+			if secretName == "" {
+				Skip("IMAGE_PULL_SECRETS not set")
+			}
+
+			By("creating new namespace-scoped Argo CD instance")
+			randomNS, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+			defer cleanupFunc()
+
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: randomNS.Name},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD to be available")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.HavePhase("Available"))
+
+			By("verifying imagePullSecrets on all component SAs")
+			componentSAs := []string{
+				"argocd-argocd-application-controller",
+				"argocd-argocd-server",
+				"argocd-argocd-dex-server",
+				"argocd-argocd-redis",
+				"argocd-argocd-repo-server",
+			}
+
+			for _, saName := range componentSAs {
+				sa := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: randomNS.Name},
+				}
+				Eventually(sa, "2m", "5s").Should(saFixture.HaveImagePullSecret(secretName))
+			}
+		})
+
+		It("validates repo-server uses dedicated SA", func() {
+
+			By("creating new namespace-scoped Argo CD instance")
+			randomNS, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+			defer cleanupFunc()
+
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: randomNS.Name},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD to be available")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.HavePhase("Available"))
+
+			By("verifying repo-server SA exists")
+			repoSA := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd-argocd-repo-server", Namespace: randomNS.Name},
+			}
+			Eventually(repoSA, "2m", "5s").Should(saFixture.Exist())
+		})
+	})
+})

--- a/tests/ginkgo/parallel/1-142_validate_image_pull_secrets_test.go
+++ b/tests/ginkgo/parallel/1-142_validate_image_pull_secrets_test.go
@@ -19,6 +19,7 @@ package parallel
 import (
 	"context"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,6 +29,7 @@ import (
 	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
 	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	secretFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/secret"
 	saFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/serviceaccount"
 	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
 
@@ -50,8 +52,6 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 		})
 
 		It("validates that all ArgoCD SAs have imagePullSecrets when env var is set", func() {
-			Skip("requires IMAGE_PULL_SECRETS env var set on operator deployment")
-
 			secretName := os.Getenv("IMAGE_PULL_SECRETS")
 			if secretName == "" {
 				Skip("IMAGE_PULL_SECRETS not set")
@@ -83,6 +83,37 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 					ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: randomNS.Name},
 				}
 				Eventually(sa, "2m", "5s").Should(saFixture.HaveImagePullSecret(secretName))
+			}
+		})
+
+		It("validates that image pull secrets are copied to ArgoCD namespace", func() {
+			secretNames := os.Getenv("IMAGE_PULL_SECRETS")
+			if secretNames == "" {
+				Skip("IMAGE_PULL_SECRETS not set")
+			}
+
+			By("creating new namespace-scoped Argo CD instance")
+			randomNS, cleanupFunc := fixture.CreateRandomE2ETestNamespaceWithCleanupFunc()
+			defer cleanupFunc()
+
+			argoCD := &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{Name: "argocd", Namespace: randomNS.Name},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD to be available")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.HavePhase("Available"))
+
+			By("verifying image pull secrets are copied to ArgoCD namespace")
+			for _, name := range strings.Split(secretNames, ",") {
+				name = strings.TrimSpace(name)
+				if name == "" {
+					continue
+				}
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: randomNS.Name},
+				}
+				Eventually(secret, "2m", "5s").Should(secretFixture.Exist())
 			}
 		})
 


### PR DESCRIPTION
assisted-by: ClaudeCode

**What type of PR is this?**
/kind enhancement

**What does this PR do / why we need it**:
Previously there was no support for users to set image_pull_secret in argocd for the operator itself, users will now be able to set IMAGE_PULL_SECRETS env var on operator deployment, that will propagate imagePullSecrets on all ArgoCD ServiceAccounts. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
- connect to cluster and run the following command

```
export IMAGE_PULL_SECRETS="11009103-gitops-testing-pull-secret"
make install run 
kubectl create -f - <<EOF
apiVersion: argoproj.io/v1beta1
kind: ArgoCD
metadata:
  name: example-argocd
  namespace: argocd
spec: {}
EOF
# check for Service Account, here checking for redis
kubectl get serviceaccount example-argocd-argocd-redis -n argocd -o yaml
# check for imagePullSecret to be set
apiVersion: v1
imagePullSecrets:
- name: 11009103-gitops-testing-pull-secret                                       #  <- set here     
kind: ServiceAccount
metadata:
  creationTimestamp: "2026-08-12T09:19:11Z"
  labels:
    app.kubernetes.io/managed-by: example-argocd
    app.kubernetes.io/name: argocd-redis
    app.kubernetes.io/part-of: argocd
  name: example-argocd-argocd-redis
  namespace: argocd```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure global image pull secrets through a comma-separated environment variable.
  * Propagate configured pull secrets to Argo CD component and agent service accounts, including updates when configuration changes.
  * Copy required image-pull Secrets into Argo CD namespaces with ownership tracking.
  * Automatically create a dedicated default service account for the repo-server when none is specified.

* **Bug Fixes**
  * Improved reconciliation to remove outdated image-pull-secret references when configuration is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->