### PR TITLE
feat: implement wildcard support for IMAGE_UPDATER_WATCH_NAMESPACES

### DIFF
--- a/controllers/argocd/argocd_controller.go
+++ b/controllers/argocd/argocd_controller.go
@@ -394,7 +394,7 @@ func (r *ReconcileArgoCD) internalReconcile(ctx context.Context, request ctrl.Re
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReconcileArgoCD) SetupWithManager(mgr ctrl.Manager) error {
 	bldr := ctrl.NewControllerManagedBy(mgr)
-	r.setResourceWatches(bldr, r.clusterResourceMapper, r.tlsSecretMapper, r.namespaceResourceMapper, r.clusterSecretResourceMapper, r.applicationSetSCMTLSConfigMapMapper, r.nmMapper, r.systemCATrustMapper, r.imagePullSecretMapper)
+	r.setResourceWatches(bldr, r.clusterResourceMapper, r.tlsSecretMapper, r.namespaceResourceMapper, r.clusterSecretResourceMapper, r.applicationSetSCMTLSConfigMapMapper, r.nmMapper, r.systemCATrustMapper, r.imagePullSecretMapper, r.imageUpdaterWatchNSMapper)
 	return bldr.Complete(r)
 }
 

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -313,9 +313,9 @@ func (r *ReconcileArgoCD) imageUpdaterWatchNSMapper(ctx context.Context, o clien
 			// "*" → cluster-wide (no per-namespace patterns)
 			continue
 		}
-		patterns := strings.Split(watchNS, ",")
-		for j := range patterns {
-			patterns[j] = strings.TrimSpace(patterns[j])
+		patterns := splitAndFilterPatterns(watchNS)
+		if len(patterns) == 0 {
+			continue
 		}
 		if glob.MatchStringInList(patterns, namespaceName, glob.REGEXP) {
 			result = append(result, reconcile.Request{

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -9,6 +9,7 @@ import (
 
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
+	"github.com/argoproj-labs/argocd-operator/controllers/argoutil"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -276,6 +277,50 @@ func (r *ReconcileArgoCD) applicationSetSCMTLSConfigMapMapper(ctx context.Contex
 		}
 		result = []reconcile.Request{
 			{NamespacedName: namespacedName},
+		}
+	}
+
+	return result
+}
+
+// imageUpdaterWatchNSMapper maps a Namespace create/delete event to every ArgoCD instance
+// whose IMAGE_UPDATER_WATCH_NAMESPACES glob/regex patterns match that namespace name.
+// This ensures RBAC and the deployment env var are refreshed immediately when a matching
+// namespace appears or disappears, rather than waiting for the next unrelated reconcile
+// on the ArgoCD CR itself.
+func (r *ReconcileArgoCD) imageUpdaterWatchNSMapper(ctx context.Context, o client.Object) []reconcile.Request {
+	var result []reconcile.Request
+
+	namespaceName := o.GetName()
+
+	argocds := &argoproj.ArgoCDList{}
+	if err := r.List(ctx, argocds, &client.ListOptions{}); err != nil {
+		return result
+	}
+
+	for i := range argocds.Items {
+		argocd := &argocds.Items[i]
+		if !argocd.Spec.ImageUpdater.Enabled {
+			continue
+		}
+		env := argoutil.EnvGet(argocd.Spec.ImageUpdater.Env, "IMAGE_UPDATER_WATCH_NAMESPACES")
+		if env == nil {
+			continue
+		}
+		watchNS := strings.TrimSpace(env.Value)
+		if watchNS == "" || watchNS == "*" {
+			// "" → namespace-scoped (no per-namespace patterns)
+			// "*" → cluster-wide (no per-namespace patterns)
+			continue
+		}
+		patterns := strings.Split(watchNS, ",")
+		for j := range patterns {
+			patterns[j] = strings.TrimSpace(patterns[j])
+		}
+		if glob.MatchStringInList(patterns, namespaceName, glob.REGEXP) {
+			result = append(result, reconcile.Request{
+				NamespacedName: client.ObjectKey{Name: argocd.Name, Namespace: argocd.Namespace},
+			})
 		}
 	}
 

--- a/controllers/argocd/custommapper.go
+++ b/controllers/argocd/custommapper.go
@@ -308,12 +308,14 @@ func (r *ReconcileArgoCD) imageUpdaterWatchNSMapper(ctx context.Context, o clien
 			continue
 		}
 		watchNS := strings.TrimSpace(env.Value)
-		if watchNS == "" || watchNS == "*" {
-			// "" → namespace-scoped (no per-namespace patterns)
-			// "*" → cluster-wide (no per-namespace patterns)
+		// normalizeWatchNamespaces canonicalizes "*," → "*", rejects "*,team-a", etc.
+		// On error (invalid config) or when the value resolves to a sentinel, skip:
+		// the main reconcile loop will surface the error.
+		normalized, err := normalizeWatchNamespaces(watchNS)
+		if err != nil || normalized == "" || normalized == "*" {
 			continue
 		}
-		patterns := splitAndFilterPatterns(watchNS)
+		patterns := splitAndFilterPatterns(normalized)
 		if len(patterns) == 0 {
 			continue
 		}

--- a/controllers/argocd/custommapper_test.go
+++ b/controllers/argocd/custommapper_test.go
@@ -1210,3 +1210,74 @@ func TestReconcileArgoCD_imageUpdaterWatchNSMapper(t *testing.T) {
 		})
 	}
 }
+
+// TestReconcileArgoCD_imageUpdaterWatchNSMapper_EmptyPatterns verifies that a trailing
+// or leading comma in IMAGE_UPDATER_WATCH_NAMESPACES does not produce a match-all empty
+// pattern, which would otherwise enqueue a reconcile for every namespace in the cluster.
+func TestReconcileArgoCD_imageUpdaterWatchNSMapper_EmptyPatterns(t *testing.T) {
+	tests := []struct {
+		name           string
+		watchNamespace string
+		triggerNS      string // namespace event that fires the mapper
+		wantReconcile  bool   // whether a reconcile request is expected
+	}{
+		{
+			name:           "trailing comma: only valid pattern matches, not everything",
+			watchNamespace: "app-*,",
+			triggerNS:      "app-frontend",
+			wantReconcile:  true,
+		},
+		{
+			name:           "trailing comma: non-matching namespace is still rejected",
+			watchNamespace: "app-*,",
+			triggerNS:      "other-ns",
+			wantReconcile:  false,
+		},
+		{
+			name:           "only commas: no valid patterns → no reconcile for any namespace",
+			watchNamespace: ",,,",
+			triggerNS:      "app-frontend",
+			wantReconcile:  false,
+		},
+		{
+			name:           "leading and trailing commas with valid pattern",
+			watchNamespace: ",app-*,",
+			triggerNS:      "app-frontend",
+			wantReconcile:  true,
+		},
+		{
+			name:           "leading and trailing commas: non-matching namespace is still rejected",
+			watchNamespace: ",app-*,",
+			triggerNS:      "other-ns",
+			wantReconcile:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argocd := makeTestArgoCD()
+			argocd.Name = "test-argocd"
+			argocd.Namespace = "test-ns"
+			argocd.Spec.ImageUpdater.Enabled = true
+			argocd.Spec.ImageUpdater.Env = []corev1.EnvVar{
+				{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: tt.watchNamespace},
+			}
+			argocd.ResourceVersion = ""
+
+			resObjs := []client.Object{argocd}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, resObjs, []runtime.Object{})
+			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tt.triggerNS}}
+			got := r.imageUpdaterWatchNSMapper(context.TODO(), ns)
+
+			if tt.wantReconcile {
+				assert.Len(t, got, 1)
+				assert.Equal(t, types.NamespacedName{Name: "test-argocd", Namespace: "test-ns"}, got[0].NamespacedName)
+			} else {
+				assert.Empty(t, got)
+			}
+		})
+	}
+}

--- a/controllers/argocd/custommapper_test.go
+++ b/controllers/argocd/custommapper_test.go
@@ -1251,6 +1251,18 @@ func TestReconcileArgoCD_imageUpdaterWatchNSMapper_EmptyPatterns(t *testing.T) {
 			triggerNS:      "other-ns",
 			wantReconcile:  false,
 		},
+		{
+			name:           "sole * with trailing comma is treated as cluster-scoped (skipped by mapper)",
+			watchNamespace: "*,",
+			triggerNS:      "any-namespace",
+			wantReconcile:  false,
+		},
+		{
+			name:           "* mixed with pattern is skipped by mapper (invalid config handled by reconciler)",
+			watchNamespace: "*,team-a",
+			triggerNS:      "team-a",
+			wantReconcile:  false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/controllers/argocd/custommapper_test.go
+++ b/controllers/argocd/custommapper_test.go
@@ -1103,3 +1103,110 @@ func TestReconcileArgoCD_nmMapper(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileArgoCD_imageUpdaterWatchNSMapper(t *testing.T) {
+	argocd1 := makeTestArgoCD()
+	argocd1.Name = "argocd1"
+	argocd1.Namespace = "argo-ns-1"
+	argocd1.Spec.ImageUpdater.Enabled = true
+	argocd1.Spec.ImageUpdater.Env = []corev1.EnvVar{
+		{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "app-*"},
+	}
+
+	argocd2 := makeTestArgoCD()
+	argocd2.Name = "argocd2"
+	argocd2.Namespace = "argo-ns-2"
+	argocd2.Spec.ImageUpdater.Enabled = true
+	argocd2.Spec.ImageUpdater.Env = []corev1.EnvVar{
+		{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "/^team-[a-z]+$/"},
+	}
+
+	argocd3 := makeTestArgoCD()
+	argocd3.Name = "argocd3"
+	argocd3.Namespace = "argo-ns-3"
+	argocd3.Spec.ImageUpdater.Enabled = false
+	argocd3.Spec.ImageUpdater.Env = []corev1.EnvVar{
+		{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "app-*"},
+	}
+
+	argocd4 := makeTestArgoCD()
+	argocd4.Name = "argocd4"
+	argocd4.Namespace = "argo-ns-4"
+	argocd4.Spec.ImageUpdater.Enabled = true
+	// No IMAGE_UPDATER_WATCH_NAMESPACES → skip
+
+	argocd5 := makeTestArgoCD()
+	argocd5.Name = "argocd5"
+	argocd5.Namespace = "argo-ns-5"
+	argocd5.Spec.ImageUpdater.Enabled = true
+	argocd5.Spec.ImageUpdater.Env = []corev1.EnvVar{
+		{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "*"},
+	}
+
+	for _, a := range []*argoproj.ArgoCD{argocd1, argocd2, argocd3, argocd4, argocd5} {
+		a.ResourceVersion = ""
+	}
+
+	resObjs := []client.Object{argocd1, argocd2, argocd3, argocd4, argocd5}
+	subresObjs := []client.Object{argocd1, argocd2, argocd3, argocd4, argocd5}
+	runtimeObjs := []runtime.Object{}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+	req1 := reconcile.Request{NamespacedName: types.NamespacedName{Name: "argocd1", Namespace: "argo-ns-1"}}
+	req2 := reconcile.Request{NamespacedName: types.NamespacedName{Name: "argocd2", Namespace: "argo-ns-2"}}
+
+	tests := []struct {
+		name      string
+		namespace string
+		want      []reconcile.Request
+	}{
+		{
+			name:      "glob match triggers reconcile for argocd1",
+			namespace: "app-frontend",
+			want:      []reconcile.Request{req1},
+		},
+		{
+			name:      "glob non-match triggers no reconcile",
+			namespace: "other-ns",
+			want:      []reconcile.Request{},
+		},
+		{
+			name:      "regex match triggers reconcile for argocd2",
+			namespace: "team-alpha",
+			want:      []reconcile.Request{req2},
+		},
+		{
+			name:      "regex non-match (digits not lower-alpha) triggers no reconcile",
+			namespace: "team-123",
+			want:      []reconcile.Request{},
+		},
+		{
+			name:      "disabled image updater is ignored",
+			namespace: "app-ignored",
+			// argocd1 has app-* and is enabled; argocd3 has app-* but is disabled
+			want: []reconcile.Request{req1},
+		},
+		{
+			name:      "argocd with no IMAGE_UPDATER_WATCH_NAMESPACES is ignored",
+			namespace: "any-namespace",
+			// argocd4 is enabled but has no env var
+			want: []reconcile.Request{},
+		},
+		{
+			name:      "wildcard '*' is skipped (cluster-wide mode, no per-namespace matching)",
+			namespace: "app-star-match",
+			// argocd1 matches app-*, argocd5 has '*' which is skipped
+			want: []reconcile.Request{req1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tt.namespace}}
+			got := r.imageUpdaterWatchNSMapper(context.TODO(), ns)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -768,14 +768,28 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, s
 	return r.reconcileDeploymentHelper(cr, desiredDeployment, "image updater", cr.Spec.ImageUpdater.Enabled)
 }
 
+// splitAndFilterPatterns splits a comma-separated pattern string, trims whitespace from
+// each token, and discards empty entries that result from trailing/leading commas or
+// consecutive commas. An empty pattern would match every namespace under glob semantics,
+// which could silently grant cluster-wide RBAC access.
+func splitAndFilterPatterns(raw string) []string {
+	var patterns []string
+	for _, p := range strings.Split(raw, ",") {
+		if t := strings.TrimSpace(p); t != "" {
+			patterns = append(patterns, t)
+		}
+	}
+	return patterns
+}
+
 // expandImageUpdaterWatchNamespaces lists all cluster namespaces and returns those that
 // match any pattern in the comma-separated watchNamespaces value. Each pattern may be a
 // glob-style wildcard or a full regular expression (the same semantics used by
 // .spec.applicationSet.sourceNamespaces). The returned slice is sorted for determinism.
 func (r *ReconcileArgoCD) expandImageUpdaterWatchNamespaces(watchNamespaces string) ([]string, error) {
-	patterns := strings.Split(watchNamespaces, ",")
-	for i := range patterns {
-		patterns[i] = strings.TrimSpace(patterns[i])
+	patterns := splitAndFilterPatterns(watchNamespaces)
+	if len(patterns) == 0 {
+		return nil, nil
 	}
 
 	clusterNamespaces := &corev1.NamespaceList{}

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -839,6 +839,8 @@ func splitAndFilterPatterns(raw string) []string {
 // match any pattern in the comma-separated watchNamespaces value. Each pattern may be a
 // glob-style wildcard or a full regular expression (the same semantics used by
 // .spec.applicationSet.sourceNamespaces). The returned slice is sorted for determinism.
+// Namespaces in a Terminating state (DeletionTimestamp != nil) are excluded from both
+// the match result and the total count, as creating content in such namespaces is forbidden.
 func (r *ReconcileArgoCD) expandImageUpdaterWatchNamespaces(watchNamespaces string) ([]string, error) {
 	patterns := splitAndFilterPatterns(watchNamespaces)
 	if len(patterns) == 0 {
@@ -850,23 +852,33 @@ func (r *ReconcileArgoCD) expandImageUpdaterWatchNamespaces(watchNamespaces stri
 		return nil, err
 	}
 
+	// Namespaces in Terminating state reject object creation with 403 (not NotFound), which
+	// would abort the entire reconcile. Exclude them from the match set — and from the
+	// all-namespaces comparison below, so a terminating namespace cannot mask a
+	// match-everything pattern.
+	activeCount := 0
 	var matched []string
 	for _, ns := range clusterNamespaces.Items {
+		if ns.DeletionTimestamp != nil {
+			log.Info("skipping terminating namespace for Image Updater RBAC", "namespace", ns.Name)
+			continue
+		}
+		activeCount++
 		if glob.MatchStringInList(patterns, ns.Name, glob.REGEXP) {
 			matched = append(matched, ns.Name)
 		}
 	}
 
-	// Guard against patterns that silently expand to every namespace (e.g. "**", "?*",
+	// Guard against patterns that silently expand to every active namespace (e.g. "**", "?*",
 	// "/.*/"). Such a result is semantically identical to cluster-scoped mode ("*") but
 	// bypasses the IsNamespaceClusterConfigNamespace restriction that the "*" sentinel
 	// enforces. Returning an error here prevents unintended privilege escalation and
 	// directs the user to the correct, explicit cluster-scoped configuration.
-	if len(clusterNamespaces.Items) > 0 && len(matched) == len(clusterNamespaces.Items) {
+	if activeCount > 0 && len(matched) == activeCount {
 		return nil, fmt.Errorf(
-			"IMAGE_UPDATER_WATCH_NAMESPACES %q matches all %d cluster namespaces; "+
+			"IMAGE_UPDATER_WATCH_NAMESPACES %q matches all %d active cluster namespaces; "+
 				"use \"*\" for cluster-scoped mode",
-			watchNamespaces, len(clusterNamespaces.Items),
+			watchNamespaces, activeCount,
 		)
 	}
 

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -60,6 +60,15 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 	if env := argoutil.EnvGet(cr.Spec.ImageUpdater.Env, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
 		watchNamespaces = strings.TrimSpace(env.Value)
 	}
+
+	// Normalize before branching: canonicalize sole-"*" variants (e.g. "*,") back to the
+	// "*" sentinel and reject ambiguous mixes like "*,team-a" that would bypass the
+	// cluster-scope restriction in reconcileImageUpdaterRBAC.
+	watchNamespaces, err = normalizeWatchNamespaces(watchNamespaces)
+	if err != nil {
+		return err
+	}
+
 	var expandedNamespaces []string
 	if watchNamespaces != "" && watchNamespaces != "*" {
 		expandedNamespaces, err = r.expandImageUpdaterWatchNamespaces(watchNamespaces)
@@ -766,6 +775,39 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, s
 	}}
 
 	return r.reconcileDeploymentHelper(cr, desiredDeployment, "image updater", cr.Spec.ImageUpdater.Enabled)
+}
+
+// normalizeWatchNamespaces validates and normalizes a raw IMAGE_UPDATER_WATCH_NAMESPACES
+// value. It strips empty tokens produced by trailing, leading, or consecutive commas,
+// then applies the following rules:
+//   - No tokens remain (e.g. ",,,"): returns "" → namespace-scoped mode.
+//   - The sole remaining token is "*" (e.g. "*,"): returns "*" → cluster-scoped mode,
+//     so the IsNamespaceClusterConfigNamespace restriction is still enforced.
+//   - "*" appears alongside other patterns (e.g. "*,team-a"): returns an error, because
+//     the combination is ambiguous and would bypass the cluster-scope restriction.
+//   - Any other non-empty pattern list: returns the original value unchanged.
+func normalizeWatchNamespaces(raw string) (string, error) {
+	// Fast path for the two already-canonical sentinels.
+	if raw == "" || raw == "*" {
+		return raw, nil
+	}
+	patterns := splitAndFilterPatterns(raw)
+	switch {
+	case len(patterns) == 0:
+		return "", nil
+	case len(patterns) == 1 && patterns[0] == "*":
+		return "*", nil
+	default:
+		for _, p := range patterns {
+			if p == "*" {
+				return "", fmt.Errorf(
+					`IMAGE_UPDATER_WATCH_NAMESPACES %q mixes "*" with other patterns; use "*" alone for cluster-scoped mode or remove "*" from the list`,
+					raw,
+				)
+			}
+		}
+		return raw, nil
+	}
 }
 
 // splitAndFilterPatterns splits a comma-separated pattern string, trims whitespace from

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -615,7 +615,18 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, s
 	// If expandedNamespaces is empty the pattern currently matches nothing: keep the raw
 	// value so the pod fails with a meaningful error rather than silently switching to
 	// namespace-scoped mode without the required RBAC.
-	if watchNamespaces != "" && watchNamespaces != "*" {
+	switch watchNamespaces {
+	case "*":
+		// Cluster-scoped: explicitly set IMAGE_UPDATER_WATCH_NAMESPACES="*"
+		imageUpdaterEnv = argoutil.EnvSet(imageUpdaterEnv, corev1.EnvVar{
+			Name:  "IMAGE_UPDATER_WATCH_NAMESPACES",
+			Value: "*",
+		})
+	case "":
+		// Namespace-scoped: remove IMAGE_UPDATER_WATCH_NAMESPACES to use the controller's default
+		imageUpdaterEnv = argoutil.EnvRemove(imageUpdaterEnv, "IMAGE_UPDATER_WATCH_NAMESPACES")
+	default:
+		// Pattern list: use expanded or raw value
 		envValue := watchNamespaces // fallback: preserve raw pattern when nothing matched yet
 		if len(expandedNamespaces) > 0 {
 			envValue = strings.Join(expandedNamespaces, ",")

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 
+	"github.com/argoproj/argo-cd/v3/util/glob"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -50,115 +52,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 		return err
 	}
 
-	// Determine the watch scope from IMAGE_UPDATER_WATCH_NAMESPACES before creating roles,
-	// because the required role set depends on the mode.
-	// Three modes are supported:
-	//   - Not set or empty: namespace-scoped (Option 1). Controller watches only its own namespace.
-	//     Single role with all rules in cr.Namespace (base + manager rules combined).
-	//   - "*": cluster-scoped (Option 3). Controller watches all namespaces.
-	//     Base role in cr.Namespace + ClusterRole with manager rules. Requires cluster-config namespace.
-	//   - "ns1,ns2,...": watches specific namespaces.
-	//     Base role in cr.Namespace + manager Role in each listed namespace.
-	watchNamespaces := ""
-	if env := argoutil.EnvGet(cr.Spec.ImageUpdater.Env, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
-		watchNamespaces = strings.TrimSpace(env.Value)
-	}
-
-	// When the mode is not cluster-scoped, remove any ClusterRole/ClusterRoleBinding that may
-	// have been created by a previous reconcile cycle when watchNamespaces was "*".
-	if watchNamespaces != "*" {
-		if err := r.deleteImageUpdaterClusterRBAC(cr); err != nil {
-			return err
-		}
-	}
-
-	switch watchNamespaces {
-	case "*":
-		if !argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) {
-			return fmt.Errorf("IMAGE_UPDATER_WATCH_NAMESPACES=\"*\" can only be configured in cluster scope")
-		}
-		// Base role (configmaps, secrets, leases, events) in cr.Namespace.
-		log.Info("reconciling Image Updater role")
-		role, err := r.reconcileImageUpdaterRole(cr, policyRuleForRoleForImageUpdaterController())
-		if err != nil {
-			return err
-		}
-		if sa != nil && role != nil {
-			log.Info("reconciling Image Updater role binding")
-			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
-				return err
-			}
-		}
-		// ClusterRole for cluster-wide manager rules (imageupdaters, applications, events).
-		log.Info("using cluster-scoped installation for Image Updater")
-		log.Info("reconciling Image Updater cluster role")
-		clusterRole, err := r.reconcileImageUpdaterClusterRole(cr)
-		if err != nil {
-			return err
-		}
-		if sa != nil && clusterRole != nil {
-			log.Info("reconciling Image Updater cluster role binding")
-			if err := r.reconcileImageUpdaterClusterRoleBinding(cr, clusterRole, sa); err != nil {
-				return err
-			}
-		}
-	case "":
-		// Namespace-scoped: both base and manager rules apply to cr.Namespace, so combine them into a single role.
-		log.Info("using namespace-scoped installation for Image Updater", "namespace", cr.Namespace)
-		log.Info("reconciling Image Updater role", "namespace", cr.Namespace)
-		allRules := append(policyRuleForRoleForImageUpdaterController(), policyRuleForRoleManagerRoleForImageUpdaterController()...)
-		role, err := r.reconcileImageUpdaterRole(cr, allRules)
-		if err != nil {
-			return err
-		}
-		if sa != nil && role != nil {
-			log.Info("reconciling Image Updater role binding", "namespace", cr.Namespace)
-			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
-				return err
-			}
-		}
-	default:
-		// Comma-separated list: base role in cr.Namespace + manager Role in each listed namespace.
-		log.Info("reconciling Image Updater role")
-		role, err := r.reconcileImageUpdaterRole(cr, policyRuleForRoleForImageUpdaterController())
-		if err != nil {
-			return err
-		}
-		if sa != nil && role != nil {
-			log.Info("reconciling Image Updater role binding")
-			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
-				return err
-			}
-		}
-		for ns := range strings.SplitSeq(watchNamespaces, ",") {
-			ns = strings.TrimSpace(ns)
-			if ns == "" {
-				continue
-			}
-			log.Info("reconciling Image Updater manager role", "namespace", ns)
-			nsRole, err := r.reconcileImageUpdaterRoleForNamespace(ns, cr, policyRuleForRoleManagerRoleForImageUpdaterController())
-			if err != nil {
-				return err
-			}
-			if sa != nil && nsRole != nil {
-				log.Info("reconciling Image Updater manager role binding", "namespace", ns)
-				if err := r.reconcileImageUpdaterRoleBindingForNamespace(ns, cr, nsRole, sa); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	// Remove per-namespace Roles/RoleBindings for namespaces no longer in the watch list.
-	desiredNamespaces := map[string]struct{}{}
-	if watchNamespaces != "" && watchNamespaces != "*" {
-		for ns := range strings.SplitSeq(watchNamespaces, ",") {
-			if ns = strings.TrimSpace(ns); ns != "" {
-				desiredNamespaces[ns] = struct{}{}
-			}
-		}
-	}
-	if err := r.pruneImageUpdaterNamespaceRBAC(cr, desiredNamespaces); err != nil {
+	if err := r.reconcileImageUpdaterRBAC(cr, sa); err != nil {
 		return err
 	}
 
@@ -197,6 +91,127 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 	}
 
 	return nil
+}
+
+// reconcileImageUpdaterRBAC reconciles all RBAC for the Image Updater controller.
+// It reads IMAGE_UPDATER_WATCH_NAMESPACES and handles three modes:
+//   - "":        namespace-scoped — single Role covering both base and manager rules in cr.Namespace.
+//   - "*":       cluster-scoped — base Role in cr.Namespace + ClusterRole for manager rules.
+//   - patterns:  comma-separated list (glob/regex) — base Role in cr.Namespace + per-namespace
+//     manager Roles in every concrete namespace that matches a pattern.
+//
+// In all cases, stale per-namespace Roles/RoleBindings from a previous configuration are pruned.
+func (r *ReconcileArgoCD) reconcileImageUpdaterRBAC(cr *argoproj.ArgoCD, sa *corev1.ServiceAccount) error {
+	watchNamespaces := ""
+	if env := argoutil.EnvGet(cr.Spec.ImageUpdater.Env, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
+		watchNamespaces = strings.TrimSpace(env.Value)
+	}
+
+	// When the mode is not cluster-scoped, remove any ClusterRole/ClusterRoleBinding that may
+	// have been created by a previous reconcile cycle when watchNamespaces was "*".
+	if watchNamespaces != "*" {
+		if err := r.deleteImageUpdaterClusterRBAC(cr); err != nil {
+			return err
+		}
+	}
+
+	// desiredNamespaces tracks which per-namespace Roles/RoleBindings should exist after this
+	// reconcile. It is populated only in the pattern-list case; for "*" and "" it stays empty,
+	// which causes pruneImageUpdaterNamespaceRBAC to remove any stale per-namespace objects.
+	desiredNamespaces := map[string]struct{}{}
+
+	switch watchNamespaces {
+	case "*":
+		if !argoutil.IsNamespaceClusterConfigNamespace(cr.Namespace) {
+			return fmt.Errorf("IMAGE_UPDATER_WATCH_NAMESPACES=\"*\" can only be configured in cluster scope")
+		}
+		// Base role (configmaps, secrets, leases, events) in cr.Namespace.
+		log.Info("reconciling Image Updater role")
+		role, err := r.reconcileImageUpdaterRole(cr, policyRuleForRoleForImageUpdaterController())
+		if err != nil {
+			return err
+		}
+		if sa != nil && role != nil {
+			log.Info("reconciling Image Updater role binding")
+			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
+				return err
+			}
+		}
+		// ClusterRole for cluster-wide manager rules (imageupdaters, applications, events).
+		log.Info("using cluster-scoped installation for Image Updater")
+		log.Info("reconciling Image Updater cluster role")
+		clusterRole, err := r.reconcileImageUpdaterClusterRole(cr)
+		if err != nil {
+			return err
+		}
+		if sa != nil && clusterRole != nil {
+			log.Info("reconciling Image Updater cluster role binding")
+			if err := r.reconcileImageUpdaterClusterRoleBinding(cr, clusterRole, sa); err != nil {
+				return err
+			}
+		}
+
+	case "":
+		// Namespace-scoped: both base and manager rules apply to cr.Namespace, so combine them into a single role.
+		log.Info("using namespace-scoped installation for Image Updater", "namespace", cr.Namespace)
+		log.Info("reconciling Image Updater role", "namespace", cr.Namespace)
+		allRules := append(policyRuleForRoleForImageUpdaterController(), policyRuleForRoleManagerRoleForImageUpdaterController()...)
+		role, err := r.reconcileImageUpdaterRole(cr, allRules)
+		if err != nil {
+			return err
+		}
+		if sa != nil && role != nil {
+			log.Info("reconciling Image Updater role binding", "namespace", cr.Namespace)
+			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
+				return err
+			}
+		}
+
+	default:
+		// Comma-separated list (may contain glob/regex patterns): base role in cr.Namespace
+		// + manager Role in each concrete namespace that matches a pattern.
+		log.Info("reconciling Image Updater role")
+		role, err := r.reconcileImageUpdaterRole(cr, policyRuleForRoleForImageUpdaterController())
+		if err != nil {
+			return err
+		}
+		if sa != nil && role != nil {
+			log.Info("reconciling Image Updater role binding")
+			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
+				return err
+			}
+		}
+
+		expandedNamespaces, err := r.expandImageUpdaterWatchNamespaces(watchNamespaces)
+		if err != nil {
+			return err
+		}
+		if len(expandedNamespaces) == 0 {
+			log.Info("IMAGE_UPDATER_WATCH_NAMESPACES matched no existing namespaces; "+
+				"no per-namespace RBAC will be created and the image-updater will have no manager permissions",
+				"pattern", watchNamespaces)
+		}
+
+		for _, ns := range expandedNamespaces {
+			desiredNamespaces[ns] = struct{}{}
+			log.Info("reconciling Image Updater manager role", "namespace", ns)
+			nsRole, err := r.reconcileImageUpdaterRoleForNamespace(ns, cr, policyRuleForRoleManagerRoleForImageUpdaterController())
+			if err != nil {
+				return err
+			}
+			if sa != nil && nsRole != nil {
+				log.Info("reconciling Image Updater manager role binding", "namespace", ns)
+				if err := r.reconcileImageUpdaterRoleBindingForNamespace(ns, cr, nsRole, sa); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Prune per-namespace Roles/RoleBindings whose namespace is no longer in the watch list.
+	// For "*" and "" desiredNamespaces is empty, removing any stale objects left from a previous
+	// pattern-list configuration.
+	return r.pruneImageUpdaterNamespaceRBAC(cr, desiredNamespaces)
 }
 
 func (r *ReconcileArgoCD) reconcileImageUpdaterControllerDisabled(cr *argoproj.ArgoCD) error {
@@ -574,6 +589,26 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, s
 	// Let user specify their own environment first
 	imageUpdaterEnv = argoutil.EnvMerge(imageUpdaterEnv, proxyEnvVars(), false)
 
+	// IMAGE_UPDATER_WATCH_NAMESPACES may contain glob/regex patterns, but the image-updater
+	// controller only understands concrete namespace names. Expand any patterns here and
+	// replace the env var value with the resolved comma-separated list before it reaches the pod.
+	// If no namespaces match the pattern yet, leave the env var unchanged.
+	if env := argoutil.EnvGet(imageUpdaterEnv, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
+		rawValue := strings.TrimSpace(env.Value)
+		if rawValue != "" && rawValue != "*" {
+			expanded, err := r.expandImageUpdaterWatchNamespaces(rawValue)
+			if err != nil {
+				return err
+			}
+			if len(expanded) > 0 {
+				imageUpdaterEnv = argoutil.EnvSet(imageUpdaterEnv, corev1.EnvVar{
+					Name:  "IMAGE_UPDATER_WATCH_NAMESPACES",
+					Value: strings.Join(expanded, ","),
+				})
+			}
+		}
+	}
+
 	podSpec := &desiredDeployment.Spec.Template.Spec
 	podSpec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: new(true),
@@ -723,6 +758,31 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, s
 	}}
 
 	return r.reconcileDeploymentHelper(cr, desiredDeployment, "image updater", cr.Spec.ImageUpdater.Enabled)
+}
+
+// expandImageUpdaterWatchNamespaces lists all cluster namespaces and returns those that
+// match any pattern in the comma-separated watchNamespaces value. Each pattern may be a
+// glob-style wildcard or a full regular expression (the same semantics used by
+// .spec.applicationSet.sourceNamespaces). The returned slice is sorted for determinism.
+func (r *ReconcileArgoCD) expandImageUpdaterWatchNamespaces(watchNamespaces string) ([]string, error) {
+	patterns := strings.Split(watchNamespaces, ",")
+	for i := range patterns {
+		patterns[i] = strings.TrimSpace(patterns[i])
+	}
+
+	clusterNamespaces := &corev1.NamespaceList{}
+	if err := r.List(context.TODO(), clusterNamespaces, &client.ListOptions{}); err != nil {
+		return nil, err
+	}
+
+	var matched []string
+	for _, ns := range clusterNamespaces.Items {
+		if glob.MatchStringInList(patterns, ns.Name, glob.REGEXP) {
+			matched = append(matched, ns.Name)
+		}
+	}
+	sort.Strings(matched)
+	return matched, nil
 }
 
 // ========================= Helpers =========================

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -845,6 +845,20 @@ func (r *ReconcileArgoCD) expandImageUpdaterWatchNamespaces(watchNamespaces stri
 			matched = append(matched, ns.Name)
 		}
 	}
+
+	// Guard against patterns that silently expand to every namespace (e.g. "**", "?*",
+	// "/.*/"). Such a result is semantically identical to cluster-scoped mode ("*") but
+	// bypasses the IsNamespaceClusterConfigNamespace restriction that the "*" sentinel
+	// enforces. Returning an error here prevents unintended privilege escalation and
+	// directs the user to the correct, explicit cluster-scoped configuration.
+	if len(clusterNamespaces.Items) > 0 && len(matched) == len(clusterNamespaces.Items) {
+		return nil, fmt.Errorf(
+			"IMAGE_UPDATER_WATCH_NAMESPACES %q matches all %d cluster namespaces; "+
+				"use \"*\" for cluster-scoped mode",
+			watchNamespaces, len(clusterNamespaces.Items),
+		)
+	}
+
 	sort.Strings(matched)
 	return matched, nil
 }

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -52,7 +52,28 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 		return err
 	}
 
-	if err := r.reconcileImageUpdaterRBAC(cr, sa); err != nil {
+	// Resolve the concrete namespace set once so that both RBAC and the deployment
+	// reconciliation operate on the same snapshot. If a namespace were created between
+	// two independent List calls, the pod could receive that namespace in
+	// IMAGE_UPDATER_WATCH_NAMESPACES without the required manager Role/RoleBinding.
+	watchNamespaces := ""
+	if env := argoutil.EnvGet(cr.Spec.ImageUpdater.Env, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
+		watchNamespaces = strings.TrimSpace(env.Value)
+	}
+	var expandedNamespaces []string
+	if watchNamespaces != "" && watchNamespaces != "*" {
+		expandedNamespaces, err = r.expandImageUpdaterWatchNamespaces(watchNamespaces)
+		if err != nil {
+			return err
+		}
+		if len(expandedNamespaces) == 0 {
+			log.Info("IMAGE_UPDATER_WATCH_NAMESPACES matched no existing namespaces; "+
+				"no per-namespace RBAC will be created and the image-updater will have no manager permissions",
+				"pattern", watchNamespaces)
+		}
+	}
+
+	if err := r.reconcileImageUpdaterRBAC(cr, sa, watchNamespaces, expandedNamespaces); err != nil {
 		return err
 	}
 
@@ -85,7 +106,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 
 	if sa != nil {
 		log.Info("reconciling Image Updater deployment")
-		if err := r.reconcileImageUpdaterDeployment(cr, sa); err != nil {
+		if err := r.reconcileImageUpdaterDeployment(cr, sa, watchNamespaces, expandedNamespaces); err != nil {
 			return err
 		}
 	}
@@ -94,19 +115,20 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerEnabled(cr *argoproj.Ar
 }
 
 // reconcileImageUpdaterRBAC reconciles all RBAC for the Image Updater controller.
-// It reads IMAGE_UPDATER_WATCH_NAMESPACES and handles three modes:
-//   - "":        namespace-scoped — single Role covering both base and manager rules in cr.Namespace.
-//   - "*":       cluster-scoped — base Role in cr.Namespace + ClusterRole for manager rules.
-//   - patterns:  comma-separated list (glob/regex) — base Role in cr.Namespace + per-namespace
-//     manager Roles in every concrete namespace that matches a pattern.
+// watchNamespaces is the raw IMAGE_UPDATER_WATCH_NAMESPACES value; expandedNamespaces
+// is the pre-computed concrete list resolved by the caller.
+// Accepting both as parameters ensures RBAC and deployment reconciliation share the same
+// namespace snapshot, preventing a race where a namespace created between independent List
+// calls could appear in the deployment env var without a manager Role/RoleBinding.
+//
+// It handles three modes:
+//   - "*":      cluster-scoped — base Role in cr.Namespace + ClusterRole for manager rules.
+//   - "":       namespace-scoped — single Role covering both base and manager rules in cr.Namespace.
+//   - patterns: comma-separated list (glob/regex) — base Role in cr.Namespace + per-namespace
+//     manager Roles in every concrete namespace from expandedNamespaces.
 //
 // In all cases, stale per-namespace Roles/RoleBindings from a previous configuration are pruned.
-func (r *ReconcileArgoCD) reconcileImageUpdaterRBAC(cr *argoproj.ArgoCD, sa *corev1.ServiceAccount) error {
-	watchNamespaces := ""
-	if env := argoutil.EnvGet(cr.Spec.ImageUpdater.Env, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
-		watchNamespaces = strings.TrimSpace(env.Value)
-	}
-
+func (r *ReconcileArgoCD) reconcileImageUpdaterRBAC(cr *argoproj.ArgoCD, sa *corev1.ServiceAccount, watchNamespaces string, expandedNamespaces []string) error {
 	// When the mode is not cluster-scoped, remove any ClusterRole/ClusterRoleBinding that may
 	// have been created by a previous reconcile cycle when watchNamespaces was "*".
 	if watchNamespaces != "*" {
@@ -169,7 +191,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRBAC(cr *argoproj.ArgoCD, sa *cor
 
 	default:
 		// Comma-separated list (may contain glob/regex patterns): base role in cr.Namespace
-		// + manager Role in each concrete namespace that matches a pattern.
+		// + manager Role in each concrete namespace from the pre-computed expandedNamespaces.
 		log.Info("reconciling Image Updater role")
 		role, err := r.reconcileImageUpdaterRole(cr, policyRuleForRoleForImageUpdaterController())
 		if err != nil {
@@ -180,16 +202,6 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRBAC(cr *argoproj.ArgoCD, sa *cor
 			if err := r.reconcileImageUpdaterRoleBinding(cr, role, sa); err != nil {
 				return err
 			}
-		}
-
-		expandedNamespaces, err := r.expandImageUpdaterWatchNamespaces(watchNamespaces)
-		if err != nil {
-			return err
-		}
-		if len(expandedNamespaces) == 0 {
-			log.Info("IMAGE_UPDATER_WATCH_NAMESPACES matched no existing namespaces; "+
-				"no per-namespace RBAC will be created and the image-updater will have no manager permissions",
-				"pattern", watchNamespaces)
 		}
 
 		for _, ns := range expandedNamespaces {
@@ -239,7 +251,6 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerDisabled(cr *argoproj.A
 	if clusterRole.Name == "" {
 		clusterRole.Name = clusterRoleName
 	}
-	// delete network policies when disable
 	// delete network policy when disabled
 	npName := generateResourceName(ImageUpdaterNetworkPolicy, cr)
 	np := &networkingv1.NetworkPolicy{}
@@ -254,7 +265,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerDisabled(cr *argoproj.A
 	}
 
 	log.Info("deleting Image Updater deployment")
-	if err := r.reconcileImageUpdaterDeployment(cr, sa); err != nil {
+	if err := r.reconcileImageUpdaterDeployment(cr, sa, "", nil); err != nil {
 		return err
 	}
 
@@ -577,7 +588,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterConfigMap(cr *argoproj.ArgoCD, de
 	return r.reconcileSecretConfigMapHelper(cr, desiredConfigMap)
 }
 
-func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, sa *corev1.ServiceAccount) error {
+func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, sa *corev1.ServiceAccount, watchNamespaces string, expandedNamespaces []string) error {
 
 	desiredDeployment := newDeploymentWithSuffix(common.ArgoCDImageUpdaterControllerComponent, "controller", cr)
 
@@ -590,23 +601,20 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterDeployment(cr *argoproj.ArgoCD, s
 	imageUpdaterEnv = argoutil.EnvMerge(imageUpdaterEnv, proxyEnvVars(), false)
 
 	// IMAGE_UPDATER_WATCH_NAMESPACES may contain glob/regex patterns, but the image-updater
-	// controller only understands concrete namespace names. Expand any patterns here and
-	// replace the env var value with the resolved comma-separated list before it reaches the pod.
-	// If no namespaces match the pattern yet, leave the env var unchanged.
-	if env := argoutil.EnvGet(imageUpdaterEnv, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
-		rawValue := strings.TrimSpace(env.Value)
-		if rawValue != "" && rawValue != "*" {
-			expanded, err := r.expandImageUpdaterWatchNamespaces(rawValue)
-			if err != nil {
-				return err
-			}
-			if len(expanded) > 0 {
-				imageUpdaterEnv = argoutil.EnvSet(imageUpdaterEnv, corev1.EnvVar{
-					Name:  "IMAGE_UPDATER_WATCH_NAMESPACES",
-					Value: strings.Join(expanded, ","),
-				})
-			}
+	// controller only understands concrete namespace names. Use the pre-computed
+	// expandedNamespaces (resolved once by the caller alongside RBAC) to set the env var.
+	// If expandedNamespaces is empty the pattern currently matches nothing: keep the raw
+	// value so the pod fails with a meaningful error rather than silently switching to
+	// namespace-scoped mode without the required RBAC.
+	if watchNamespaces != "" && watchNamespaces != "*" {
+		envValue := watchNamespaces // fallback: preserve raw pattern when nothing matched yet
+		if len(expandedNamespaces) > 0 {
+			envValue = strings.Join(expandedNamespaces, ",")
 		}
+		imageUpdaterEnv = argoutil.EnvSet(imageUpdaterEnv, corev1.EnvVar{
+			Name:  "IMAGE_UPDATER_WATCH_NAMESPACES",
+			Value: envValue,
+		})
 	}
 
 	podSpec := &desiredDeployment.Spec.Template.Spec

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -140,7 +140,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRBAC(cr *argoproj.ArgoCD, sa *cor
 	// desiredNamespaces tracks which per-namespace Roles/RoleBindings should exist after this
 	// reconcile. It is populated only in the pattern-list case; for "*" and "" it stays empty,
 	// which causes pruneImageUpdaterNamespaceRBAC to remove any stale per-namespace objects.
-	desiredNamespaces := map[string]struct{}{}
+	desiredNamespaces := map[string]any{}
 
 	switch watchNamespaces {
 	case "*":
@@ -205,7 +205,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRBAC(cr *argoproj.ArgoCD, sa *cor
 		}
 
 		for _, ns := range expandedNamespaces {
-			desiredNamespaces[ns] = struct{}{}
+			desiredNamespaces[ns] = nil
 			log.Info("reconciling Image Updater manager role", "namespace", ns)
 			nsRole, err := r.reconcileImageUpdaterRoleForNamespace(ns, cr, policyRuleForRoleManagerRoleForImageUpdaterController())
 			if err != nil {
@@ -299,7 +299,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterControllerDisabled(cr *argoproj.A
 	// Delete all per-namespace Roles/RoleBindings previously created for any watch-namespace list.
 	// pruneImageUpdaterNamespaceRBAC with an empty desired set removes everything it finds by label.
 	log.Info("deleting Image Updater namespace roles and role bindings")
-	if err := r.pruneImageUpdaterNamespaceRBAC(cr, map[string]struct{}{}); err != nil {
+	if err := r.pruneImageUpdaterNamespaceRBAC(cr, map[string]any{}); err != nil {
 		return err
 	}
 
@@ -463,7 +463,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterRoleBindingForNamespace(namespace
 // whose namespace is not present in desiredNamespaces. Pass an empty map to remove all of them
 // (used when Image Updater is disabled). Only objects carrying imageUpdaterManagedNamespaceLabel
 // are considered, so no other operator-managed RBAC is touched.
-func (r *ReconcileArgoCD) pruneImageUpdaterNamespaceRBAC(cr *argoproj.ArgoCD, desiredNamespaces map[string]struct{}) error {
+func (r *ReconcileArgoCD) pruneImageUpdaterNamespaceRBAC(cr *argoproj.ArgoCD, desiredNamespaces map[string]any) error {
 	matchLabels := client.MatchingLabels{
 		common.ArgoCDKeyName:              cr.Name,
 		imageUpdaterManagedNamespaceLabel: "true",

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -677,14 +677,14 @@ func TestReconcileImageUpdaterRBAC_WatchScope(t *testing.T) {
 		{
 			name:                  "exact list: two namespaces",
 			watchNamespacesEnv:    "ns1,ns2",
-			clusterNamespaces:     []string{"ns1", "ns2"},
+			clusterNamespaces:     []string{"ns1", "ns2", "other"},
 			expectClusterRole:     false,
 			expectManagerRoleInNS: []string{"ns1", "ns2"},
 		},
 		{
 			name:                  "exact list: single namespace",
 			watchNamespacesEnv:    "ns1",
-			clusterNamespaces:     []string{"ns1"},
+			clusterNamespaces:     []string{"ns1", "other"},
 			expectClusterRole:     false,
 			expectManagerRoleInNS: []string{"ns1"},
 		},
@@ -1002,6 +1002,7 @@ func TestReconcileImageUpdaterRBAC_PrunesStaleNamespaces(t *testing.T) {
 		a,
 		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
 		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns2"}},
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "other"}}, // decoy: keeps patterns from matching the full cluster
 	}
 	subresObjs := []client.Object{a}
 	runtimeObjs := []runtime.Object{}
@@ -1071,7 +1072,7 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 		},
 		{
 			name:            "exact names are passed through unchanged",
-			clusterNS:       []string{"ns1", "ns2"},
+			clusterNS:       []string{"ns1", "ns2", "other"},
 			watchNamespaces: "ns1,ns2",
 			wantEnvValue:    "ns1,ns2",
 		},
@@ -1103,7 +1104,7 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 			// Exact name alongside an unmatched glob: exact name expands normally,
 			// unmatched glob is dropped from the env var.
 			name:            "exact name expands, unmatched glob dropped",
-			clusterNS:       []string{"ns1"},
+			clusterNS:       []string{"ns1", "other"},
 			watchNamespaces: "ns1,app-*",
 			wantEnvValue:    "ns1",
 		},
@@ -1200,6 +1201,7 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 		clusterNS       []string // Namespace objects to pre-create in the fake client
 		watchNamespaces string   // raw value passed to expandImageUpdaterWatchNamespaces
 		want            []string // expected result, must be sorted
+		wantErr         bool     // true when an error is expected instead of a result
 	}{
 		{
 			name:            "exact match: single namespace",
@@ -1248,19 +1250,19 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 		},
 		{
 			name:            "whitespace trimmed from each pattern",
-			clusterNS:       []string{"ns1", "ns2"},
+			clusterNS:       []string{"ns1", "ns2", "unrelated"},
 			watchNamespaces: " ns1 , ns2 ",
 			want:            []string{"ns1", "ns2"},
 		},
 		{
 			name:            "result is sorted regardless of cluster order",
-			clusterNS:       []string{"z-ns", "a-ns", "m-ns"},
+			clusterNS:       []string{"z-ns", "a-ns", "m-ns", "not-a-match"},
 			watchNamespaces: "*-ns",
 			want:            []string{"a-ns", "m-ns", "z-ns"},
 		},
 		{
 			name:            "namespace matched by two patterns is returned only once",
-			clusterNS:       []string{"ns1"},
+			clusterNS:       []string{"ns1", "other"},
 			watchNamespaces: "ns1,ns*",
 			want:            []string{"ns1"},
 		},
@@ -1284,7 +1286,7 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 		},
 		{
 			name:            "leading and trailing commas are stripped",
-			clusterNS:       []string{"app-ns"},
+			clusterNS:       []string{"app-ns", "other-ns"},
 			watchNamespaces: ",app-ns,",
 			want:            []string{"app-ns"},
 		},
@@ -1293,6 +1295,32 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 			clusterNS:       []string{"app-ns"},
 			watchNamespaces: ",,,",
 			want:            nil,
+		},
+		// Patterns that expand to every namespace must be rejected — they are semantically
+		// equivalent to cluster-scoped mode ("*") but bypass IsNamespaceClusterConfigNamespace.
+		{
+			name:            "double-star glob matches all namespaces → error",
+			clusterNS:       []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: "**",
+			wantErr:         true,
+		},
+		{
+			name:            "question-star glob matches all namespaces → error",
+			clusterNS:       []string{"ns1", "ns2"},
+			watchNamespaces: "?*",
+			wantErr:         true,
+		},
+		{
+			name:            "match-all regex matches all namespaces → error",
+			clusterNS:       []string{"ns1", "ns2"},
+			watchNamespaces: "/.*/",
+			wantErr:         true,
+		},
+		{
+			name:            "pattern that matches a strict subset is allowed",
+			clusterNS:       []string{"app-ns-1", "app-ns-2", "other-ns"},
+			watchNamespaces: "app-ns-*",
+			want:            []string{"app-ns-1", "app-ns-2"},
 		},
 	}
 
@@ -1311,8 +1339,12 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 			got, err := r.expandImageUpdaterWatchNamespaces(tt.watchNamespaces)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
 		})
 	}
 }

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -1148,6 +1148,50 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 	}
 }
 
+func TestNormalizeWatchNamespaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		// Canonical sentinels pass through unchanged.
+		{name: "empty string (namespace-scoped)", raw: "", want: ""},
+		{name: "bare * (cluster-scoped)", raw: "*", want: "*"},
+
+		// Trailing/leading commas around sole *.
+		{name: "trailing comma on *", raw: "*,", want: "*"},
+		{name: "leading comma on *", raw: ",*", want: "*"},
+		{name: "* surrounded by commas", raw: ",*,", want: "*"},
+
+		// Only commas collapse to namespace-scoped.
+		{name: "only commas", raw: ",,,", want: ""},
+
+		// * mixed with other patterns is rejected.
+		{name: "* mixed with pattern", raw: "*,team-a", wantErr: true},
+		{name: "pattern then *", raw: "team-a,*", wantErr: true},
+		{name: "* in the middle of a list", raw: "app-*,*,team-b", wantErr: true},
+
+		// Valid pattern lists are returned unchanged.
+		{name: "single glob pattern", raw: "app-*", want: "app-*"},
+		{name: "multiple patterns", raw: "app-*,team-b", want: "app-*,team-b"},
+		{name: "regex pattern", raw: "/^app-[a-z]+$/", want: "/^app-[a-z]+$/"},
+		{name: "pattern with trailing comma (raw unchanged)", raw: "app-*,", want: "app-*,"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeWatchNamespaces(tt.raw)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -1216,11 +1216,12 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
-		name            string
-		clusterNS       []string // Namespace objects to pre-create in the fake client
-		watchNamespaces string   // raw value passed to expandImageUpdaterWatchNamespaces
-		want            []string // expected result, must be sorted
-		wantErr         bool     // true when an error is expected instead of a result
+		name               string
+		clusterNS          []string // Namespace objects to pre-create in the fake client
+		terminatingNS      []string // Namespaces to mark as terminating (DeletionTimestamp != nil)
+		watchNamespaces    string   // raw value passed to expandImageUpdaterWatchNamespaces
+		want               []string // expected result, must be sorted
+		wantErr            bool     // true when an error is expected instead of a result
 	}{
 		{
 			name:            "exact match: single namespace",
@@ -1341,6 +1342,27 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 			watchNamespaces: "app-ns-*",
 			want:            []string{"app-ns-1", "app-ns-2"},
 		},
+		{
+			name:            "terminating namespace is excluded from matches",
+			clusterNS:       []string{"ns1", "ns2-terminating", "other"},
+			terminatingNS:   []string{"ns2-terminating"},
+			watchNamespaces: "ns*",
+			want:            []string{"ns1"},
+		},
+		{
+			name:            "terminating namespace does not prevent valid pattern matches",
+			clusterNS:       []string{"app-a", "app-b", "app-term", "other-ns"},
+			terminatingNS:   []string{"app-term"},
+			watchNamespaces: "app-*",
+			want:            []string{"app-a", "app-b"},
+		},
+		{
+			name:            "pattern that would match all active namespaces (with terminating ones present) is rejected",
+			clusterNS:       []string{"ns1", "ns2", "ns-term"},
+			terminatingNS:   []string{"ns-term"},
+			watchNamespaces: "ns*",
+			wantErr:         true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1350,8 +1372,20 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 			})
 
 			resObjs := []client.Object{a}
+			terminatingSet := make(map[string]struct{})
+			for _, ns := range tt.terminatingNS {
+				terminatingSet[ns] = struct{}{}
+			}
 			for _, ns := range tt.clusterNS {
-				resObjs = append(resObjs, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+				nsObj := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+				if _, isTerminating := terminatingSet[ns]; isTerminating {
+					// Mark namespace as terminating by setting DeletionTimestamp and Finalizers
+					// (fake client requires finalizers when DeletionTimestamp is set)
+					now := metav1.Now()
+					nsObj.ObjectMeta.DeletionTimestamp = &now
+					nsObj.ObjectMeta.Finalizers = []string{"kubernetes"}
+				}
+				resObjs = append(resObjs, nsObj)
 			}
 			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
 			cl := makeTestReconcilerClient(sch, resObjs, resObjs, []runtime.Object{})

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -810,7 +810,7 @@ func TestReconcileImageUpdaterRBAC_WatchScope(t *testing.T) {
 					Name:      getRoleNameForApplicationSourceNamespaces(ns, a),
 					Namespace: ns,
 				}, &rbacv1.Role{})
-				assert.True(t, errors.IsNotFound(err), "namespace %s should not have a manager role", ns)
+				assert.True(t, errors.IsNotFound(err), "namespace %s should not have a manager role, got error: %v", ns, err)
 			}
 
 			clusterRBACName := GenerateUniqueResourceName(common.ArgoCDImageUpdaterControllerComponent, a)
@@ -934,7 +934,7 @@ func TestPruneImageUpdaterNamespaceRBAC(t *testing.T) {
 
 	t.Run("prune removes roles not in the desired set", func(t *testing.T) {
 		// Keep only ns1; ns2 and ns3 should be pruned.
-		desired := map[string]struct{}{"ns1": {}}
+		desired := map[string]any{"ns1": nil}
 		assert.NoError(t, r.pruneImageUpdaterNamespaceRBAC(a, desired))
 
 		// ns1 must still exist.
@@ -964,7 +964,7 @@ func TestPruneImageUpdaterNamespaceRBAC(t *testing.T) {
 	})
 
 	t.Run("prune with empty set removes all remaining namespace RBAC", func(t *testing.T) {
-		assert.NoError(t, r.pruneImageUpdaterNamespaceRBAC(a, map[string]struct{}{}))
+		assert.NoError(t, r.pruneImageUpdaterNamespaceRBAC(a, map[string]any{}))
 
 		err := r.Get(context.TODO(), types.NamespacedName{
 			Name:      getRoleNameForApplicationSourceNamespaces("ns1", a),
@@ -980,7 +980,7 @@ func TestPruneImageUpdaterNamespaceRBAC(t *testing.T) {
 	})
 
 	t.Run("prune is idempotent on empty cluster", func(t *testing.T) {
-		assert.NoError(t, r.pruneImageUpdaterNamespaceRBAC(a, map[string]struct{}{}))
+		assert.NoError(t, r.pruneImageUpdaterNamespaceRBAC(a, map[string]any{}))
 	})
 }
 

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -1062,24 +1062,33 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 		name            string
 		clusterNS       []string
 		watchNamespaces string
-		wantEnvValue    string // expected value of IMAGE_UPDATER_WATCH_NAMESPACES in the pod
+		wantEnvValue    string // expected value of IMAGE_UPDATER_WATCH_NAMESPACES in the pod, empty means env var should not be set
+		wantEnvSet      bool   // whether IMAGE_UPDATER_WATCH_NAMESPACES should be present in the pod env
 	}{
 		{
 			name:            "glob pattern is expanded to concrete names",
 			clusterNS:       []string{"team-a-argocd", "team-b-argocd", "unrelated"},
 			watchNamespaces: "*-argocd",
 			wantEnvValue:    "team-a-argocd,team-b-argocd",
+			wantEnvSet:      true,
 		},
 		{
 			name:            "exact names are passed through unchanged",
 			clusterNS:       []string{"ns1", "ns2", "other"},
 			watchNamespaces: "ns1,ns2",
 			wantEnvValue:    "ns1,ns2",
+			wantEnvSet:      true,
 		},
 		{
-			name:            "* is passed through unchanged (cluster-scoped mode)",
+			name:            "* is explicitly set to ensure cluster-scoped mode",
 			watchNamespaces: "*",
 			wantEnvValue:    "*",
+			wantEnvSet:      true,
+		},
+		{
+			name:            "empty string does not set IMAGE_UPDATER_WATCH_NAMESPACES (namespace-scoped mode uses default)",
+			watchNamespaces: "",
+			wantEnvSet:      false,
 		},
 		{
 			// When the pattern matches no existing namespaces the env var must NOT be
@@ -1089,6 +1098,7 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 			clusterNS:       []string{"unrelated"},
 			watchNamespaces: "app-*",
 			wantEnvValue:    "app-*",
+			wantEnvSet:      true,
 		},
 		{
 			// Mixed list where one pattern has matches and another does not.
@@ -1099,6 +1109,7 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 			clusterNS:       []string{"team-a", "team-b", "unrelated"},
 			watchNamespaces: "team-*,future-*",
 			wantEnvValue:    "team-a,team-b",
+			wantEnvSet:      true,
 		},
 		{
 			// Exact name alongside an unmatched glob: exact name expands normally,
@@ -1107,6 +1118,7 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 			clusterNS:       []string{"ns1", "other"},
 			watchNamespaces: "ns1,app-*",
 			wantEnvValue:    "ns1",
+			wantEnvSet:      true,
 		},
 	}
 
@@ -1138,13 +1150,20 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 			}, deployment))
 
 			var gotValue string
+			var found bool
 			for _, e := range deployment.Spec.Template.Spec.Containers[0].Env {
 				if e.Name == "IMAGE_UPDATER_WATCH_NAMESPACES" {
 					gotValue = e.Value
+					found = true
 					break
 				}
 			}
-			assert.Equal(t, tt.wantEnvValue, gotValue)
+			if tt.wantEnvSet {
+				assert.True(t, found, "IMAGE_UPDATER_WATCH_NAMESPACES should be set")
+				assert.Equal(t, tt.wantEnvValue, gotValue)
+			} else {
+				assert.False(t, found, "IMAGE_UPDATER_WATCH_NAMESPACES should not be set")
+			}
 		})
 	}
 }

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -1216,12 +1216,12 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
-		name               string
-		clusterNS          []string // Namespace objects to pre-create in the fake client
-		terminatingNS      []string // Namespaces to mark as terminating (DeletionTimestamp != nil)
-		watchNamespaces    string   // raw value passed to expandImageUpdaterWatchNamespaces
-		want               []string // expected result, must be sorted
-		wantErr            bool     // true when an error is expected instead of a result
+		name            string
+		clusterNS       []string // Namespace objects to pre-create in the fake client
+		terminatingNS   []string // Namespaces to mark as terminating (DeletionTimestamp != nil)
+		watchNamespaces string   // raw value passed to expandImageUpdaterWatchNamespaces
+		want            []string // expected result, must be sorted
+		wantErr         bool     // true when an error is expected instead of a result
 	}{
 		{
 			name:            "exact match: single namespace",
@@ -1382,8 +1382,8 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 					// Mark namespace as terminating by setting DeletionTimestamp and Finalizers
 					// (fake client requires finalizers when DeletionTimestamp is set)
 					now := metav1.Now()
-					nsObj.ObjectMeta.DeletionTimestamp = &now
-					nsObj.ObjectMeta.Finalizers = []string{"kubernetes"}
+					nsObj.DeletionTimestamp = &now
+					nsObj.Finalizers = []string{"kubernetes"}
 				}
 				resObjs = append(resObjs, nsObj)
 			}

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -32,6 +33,25 @@ import (
 	argoproj "github.com/argoproj-labs/argocd-operator/api/v1beta1"
 	"github.com/argoproj-labs/argocd-operator/common"
 )
+
+// testResolveWatchNamespaces mirrors the logic in reconcileImageUpdaterControllerEnabled:
+// it extracts watchNamespaces from the CR env and expands patterns to concrete namespace
+// names using the fake client. Tests use this to obtain pre-computed values before calling
+// reconcileImageUpdaterRBAC or reconcileImageUpdaterDeployment directly.
+func testResolveWatchNamespaces(t *testing.T, r *ReconcileArgoCD, a *argoproj.ArgoCD) (string, []string) {
+	t.Helper()
+	watchNamespaces := ""
+	if env := argoutil.EnvGet(a.Spec.ImageUpdater.Env, "IMAGE_UPDATER_WATCH_NAMESPACES"); env != nil {
+		watchNamespaces = strings.TrimSpace(env.Value)
+	}
+	var expanded []string
+	if watchNamespaces != "" && watchNamespaces != "*" {
+		var err error
+		expanded, err = r.expandImageUpdaterWatchNamespaces(watchNamespaces)
+		require.NoError(t, err)
+	}
+	return watchNamespaces, expanded
+}
 
 func TestReconcileImageUpdater_CreateRoles(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
@@ -235,7 +255,7 @@ func TestReconcileImageUpdater_CreateDeployments(t *testing.T) {
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 	sa := v1.ServiceAccount{}
 
-	assert.NoError(t, r.reconcileImageUpdaterDeployment(a, &sa))
+	assert.NoError(t, r.reconcileImageUpdaterDeployment(a, &sa, "", nil))
 
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.Get(
@@ -401,7 +421,7 @@ func TestReconcileImageUpdater_CreateDeployments(t *testing.T) {
 	}
 
 	a.Spec.ImageUpdater.Enabled = false
-	err := r.reconcileImageUpdaterDeployment(a, &sa)
+	err := r.reconcileImageUpdaterDeployment(a, &sa, "", nil)
 	assert.NoError(t, err)
 
 	err = r.Get(context.TODO(), types.NamespacedName{
@@ -741,7 +761,8 @@ func TestReconcileImageUpdaterRBAC_WatchScope(t *testing.T) {
 
 			sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: a.Namespace}}
 
-			err := r.reconcileImageUpdaterRBAC(a, sa)
+			ws, expanded := testResolveWatchNamespaces(t, r, a)
+			err := r.reconcileImageUpdaterRBAC(a, sa, ws, expanded)
 			if tt.expectError {
 				assert.Error(t, err)
 				return
@@ -831,7 +852,7 @@ func TestReconcileImageUpdater_testEnvVars(t *testing.T) {
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 	sa := v1.ServiceAccount{}
-	assert.NoError(t, r.reconcileImageUpdaterDeployment(a, &sa))
+	assert.NoError(t, r.reconcileImageUpdaterDeployment(a, &sa, "", nil))
 
 	deployment := &appsv1.Deployment{}
 	assert.NoError(t, r.Get(
@@ -862,7 +883,7 @@ func TestReconcileImageUpdater_testEnvVars(t *testing.T) {
 	assert.NoError(t, r.Update(context.TODO(), deployment))
 
 	// Reconcile back
-	assert.NoError(t, r.reconcileImageUpdaterDeployment(a, &sa))
+	assert.NoError(t, r.reconcileImageUpdaterDeployment(a, &sa, "", nil))
 
 	// Get the updated deployment
 	assert.NoError(t, r.Get(
@@ -991,7 +1012,8 @@ func TestReconcileImageUpdaterRBAC_PrunesStaleNamespaces(t *testing.T) {
 	sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: a.Namespace}}
 
 	// First reconcile: both namespaces get roles.
-	assert.NoError(t, r.reconcileImageUpdaterRBAC(a, sa))
+	ws, expanded := testResolveWatchNamespaces(t, r, a)
+	assert.NoError(t, r.reconcileImageUpdaterRBAC(a, sa, ws, expanded))
 
 	for _, ns := range []string{"ns1", "ns2"} {
 		assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -1006,7 +1028,8 @@ func TestReconcileImageUpdaterRBAC_PrunesStaleNamespaces(t *testing.T) {
 	}
 
 	// Second reconcile: ns2 role and binding should be pruned.
-	assert.NoError(t, r.reconcileImageUpdaterRBAC(a, sa))
+	ws, expanded = testResolveWatchNamespaces(t, r, a)
+	assert.NoError(t, r.reconcileImageUpdaterRBAC(a, sa, ws, expanded))
 
 	// ns1 still exists.
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -1066,6 +1089,24 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 			watchNamespaces: "app-*",
 			wantEnvValue:    "app-*",
 		},
+		{
+			// Mixed list where one pattern has matches and another does not.
+			// expandImageUpdaterWatchNamespaces returns only concrete matches, so
+			// the unmatched "future-*" is dropped from the deployment env var.
+			// The concrete names are sorted.
+			name:            "mixed-match: matched patterns expanded, unmatched pattern dropped",
+			clusterNS:       []string{"team-a", "team-b", "unrelated"},
+			watchNamespaces: "team-*,future-*",
+			wantEnvValue:    "team-a,team-b",
+		},
+		{
+			// Exact name alongside an unmatched glob: exact name expands normally,
+			// unmatched glob is dropped from the env var.
+			name:            "exact name expands, unmatched glob dropped",
+			clusterNS:       []string{"ns1"},
+			watchNamespaces: "ns1,app-*",
+			wantEnvValue:    "ns1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1086,7 +1127,8 @@ func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
 			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
 			sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: a.Namespace}}
-			assert.NoError(t, r.reconcileImageUpdaterDeployment(a, sa))
+			ws, expanded := testResolveWatchNamespaces(t, r, a)
+			assert.NoError(t, r.reconcileImageUpdaterDeployment(a, sa, ws, expanded))
 
 			deployment := &appsv1.Deployment{}
 			assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -1260,7 +1302,7 @@ func TestReconcileImageUpdaterDeployment_TLSArgs(t *testing.T) {
 				Scheme:                  scheme,
 				CentralTLSConfigProfile: tt.centralTLS,
 			}
-			err := r.reconcileImageUpdaterDeployment(cr, sa)
+			err := r.reconcileImageUpdaterDeployment(cr, sa, "", nil)
 			require.NoError(t, err)
 			deployment := &appsv1.Deployment{}
 			err = client.Get(context.TODO(), types.NamespacedName{Name: nameWithSuffix(common.ArgoCDImageUpdaterControllerComponent, cr), Namespace: cr.Namespace}, deployment)

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -622,18 +622,24 @@ func TestReconcileImageUpdater_RoleBindingForNamespace(t *testing.T) {
 	assert.True(t, errors.IsNotFound(err))
 }
 
-func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
+func TestReconcileImageUpdaterRBAC_WatchScope(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
 	tests := []struct {
-		name               string
-		watchNamespacesEnv string // raw value set in the env var; empty string means env var not set
-		// clusterConfigNS, when non-empty, is set as ARGOCD_CLUSTER_CONFIG_NAMESPACES for the subtest
-		clusterConfigNS   string
-		expectError       bool // reconcile must return an error
+		name string
+		// watchNamespacesEnv is the raw value placed in IMAGE_UPDATER_WATCH_NAMESPACES.
+		// An empty string means the env var is not set at all.
+		watchNamespacesEnv string
+		// clusterConfigNS, when non-empty, is set as ARGOCD_CLUSTER_CONFIG_NAMESPACES.
+		clusterConfigNS string
+		// clusterNamespaces are Namespace objects pre-created in the fake client so that
+		// expandImageUpdaterWatchNamespaces can match patterns against real namespace names.
+		clusterNamespaces []string
+		expectError       bool
 		expectClusterRole bool
 		expectClusterRB   bool
-		// namespaces where a manager role is expected (testNamespace = combined role in own ns)
+		// expectManagerRoleInNS lists every namespace where a manager Role is expected.
+		// Use testNamespace to assert the combined (base + manager) role in cr.Namespace.
 		expectManagerRoleInNS []string
 	}{
 		{
@@ -649,16 +655,43 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 			expectManagerRoleInNS: []string{testNamespace},
 		},
 		{
-			name:                  "comma-separated: two namespaces",
+			name:                  "exact list: two namespaces",
 			watchNamespacesEnv:    "ns1,ns2",
+			clusterNamespaces:     []string{"ns1", "ns2"},
 			expectClusterRole:     false,
 			expectManagerRoleInNS: []string{"ns1", "ns2"},
 		},
 		{
-			name:                  "comma-separated: single namespace",
+			name:                  "exact list: single namespace",
 			watchNamespacesEnv:    "ns1",
+			clusterNamespaces:     []string{"ns1"},
 			expectClusterRole:     false,
 			expectManagerRoleInNS: []string{"ns1"},
+		},
+		{
+			// Wildcard suffix — the typical Apps-in-Any-Namespace tenant pattern.
+			name:                  "glob wildcard: suffix pattern matches subset of namespaces",
+			watchNamespacesEnv:    "*-argocd",
+			clusterNamespaces:     []string{"team-a-argocd", "team-b-argocd", "unrelated"},
+			expectClusterRole:     false,
+			expectManagerRoleInNS: []string{"team-a-argocd", "team-b-argocd"},
+		},
+		{
+			// Multiple patterns — one glob and one exact name.
+			name:                  "glob wildcard: multiple patterns",
+			watchNamespacesEnv:    "*-argocd,staging",
+			clusterNamespaces:     []string{"team-a-argocd", "staging", "prod"},
+			expectClusterRole:     false,
+			expectManagerRoleInNS: []string{"team-a-argocd", "staging"},
+		},
+		{
+			// A namespace that exists in the cluster but is not matched by the pattern must
+			// not receive any RBAC objects.
+			name:                  "glob wildcard: non-matching namespaces get no RBAC",
+			watchNamespacesEnv:    "team-*",
+			clusterNamespaces:     []string{"team-a", "other"},
+			expectClusterRole:     false,
+			expectManagerRoleInNS: []string{"team-a"},
 		},
 		{
 			name:                  "cluster-scoped: watch namespaces set to *",
@@ -697,13 +730,18 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 			})
 
 			resObjs := []client.Object{a}
+			for _, ns := range tt.clusterNamespaces {
+				resObjs = append(resObjs, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+			}
 			subresObjs := []client.Object{a}
 			runtimeObjs := []runtime.Object{}
 			sch := makeTestReconcilerScheme(argoproj.AddToScheme, promoter.AddToScheme, apiregistrationv1.AddToScheme)
 			cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
-			err := r.reconcileImageUpdaterControllerEnabled(a)
+			sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: a.Namespace}}
+
+			err := r.reconcileImageUpdaterRBAC(a, sa)
 			if tt.expectError {
 				assert.Error(t, err)
 				return
@@ -712,7 +750,7 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 
 			for _, ns := range tt.expectManagerRoleInNS {
 				if ns == testNamespace {
-					// Namespace-scoped: base + manager rules are merged into a single role.
+					// Namespace-scoped mode: base + manager rules merged into a single role in cr.Namespace.
 					role := &rbacv1.Role{}
 					assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
 						Name:      generateResourceName(common.ArgoCDImageUpdaterControllerComponent, a),
@@ -720,7 +758,7 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 					}, role), "expected combined role in namespace %s", ns)
 					assert.NotEmpty(t, role.Rules)
 				} else {
-					// Comma-separated: manager role in the listed namespace.
+					// Pattern-list mode: per-namespace manager role.
 					role := &rbacv1.Role{}
 					assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
 						Name:      getRoleNameForApplicationSourceNamespaces(ns, a),
@@ -736,6 +774,22 @@ func TestReconcileImageUpdater_WatchNamespacesMode(t *testing.T) {
 					assert.Equal(t, role.Name, rb.RoleRef.Name)
 					assert.Equal(t, a.Namespace, rb.Subjects[0].Namespace)
 				}
+			}
+
+			// Assert namespaces that exist in the cluster but were NOT matched get no RBAC.
+			allMatched := make(map[string]struct{}, len(tt.expectManagerRoleInNS))
+			for _, ns := range tt.expectManagerRoleInNS {
+				allMatched[ns] = struct{}{}
+			}
+			for _, ns := range tt.clusterNamespaces {
+				if _, expected := allMatched[ns]; expected {
+					continue
+				}
+				err := r.Get(context.TODO(), types.NamespacedName{
+					Name:      getRoleNameForApplicationSourceNamespaces(ns, a),
+					Namespace: ns,
+				}, &rbacv1.Role{})
+				assert.True(t, errors.IsNotFound(err), "namespace %s should not have a manager role", ns)
 			}
 
 			clusterRBACName := GenerateUniqueResourceName(common.ArgoCDImageUpdaterControllerComponent, a)
@@ -909,10 +963,10 @@ func TestPruneImageUpdaterNamespaceRBAC(t *testing.T) {
 	})
 }
 
-// TestReconcileImageUpdaterControllerEnabled_PrunesStaleNamespaceRBAC verifies that when the
-// watch-namespace list shrinks, the operator removes roles and bindings for the dropped namespaces
-// without touching the remaining ones.
-func TestReconcileImageUpdaterControllerEnabled_PrunesStaleNamespaceRBAC(t *testing.T) {
+// TestReconcileImageUpdaterRBAC_PrunesStaleNamespaces verifies that when the
+// watch-namespace list shrinks, reconcileImageUpdaterRBAC removes roles and bindings
+// for the dropped namespaces without touching the remaining ones.
+func TestReconcileImageUpdaterRBAC_PrunesStaleNamespaces(t *testing.T) {
 	logf.SetLogger(ZapLogger(true))
 
 	// Start with ns1 and ns2 in the watch list.
@@ -923,15 +977,21 @@ func TestReconcileImageUpdaterControllerEnabled_PrunesStaleNamespaceRBAC(t *test
 		}
 	})
 
-	resObjs := []client.Object{a}
+	resObjs := []client.Object{
+		a,
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}},
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns2"}},
+	}
 	subresObjs := []client.Object{a}
 	runtimeObjs := []runtime.Object{}
 	sch := makeTestReconcilerScheme(argoproj.AddToScheme, promoter.AddToScheme, apiregistrationv1.AddToScheme)
 	cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
 	r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
+	sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: a.Namespace}}
+
 	// First reconcile: both namespaces get roles.
-	assert.NoError(t, r.reconcileImageUpdaterControllerEnabled(a))
+	assert.NoError(t, r.reconcileImageUpdaterRBAC(a, sa))
 
 	for _, ns := range []string{"ns1", "ns2"} {
 		assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -946,7 +1006,7 @@ func TestReconcileImageUpdaterControllerEnabled_PrunesStaleNamespaceRBAC(t *test
 	}
 
 	// Second reconcile: ns2 role and binding should be pruned.
-	assert.NoError(t, r.reconcileImageUpdaterControllerEnabled(a))
+	assert.NoError(t, r.reconcileImageUpdaterRBAC(a, sa))
 
 	// ns1 still exists.
 	assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
@@ -966,6 +1026,191 @@ func TestReconcileImageUpdaterControllerEnabled_PrunesStaleNamespaceRBAC(t *test
 		Namespace: "ns2",
 	}, &rbacv1.RoleBinding{})
 	assert.True(t, errors.IsNotFound(err), "stale role binding in ns2 should have been pruned")
+}
+
+// TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded verifies that glob/regex patterns
+// in IMAGE_UPDATER_WATCH_NAMESPACES are resolved to concrete namespace names before being
+// injected into the pod env, because the image-updater controller itself does not understand patterns.
+func TestReconcileImageUpdaterDeployment_WatchNamespacesExpanded(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	tests := []struct {
+		name            string
+		clusterNS       []string
+		watchNamespaces string
+		wantEnvValue    string // expected value of IMAGE_UPDATER_WATCH_NAMESPACES in the pod
+	}{
+		{
+			name:            "glob pattern is expanded to concrete names",
+			clusterNS:       []string{"team-a-argocd", "team-b-argocd", "unrelated"},
+			watchNamespaces: "*-argocd",
+			wantEnvValue:    "team-a-argocd,team-b-argocd",
+		},
+		{
+			name:            "exact names are passed through unchanged",
+			clusterNS:       []string{"ns1", "ns2"},
+			watchNamespaces: "ns1,ns2",
+			wantEnvValue:    "ns1,ns2",
+		},
+		{
+			name:            "* is passed through unchanged (cluster-scoped mode)",
+			watchNamespaces: "*",
+			wantEnvValue:    "*",
+		},
+		{
+			// When the pattern matches no existing namespaces the env var must NOT be
+			// replaced with "". Overwriting with "" would silently put the pod into
+			// namespace-scoped mode while the RBAC for that mode was never created.
+			name:            "no-match pattern is left unchanged in the pod",
+			clusterNS:       []string{"unrelated"},
+			watchNamespaces: "app-*",
+			wantEnvValue:    "app-*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+				a.Spec.ImageUpdater.Enabled = true
+				a.Spec.ImageUpdater.Env = []v1.EnvVar{
+					{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: tt.watchNamespaces},
+				}
+			})
+
+			resObjs := []client.Object{a}
+			for _, ns := range tt.clusterNS {
+				resObjs = append(resObjs, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+			}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, resObjs, []runtime.Object{})
+			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+			sa := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: a.Namespace}}
+			assert.NoError(t, r.reconcileImageUpdaterDeployment(a, sa))
+
+			deployment := &appsv1.Deployment{}
+			assert.NoError(t, r.Get(context.TODO(), types.NamespacedName{
+				Name:      generateResourceName(common.ArgoCDImageUpdaterControllerComponent, a),
+				Namespace: a.Namespace,
+			}, deployment))
+
+			var gotValue string
+			for _, e := range deployment.Spec.Template.Spec.Containers[0].Env {
+				if e.Name == "IMAGE_UPDATER_WATCH_NAMESPACES" {
+					gotValue = e.Value
+					break
+				}
+			}
+			assert.Equal(t, tt.wantEnvValue, gotValue)
+		})
+	}
+}
+
+func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	tests := []struct {
+		name            string
+		clusterNS       []string // Namespace objects to pre-create in the fake client
+		watchNamespaces string   // raw value passed to expandImageUpdaterWatchNamespaces
+		want            []string // expected result, must be sorted
+	}{
+		{
+			name:            "exact match: single namespace",
+			clusterNS:       []string{"ns1", "ns2"},
+			watchNamespaces: "ns1",
+			want:            []string{"ns1"},
+		},
+		{
+			name:            "exact match: multiple namespaces",
+			clusterNS:       []string{"ns1", "ns2", "ns3"},
+			watchNamespaces: "ns1,ns2",
+			want:            []string{"ns1", "ns2"},
+		},
+		{
+			name:            "glob: suffix wildcard",
+			clusterNS:       []string{"team-a-argocd", "team-b-argocd", "unrelated"},
+			watchNamespaces: "*-argocd",
+			want:            []string{"team-a-argocd", "team-b-argocd"},
+		},
+		{
+			name:            "glob: prefix wildcard",
+			clusterNS:       []string{"argocd-east", "argocd-west", "other"},
+			watchNamespaces: "argocd-*",
+			want:            []string{"argocd-east", "argocd-west"},
+		},
+		{
+			name:            "glob: multiple patterns, one glob and one exact",
+			clusterNS:       []string{"team-a-argocd", "staging", "prod"},
+			watchNamespaces: "*-argocd,staging",
+			want:            []string{"staging", "team-a-argocd"},
+		},
+		{
+			// Regex patterns must be wrapped in "/" to be treated as a true regular expression;
+			// without the slashes the pattern falls through to glob matching.
+			name:            "regex: slash-delimited pattern matches numeric suffix",
+			clusterNS:       []string{"tenant-001", "tenant-002", "tenant-abc", "not-tenant"},
+			watchNamespaces: "/tenant-[0-9]+/",
+			want:            []string{"tenant-001", "tenant-002"},
+		},
+		{
+			// Glob character classes work without regex delimiters.
+			name:            "glob: character class in pattern",
+			clusterNS:       []string{"tenant-001", "tenant-002", "tenant-abc"},
+			watchNamespaces: "tenant-[0-9][0-9][0-9]",
+			want:            []string{"tenant-001", "tenant-002"},
+		},
+		{
+			name:            "whitespace trimmed from each pattern",
+			clusterNS:       []string{"ns1", "ns2"},
+			watchNamespaces: " ns1 , ns2 ",
+			want:            []string{"ns1", "ns2"},
+		},
+		{
+			name:            "result is sorted regardless of cluster order",
+			clusterNS:       []string{"z-ns", "a-ns", "m-ns"},
+			watchNamespaces: "*-ns",
+			want:            []string{"a-ns", "m-ns", "z-ns"},
+		},
+		{
+			name:            "namespace matched by two patterns is returned only once",
+			clusterNS:       []string{"ns1"},
+			watchNamespaces: "ns1,ns*",
+			want:            []string{"ns1"},
+		},
+		{
+			name:            "pattern matches no namespaces",
+			clusterNS:       []string{"ns1", "ns2"},
+			watchNamespaces: "nonexistent",
+			want:            nil,
+		},
+		{
+			name:            "no cluster namespaces",
+			clusterNS:       []string{},
+			watchNamespaces: "ns1",
+			want:            nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+				a.Spec.ImageUpdater.Enabled = true
+			})
+
+			resObjs := []client.Object{a}
+			for _, ns := range tt.clusterNS {
+				resObjs = append(resObjs, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+			}
+			sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+			cl := makeTestReconcilerClient(sch, resObjs, resObjs, []runtime.Object{})
+			r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+			got, err := r.expandImageUpdaterWatchNamespaces(tt.watchNamespaces)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestReconcileImageUpdaterDeployment_TLSArgs(t *testing.T) {

--- a/controllers/argocd/image_updater_test.go
+++ b/controllers/argocd/image_updater_test.go
@@ -1232,6 +1232,24 @@ func TestExpandImageUpdaterWatchNamespaces(t *testing.T) {
 			watchNamespaces: "ns1",
 			want:            nil,
 		},
+		{
+			name:            "trailing comma does not produce an empty match-all pattern",
+			clusterNS:       []string{"app-ns", "other-ns"},
+			watchNamespaces: "app-ns,",
+			want:            []string{"app-ns"},
+		},
+		{
+			name:            "leading and trailing commas are stripped",
+			clusterNS:       []string{"app-ns"},
+			watchNamespaces: ",app-ns,",
+			want:            []string{"app-ns"},
+		},
+		{
+			name:            "only commas returns nil (no valid patterns)",
+			clusterNS:       []string{"app-ns"},
+			watchNamespaces: ",,,",
+			want:            nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -825,7 +825,7 @@ func removeString(slice []string, s string) []string {
 }
 
 // setResourceWatches will register Watches for each of the supported Resources.
-func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResourceMapper, tlsSecretMapper, namespaceResourceMapper, clusterSecretResourceMapper, applicationSetGitlabSCMTLSConfigMapMapper, nmMapper, systemCATrustMapper, imagePullSecretMapper handler.MapFunc) *builder.Builder {
+func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResourceMapper, tlsSecretMapper, namespaceResourceMapper, clusterSecretResourceMapper, applicationSetGitlabSCMTLSConfigMapMapper, nmMapper, systemCATrustMapper, imagePullSecretMapper handler.MapFunc, imageUpdaterWatchNSMapper handler.MapFunc) *builder.Builder {
 
 	// Add new predicate to delete Notifications Resources. The predicate watches the Argo CD CR for changes to the `.spec.Notifications.Enabled`
 	// field. When a change is detected that results in notifications being disabled, we trigger deletion of notifications resources
@@ -929,6 +929,17 @@ func (r *ReconcileArgoCD) setResourceWatches(bldr *builder.Builder, clusterResou
 
 	namespaceHandler := handler.EnqueueRequestsFromMapFunc(namespaceResourceMapper)
 	bldr.Watches(&corev1.Namespace{}, namespaceHandler, builder.WithPredicates(r.namespaceFilterPredicate()))
+
+	// Watch Namespace create/delete events that may match IMAGE_UPDATER_WATCH_NAMESPACES patterns so
+	// that RBAC and the deployment env var are updated without delay when a new tenant namespace appears
+	// or an existing one is removed.
+	bldr.Watches(&corev1.Namespace{}, handler.EnqueueRequestsFromMapFunc(imageUpdaterWatchNSMapper),
+		builder.WithPredicates(predicate.Funcs{
+			CreateFunc:  func(e event.CreateEvent) bool { return true },
+			DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+			UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+			GenericFunc: func(e event.GenericEvent) bool { return false },
+		}))
 
 	bldrHook := newBuilderHook(r.Client, bldr)
 	err := applyReconcilerHook(&argoproj.ArgoCD{}, bldrHook, "")

--- a/docs/usage/image-updater.md
+++ b/docs/usage/image-updater.md
@@ -28,7 +28,7 @@ The operator supports two installation modes:
 
 The controller runs in the same namespace as the Argo CD instance and watches only that namespace. This is the default behavior when `IMAGE_UPDATER_WATCH_NAMESPACES` is not set or is empty.
 
-If you use Argo CD's [Applications in any namespace](https://argocd-operator.readthedocs.io/en/latest/usage/apps-in-any-namespace/) feature and have `Application` resources in additional namespaces, you can specify a comma-separated list of namespaces to watch:
+If you use Argo CD's [Applications in any namespace](https://argocd-operator.readthedocs.io/en/latest/usage/apps-in-any-namespace/) feature and have `Application` resources in additional namespaces, you can specify a comma-separated list of namespaces to watch. Each entry can be an exact name, a glob-style wildcard, or a regular expression:
 
 ``` yaml
 spec:
@@ -36,10 +36,23 @@ spec:
     enabled: true
     env:
       - name: IMAGE_UPDATER_WATCH_NAMESPACES
-        value: "app-ns1,app-ns2"
+        value: "app-ns1,app-ns2"          # exact names
 ```
 
-The operator will create a `Role` and `RoleBinding` in each listed namespace so the controller can access resources there.
+``` yaml
+      - name: IMAGE_UPDATER_WATCH_NAMESPACES
+        value: "*-argocd"                 # glob: matches team-a-argocd, team-b-argocd, ...
+```
+
+``` yaml
+      - name: IMAGE_UPDATER_WATCH_NAMESPACES
+        value: "/^team-[0-9]+$/"          # regex (must be wrapped in /.../)
+```
+
+The operator resolves the patterns to concrete namespaces at reconcile time and creates a `Role` and `RoleBinding` in each matching namespace. When the namespace list changes (e.g. a new tenant namespace is created that matches the pattern), the operator automatically provisions the required RBAC on the next reconcile.
+
+!!! note
+    Regular expression patterns must be wrapped in forward slashes (`/pattern/`). Patterns without slashes are treated as glob patterns. For example, `team-*` is a glob (matches `team-1`, `team-frontend`, etc.), while `/^team-[0-9]+$/` is a regex (matches `team-1` but not `team-frontend`).
 
 #### Cluster-scoped installation
 

--- a/examples/argocd-image-updater.yaml
+++ b/examples/argocd-image-updater.yaml
@@ -10,6 +10,8 @@ spec:
     env:
       - name: IMAGE_UPDATER_LOGLEVEL
         value: trace
+      - name: IMAGE_UPDATER_WATCH_NAMESPACES
+        value: "*-argocd"
     resources:
       limits:
         cpu: 500m

--- a/tests/ginkgo/sequential/1-142_validate_image_updater_watch_namespaces_test.go
+++ b/tests/ginkgo/sequential/1-142_validate_image_updater_watch_namespaces_test.go
@@ -127,14 +127,82 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			}, "2m", "5s").Should(k8sFixture.NotExistByName())
 		}
 
+		It("verifies that creating a new namespace matching IMAGE_UPDATER_WATCH_NAMESPACES triggers automatic RBAC creation without manual operator interaction", func() {
+
+			By("creating a cluster-scoped namespace for the Argo CD instance")
+			argoNamespace, _ = fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-iuw-new-ns")
+			cleanupFunctions = append(cleanupFunctions, func() { fixture.DeleteNamespace(argoNamespace) })
+
+			By("creating an initial matching namespace app-ns-1 before ArgoCD is configured")
+			appNs1, cleanup := fixture.CreateNamespaceWithCleanupFunc("app-dyn-1")
+			cleanupFunctions = append(cleanupFunctions, cleanup)
+
+			By("creating ArgoCD CR with Image Updater enabled and IMAGE_UPDATER_WATCH_NAMESPACES=app-dyn-* (glob)")
+			argoCD = &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      argocdName,
+					Namespace: argoNamespace.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					ImageUpdater: argov1beta1api.ArgoCDImageUpdaterSpec{
+						Enabled: true,
+						Env: []corev1.EnvVar{
+							{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "app-dyn-*"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD instance to become available")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			By("verifying initial RBAC is created in app-dyn-1 (pre-existing namespace matched by the pattern)")
+			expectRBACExists(appNs1.Name)
+
+			By("verifying IMAGE_UPDATER_WATCH_NAMESPACES in the deployment is set to app-dyn-1")
+			imageUpdaterDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-argocd-image-updater-controller", argocdName),
+					Namespace: argoNamespace.Name,
+				},
+			}
+			Eventually(imageUpdaterDeployment, "2m", "5s").Should(
+				deplFixture.HaveContainerWithEnvVar("IMAGE_UPDATER_WATCH_NAMESPACES", "app-dyn-1", 0),
+			)
+
+			By("creating a new namespace app-dyn-2 AFTER the operator is already running")
+			appNs2, cleanup := fixture.CreateNamespaceWithCleanupFunc("app-dyn-2")
+			cleanupFunctions = append(cleanupFunctions, cleanup)
+
+			By("verifying the operator auto-reconciles and creates RBAC in app-dyn-2 (triggered by imageUpdaterWatchNSMapper)")
+			expectRBACExists(appNs2.Name)
+
+			By("verifying IMAGE_UPDATER_WATCH_NAMESPACES in the deployment is expanded to include app-dyn-2")
+			Eventually(imageUpdaterDeployment, "2m", "5s").Should(
+				deplFixture.HaveContainerWithEnvVar("IMAGE_UPDATER_WATCH_NAMESPACES", "app-dyn-1,app-dyn-2", 0),
+			)
+
+			By("creating another non-matching namespace to confirm it does not affect RBAC or deployment env var")
+			_, cleanup = fixture.CreateNamespaceWithCleanupFunc("other-dyn-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanup)
+
+			By("verifying RBAC is absent in other-dyn-ns (no match)")
+			expectRBACAbsent("other-dyn-ns")
+
+			By("verifying deployment env var is still app-dyn-1,app-dyn-2 after unmatched namespace creation")
+			Eventually(imageUpdaterDeployment, "1m", "5s").Should(
+				deplFixture.HaveContainerWithEnvVar("IMAGE_UPDATER_WATCH_NAMESPACES", "app-dyn-1,app-dyn-2", 0),
+			)
+		})
+
 		It("verifies glob and regex patterns in IMAGE_UPDATER_WATCH_NAMESPACES create RBAC only in matching namespaces and prune stale entries", func() {
 
 			By("creating a cluster-scoped namespace for the Argo CD instance")
 			argoNamespace, _ = fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-iuw-ns")
-			// argoNamespace is cleaned up via argoCD deletion first, then the namespace cleanup below.
 			cleanupFunctions = append(cleanupFunctions, func() { fixture.DeleteNamespace(argoNamespace) })
 
-			By("creating target namespaces: app-ns-1 and app-ns-2 (should match), other-ns (should not)")
+			By("creating target namespaces: app-ns-1 and app-ns-2 (match app-ns-*), other-ns (no match)")
 			appNs1, cleanup := fixture.CreateNamespaceWithCleanupFunc("app-ns-1")
 			cleanupFunctions = append(cleanupFunctions, cleanup)
 
@@ -179,7 +247,8 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 					Namespace: argoNamespace.Name,
 				},
 			}
-			// expandImageUpdaterWatchNamespaces sorts results, so app-ns-1 comes before app-ns-2.
+			// resolveImageUpdaterWatchNamespaces sorts within each pattern's matches, so
+			// app-ns-1 comes before app-ns-2.
 			Eventually(imageUpdaterDeployment, "2m", "5s").Should(
 				deplFixture.HaveContainerWithEnvVar("IMAGE_UPDATER_WATCH_NAMESPACES", "app-ns-1,app-ns-2", 0),
 			)
@@ -191,13 +260,13 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 				}
 			})
 
-			By("verifying RBAC for app-ns-1 is retained")
+			By("verifying RBAC for app-ns-1 is retained (regex still matches)")
 			expectRBACExists(appNs1.Name)
 
-			By("verifying RBAC for app-ns-2 is pruned after pattern change")
+			By("verifying RBAC for app-ns-2 is pruned (no longer matched by any pattern)")
 			expectRBACPruned(appNs2.Name)
 
-			By("verifying IMAGE_UPDATER_WATCH_NAMESPACES env var in the deployment is updated to only app-ns-1")
+			By("verifying IMAGE_UPDATER_WATCH_NAMESPACES in the deployment is updated to only app-ns-1")
 			Eventually(imageUpdaterDeployment, "2m", "5s").Should(
 				deplFixture.HaveContainerWithEnvVar("IMAGE_UPDATER_WATCH_NAMESPACES", "app-ns-1", 0),
 			)

--- a/tests/ginkgo/sequential/1-142_validate_image_updater_watch_namespaces_test.go
+++ b/tests/ginkgo/sequential/1-142_validate_image_updater_watch_namespaces_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sequential
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	argov1beta1api "github.com/argoproj-labs/argocd-operator/api/v1beta1"
+	argoutil "github.com/argoproj-labs/argocd-operator/controllers/argoutil"
+	"github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture"
+	argocdFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/argocd"
+	deplFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/deployment"
+	k8sFixture "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/k8s"
+	fixtureUtils "github.com/argoproj-labs/argocd-operator/tests/ginkgo/fixture/utils"
+)
+
+var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
+
+	Context("1-142_validate_image_updater_watch_namespaces", func() {
+
+		const argocdName = "example-argocd"
+
+		var (
+			k8sClient        client.Client
+			ctx              context.Context
+			argoNamespace    *corev1.Namespace
+			argoCD           *argov1beta1api.ArgoCD
+			cleanupFunctions []func()
+		)
+
+		BeforeEach(func() {
+			fixture.EnsureSequentialCleanSlate()
+			k8sClient, _ = fixtureUtils.GetE2ETestKubeClient()
+			ctx = context.Background()
+			cleanupFunctions = []func(){}
+		})
+
+		AfterEach(func() {
+			fixture.OutputDebugOnFail(argoNamespace)
+
+			if argoCD != nil {
+				err := k8sClient.Delete(ctx, argoCD)
+				if err != nil && !apierrors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
+
+			for _, f := range cleanupFunctions {
+				f()
+			}
+		})
+
+		// imageUpdaterRoleName returns the expected Role name created by the operator
+		// in a watch namespace for the Image Updater.
+		imageUpdaterRoleName := func(ns string) string {
+			return fmt.Sprintf("%s_%s", argocdName, ns)
+		}
+
+		// imageUpdaterRoleBindingName returns the expected RoleBinding name (possibly truncated).
+		imageUpdaterRoleBindingName := func(ns string) string {
+			return argoutil.TruncateWithHash(fmt.Sprintf("%s_%s", argocdName, ns), argoutil.GetMaxLabelLength())
+		}
+
+		// expectRBACExists asserts that the operator has created a Role and RoleBinding in ns.
+		expectRBACExists := func(ns string) {
+			GinkgoHelper()
+			By("verifying Role exists in " + ns)
+			Eventually(&rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: imageUpdaterRoleName(ns), Namespace: ns},
+			}, "2m", "5s").Should(k8sFixture.ExistByName())
+
+			By("verifying RoleBinding exists in " + ns)
+			Eventually(&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: imageUpdaterRoleBindingName(ns), Namespace: ns},
+			}, "2m", "5s").Should(k8sFixture.ExistByName())
+		}
+
+		// expectRBACAbsent asserts that no Image Updater Role or RoleBinding is present in ns.
+		expectRBACAbsent := func(ns string) {
+			GinkgoHelper()
+			By("verifying Role is absent in " + ns)
+			Consistently(&rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: imageUpdaterRoleName(ns), Namespace: ns},
+			}, "15s", "3s").Should(k8sFixture.NotExistByName())
+
+			By("verifying RoleBinding is absent in " + ns)
+			Consistently(&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: imageUpdaterRoleBindingName(ns), Namespace: ns},
+			}, "15s", "3s").Should(k8sFixture.NotExistByName())
+		}
+
+		// expectRBACPruned asserts that a previously existing Role and RoleBinding are eventually deleted.
+		expectRBACPruned := func(ns string) {
+			GinkgoHelper()
+			By("verifying Role is pruned from " + ns)
+			Eventually(&rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: imageUpdaterRoleName(ns), Namespace: ns},
+			}, "2m", "5s").Should(k8sFixture.NotExistByName())
+
+			By("verifying RoleBinding is pruned from " + ns)
+			Eventually(&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: imageUpdaterRoleBindingName(ns), Namespace: ns},
+			}, "2m", "5s").Should(k8sFixture.NotExistByName())
+		}
+
+		It("verifies glob and regex patterns in IMAGE_UPDATER_WATCH_NAMESPACES create RBAC only in matching namespaces and prune stale entries", func() {
+
+			By("creating a cluster-scoped namespace for the Argo CD instance")
+			argoNamespace, _ = fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-iuw-ns")
+			// argoNamespace is cleaned up via argoCD deletion first, then the namespace cleanup below.
+			cleanupFunctions = append(cleanupFunctions, func() { fixture.DeleteNamespace(argoNamespace) })
+
+			By("creating target namespaces: app-ns-1 and app-ns-2 (should match), other-ns (should not)")
+			appNs1, cleanup := fixture.CreateNamespaceWithCleanupFunc("app-ns-1")
+			cleanupFunctions = append(cleanupFunctions, cleanup)
+
+			appNs2, cleanup := fixture.CreateNamespaceWithCleanupFunc("app-ns-2")
+			cleanupFunctions = append(cleanupFunctions, cleanup)
+
+			_, cleanup = fixture.CreateNamespaceWithCleanupFunc("other-ns")
+			cleanupFunctions = append(cleanupFunctions, cleanup)
+
+			By("creating ArgoCD CR with Image Updater enabled and IMAGE_UPDATER_WATCH_NAMESPACES=app-ns-* (glob)")
+			argoCD = &argov1beta1api.ArgoCD{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      argocdName,
+					Namespace: argoNamespace.Name,
+				},
+				Spec: argov1beta1api.ArgoCDSpec{
+					ImageUpdater: argov1beta1api.ArgoCDImageUpdaterSpec{
+						Enabled: true,
+						Env: []corev1.EnvVar{
+							{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "app-ns-*"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, argoCD)).To(Succeed())
+
+			By("waiting for ArgoCD instance to become available")
+			Eventually(argoCD, "5m", "5s").Should(argocdFixture.BeAvailable())
+
+			By("verifying RBAC is created in app-ns-1 and app-ns-2 (glob matches)")
+			expectRBACExists(appNs1.Name)
+			expectRBACExists(appNs2.Name)
+
+			By("verifying RBAC is NOT created in other-ns (pattern does not match)")
+			expectRBACAbsent("other-ns")
+
+			By("verifying IMAGE_UPDATER_WATCH_NAMESPACES env var in the deployment is expanded to concrete namespaces")
+			imageUpdaterDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					// Deployment name: {argocd-name}-argocd-image-updater-controller
+					Name:      fmt.Sprintf("%s-argocd-image-updater-controller", argocdName),
+					Namespace: argoNamespace.Name,
+				},
+			}
+			// expandImageUpdaterWatchNamespaces sorts results, so app-ns-1 comes before app-ns-2.
+			Eventually(imageUpdaterDeployment, "2m", "5s").Should(
+				deplFixture.HaveContainerWithEnvVar("IMAGE_UPDATER_WATCH_NAMESPACES", "app-ns-1,app-ns-2", 0),
+			)
+
+			By("updating IMAGE_UPDATER_WATCH_NAMESPACES to a regex that only matches app-ns-1")
+			argocdFixture.Update(argoCD, func(ac *argov1beta1api.ArgoCD) {
+				ac.Spec.ImageUpdater.Env = []corev1.EnvVar{
+					{Name: "IMAGE_UPDATER_WATCH_NAMESPACES", Value: "/^app-ns-1$/"},
+				}
+			})
+
+			By("verifying RBAC for app-ns-1 is retained")
+			expectRBACExists(appNs1.Name)
+
+			By("verifying RBAC for app-ns-2 is pruned after pattern change")
+			expectRBACPruned(appNs2.Name)
+
+			By("verifying IMAGE_UPDATER_WATCH_NAMESPACES env var in the deployment is updated to only app-ns-1")
+			Eventually(imageUpdaterDeployment, "2m", "5s").Should(
+				deplFixture.HaveContainerWithEnvVar("IMAGE_UPDATER_WATCH_NAMESPACES", "app-ns-1", 0),
+			)
+		})
+	})
+})

--- a/tests/ginkgo/sequential/1-142_validate_image_updater_watch_namespaces_test.go
+++ b/tests/ginkgo/sequential/1-142_validate_image_updater_watch_namespaces_test.go
@@ -133,7 +133,7 @@ var _ = Describe("GitOps Operator Sequential E2E Tests", func() {
 			argoNamespace, _ = fixture.CreateNamespaceWithCleanupFunc("argocd-e2e-iuw-new-ns")
 			cleanupFunctions = append(cleanupFunctions, func() { fixture.DeleteNamespace(argoNamespace) })
 
-			By("creating an initial matching namespace app-ns-1 before ArgoCD is configured")
+			By("creating an initial matching namespace app-dyn-1 before ArgoCD is configured")
 			appNs1, cleanup := fixture.CreateNamespaceWithCleanupFunc("app-dyn-1")
 			cleanupFunctions = append(cleanupFunctions, cleanup)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
see GITOPS-10660
Update ImageUpdater in ArgoCD Operator to accept wildcard patterns in IMAGE_UPDATER_WATCH_NAMESPACES, in addition to explicit comma-separated namespaces. Ensure namespace selection follows the same pattern semantics used by other OpenShift GitOps components, including common tenant patterns such as *-argocd.

The implementation should follow applicationSet.sourceNamespaces

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?
GITOPS-10660

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image Updater supports exact namespace names, glob patterns, and regular expressions for watch scope.
  - Matching namespaces are reflected in deployment configuration and access permissions.
  - Watch-scope changes automatically update permissions and deployment settings as namespaces match or stop matching.
  - Creating or removing namespaces triggers watch-scope updates.
  - Image pull secret references are updated automatically on supported platforms.

- **Bug Fixes**
  - Terminating namespaces are excluded from watch-scope matching.
  - Invalid, overly broad, or conflicting patterns are rejected.

- **Documentation**
  - Updated watch-scope guidance and examples.

- **Tests**
  - Added coverage for pattern matching, updates, and stale permission cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->