### PR TITLE
fix: retain controller volumes when importing from ArgoCDExport

### DIFF
--- a/controllers/argocd/statefulset.go
+++ b/controllers/argocd/statefulset.go
@@ -865,7 +865,7 @@ func (r *ReconcileArgoCD) reconcileApplicationControllerStatefulSet(cr *argoproj
 			VolumeMounts:    getArgoImportVolumeMounts(),
 		}}
 
-		podSpec.Volumes = getArgoImportVolumes(export)
+		podSpec.Volumes = append(controllerVolumes, getArgoImportVolumes(export)...)
 	}
 
 	invalidImagePod, err := containsInvalidImage(*cr, r)

--- a/controllers/argocd/statefulset_test.go
+++ b/controllers/argocd/statefulset_test.go
@@ -437,6 +437,15 @@ func TestReconcileArgoCD_reconcileApplicationController_withResources(t *testing
 		},
 		ss))
 
+	volumeNames := make(map[string]bool)
+	for _, vol := range ss.Spec.Template.Spec.Volumes {
+		volumeNames[vol.Name] = true
+	}
+	assert.True(t, volumeNames["argocd-repo-server-tls"])
+	assert.True(t, volumeNames[common.ArgoCDRedisServerTLSSecretName])
+	assert.True(t, volumeNames["backup-storage"])
+	assert.True(t, volumeNames["secret-storage"])
+
 	testResources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: resourcev1.MustParse("1024Mi"),


### PR DESCRIPTION
## Summary
Fixes application controller pod validation failure when restoring ArgoCD from ArgoCDExport (`spec.import`). Import volumes are appended to controller volumes instead of replacing them, so TLS volume mounts remain valid.

Fixes #1720

Red Hat bug: https://redhat.atlassian.net/browse/OCPBUGS-121935

## Problem
When `spec.import` is set, the operator replaced `podSpec.Volumes` with import-only volumes while TLS volume mounts on the application controller container remained. Kubernetes rejects the pod:

```
volumeMounts[0].name: Not found: "argocd-repo-server-tls"
volumeMounts[1].name: Not found: "argocd-operator-redis-tls"
```

ArgoCDExport restore / DR workflow fails with `applicationController: Pending`.

## Fix
```go
podSpec.Volumes = append(controllerVolumes, getArgoImportVolumes(export)...)
```

## Test plan
- [x] `go test ./controllers/argocd/ -run TestReconcileArgoCD_reconcileApplicationController_withResources`
- [x] Asserts TLS volumes and import volumes coexist when `spec.import` is set


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ArgoCD application controller deployments now retain their standard volumes when ArgoCDExport import volumes are configured.
  * Prevents required TLS, backup, and secret storage volumes from being omitted.

* **Tests**
  * Added coverage verifying that all expected application controller volumes are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->