### PR TITLE
fix: include ca.crt key in auto-generated CA ConfigMap

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -381,7 +381,13 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoproj.ArgoCD) error {
 
 	// ConfigMap exists — only update if ca.crt key is missing (backfill for pre-fix ConfigMaps)
 	if _, hasCACert := existingCM.Data[common.ArgoCDKeyTLSCACert]; !hasCACert {
-		existingCM.Data = desiredData
+		if existingCM.Data == nil {
+			existingCM.Data = make(map[string]string)
+		}
+		if _, hasTLSCert := existingCM.Data[common.ArgoCDKeyTLSCert]; !hasTLSCert {
+			existingCM.Data[common.ArgoCDKeyTLSCert] = desiredData[common.ArgoCDKeyTLSCert]
+		}
+		existingCM.Data[common.ArgoCDKeyTLSCACert] = desiredData[common.ArgoCDKeyTLSCACert]
 		argoutil.LogResourceUpdate(log, existingCM)
 		return r.Update(context.TODO(), existingCM)
 	}

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -369,11 +369,10 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoproj.ArgoCD) error {
 		common.ArgoCDKeyTLSCACert: string(caSecret.Data[common.ArgoCDKeyTLSCACert]),
 	}
 
-	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
-		return err
-	}
-
 	if !configMapExists {
+		if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
+			return err
+		}
 		cm.Data = desiredData
 		argoutil.LogResourceCreation(log, cm)
 		return r.Create(context.TODO(), cm)

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -348,14 +348,6 @@ func (r *ReconcileArgoCD) reconcileConfigMaps(cr *argoproj.ArgoCD, useTLSForRedi
 func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(getCAConfigMapName(cr), cr)
 
-	configMapExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, cm)
-	if err != nil {
-		return err
-	}
-	if configMapExists {
-		return nil // ConfigMap found, do nothing
-	}
-
 	caSecret := argoutil.NewSecretWithSuffix(cr, common.ArgoCDCASuffix)
 	caSecretExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, caSecret.Name, caSecret)
 	if err != nil {
@@ -366,15 +358,35 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoproj.ArgoCD) error {
 		return nil
 	}
 
-	cm.Data = map[string]string{
-		common.ArgoCDKeyTLSCert: string(caSecret.Data[common.ArgoCDKeyTLSCert]),
+	existingCM := &corev1.ConfigMap{}
+	configMapExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, cm.Name, existingCM)
+	if err != nil {
+		return err
+	}
+
+	desiredData := map[string]string{
+		common.ArgoCDKeyTLSCert:   string(caSecret.Data[common.ArgoCDKeyTLSCert]),
+		common.ArgoCDKeyTLSCACert: string(caSecret.Data[common.ArgoCDKeyTLSCACert]),
 	}
 
 	if err := controllerutil.SetControllerReference(cr, cm, r.Scheme); err != nil {
 		return err
 	}
-	argoutil.LogResourceCreation(log, cm)
-	return r.Create(context.TODO(), cm)
+
+	if !configMapExists {
+		cm.Data = desiredData
+		argoutil.LogResourceCreation(log, cm)
+		return r.Create(context.TODO(), cm)
+	}
+
+	// ConfigMap exists — only update if ca.crt key is missing (backfill for pre-fix ConfigMaps)
+	if _, hasCACert := existingCM.Data[common.ArgoCDKeyTLSCACert]; !hasCACert {
+		existingCM.Data = desiredData
+		argoutil.LogResourceUpdate(log, existingCM)
+		return r.Update(context.TODO(), existingCM)
+	}
+
+	return nil
 }
 
 // reconcileConfiguration will ensure that the main ConfigMap for ArgoCD is present.

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -2138,3 +2138,75 @@ func TestReconcileArgoCD_reconcileArgoConfigMap_sensitiveAnnotations(t *testing.
 			"token annotation should not be duplicated")
 	})
 }
+
+func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	t.Run("creates ConfigMap with both tls.crt and ca.crt keys", func(t *testing.T) {
+		a := makeTestArgoCD()
+
+		caSecret, err := newCASecret(a)
+		require.NoError(t, err)
+
+		resObjs := []client.Object{a, caSecret}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err = r.reconcileCAConfigMap(a)
+		require.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      getCAConfigMapName(a),
+			Namespace: a.Namespace,
+		}, cm)
+		require.NoError(t, err)
+
+		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCert, "ConfigMap should have tls.crt key")
+		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCACert, "ConfigMap should have ca.crt key")
+		assert.Equal(t, string(caSecret.Data[corev1.TLSCertKey]), cm.Data[common.ArgoCDKeyTLSCert])
+		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
+	})
+
+	t.Run("updates ConfigMap when ca.crt key is missing", func(t *testing.T) {
+		a := makeTestArgoCD()
+
+		caSecret, err := newCASecret(a)
+		require.NoError(t, err)
+
+		// Create ConfigMap with only tls.crt (simulating pre-fix state)
+		oldCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      getCAConfigMapName(a),
+				Namespace: a.Namespace,
+			},
+			Data: map[string]string{
+				common.ArgoCDKeyTLSCert: string(caSecret.Data[corev1.TLSCertKey]),
+			},
+		}
+
+		resObjs := []client.Object{a, caSecret, oldCM}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err = r.reconcileCAConfigMap(a)
+		require.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      getCAConfigMapName(a),
+			Namespace: a.Namespace,
+		}, cm)
+		require.NoError(t, err)
+
+		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCert, "ConfigMap should still have tls.crt key")
+		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCACert, "ConfigMap should now have ca.crt key added")
+		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
+	})
+}

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -30,9 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	testclient "k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	testclient "k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -2185,7 +2185,7 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 				Namespace: a.Namespace,
 			},
 			Data: map[string]string{
-				common.ArgoCDKeyTLSCert: string(caSecret.Data[corev1.TLSCertKey]),
+				common.ArgoCDKeyTLSCert: "existing-tls",
 				"someOtherKey":          "someValue",
 			},
 		}
@@ -2207,7 +2207,7 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		}, cm)
 		require.NoError(t, err)
 
-		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCert, "ConfigMap should still have tls.crt key")
+		assert.Equal(t, "existing-tls", cm.Data[common.ArgoCDKeyTLSCert], "existing tls.crt should be preserved")
 		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCACert, "ConfigMap should now have ca.crt key added")
 		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
 		assert.Contains(t, cm.Data, "someOtherKey", "existing keys should be preserved")
@@ -2220,29 +2220,26 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		caSecret, err := newCASecret(a)
 		require.NoError(t, err)
 
-		// Create ConfigMap with both keys (simulating post-fix state)
+		// Create ConfigMap with sentinel values (simulating post-fix state)
 		existingCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      getCAConfigMapName(a),
 				Namespace: a.Namespace,
 			},
 			Data: map[string]string{
-				common.ArgoCDKeyTLSCert:   string(caSecret.Data[corev1.TLSCertKey]),
-				common.ArgoCDKeyTLSCACert: string(caSecret.Data[corev1.ServiceAccountRootCAKey]),
+				common.ArgoCDKeyTLSCert:   "sentinel-tls",
+				common.ArgoCDKeyTLSCACert: "sentinel-ca",
 			},
 		}
-
-		k8sClient := testclient.NewSimpleClientset()
-		k8sClient.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
-			return true, nil, fmt.Errorf("unexpected Update call to configmaps")
-		})
 
 		resObjs := []client.Object{a, caSecret, existingCM}
 		subresObjs := []client.Object{a}
 		runtimeObjs := []runtime.Object{}
 		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
-		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
-		r := makeTestReconciler(cl, sch, k8sClient)
+		cl := fake.NewClientBuilder().WithScheme(sch).WithObjects(resObjs...).WithStatusSubresource(subresObjs...).WithRuntimeObjects(runtimeObjs...).WithInterceptorFuncs(interceptor.Funcs{Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			return fmt.Errorf("unexpected Update call to configmaps")
+		}}).Build()
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 		err = r.reconcileCAConfigMap(a)
 		require.NoError(t, err)
@@ -2254,7 +2251,7 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		}, cm)
 		require.NoError(t, err)
 
-		assert.Equal(t, string(caSecret.Data[corev1.TLSCertKey]), cm.Data[common.ArgoCDKeyTLSCert])
-		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
+		assert.Equal(t, "sentinel-tls", cm.Data[common.ArgoCDKeyTLSCert], "existing tls.crt should be preserved unchanged")
+		assert.Equal(t, "sentinel-ca", cm.Data[common.ArgoCDKeyTLSCACert], "existing ca.crt should be preserved unchanged")
 	})
 }

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -2177,7 +2177,7 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		caSecret, err := newCASecret(a)
 		require.NoError(t, err)
 
-		// Create ConfigMap with only tls.crt (simulating pre-fix state)
+		// Create ConfigMap with only tls.crt + an extra key (simulating pre-fix state with custom data)
 		oldCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      getCAConfigMapName(a),
@@ -2185,6 +2185,7 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 			},
 			Data: map[string]string{
 				common.ArgoCDKeyTLSCert: string(caSecret.Data[corev1.TLSCertKey]),
+				"someOtherKey":          "someValue",
 			},
 		}
 
@@ -2208,5 +2209,7 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCert, "ConfigMap should still have tls.crt key")
 		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCACert, "ConfigMap should now have ca.crt key added")
 		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
+		assert.Contains(t, cm.Data, "someOtherKey", "existing keys should be preserved")
+		assert.Equal(t, "someValue", cm.Data["someOtherKey"], "existing key values should be preserved")
 	})
 }

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	testclient "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -2211,5 +2212,49 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
 		assert.Contains(t, cm.Data, "someOtherKey", "existing keys should be preserved")
 		assert.Equal(t, "someValue", cm.Data["someOtherKey"], "existing key values should be preserved")
+	})
+
+	t.Run("no-op when both keys are already present", func(t *testing.T) {
+		a := makeTestArgoCD()
+
+		caSecret, err := newCASecret(a)
+		require.NoError(t, err)
+
+		// Create ConfigMap with both keys (simulating post-fix state)
+		existingCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      getCAConfigMapName(a),
+				Namespace: a.Namespace,
+			},
+			Data: map[string]string{
+				common.ArgoCDKeyTLSCert:   string(caSecret.Data[corev1.TLSCertKey]),
+				common.ArgoCDKeyTLSCACert: string(caSecret.Data[corev1.ServiceAccountRootCAKey]),
+			},
+		}
+
+		k8sClient := testclient.NewSimpleClientset()
+		k8sClient.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("unexpected Update call to configmaps")
+		})
+
+		resObjs := []client.Object{a, caSecret, existingCM}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, k8sClient)
+
+		err = r.reconcileCAConfigMap(a)
+		require.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      getCAConfigMapName(a),
+			Namespace: a.Namespace,
+		}, cm)
+		require.NoError(t, err)
+
+		assert.Equal(t, string(caSecret.Data[corev1.TLSCertKey]), cm.Data[common.ArgoCDKeyTLSCert])
+		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
 	})
 }


### PR DESCRIPTION
## Problem

When `tls.ca: {}` is set (auto-generate CA), the operator creates the CA ConfigMap (`argocd-ca`) with only the `tls.crt` key. OpenShift-native consumers (BackendTLSPolicy, service-ca) expect the CA certificate under the standard `ca.crt` key, requiring a Kyverno mutation policy workaround.

## Solution

Populate the ConfigMap with both `tls.crt` and `ca.crt` keys. This matches the pattern already used by the CA Secret, which stores the certificate under both keys via `corev1.TLSCertKey` and `corev1.ServiceAccountRootCAKey`.

The ConfigMap update is conditional — existing ConfigMaps are only updated if the `ca.crt` key is missing, avoiding unnecessary API calls on subsequent reconciles.

## Fixes

- argoproj-labs/argocd-operator#147 — "Using custom TLS certificates with ArgoCD"
- argoproj-labs/argocd-operator#235 — "Changing route termination to reencrypt fails"
- ArthurVardevanyan/HomeLab#508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CA ConfigMaps now include both certificate and CA certificate data when created.
  * Existing CA ConfigMaps missing CA certificate data are automatically updated during reconciliation.
  * Existing certificate data and custom configuration are preserved during updates.
  * ConfigMaps that already contain CA certificate data remain unchanged.
  * Prevents incomplete certificate configuration from persisting and improves certificate configuration reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->