### PR TITLE
chore: migrate deprecated patchesJson6902 to patches in kustomization

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,30 +9,28 @@ resources:
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-patchesJson6902:
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: controller-manager
-    namespace: system
-  patch: |-
-    # Add ENABLE_CONVERSION_WEBHOOK env to enable conversion webhook
-    - op: add
-      path: /spec/template/spec/containers/0/env/-
-      value:
-        name: "ENABLE_CONVERSION_WEBHOOK"
-        value: "true"
-    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
-    # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
-    - op: remove
-      path: /spec/template/spec/containers/0/volumeMounts/0
-    # Remove the "cert" volume, since OLM will create and mount a set of certs.
-    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
-    - op: remove
-      path: /spec/template/spec/volumes/0
-
 patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: controller-manager
+      namespace: system
+    patch: |-
+      # Add ENABLE_CONVERSION_WEBHOOK env to enable conversion webhook
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: "ENABLE_CONVERSION_WEBHOOK"
+          value: "true"
+      # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.
+      # Update the indices in this path if adding or removing containers/volumeMounts in the manager's Deployment.
+      - op: remove
+        path: /spec/template/spec/containers/0/volumeMounts/0
+      # Remove the "cert" volume, since OLM will create and mount a set of certs.
+      # Update the indices in this path if adding or removing volumes in the manager's Deployment.
+      - op: remove
+        path: /spec/template/spec/volumes/0
   - target:
       group: operators.coreos.com
       version: v1alpha1

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
@@ -13,4 +13,4 @@ patchesJson6902:
     version: v1alpha3
     kind: Configuration
     name: config
-#+kubebuilder:scaffold:patchesJson6902
+#+kubebuilder:scaffold:patches


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

`make bundle` prints the kustomize deprecation warning for `patchesJson6902` twice, once for `config/manifests/kustomization.yaml` and once for `config/scorecard/kustomization.yaml`. This moves both blocks to the `patches` field, which accepts the same JSON Patch targets, and updates the scorecard scaffold marker to the one current operator-sdk versions emit (`#+kubebuilder:scaffold:patches`, see the operator-sdk `testdata/go/v4` scaffold).

The three JSON Patch operations on the manager Deployment (add `ENABLE_CONVERSION_WEBHOOK`, remove the cert volumeMount, remove the cert volume) and the two scorecard patches are kept as they were.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #2352

**How to test changes / Special notes to the reviewer**:

- `make bundle` before and after this change: the generated `bundle/` directory is identical apart from the `createdAt` timestamp, which the `codegen` workflow already ignores
- `make bundle` after this change prints no `patchesJson6902` warning



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration patch syntax for compatibility with current Kustomize conventions.
  * Preserved existing controller configuration behavior, including conversion webhook settings and certificate volume adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->