### PR TITLE
fix: convert logr printf-style to key-value pairs in networkpolicies

### DIFF
--- a/controllers/argocd/networkpolicies.go
+++ b/controllers/argocd/networkpolicies.go
@@ -240,7 +240,7 @@ func (r *ReconcileArgoCD) ReconcileDexServerNetworkPolicy(cr *argoproj.ArgoCD) e
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -254,7 +254,7 @@ func (r *ReconcileArgoCD) ReconcileDexServerNetworkPolicy(cr *argoproj.ArgoCD) e
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -345,7 +345,7 @@ func (r *ReconcileArgoCD) ReconcileApplicationSetControllerNetworkPolicy(cr *arg
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -359,7 +359,7 @@ func (r *ReconcileArgoCD) ReconcileApplicationSetControllerNetworkPolicy(cr *arg
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -713,7 +713,7 @@ func (r *ReconcileArgoCD) ReconcileNotificationsControllerNetworkPolicy(cr *argo
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -727,7 +727,7 @@ func (r *ReconcileArgoCD) ReconcileNotificationsControllerNetworkPolicy(cr *argo
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -793,7 +793,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDServerNetworkPolicy(cr *argoproj.ArgoCD
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -807,7 +807,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDServerNetworkPolicy(cr *argoproj.ArgoCD
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -888,7 +888,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDApplicationControllerNetworkPolicy(cr *
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -902,7 +902,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDApplicationControllerNetworkPolicy(cr *
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -1030,7 +1030,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDRepoServerNetworkPolicy(cr *argoproj.Ar
 		if modified {
 			argoutil.LogResourceUpdate(log, existing, "updating", explanation)
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, "Failed to update %s network policy in namespace %s", existing.Name, cr.Namespace)
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -1044,7 +1044,7 @@ func (r *ReconcileArgoCD) ReconcileArgoCDRepoServerNetworkPolicy(cr *argoproj.Ar
 
 	argoutil.LogResourceCreation(log, desired)
 	if err := r.Create(context.TODO(), desired); err != nil {
-		log.Error(err, "Failed to create %s network policy in namespace %s", existing.Name, cr.Namespace)
+		log.Error(err, "Failed to create network policy", "name", existing.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 	}
 
@@ -1116,7 +1116,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterNetworkPolicy(name string, cr *ar
 		if len(changes) > 0 {
 			argoutil.LogResourceUpdate(log, existing, "updating", strings.Join(changes, ", "))
 			if err := r.Update(context.TODO(), existing); err != nil {
-				log.Error(err, fmt.Sprintf("Failed to update %s network policy in namespace: %s", existing.Name, cr.Namespace))
+				log.Error(err, "Failed to update network policy", "name", existing.Name, "namespace", cr.Namespace)
 				return fmt.Errorf("failed to update %s network policy in namespace %s. error: %w", existing.Name, cr.Namespace, err)
 			}
 		}
@@ -1128,7 +1128,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterNetworkPolicy(name string, cr *ar
 	}
 	argoutil.LogResourceCreation(log, policy)
 	if err := r.Create(context.TODO(), policy); err != nil {
-		log.Error(err, fmt.Sprintf("Failed to create %s network policy in namespace: %s", policy.Name, cr.Namespace))
+		log.Error(err, "Failed to create network policy", "name", policy.Name, "namespace", cr.Namespace)
 		return fmt.Errorf("failed to create %s network policy in namespace %s. error: %w", policy.Name, cr.Namespace, err)
 	}
 	return nil


### PR DESCRIPTION
logr.Logger.Error() expects a static message string followed by structured key-value pairs. Several call sites in controllers/argocd/networkpolicies.go were passing printf-style format strings with %s placeholders and extra positional arguments directly to log.Error(), which would not interpolate as intended and instead be treated as invalid key-value pairs.

Converted all 14 affected call sites to use logr's key-value pair convention, and replaced the two fmt.Sprintf-based workarounds with the same pattern for consistency.

Fixes #2271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for network policy creation and updates by clearly identifying the affected policy name and namespace.
  * Network policy error handling and return behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->