### PR TITLE
fix: remove Redis-related NetworkPolicies when networkPolicy disabled

### DIFF
--- a/controllers/argocd/networkpolicies.go
+++ b/controllers/argocd/networkpolicies.go
@@ -54,7 +54,11 @@ func (r *ReconcileArgoCD) ReconcileNetworkPolicies(cr *argoproj.ArgoCD) error {
 		}
 	}
 
-	// Reconcile Redis network policy
+	if !cr.Spec.NetworkPolicy.IsEnabled() {
+		return r.deleteArgoCDNetworkPolicies(cr)
+	}
+
+	// Reconcile Redis network policy (only if enabled)
 	if err := r.ReconcileRedisNetworkPolicy(cr); err != nil {
 		return err
 	}
@@ -62,10 +66,6 @@ func (r *ReconcileArgoCD) ReconcileNetworkPolicies(cr *argoproj.ArgoCD) error {
 	// Reconcile Redis HA network policy
 	if err := r.ReconcileRedisHANetworkPolicy(cr); err != nil {
 		return err
-	}
-
-	if !cr.Spec.NetworkPolicy.IsEnabled() {
-		return r.deleteArgoCDNetworkPolicies(cr)
 	}
 
 	// Reconcile Notifications Controller network policy
@@ -104,6 +104,8 @@ func (r *ReconcileArgoCD) ReconcileNetworkPolicies(cr *argoproj.ArgoCD) error {
 
 func (r *ReconcileArgoCD) deleteArgoCDNetworkPolicies(cr *argoproj.ArgoCD) error {
 	names := []string{
+		nameWithSuffix(RedisNetworkPolicy, cr),
+		nameWithSuffix(RedisHANetworkPolicy, cr),
 		nameWithSuffix(ArgoCDNotificationsControllerNetworkPolicy, cr),
 		nameWithSuffix(ArgoCDDexServerNetworkPolicy, cr),
 		nameWithSuffix(ArgoCDApplicationSetControllerNetworkPolicy, cr),

--- a/controllers/argocd/networkpolicies_test.go
+++ b/controllers/argocd/networkpolicies_test.go
@@ -58,6 +58,8 @@ func TestReconcileNetworkPolicies_DisabledDeletesExisting(t *testing.T) {
 	assert.NoError(t, err)
 
 	nps := []string{
+		nameWithSuffix(RedisNetworkPolicy, a),
+		nameWithSuffix(RedisHANetworkPolicy, a),
 		nameWithSuffix(ArgoCDNotificationsControllerNetworkPolicy, a),
 		nameWithSuffix(ArgoCDDexServerNetworkPolicy, a),
 		nameWithSuffix(ArgoCDApplicationSetControllerNetworkPolicy, a),
@@ -566,4 +568,39 @@ func TestNameWithSuffix(t *testing.T) {
 	result = nameWithSuffix("redis", a)
 	assert.Contains(t, result, "-redis") // Suffix should be preserved
 	assert.Len(t, result, 37+6)          // truncated name (37) + "-redis" (6) = 43
+}
+
+func TestReconcileRedisNetworkPoliciesDisabledDeletesExisting(t *testing.T) {
+	a := makeTestArgoCD()
+	r := makeTestReconciler(makeTestReconcilerClient(makeTestReconcilerScheme(argoproj.AddToScheme, promoter.AddToScheme, apiregistrationv1.AddToScheme), []client.Object{a}, []client.Object{a}, []runtime.Object{}), makeTestReconcilerScheme(argoproj.AddToScheme), testclient.NewSimpleClientset())
+
+	// Create all redis network policies
+	err := r.ReconcileRedisNetworkPolicy(a)
+	assert.NoError(t, err)
+
+	err = r.ReconcileRedisHANetworkPolicy(a)
+	assert.NoError(t, err)
+
+	// Verify they exist
+	redisNP := &networkingv1.NetworkPolicy{}
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(RedisNetworkPolicy, a), Namespace: a.Namespace}, redisNP)
+	assert.NoError(t, err, "redis network policy should exist before disabling")
+
+	redisHANP := &networkingv1.NetworkPolicy{}
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(RedisHANetworkPolicy, a), Namespace: a.Namespace}, redisHANP)
+	assert.NoError(t, err, "redis-ha network policy should exist before disabling")
+
+	// Disable NetworkPolicy and reconcile
+	a.Spec.NetworkPolicy.Enabled = new(false)
+	err = r.ReconcileNetworkPolicies(a)
+	assert.NoError(t, err)
+
+	// Verify redis policies are deleted
+	redisNPAfter := &networkingv1.NetworkPolicy{}
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(RedisNetworkPolicy, a), Namespace: a.Namespace}, redisNPAfter)
+	assert.Error(t, err, "redis network policy should be deleted when NetworkPolicy is disabled")
+
+	redisHANPAfter := &networkingv1.NetworkPolicy{}
+	err = r.Get(context.TODO(), client.ObjectKey{Name: nameWithSuffix(RedisHANetworkPolicy, a), Namespace: a.Namespace}, redisHANPAfter)
+	assert.Error(t, err, "redis-ha network policy should be deleted when NetworkPolicy is disabled")
 }

--- a/tests/ginkgo/parallel/1-124_validate_networkpolicies_test.go
+++ b/tests/ginkgo/parallel/1-124_validate_networkpolicies_test.go
@@ -368,6 +368,8 @@ var _ = Describe("GitOps Operator Parallel E2E Tests", func() {
 				"example-argocd-repo-server-network-policy",
 				"example-argocd-server-network-policy",
 				"example-argocd-application-controller-network-policy",
+				"example-argocd-redis-network-policy",
+				"example-argocd-redis-ha-network-policy",
 			}
 			for _, npName := range coreNPs {
 				Eventually(&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: npName, Namespace: nsObj.Name}}, "3m", "5s").Should(k8sFixture.NotExistByName())


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What does this PR do / why we need it**:
Removes redis network policies immediately when networkPolicy.enabled=false

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:
JIRA - https://redhat.atlassian.net/browse/GITOPS-10657
Fixes #?

**How to test changes / Special notes to the reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabling network policies now also removes existing Redis and Redis HA network policies.
  * Redis and Redis HA network policies are no longer recreated while network policies remain disabled.

* **Tests**
  * Added coverage to verify deletion and non-recreation of Redis network policies when the feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->