### PR TITLE
fix: skip SA imagePullSecrets management on OpenShift

### DIFF
--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -518,27 +518,32 @@ func (r *ReconcileArgoCD) reconcileApplicationSetServiceAccount(cr *argoproj.Arg
 			return sa, err
 		}
 
-		refs, err := r.getImagePullSecretRefs(cr)
-		if err != nil {
-			return sa, err
+		if !IsOpenShiftCluster() {
+			refs, err := r.getImagePullSecretRefs(cr)
+			if err != nil {
+				return sa, err
+			}
+			sa.ImagePullSecrets = refs
 		}
-		sa.ImagePullSecrets = refs
 		argoutil.LogResourceCreation(log, sa)
-		err = r.Create(context.TODO(), sa)
-		if err != nil {
+		if err := r.Create(context.TODO(), sa); err != nil {
 			return sa, err
 		}
 	}
 
-	desired, err := r.getImagePullSecretRefs(cr)
-	if err != nil {
-		return sa, err
-	}
-	if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
-		sa.ImagePullSecrets = desired
-		argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
-		if err := r.Update(context.TODO(), sa); err != nil {
+	// On OpenShift the platform injects dockercfg secrets into SAs;
+	// do not touch ImagePullSecrets to avoid clobbering them.
+	if !IsOpenShiftCluster() {
+		desired, err := r.getImagePullSecretRefs(cr)
+		if err != nil {
 			return sa, err
+		}
+		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+			sa.ImagePullSecrets = desired
+			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
+			if err := r.Update(context.TODO(), sa); err != nil {
+				return sa, err
+			}
 		}
 	}
 

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -529,6 +529,7 @@ func (r *ReconcileArgoCD) reconcileApplicationSetServiceAccount(cr *argoproj.Arg
 		if err := r.Create(context.TODO(), sa); err != nil {
 			return sa, err
 		}
+		return sa, nil
 	}
 
 	// On OpenShift the platform injects dockercfg secrets into SAs;

--- a/controllers/argocd/applicationset.go
+++ b/controllers/argocd/applicationset.go
@@ -538,7 +538,11 @@ func (r *ReconcileArgoCD) reconcileApplicationSetServiceAccount(cr *argoproj.Arg
 		if err != nil {
 			return sa, err
 		}
-		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+		existing := sa.ImagePullSecrets
+		if existing == nil {
+			existing = []corev1.LocalObjectReference{}
+		}
+		if !reflect.DeepEqual(existing, desired) {
 			sa.ImagePullSecrets = desired
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := r.Update(context.TODO(), sa); err != nil {

--- a/controllers/argocd/image_pull_secrets_test.go
+++ b/controllers/argocd/image_pull_secrets_test.go
@@ -949,3 +949,125 @@ func TestImagePullSecretPredicate_AcceptsLabelFalseToTrue(t *testing.T) {
 	assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldSecret, ObjectNew: newSecret}),
 		"must accept false→true transition for propagation")
 }
+
+// --- OpenShift guards: SA ImagePullSecrets must not be touched ---
+
+func setOpenShift(t *testing.T, enabled bool) {
+	t.Helper()
+	original := versionAPIFound
+	versionAPIFound = enabled
+	t.Cleanup(func() { versionAPIFound = original })
+}
+
+func TestReconcileServiceAccount_OpenShift_DoesNotSetImagePullSecrets(t *testing.T) {
+	setOpenShift(t, true)
+	operatorNS := "operator-ns"
+	setOperatorNamespace(t, operatorNS)
+
+	cr := makeTestArgoCD()
+
+	copiedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				common.ArgoCDImagePullSecretCopiedLabel: "my-pull-secret",
+			},
+			OwnerReferences: []metav1.OwnerReference{testOwnerRef(cr)},
+		},
+	}
+
+	resObjs := []client.Object{cr, copiedSecret}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, nil, nil)
+	r := makeTestReconciler(cl, sch, nil)
+
+	sa, err := r.reconcileServiceAccount(common.ArgoCDServerComponent, cr)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	retrieved := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: testNamespace}, retrieved)
+	assert.NoError(t, err)
+	assert.Empty(t, retrieved.ImagePullSecrets,
+		"on OpenShift, newly created SA must not have operator-managed imagePullSecrets")
+}
+
+func TestReconcileServiceAccount_OpenShift_DoesNotOverwriteExistingSecrets(t *testing.T) {
+	setOpenShift(t, true)
+	operatorNS := "operator-ns"
+	setOperatorNamespace(t, operatorNS)
+
+	cr := makeTestArgoCD()
+
+	existingSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getServiceAccountName(cr.Name, common.ArgoCDServerComponent),
+			Namespace: testNamespace,
+			Labels:    argoutil.LabelsForCluster(cr),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "argoproj.io/v1beta1",
+					Kind:       "ArgoCD",
+					Name:       cr.Name,
+					UID:        cr.UID,
+				},
+			},
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "openshift-dockercfg-abc123"},
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSA}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, nil, nil)
+	r := makeTestReconciler(cl, sch, nil)
+
+	sa, err := r.reconcileServiceAccount(common.ArgoCDServerComponent, cr)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	retrieved := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: testNamespace}, retrieved)
+	assert.NoError(t, err)
+	assert.Len(t, retrieved.ImagePullSecrets, 1)
+	assert.Equal(t, "openshift-dockercfg-abc123", retrieved.ImagePullSecrets[0].Name,
+		"on OpenShift, operator must not overwrite platform-injected imagePullSecrets")
+}
+
+func TestReconcileImagePullSecrets_OpenShift_SkipsReconciliation(t *testing.T) {
+	setOpenShift(t, true)
+	operatorNS := "operator-ns"
+	setOperatorNamespace(t, operatorNS)
+
+	cr := makeTestArgoCD()
+
+	srcSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: operatorNS,
+			Labels: map[string]string{
+				common.ArgoCDImagePullSecretPropagateLabel: "true",
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{".dockerconfigjson": []byte(`{"auths":{}}`)},
+	}
+
+	resObjs := []client.Object{cr, srcSecret}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, nil, nil)
+	r := makeTestReconciler(cl, sch, nil)
+
+	// reconcileResources calls reconcileImagePullSecrets only on non-OpenShift;
+	// calling it directly here should still work but the reconcileResources path
+	// is what matters. Verify the guard via reconcileResources indirectly by
+	// checking that no secret copy is created in the target namespace.
+	err := r.reconcileImagePullSecrets(cr)
+	assert.NoError(t, err)
+
+	// The function itself still runs (it's guarded at the call-site), so
+	// verify the call-site guard by checking IsOpenShiftCluster().
+	assert.True(t, IsOpenShiftCluster(), "OpenShift detection must be active for this test")
+}

--- a/controllers/argocd/image_pull_secrets_test.go
+++ b/controllers/argocd/image_pull_secrets_test.go
@@ -952,15 +952,15 @@ func TestImagePullSecretPredicate_AcceptsLabelFalseToTrue(t *testing.T) {
 
 // --- OpenShift guards: SA ImagePullSecrets must not be touched ---
 
-func setOpenShift(t *testing.T, enabled bool) {
+func setOpenShift(t *testing.T) {
 	t.Helper()
 	original := versionAPIFound
-	versionAPIFound = enabled
+	versionAPIFound = true
 	t.Cleanup(func() { versionAPIFound = original })
 }
 
 func TestReconcileServiceAccount_OpenShift_DoesNotSetImagePullSecrets(t *testing.T) {
-	setOpenShift(t, true)
+	setOpenShift(t)
 	operatorNS := "operator-ns"
 	setOperatorNamespace(t, operatorNS)
 
@@ -994,7 +994,7 @@ func TestReconcileServiceAccount_OpenShift_DoesNotSetImagePullSecrets(t *testing
 }
 
 func TestReconcileServiceAccount_OpenShift_DoesNotOverwriteExistingSecrets(t *testing.T) {
-	setOpenShift(t, true)
+	setOpenShift(t)
 	operatorNS := "operator-ns"
 	setOperatorNamespace(t, operatorNS)
 
@@ -1037,7 +1037,7 @@ func TestReconcileServiceAccount_OpenShift_DoesNotOverwriteExistingSecrets(t *te
 }
 
 func TestReconcileImagePullSecrets_OpenShift_SkipsReconciliation(t *testing.T) {
-	setOpenShift(t, true)
+	setOpenShift(t)
 	operatorNS := "operator-ns"
 	setOperatorNamespace(t, operatorNS)
 
@@ -1074,7 +1074,7 @@ func TestReconcileImagePullSecrets_OpenShift_SkipsReconciliation(t *testing.T) {
 }
 
 func TestReconcileApplicationSetServiceAccount_OpenShift_DoesNotSetImagePullSecrets(t *testing.T) {
-	setOpenShift(t, true)
+	setOpenShift(t)
 	operatorNS := "operator-ns"
 	setOperatorNamespace(t, operatorNS)
 
@@ -1110,7 +1110,7 @@ func TestReconcileApplicationSetServiceAccount_OpenShift_DoesNotSetImagePullSecr
 }
 
 func TestReconcileImageUpdaterServiceAccount_OpenShift_DoesNotSetImagePullSecrets(t *testing.T) {
-	setOpenShift(t, true)
+	setOpenShift(t)
 	operatorNS := "operator-ns"
 	setOperatorNamespace(t, operatorNS)
 
@@ -1146,7 +1146,7 @@ func TestReconcileImageUpdaterServiceAccount_OpenShift_DoesNotSetImagePullSecret
 }
 
 func TestReconcileApplicationSetServiceAccount_OpenShift_DoesNotOverwriteExistingSecrets(t *testing.T) {
-	setOpenShift(t, true)
+	setOpenShift(t)
 	operatorNS := "operator-ns"
 	setOperatorNamespace(t, operatorNS)
 
@@ -1183,7 +1183,7 @@ func TestReconcileApplicationSetServiceAccount_OpenShift_DoesNotOverwriteExistin
 }
 
 func TestReconcileImageUpdaterServiceAccount_OpenShift_DoesNotOverwriteExistingSecrets(t *testing.T) {
-	setOpenShift(t, true)
+	setOpenShift(t)
 	operatorNS := "operator-ns"
 	setOperatorNamespace(t, operatorNS)
 

--- a/controllers/argocd/image_pull_secrets_test.go
+++ b/controllers/argocd/image_pull_secrets_test.go
@@ -1060,14 +1060,161 @@ func TestReconcileImagePullSecrets_OpenShift_SkipsReconciliation(t *testing.T) {
 	cl := makeTestReconcilerClient(sch, resObjs, nil, nil)
 	r := makeTestReconciler(cl, sch, nil)
 
-	// reconcileResources calls reconcileImagePullSecrets only on non-OpenShift;
-	// calling it directly here should still work but the reconcileResources path
-	// is what matters. Verify the guard via reconcileResources indirectly by
-	// checking that no secret copy is created in the target namespace.
+	assert.True(t, IsOpenShiftCluster(), "OpenShift detection must be active for this test")
+
 	err := r.reconcileImagePullSecrets(cr)
 	assert.NoError(t, err)
 
-	// The function itself still runs (it's guarded at the call-site), so
-	// verify the call-site guard by checking IsOpenShiftCluster().
-	assert.True(t, IsOpenShiftCluster(), "OpenShift detection must be active for this test")
+	copiedSecrets := &corev1.SecretList{}
+	err = cl.List(context.TODO(), copiedSecrets,
+		client.InNamespace(testNamespace),
+		client.HasLabels{common.ArgoCDImagePullSecretCopiedLabel})
+	assert.NoError(t, err)
+	assert.Empty(t, copiedSecrets.Items, "on OpenShift, operator must not copy image pull secrets to ArgoCD namespace")
+}
+
+func TestReconcileApplicationSetServiceAccount_OpenShift_DoesNotSetImagePullSecrets(t *testing.T) {
+	setOpenShift(t, true)
+	operatorNS := "operator-ns"
+	setOperatorNamespace(t, operatorNS)
+
+	cr := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
+	})
+
+	copiedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				common.ArgoCDImagePullSecretCopiedLabel: "my-pull-secret",
+			},
+			OwnerReferences: []metav1.OwnerReference{testOwnerRef(cr)},
+		},
+	}
+
+	resObjs := []client.Object{cr, copiedSecret}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, nil, nil)
+	r := makeTestReconciler(cl, sch, nil)
+
+	sa, err := r.reconcileApplicationSetServiceAccount(cr)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	retrieved := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: testNamespace}, retrieved)
+	assert.NoError(t, err)
+	assert.Empty(t, retrieved.ImagePullSecrets,
+		"on OpenShift, applicationset SA must not have operator-managed imagePullSecrets")
+}
+
+func TestReconcileImageUpdaterServiceAccount_OpenShift_DoesNotSetImagePullSecrets(t *testing.T) {
+	setOpenShift(t, true)
+	operatorNS := "operator-ns"
+	setOperatorNamespace(t, operatorNS)
+
+	cr := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+	})
+
+	copiedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pull-secret",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				common.ArgoCDImagePullSecretCopiedLabel: "my-pull-secret",
+			},
+			OwnerReferences: []metav1.OwnerReference{testOwnerRef(cr)},
+		},
+	}
+
+	resObjs := []client.Object{cr, copiedSecret}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, nil, nil)
+	r := makeTestReconciler(cl, sch, nil)
+
+	sa, err := r.reconcileImageUpdaterServiceAccount(cr)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	retrieved := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: testNamespace}, retrieved)
+	assert.NoError(t, err)
+	assert.Empty(t, retrieved.ImagePullSecrets,
+		"on OpenShift, image-updater SA must not have operator-managed imagePullSecrets")
+}
+
+func TestReconcileApplicationSetServiceAccount_OpenShift_DoesNotOverwriteExistingSecrets(t *testing.T) {
+	setOpenShift(t, true)
+	operatorNS := "operator-ns"
+	setOperatorNamespace(t, operatorNS)
+
+	cr := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ApplicationSet = &argoproj.ArgoCDApplicationSet{}
+	})
+
+	existingSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getServiceAccountName(cr.Name, "applicationset-controller"),
+			Namespace: testNamespace,
+			Labels:    argoutil.LabelsForCluster(cr),
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "openshift-dockercfg-abc123"},
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSA}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, nil, nil)
+	r := makeTestReconciler(cl, sch, nil)
+
+	sa, err := r.reconcileApplicationSetServiceAccount(cr)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	retrieved := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: testNamespace}, retrieved)
+	assert.NoError(t, err)
+	assert.Len(t, retrieved.ImagePullSecrets, 1)
+	assert.Equal(t, "openshift-dockercfg-abc123", retrieved.ImagePullSecrets[0].Name,
+		"on OpenShift, operator must not overwrite platform-injected imagePullSecrets on applicationset SA")
+}
+
+func TestReconcileImageUpdaterServiceAccount_OpenShift_DoesNotOverwriteExistingSecrets(t *testing.T) {
+	setOpenShift(t, true)
+	operatorNS := "operator-ns"
+	setOperatorNamespace(t, operatorNS)
+
+	cr := makeTestArgoCD(func(a *argoproj.ArgoCD) {
+		a.Spec.ImageUpdater.Enabled = true
+	})
+
+	existingSA := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getServiceAccountName(cr.Name, common.ArgoCDImageUpdaterControllerComponent),
+			Namespace: testNamespace,
+			Labels:    argoutil.LabelsForCluster(cr),
+		},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "openshift-dockercfg-abc123"},
+		},
+	}
+
+	resObjs := []client.Object{cr, existingSA}
+	sch := makeTestReconcilerScheme(argoproj.AddToScheme)
+	cl := makeTestReconcilerClient(sch, resObjs, nil, nil)
+	r := makeTestReconciler(cl, sch, nil)
+
+	sa, err := r.reconcileImageUpdaterServiceAccount(cr)
+	assert.NoError(t, err)
+	assert.NotNil(t, sa)
+
+	retrieved := &corev1.ServiceAccount{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: sa.Name, Namespace: testNamespace}, retrieved)
+	assert.NoError(t, err)
+	assert.Len(t, retrieved.ImagePullSecrets, 1)
+	assert.Equal(t, "openshift-dockercfg-abc123", retrieved.ImagePullSecrets[0].Name,
+		"on OpenShift, operator must not overwrite platform-injected imagePullSecrets on image-updater SA")
 }

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -338,6 +338,7 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterServiceAccount(cr *argoproj.ArgoC
 		if err != nil {
 			return nil, err
 		}
+		return sa, nil
 	}
 
 	// SA exists but shouldn't, so it should be deleted

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -326,11 +326,13 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterServiceAccount(cr *argoproj.ArgoC
 			return nil, err
 		}
 
-		refs, err := r.getImagePullSecretRefs(cr)
-		if err != nil {
-			return nil, err
+		if !IsOpenShiftCluster() {
+			refs, err := r.getImagePullSecretRefs(cr)
+			if err != nil {
+				return nil, err
+			}
+			sa.ImagePullSecrets = refs
 		}
-		sa.ImagePullSecrets = refs
 		argoutil.LogResourceCreation(log, sa)
 		err = r.Create(context.TODO(), sa)
 		if err != nil {
@@ -344,15 +346,19 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterServiceAccount(cr *argoproj.ArgoC
 		return nil, r.Delete(context.TODO(), sa)
 	}
 
-	desired, err := r.getImagePullSecretRefs(cr)
-	if err != nil {
-		return nil, err
-	}
-	if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
-		sa.ImagePullSecrets = desired
-		argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
-		if err := r.Update(context.TODO(), sa); err != nil {
+	// On OpenShift the platform injects dockercfg secrets into SAs;
+	// do not touch ImagePullSecrets to avoid clobbering them.
+	if !IsOpenShiftCluster() {
+		desired, err := r.getImagePullSecretRefs(cr)
+		if err != nil {
 			return nil, err
+		}
+		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+			sa.ImagePullSecrets = desired
+			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
+			if err := r.Update(context.TODO(), sa); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/controllers/argocd/image_updater.go
+++ b/controllers/argocd/image_updater.go
@@ -353,7 +353,11 @@ func (r *ReconcileArgoCD) reconcileImageUpdaterServiceAccount(cr *argoproj.ArgoC
 		if err != nil {
 			return nil, err
 		}
-		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+		existing := sa.ImagePullSecrets
+		if existing == nil {
+			existing = []corev1.LocalObjectReference{}
+		}
+		if !reflect.DeepEqual(existing, desired) {
 			sa.ImagePullSecrets = desired
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := r.Update(context.TODO(), sa); err != nil {

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -229,11 +229,13 @@ func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoproj.Argo
 			return nil, err
 		}
 
-		refs, err := r.getImagePullSecretRefs(cr)
-		if err != nil {
-			return nil, err
+		if !IsOpenShiftCluster() {
+			refs, err := r.getImagePullSecretRefs(cr)
+			if err != nil {
+				return nil, err
+			}
+			sa.ImagePullSecrets = refs
 		}
-		sa.ImagePullSecrets = refs
 		argoutil.LogResourceCreation(log, sa)
 		err = r.Create(context.TODO(), sa)
 		if err != nil {
@@ -247,15 +249,19 @@ func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoproj.Argo
 		return nil, r.Delete(context.TODO(), sa)
 	}
 
-	desired, err := r.getImagePullSecretRefs(cr)
-	if err != nil {
-		return nil, err
-	}
-	if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
-		sa.ImagePullSecrets = desired
-		argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
-		if err := r.Update(context.TODO(), sa); err != nil {
+	// On OpenShift the platform injects dockercfg secrets into SAs;
+	// do not touch ImagePullSecrets to avoid clobbering them.
+	if !IsOpenShiftCluster() {
+		desired, err := r.getImagePullSecretRefs(cr)
+		if err != nil {
 			return nil, err
+		}
+		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+			sa.ImagePullSecrets = desired
+			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
+			if err := r.Update(context.TODO(), sa); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -241,6 +241,7 @@ func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoproj.Argo
 		if err != nil {
 			return nil, err
 		}
+		return sa, nil
 	}
 
 	// SA exists but shouldn't, so it should be deleted

--- a/controllers/argocd/notifications.go
+++ b/controllers/argocd/notifications.go
@@ -256,7 +256,11 @@ func (r *ReconcileArgoCD) reconcileNotificationsServiceAccount(cr *argoproj.Argo
 		if err != nil {
 			return nil, err
 		}
-		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+		existing := sa.ImagePullSecrets
+		if existing == nil {
+			existing = []corev1.LocalObjectReference{}
+		}
+		if !reflect.DeepEqual(existing, desired) {
 			sa.ImagePullSecrets = desired
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := r.Update(context.TODO(), sa); err != nil {

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -1054,7 +1054,9 @@ func (r *ReconcileArgoCD) reconcileImagePullSecrets(cr *argoproj.ArgoCD) error {
 
 func (r *ReconcileArgoCD) getImagePullSecretRefs(cr *argoproj.ArgoCD) ([]corev1.LocalObjectReference, error) {
 	ctx := context.TODO()
-	var refs []corev1.LocalObjectReference
+	// Use a non-nil empty slice so callers can distinguish "no secrets to set"
+	// (empty slice) from "don't manage this field" (nil, used on OpenShift).
+	refs := make([]corev1.LocalObjectReference, 0)
 
 	operatorNS, err := argoutil.GetOperatorNamespace()
 	if err != nil {

--- a/controllers/argocd/secret.go
+++ b/controllers/argocd/secret.go
@@ -937,6 +937,12 @@ func (r *ReconcileArgoCD) reconcileSecrets(cr *argoproj.ArgoCD) error {
 }
 
 func (r *ReconcileArgoCD) reconcileImagePullSecrets(cr *argoproj.ArgoCD) error {
+	// On OpenShift, the platform injects dockercfg secrets into ServiceAccounts;
+	// skip propagation to avoid clobbering them.
+	if IsOpenShiftCluster() {
+		return nil
+	}
+
 	ctx := context.TODO()
 
 	operatorNS, err := argoutil.GetOperatorNamespace()
@@ -1054,8 +1060,6 @@ func (r *ReconcileArgoCD) reconcileImagePullSecrets(cr *argoproj.ArgoCD) error {
 
 func (r *ReconcileArgoCD) getImagePullSecretRefs(cr *argoproj.ArgoCD) ([]corev1.LocalObjectReference, error) {
 	ctx := context.TODO()
-	// Use a non-nil empty slice so callers can distinguish "no secrets to set"
-	// (empty slice) from "don't manage this field" (nil, used on OpenShift).
 	refs := make([]corev1.LocalObjectReference, 0)
 
 	operatorNS, err := argoutil.GetOperatorNamespace()

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -140,30 +140,35 @@ func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoproj.Argo
 			return sa, r.Delete(context.TODO(), sa)
 		}
 
-		desired, err := r.getImagePullSecretRefs(cr)
-		if err != nil {
-			return sa, err
-		}
-		if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
-			sa.ImagePullSecrets = desired
-			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
-			return sa, r.Update(context.TODO(), sa)
+		// On OpenShift the platform injects dockercfg secrets into SAs;
+		// do not touch ImagePullSecrets to avoid clobbering them.
+		if !IsOpenShiftCluster() {
+			desired, err := r.getImagePullSecretRefs(cr)
+			if err != nil {
+				return sa, err
+			}
+			if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+				sa.ImagePullSecrets = desired
+				argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
+				return sa, r.Update(context.TODO(), sa)
+			}
 		}
 		return sa, nil
 	}
 
-	refs, err := r.getImagePullSecretRefs(cr)
-	if err != nil {
-		return nil, err
+	if !IsOpenShiftCluster() {
+		refs, err := r.getImagePullSecretRefs(cr)
+		if err != nil {
+			return nil, err
+		}
+		sa.ImagePullSecrets = refs
 	}
-	sa.ImagePullSecrets = refs
 	if err := controllerutil.SetControllerReference(cr, sa, r.Scheme); err != nil {
 		return nil, err
 	}
 
 	argoutil.LogResourceCreation(log, sa)
-	err = r.Create(context.TODO(), sa)
-	if err != nil {
+	if err := r.Create(context.TODO(), sa); err != nil {
 		return nil, err
 	}
 

--- a/controllers/argocd/service_account.go
+++ b/controllers/argocd/service_account.go
@@ -147,7 +147,11 @@ func (r *ReconcileArgoCD) reconcileServiceAccount(name string, cr *argoproj.Argo
 			if err != nil {
 				return sa, err
 			}
-			if !reflect.DeepEqual(sa.ImagePullSecrets, desired) {
+			existing := sa.ImagePullSecrets
+			if existing == nil {
+				existing = []corev1.LocalObjectReference{}
+			}
+			if !reflect.DeepEqual(existing, desired) {
 				sa.ImagePullSecrets = desired
 				argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 				return sa, r.Update(context.TODO(), sa)

--- a/controllers/argocd/util.go
+++ b/controllers/argocd/util.go
@@ -553,10 +553,15 @@ func (r *ReconcileArgoCD) reconcileResources(cr *argoproj.ArgoCD, argocdStatus *
 		return err
 	}
 
-	log.Info("reconciling image pull secrets")
-	if err := r.reconcileImagePullSecrets(cr); err != nil {
-		log.Info(err.Error())
-		return err
+	// On OpenShift, clusters already have access to registry.redhat.io and the
+	// platform injects dockercfg secrets into ServiceAccounts. Skip image pull
+	// secret propagation to avoid clobbering those platform-managed entries.
+	if !IsOpenShiftCluster() {
+		log.Info("reconciling image pull secrets")
+		if err := r.reconcileImagePullSecrets(cr); err != nil {
+			log.Info(err.Error())
+			return err
+		}
 	}
 
 	log.Info("reconciling service accounts")
@@ -1691,9 +1696,12 @@ func (r *ReconcileArgoCD) reconcileArgoCDAgent(cr *argoproj.ArgoCD) error {
 	var err error
 
 	log.Info("reconciling ArgoCD Agent's Principal service account")
-	pullSecretRefs, err := r.getImagePullSecretRefs(cr)
-	if err != nil {
-		return err
+	var pullSecretRefs []corev1.LocalObjectReference
+	if !IsOpenShiftCluster() {
+		pullSecretRefs, err = r.getImagePullSecretRefs(cr)
+		if err != nil {
+			return err
+		}
 	}
 	if sa, err = argocdagent.ReconcilePrincipalServiceAccount(r.Client, compName, cr, r.Scheme, pullSecretRefs); err != nil {
 		return err
@@ -1771,9 +1779,12 @@ func (r *ReconcileArgoCD) reconcileArgoCDAgent(cr *argoproj.ArgoCD) error {
 
 	log.Info("reconciling ArgoCD Agent's Agent service account")
 	var agentSa *corev1.ServiceAccount
-	agentPullSecretRefs, err := r.getImagePullSecretRefs(cr)
-	if err != nil {
-		return err
+	var agentPullSecretRefs []corev1.LocalObjectReference
+	if !IsOpenShiftCluster() {
+		agentPullSecretRefs, err = r.getImagePullSecretRefs(cr)
+		if err != nil {
+			return err
+		}
 	}
 	if agentSa, err = agent.ReconcileAgentServiceAccount(r.Client, agentCompName, cr, r.Scheme, agentPullSecretRefs); err != nil {
 		return err
@@ -2158,9 +2169,12 @@ func (r *ReconcileArgoCD) reconcileGitOpsPromoter(cr *argoproj.ArgoCD) error {
 	var sa *corev1.ServiceAccount
 	var err error
 
-	pullSecretRefs, err := r.getImagePullSecretRefs(cr)
-	if err != nil {
-		return err
+	var pullSecretRefs []corev1.LocalObjectReference
+	if !IsOpenShiftCluster() {
+		pullSecretRefs, err = r.getImagePullSecretRefs(cr)
+		if err != nil {
+			return err
+		}
 	}
 
 	log.Info("reconciling GitOps Promoter's Controller Manager ServiceAccount")

--- a/controllers/argocdagent/agent/service_account.go
+++ b/controllers/argocdagent/agent/service_account.go
@@ -61,7 +61,11 @@ func ReconcileAgentServiceAccount(client client.Client, compName string, cr *arg
 
 		// nil imagePullSecrets means the caller chose not to manage this field
 		// (e.g. on OpenShift where the platform injects dockercfg secrets).
-		if imagePullSecrets != nil && !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
+		existing := sa.ImagePullSecrets
+		if existing == nil {
+			existing = []corev1.LocalObjectReference{}
+		}
+		if imagePullSecrets != nil && !reflect.DeepEqual(existing, imagePullSecrets) {
 			sa.ImagePullSecrets = imagePullSecrets
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := client.Update(context.TODO(), sa); err != nil {

--- a/controllers/argocdagent/agent/service_account.go
+++ b/controllers/argocdagent/agent/service_account.go
@@ -59,7 +59,9 @@ func ReconcileAgentServiceAccount(client client.Client, compName string, cr *arg
 			return sa, nil
 		}
 
-		if !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
+		// nil imagePullSecrets means the caller chose not to manage this field
+		// (e.g. on OpenShift where the platform injects dockercfg secrets).
+		if imagePullSecrets != nil && !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
 			sa.ImagePullSecrets = imagePullSecrets
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := client.Update(context.TODO(), sa); err != nil {
@@ -74,7 +76,9 @@ func ReconcileAgentServiceAccount(client client.Client, compName string, cr *arg
 		return sa, nil
 	}
 
-	sa.ImagePullSecrets = imagePullSecrets
+	if imagePullSecrets != nil {
+		sa.ImagePullSecrets = imagePullSecrets
+	}
 	if err := controllerutil.SetControllerReference(cr, sa, scheme); err != nil {
 		return nil, fmt.Errorf("failed to set ArgoCD CR %s as owner for service account %s: %w", cr.Name, sa.Name, err)
 	}

--- a/controllers/argocdagent/service_account.go
+++ b/controllers/argocdagent/service_account.go
@@ -59,7 +59,9 @@ func ReconcilePrincipalServiceAccount(client client.Client, compName string, cr 
 			return sa, nil
 		}
 
-		if !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
+		// nil imagePullSecrets means the caller chose not to manage this field
+		// (e.g. on OpenShift where the platform injects dockercfg secrets).
+		if imagePullSecrets != nil && !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
 			sa.ImagePullSecrets = imagePullSecrets
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := client.Update(context.TODO(), sa); err != nil {
@@ -74,7 +76,9 @@ func ReconcilePrincipalServiceAccount(client client.Client, compName string, cr 
 		return sa, nil
 	}
 
-	sa.ImagePullSecrets = imagePullSecrets
+	if imagePullSecrets != nil {
+		sa.ImagePullSecrets = imagePullSecrets
+	}
 	if err := controllerutil.SetControllerReference(cr, sa, scheme); err != nil {
 		return nil, fmt.Errorf("failed to set ArgoCD CR %s as owner for service account %s: %w", cr.Name, sa.Name, err)
 	}

--- a/controllers/argocdagent/service_account.go
+++ b/controllers/argocdagent/service_account.go
@@ -61,7 +61,11 @@ func ReconcilePrincipalServiceAccount(client client.Client, compName string, cr 
 
 		// nil imagePullSecrets means the caller chose not to manage this field
 		// (e.g. on OpenShift where the platform injects dockercfg secrets).
-		if imagePullSecrets != nil && !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
+		existing := sa.ImagePullSecrets
+		if existing == nil {
+			existing = []corev1.LocalObjectReference{}
+		}
+		if imagePullSecrets != nil && !reflect.DeepEqual(existing, imagePullSecrets) {
 			sa.ImagePullSecrets = imagePullSecrets
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := client.Update(context.TODO(), sa); err != nil {

--- a/controllers/gitopspromoter/service_account.go
+++ b/controllers/gitopspromoter/service_account.go
@@ -69,7 +69,11 @@ func ReconcilePromoterServiceAccount(client client.Client, compName string, cr *
 		}
 		// nil imagePullSecrets means the caller chose not to manage this field
 		// (e.g. on OpenShift where the platform injects dockercfg secrets).
-		if imagePullSecrets != nil && !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
+		existing := sa.ImagePullSecrets
+		if existing == nil {
+			existing = []corev1.LocalObjectReference{}
+		}
+		if imagePullSecrets != nil && !reflect.DeepEqual(existing, imagePullSecrets) {
 			sa.ImagePullSecrets = imagePullSecrets
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := client.Update(context.Background(), sa); err != nil {

--- a/controllers/gitopspromoter/service_account.go
+++ b/controllers/gitopspromoter/service_account.go
@@ -67,7 +67,9 @@ func ReconcilePromoterServiceAccount(client client.Client, compName string, cr *
 			}
 			return sa, nil
 		}
-		if !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
+		// nil imagePullSecrets means the caller chose not to manage this field
+		// (e.g. on OpenShift where the platform injects dockercfg secrets).
+		if imagePullSecrets != nil && !reflect.DeepEqual(sa.ImagePullSecrets, imagePullSecrets) {
 			sa.ImagePullSecrets = imagePullSecrets
 			argoutil.LogResourceUpdate(log, sa, "imagePullSecrets changed")
 			if err := client.Update(context.Background(), sa); err != nil {
@@ -81,7 +83,9 @@ func ReconcilePromoterServiceAccount(client client.Client, compName string, cr *
 		return sa, nil
 	}
 
-	sa.ImagePullSecrets = imagePullSecrets
+	if imagePullSecrets != nil {
+		sa.ImagePullSecrets = imagePullSecrets
+	}
 	if err := controllerutil.SetControllerReference(cr, sa, scheme); err != nil {
 		return nil, fmt.Errorf("failed to set argocd cr %s as owner for service account %s: %v", cr.Name, sa.Name, err)
 	}

--- a/controllers/gitopspromoter/service_account_test.go
+++ b/controllers/gitopspromoter/service_account_test.go
@@ -264,8 +264,9 @@ func TestReconcilePromoterServiceAccount_Exists_UpdatesImagePullSecrets(t *testi
 	assert.NoError(t, err)
 	assert.Equal(t, refs, retrievedSA.ImagePullSecrets)
 
-	// nil refs (label removed) should clear the imagePullSecrets
-	_, err = ReconcilePromoterServiceAccount(client, testCompName, cr, sch, true, nil)
+	// empty (non-nil) refs (label removed) should clear the imagePullSecrets.
+	// nil refs means "don't touch" (used on OpenShift).
+	_, err = ReconcilePromoterServiceAccount(client, testCompName, cr, sch, true, []corev1.LocalObjectReference{})
 	assert.NoError(t, err)
 
 	err = client.Get(context.Background(), types.NamespacedName{


### PR DESCRIPTION
assisted-by: cursor

**What type of PR is this?**
/kind bug


**What does this PR do / why we need it**:
When running on Openshift, do not update the update pullsecrets in SA. Openshift injects pull-secrets in Service Accounts and secret propagation should not interfear with it.
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved platform-injected image pull secrets on OpenShift ServiceAccounts.
  * Prevented reconciliation from clearing or overwriting OpenShift-managed pull secrets.
  * Prevented creation of copied image-pull secrets on OpenShift.
  * Retained existing behavior on non-OpenShift clusters, including explicitly clearing secrets when configured.

* **Tests**
  * Added coverage verifying that ServiceAccount image pull secrets remain untouched on OpenShift.
  * Added coverage for Argo CD, ApplicationSet, Image Updater, and GitOps Promoter ServiceAccounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->