### PR TITLE
fix: implement the defined but unconsumed `spec.tls.ca.secretName` field

### DIFF
--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -386,15 +386,21 @@ func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoproj.ArgoCD) error {
 		return r.Create(context.TODO(), cm)
 	}
 
-	// ConfigMap exists — only update if ca.crt key is missing (backfill for pre-fix ConfigMaps)
-	if _, hasCACert := existingCM.Data[common.ArgoCDKeyTLSCACert]; !hasCACert {
-		if existingCM.Data == nil {
-			existingCM.Data = make(map[string]string)
+	// ConfigMap exists — sync only the operator-managed keys (tls.crt, ca.crt).
+	// This handles both the initial backfill (missing keys) and cert rotation
+	// when spec.tls.ca.secretName is changed to a different secret.
+	// Unrelated keys added by the user are preserved.
+	needsUpdate := false
+	if existingCM.Data == nil {
+		existingCM.Data = make(map[string]string)
+	}
+	for key, desiredVal := range desiredData {
+		if existingCM.Data[key] != desiredVal {
+			existingCM.Data[key] = desiredVal
+			needsUpdate = true
 		}
-		if _, hasTLSCert := existingCM.Data[common.ArgoCDKeyTLSCert]; !hasTLSCert {
-			existingCM.Data[common.ArgoCDKeyTLSCert] = desiredData[common.ArgoCDKeyTLSCert]
-		}
-		existingCM.Data[common.ArgoCDKeyTLSCACert] = desiredData[common.ArgoCDKeyTLSCACert]
+	}
+	if needsUpdate {
 		argoutil.LogResourceUpdate(log, existingCM)
 		return r.Update(context.TODO(), existingCM)
 	}

--- a/controllers/argocd/configmap.go
+++ b/controllers/argocd/configmap.go
@@ -76,6 +76,14 @@ func getCAConfigMapName(cr *argoproj.ArgoCD) string {
 	return nameWithSuffix(common.ArgoCDCASuffix, cr)
 }
 
+// getCASecretName will return the CA Secret name for the given ArgoCD.
+func getCASecretName(cr *argoproj.ArgoCD) string {
+	if len(cr.Spec.TLS.CA.SecretName) > 0 {
+		return cr.Spec.TLS.CA.SecretName
+	}
+	return nameWithSuffix(common.ArgoCDCASuffix, cr)
+}
+
 // getSCMRootCAConfigMapName will return the SCMRootCA ConfigMap name for the given ArgoCD ApplicationSet Controller.
 func getSCMRootCAConfigMapName(cr *argoproj.ArgoCD) string {
 	if cr.Spec.ApplicationSet.SCMRootCAConfigMap != "" && len(cr.Spec.ApplicationSet.SCMRootCAConfigMap) > 0 {
@@ -348,7 +356,7 @@ func (r *ReconcileArgoCD) reconcileConfigMaps(cr *argoproj.ArgoCD, useTLSForRedi
 func (r *ReconcileArgoCD) reconcileCAConfigMap(cr *argoproj.ArgoCD) error {
 	cm := newConfigMapWithName(getCAConfigMapName(cr), cr)
 
-	caSecret := argoutil.NewSecretWithSuffix(cr, common.ArgoCDCASuffix)
+	caSecret := argoutil.NewSecretWithName(cr, getCASecretName(cr))
 	caSecretExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, caSecret.Name, caSecret)
 	if err != nil {
 		return err

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -2250,4 +2250,52 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		assert.Equal(t, "sentinel-tls", cm.Data[common.ArgoCDKeyTLSCert], "existing tls.crt should be preserved unchanged")
 		assert.Equal(t, "sentinel-ca", cm.Data[common.ArgoCDKeyTLSCACert], "existing ca.crt should be preserved unchanged")
 	})
+
+	t.Run("uses custom CA secret name from spec.tls.ca.secretName", func(t *testing.T) {
+		const customSecretName = "my-custom-ca"
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+			a.Spec.TLS.CA.SecretName = customSecretName
+		})
+
+		caSecret, err := newCASecret(a)
+		require.NoError(t, err)
+		require.Equal(t, customSecretName, caSecret.Name, "newCASecret must honour spec.tls.ca.secretName")
+
+		resObjs := []client.Object{a, caSecret}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err = r.reconcileCAConfigMap(a)
+		require.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      getCAConfigMapName(a),
+			Namespace: a.Namespace,
+		}, cm)
+		require.NoError(t, err)
+
+		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCert, "ConfigMap should have tls.crt key")
+		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCACert, "ConfigMap should have ca.crt key")
+		assert.Equal(t, string(caSecret.Data[corev1.TLSCertKey]), cm.Data[common.ArgoCDKeyTLSCert])
+		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
+	})
+}
+
+func TestGetCASecretName(t *testing.T) {
+	t.Run("returns default suffix-based name when SecretName is not set", func(t *testing.T) {
+		a := makeTestArgoCD()
+		// testArgoCDName is "argocd", so the default is "argocd-ca"
+		assert.Equal(t, "argocd-ca", getCASecretName(a))
+	})
+
+	t.Run("returns custom name when spec.tls.ca.secretName is set", func(t *testing.T) {
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+			a.Spec.TLS.CA.SecretName = "my-custom-ca"
+		})
+		assert.Equal(t, "my-custom-ca", getCASecretName(a))
+	})
 }

--- a/controllers/argocd/configmap_test.go
+++ b/controllers/argocd/configmap_test.go
@@ -2174,14 +2174,14 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		caSecret, err := newCASecret(a)
 		require.NoError(t, err)
 
-		// Create ConfigMap with only tls.crt + an extra key (simulating pre-fix state with custom data)
+		// ConfigMap has only a stale tls.crt and an unrelated user key; ca.crt is absent.
 		oldCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      getCAConfigMapName(a),
 				Namespace: a.Namespace,
 			},
 			Data: map[string]string{
-				common.ArgoCDKeyTLSCert: "existing-tls",
+				common.ArgoCDKeyTLSCert: "stale-tls",
 				"someOtherKey":          "someValue",
 			},
 		}
@@ -2203,28 +2203,29 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		}, cm)
 		require.NoError(t, err)
 
-		assert.Equal(t, "existing-tls", cm.Data[common.ArgoCDKeyTLSCert], "existing tls.crt should be preserved")
-		assert.Contains(t, cm.Data, common.ArgoCDKeyTLSCACert, "ConfigMap should now have ca.crt key added")
-		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
-		assert.Contains(t, cm.Data, "someOtherKey", "existing keys should be preserved")
-		assert.Equal(t, "someValue", cm.Data["someOtherKey"], "existing key values should be preserved")
+		// Both managed keys must now reflect the current secret.
+		assert.Equal(t, string(caSecret.Data[corev1.TLSCertKey]), cm.Data[common.ArgoCDKeyTLSCert], "tls.crt should be updated from secret")
+		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert], "ca.crt should be added from secret")
+		// Unrelated keys must survive untouched.
+		assert.Equal(t, "someValue", cm.Data["someOtherKey"], "unrelated keys must be preserved")
 	})
 
-	t.Run("no-op when both keys are already present", func(t *testing.T) {
+	t.Run("no-op when both keys already match the current secret", func(t *testing.T) {
 		a := makeTestArgoCD()
 
 		caSecret, err := newCASecret(a)
 		require.NoError(t, err)
 
-		// Create ConfigMap with sentinel values (simulating post-fix state)
+		// Pre-populate the ConfigMap with the exact values from the secret so reconcile is a no-op.
 		existingCM := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      getCAConfigMapName(a),
 				Namespace: a.Namespace,
 			},
 			Data: map[string]string{
-				common.ArgoCDKeyTLSCert:   "sentinel-tls",
-				common.ArgoCDKeyTLSCACert: "sentinel-ca",
+				common.ArgoCDKeyTLSCert:   string(caSecret.Data[corev1.TLSCertKey]),
+				common.ArgoCDKeyTLSCACert: string(caSecret.Data[corev1.ServiceAccountRootCAKey]),
+				"someOtherKey":            "someValue",
 			},
 		}
 
@@ -2233,7 +2234,7 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		runtimeObjs := []runtime.Object{}
 		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
 		cl := fake.NewClientBuilder().WithScheme(sch).WithObjects(resObjs...).WithStatusSubresource(subresObjs...).WithRuntimeObjects(runtimeObjs...).WithInterceptorFuncs(interceptor.Funcs{Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-			return fmt.Errorf("unexpected Update call to configmaps")
+			return fmt.Errorf("unexpected Update call to configmap")
 		}}).Build()
 		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
 
@@ -2247,8 +2248,56 @@ func TestReconcileArgoCD_reconcileCAConfigMap(t *testing.T) {
 		}, cm)
 		require.NoError(t, err)
 
-		assert.Equal(t, "sentinel-tls", cm.Data[common.ArgoCDKeyTLSCert], "existing tls.crt should be preserved unchanged")
-		assert.Equal(t, "sentinel-ca", cm.Data[common.ArgoCDKeyTLSCACert], "existing ca.crt should be preserved unchanged")
+		assert.Equal(t, string(caSecret.Data[corev1.TLSCertKey]), cm.Data[common.ArgoCDKeyTLSCert])
+		assert.Equal(t, string(caSecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert])
+		assert.Equal(t, "someValue", cm.Data["someOtherKey"], "unrelated keys must be preserved")
+	})
+
+	t.Run("updates stale managed keys when spec.tls.ca.secretName is rotated to a different secret", func(t *testing.T) {
+		const newSecretName = "my-rotated-ca"
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+			a.Spec.TLS.CA.SecretName = newSecretName
+		})
+
+		newCASecret, err := newCASecret(a)
+		require.NoError(t, err)
+		require.Equal(t, newSecretName, newCASecret.Name)
+
+		// ConfigMap still holds data from the old secret (stale) plus an unrelated user key.
+		staleCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      getCAConfigMapName(a),
+				Namespace: a.Namespace,
+			},
+			Data: map[string]string{
+				common.ArgoCDKeyTLSCert:   "old-tls-cert-data",
+				common.ArgoCDKeyTLSCACert: "old-ca-cert-data",
+				"someOtherKey":            "someValue",
+			},
+		}
+
+		resObjs := []client.Object{a, newCASecret, staleCM}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err = r.reconcileCAConfigMap(a)
+		require.NoError(t, err)
+
+		cm := &corev1.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      getCAConfigMapName(a),
+			Namespace: a.Namespace,
+		}, cm)
+		require.NoError(t, err)
+
+		// Managed keys must now reflect the new (rotated) secret.
+		assert.Equal(t, string(newCASecret.Data[corev1.TLSCertKey]), cm.Data[common.ArgoCDKeyTLSCert], "tls.crt must be updated from the new secret")
+		assert.Equal(t, string(newCASecret.Data[corev1.ServiceAccountRootCAKey]), cm.Data[common.ArgoCDKeyTLSCACert], "ca.crt must be updated from the new secret")
+		// Unrelated keys must survive untouched.
+		assert.Equal(t, "someValue", cm.Data["someOtherKey"], "unrelated keys must be preserved")
 	})
 
 	t.Run("uses custom CA secret name from spec.tls.ca.secretName", func(t *testing.T) {

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -81,9 +81,11 @@ func nowNano() string {
 	return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 }
 
-// newCASecret creates a new CA secret with the given suffix for the given ArgoCD.
+// newCASecret creates a new CA secret for the given ArgoCD.
+// The secret name is taken from spec.tls.ca.secretName when set, otherwise it defaults to the "{cr.Name}-ca" suffix.
 func newCASecret(cr *argoproj.ArgoCD) (*corev1.Secret, error) {
-	secret := argoutil.NewTLSSecret(cr, "ca")
+	secret := argoutil.NewSecretWithName(cr, getCASecretName(cr))
+	secret.Type = corev1.SecretTypeTLS
 
 	key, err := argoutil.NewPrivateKey()
 	if err != nil {
@@ -260,7 +262,7 @@ func (r *ReconcileArgoCD) reconcileClusterTLSSecret(cr *argoproj.ArgoCD) error {
 		return nil // Secret found, do nothing
 	}
 
-	caSecret := argoutil.NewSecretWithSuffix(cr, "ca")
+	caSecret := argoutil.NewSecretWithName(cr, getCASecretName(cr))
 	caSecret, err = argoutil.FetchSecret(r.Client, cr.ObjectMeta, caSecret.Name)
 	if err != nil {
 		return err
@@ -291,7 +293,7 @@ func (r *ReconcileArgoCD) reconcileClusterTLSSecret(cr *argoproj.ArgoCD) error {
 
 // reconcileClusterCASecret ensures the CA Secret is created for the ArgoCD cluster.
 func (r *ReconcileArgoCD) reconcileClusterCASecret(cr *argoproj.ArgoCD) error {
-	secret := argoutil.NewSecretWithSuffix(cr, "ca")
+	secret := argoutil.NewSecretWithName(cr, getCASecretName(cr))
 	secretExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, secret.Name, secret)
 	if err != nil {
 		return err

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -293,7 +293,18 @@ func (r *ReconcileArgoCD) reconcileClusterTLSSecret(cr *argoproj.ArgoCD) error {
 
 // reconcileClusterCASecret ensures the CA Secret is created for the ArgoCD cluster.
 func (r *ReconcileArgoCD) reconcileClusterCASecret(cr *argoproj.ArgoCD) error {
-	secret := argoutil.NewSecretWithName(cr, getCASecretName(cr))
+	caSecretName := getCASecretName(cr)
+
+	// If spec.tls.ca.secretName equals {cr.Name}-tls, CA reconciliation would create
+	// or adopt that secret first, and TLS reconciliation would then see it as the
+	// existing server-TLS secret and skip generating a proper signed certificate.
+	tlsSecretName := argoutil.GetSecretNameWithSuffix(cr, "tls")
+	if caSecretName == tlsSecretName {
+		return fmt.Errorf("spec.tls.ca.secretName %q conflicts with the operator-managed cluster TLS secret %q; choose a different name",
+			caSecretName, tlsSecretName)
+	}
+
+	secret := argoutil.NewSecretWithName(cr, caSecretName)
 	secretExists, err := argoutil.IsObjectFound(r.Client, cr.Namespace, secret.Name, secret)
 	if err != nil {
 		return err

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	testclient "k8s.io/client-go/kubernetes/fake"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
@@ -130,7 +131,7 @@ func TestReconcileArgoCD_reconcileClusterCASecret(t *testing.T) {
 			Name:      argoutil.GetSecretNameWithSuffix(a, common.ArgoCDCASuffix),
 			Namespace: a.Namespace,
 		}, defaultSecret)
-		assert.True(t, err != nil, "default-named CA secret must not be created when a custom name is set")
+		assert.True(t, apierrors.IsNotFound(err), "default-named CA secret must not be created when a custom name is set; got err: %v", err)
 	})
 
 	t.Run("skips creation when custom-named CA secret already exists", func(t *testing.T) {

--- a/controllers/argocd/secret_test.go
+++ b/controllers/argocd/secret_test.go
@@ -57,6 +57,116 @@ func Test_newCASecret(t *testing.T) {
 	}
 }
 
+func TestReconcileArgoCD_reconcileClusterCASecret(t *testing.T) {
+	logf.SetLogger(ZapLogger(true))
+
+	t.Run("returns error when spec.tls.ca.secretName collides with the cluster TLS secret name", func(t *testing.T) {
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+			// testArgoCDName is "argocd", so the TLS secret name is "argocd-tls".
+			// Setting secretName to that value must be rejected.
+			a.Spec.TLS.CA.SecretName = argoutil.GetSecretNameWithSuffix(a, "tls")
+		})
+
+		resObjs := []client.Object{a}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err := r.reconcileClusterCASecret(a)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicts with the operator-managed cluster TLS secret")
+	})
+
+	t.Run("creates CA secret with default name when spec.tls.ca.secretName is not set", func(t *testing.T) {
+		a := makeTestArgoCD()
+
+		resObjs := []client.Object{a}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err := r.reconcileClusterCASecret(a)
+		require.NoError(t, err)
+
+		secret := &corev1.Secret{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      getCASecretName(a), // "argocd-ca"
+			Namespace: a.Namespace,
+		}, secret)
+		require.NoError(t, err)
+		assert.Equal(t, corev1.SecretTypeTLS, secret.Type)
+		assert.NotEmpty(t, secret.Data[corev1.TLSCertKey])
+		assert.NotEmpty(t, secret.Data[corev1.TLSPrivateKeyKey])
+	})
+
+	t.Run("creates CA secret with custom name when spec.tls.ca.secretName is set", func(t *testing.T) {
+		const customName = "my-custom-ca"
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+			a.Spec.TLS.CA.SecretName = customName
+		})
+
+		resObjs := []client.Object{a}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err := r.reconcileClusterCASecret(a)
+		require.NoError(t, err)
+
+		secret := &corev1.Secret{}
+		err = r.Get(context.TODO(), types.NamespacedName{Name: customName, Namespace: a.Namespace}, secret)
+		require.NoError(t, err, "secret must be created under the custom name")
+		assert.Equal(t, corev1.SecretTypeTLS, secret.Type)
+
+		// Default-named secret must NOT exist.
+		defaultSecret := &corev1.Secret{}
+		err = r.Get(context.TODO(), types.NamespacedName{
+			Name:      argoutil.GetSecretNameWithSuffix(a, common.ArgoCDCASuffix),
+			Namespace: a.Namespace,
+		}, defaultSecret)
+		assert.True(t, err != nil, "default-named CA secret must not be created when a custom name is set")
+	})
+
+	t.Run("skips creation when custom-named CA secret already exists", func(t *testing.T) {
+		const customName = "my-custom-ca"
+		a := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+			a.Spec.TLS.CA.SecretName = customName
+		})
+
+		existingSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: customName, Namespace: a.Namespace},
+			Type:       corev1.SecretTypeTLS,
+			Data: map[string][]byte{
+				corev1.TLSCertKey:              []byte("existing-cert"),
+				corev1.TLSPrivateKeyKey:        []byte("existing-key"),
+				corev1.ServiceAccountRootCAKey: []byte("existing-ca"),
+			},
+		}
+
+		resObjs := []client.Object{a, existingSecret}
+		subresObjs := []client.Object{a}
+		runtimeObjs := []runtime.Object{}
+		sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+		cl := makeTestReconcilerClient(sch, resObjs, subresObjs, runtimeObjs)
+		r := makeTestReconciler(cl, sch, testclient.NewSimpleClientset())
+
+		err := r.reconcileClusterCASecret(a)
+		require.NoError(t, err)
+
+		// Data must be unchanged — operator must not overwrite a pre-existing secret.
+		secret := &corev1.Secret{}
+		err = r.Get(context.TODO(), types.NamespacedName{Name: customName, Namespace: a.Namespace}, secret)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("existing-cert"), secret.Data[corev1.TLSCertKey], "pre-existing cert must not be overwritten")
+	})
+}
+
 func byteMapKeys(m map[string][]byte) []string {
 	r := []string{}
 	for k := range m {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:
Currently, the ArgoCD CR field (spec.tls.ca.secretName) exists and is exposed in the documentation. However, the operator's controller reconciliation logic does not actually consume this field. Instead, it relies on a hardcoded suffix pattern ({cr.name}-ca and {cr.name}-tls) to identify or generate the secrets used for internal component trust.

While the operator currently allows a workaround—exiting reconciliation early if a secret matching the hardcoded name already exists—this prevents integration with external secret managers (like cert-manager) that may require dynamic or pre-existing custom naming conventions.
This request is to fully implement the logic for spec.tls.ca.secretName (and related TLS secret fields) so that the operator actively honors user-specified secret names instead of defaulting strictly to the hardcoded naming convention.
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/GITOPS-10308
Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom name for the Argo CD CA Secret through `spec.tls.ca.secretName`.
  * CA-related resources now consistently use the configured Secret name, or the default name when none is provided.
  * CA data is correctly propagated to the generated ConfigMap when using a custom Secret name.

* **Bug Fixes**
  * Updated managed CA certificate values when missing or stale while preserving unrelated ConfigMap data.
  * Prevented conflicting names between the CA Secret and cluster TLS Secret.
  * Improved image-pull-secret handling on OpenShift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->